### PR TITLE
Abstract validators

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -369,14 +369,14 @@ Lemma validator_component_byzantine_fault_tolerance
     (IM : index -> VLSM message)
     (constraint : composite_label IM -> composite_state IM  * option message -> Prop)
     (i : index)
-    (Hvalidator: projection_validator_prop IM constraint i)
+    (Hvalidator: component_projection_validator_prop IM constraint i)
     : forall tr, byzantine_trace_prop (IM i) tr ->
         valid_trace_prop (composite_vlsm_constrained_projection IM constraint i) tr.
 Proof.
     intros tr Htr.
     apply
         (VLSM_incl_valid_trace
-            (pre_loaded_with_all_messages_validator_proj_incl _ _ _ Hvalidator)).
+            (pre_loaded_with_all_messages_validator_component_proj_incl _ _ _ Hvalidator)).
     revert Htr.
     apply byzantine_pre_loaded_with_all_messages.
 Qed.
@@ -399,7 +399,7 @@ Section composite_validator_byzantine_traces.
             (X := composite_vlsm IM constraint)
             (PreLoadedX := pre_loaded_with_all_messages_vlsm X)
             (FreeX := free_composite_vlsm IM)
-            (Hvalidator: forall i : index, projection_validator_prop IM constraint i)
+            (Hvalidator: forall i : index, component_projection_validator_prop IM constraint i)
             .
 
 (**

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -821,7 +821,7 @@ End assuming_initial_messages_lift.
 Context
   (Hvalidator:
     forall i : index, i ∉ selection ->
-    projection_validator_prop IM (fixed_equivocation_constraint IM Hbs Hbr selection) i)
+    component_projection_validator_prop IM (fixed_equivocation_constraint IM Hbs Hbr selection) i)
   .
 
 Lemma validator_fixed_non_byzantine_vlsm_lift_initial_message

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -57,7 +57,7 @@ Context
   {is_equivocating_tracewise_no_has_been_sent_dec : RelDecision (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
   (limited_constraint := limited_equivocation_constraint IM (listing_from_finite index) sender)
   (Limited : VLSM message := composite_vlsm IM limited_constraint)
-  (Hvalidator: forall i : index, projection_validator_prop IM limited_constraint i)
+  (Hvalidator: forall i : index, component_projection_validator_prop IM limited_constraint i)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   (can_emit_signed : channel_authentication_prop IM Datatypes.id sender)
   (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -277,7 +277,7 @@ Proof.
   apply VLSM_eq_incl_iff.
   split.
   - apply basic_VLSM_strong_incl.
-    + intros s Hs.
+    + intros s Hs; cbn; red.
       exists (lift_to_composite_state IM j s).
       split; [apply state_update_eq|].
       apply (lift_to_composite_state_initial IM).
@@ -295,7 +295,6 @@ Proof.
       cbn.
       unfold lift_to_composite_state at 1.
       rewrite state_update_eq.
-      cbn.
       intros Ht.
       setoid_rewrite Ht.
       rewrite state_update_eq.
@@ -306,7 +305,7 @@ Proof.
     + intros m Him.
       exists (exist _ m Him).
       reflexivity.
-    + intros l s iom [[i li] [sX [HlX [<- Hv]]]].
+    + intros l s iom ((i, li) & sX & HlX & <- & Hv).
       exists sX.
       split; [reflexivity|].
       unfold composite_project_label in HlX.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -402,7 +402,7 @@ Proof.
     + apply component_label_projection_lift.
     + apply component_state_projection_lift.
     + apply component_transition_projection_Some.
-Qed. 
+Qed.
 
 (** The projection on component <<j>> of valid traces from <<X>> is valid
 for the <<j>>th projection.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -671,10 +671,9 @@ given inputs and that they have a [valid_state] and a [valid_message].
       (l : label)
       (som : state * option message)
       (Hv : input_valid l som)
-      : exists (som' : state * option message),
+      : forall som', transition l som = som' ->
         input_valid_transition l som som'.
     Proof.
-      exists (transition l som).
       repeat split; assumption.
     Qed.
 
@@ -686,7 +685,8 @@ given inputs and that they have a [valid_state] and a [valid_message].
             input_valid_transition l som som'.
     Proof.
       split.
-      - apply input_valid_can_transition.
+      - eexists.
+        apply input_valid_can_transition; [assumption|reflexivity].
       - intros [som' Hivt].
         apply input_valid_transition_valid with som'.
         assumption.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -641,6 +641,9 @@ given inputs and that they have a [valid_state] and a [valid_message].
       input_valid l som
       /\  transition l som = som'.
 
+    Definition input_valid_transition_item (s : state) (item : transition_item) :=
+      input_valid_transition (l item) (s, input item) (destination item, output item).
+
     Definition input_valid_transition_preserving
       (R : state -> state -> Prop)
       : Prop

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -641,7 +641,10 @@ given inputs and that they have a [valid_state] and a [valid_message].
       input_valid l som
       /\  transition l som = som'.
 
-    Definition input_valid_transition_item (s : state) (item : transition_item) :=
+    Definition input_valid_transition_item
+      (s : state)
+      (item : transition_item)
+      :=
       input_valid_transition (l item) (s, input item) (destination item, output item).
 
     Definition input_valid_transition_preserving

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -136,9 +136,7 @@ Lemma VLSM_weak_partial_projection_input_valid
     input_valid Y (l itemY) (sY, input itemY).
 Proof.
   intros sX itemX HitemX sY itemY Hpr.
-  eapply VLSM_weak_partial_projection_input_valid_transition
-  ; [eassumption|].
-  assumption.
+  eapply VLSM_weak_partial_projection_input_valid_transition; eassumption.
 Qed.
 
 End weak_partial_projection_properties.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -683,8 +683,8 @@ Lemma VLSM_weak_projection_input_valid
 Proof.
   intros lX lY Hpr sX im HvX.
   destruct (vtransition X lX (sX, im)) eqn:HtX.
-  eapply proj1, VLSM_weak_projection_input_valid_transition, input_valid_can_transition
-  ; [eassumption|assumption|exact HtX].
+  eapply VLSM_weak_projection_input_valid_transition, input_valid_can_transition
+  ; eassumption.
 Qed.
 
 Lemma VLSM_weak_projection_finite_valid_trace_from_to
@@ -1320,7 +1320,7 @@ Lemma VLSM_weak_full_projection_input_valid l s im
 Proof.
   intros.
   eapply (VLSM_weak_projection_input_valid VLSM_weak_full_projection_is_projection)
-  ; [reflexivity|assumption].
+  ; trivial.
 Qed.
 
 Lemma VLSM_weak_full_projection_infinite_valid_trace_from
@@ -3023,13 +3023,12 @@ Lemma induced_projection_valid_is_input_valid
   : vvalid projection_induced_vlsm l (s, om) -> input_valid projection_induced_vlsm l (s,om).
 Proof.
   intro Hv.
-  destruct (id Hv) as [lX [sX [HlX [<- [Hps [Hopm _]]]]]].
-  repeat split.
-  - apply (VLSM_projection_valid_state Hproj). assumption.
+  destruct (id Hv) as (lX & sX & HlX & <- & Hps & Hopm & _).
+  repeat split; [| | assumption].
+  - eapply VLSM_projection_valid_state; eassumption.
   - destruct om as [m|]; [|apply option_valid_message_None].
     apply option_initial_message_is_valid.
     assumption.
-  - assumption.
 Qed.
 
 Section projection_induced_friendliness.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -131,17 +131,14 @@ Proof.
 Qed.
 
 Lemma VLSM_weak_partial_projection_input_valid
-  : forall lX sX inX, input_valid X lX (sX, inX) ->
-    forall sX' outX, vtransition X lX (sX, inX) = (sX', outX) ->
-    forall sY itemY,
-    trace_project (sX, [{| l := lX;  input := inX; destination := sX'; output := outX |}])
-      = Some (sY, [itemY]) ->
+  : forall sX itemX, input_valid_transition_item X sX itemX ->
+    forall sY itemY, trace_project (sX, [itemX]) = Some (sY, [itemY]) ->
     input_valid Y (l itemY) (sY, input itemY).
 Proof.
-  intros lX sX inX HvX sX' outX HtX sY itemY Hpr.
-  eapply proj1, VLSM_weak_partial_projection_input_valid_transition
+  intros sX itemX HitemX sY itemY Hpr.
+  eapply VLSM_weak_partial_projection_input_valid_transition
   ; [eassumption|].
-  split; assumption.
+  assumption.
 Qed.
 
 End weak_partial_projection_properties.
@@ -210,12 +207,6 @@ Definition VLSM_partial_projection_input_valid_transition
   := VLSM_weak_partial_projection_input_valid_transition VLSM_partial_projection_weaken.
 
 Definition VLSM_partial_projection_input_valid
-  : forall lX sX inX, input_valid X lX (sX, inX) ->
-    forall sX' outX, vtransition X lX (sX, inX) = (sX', outX) ->
-    forall sY itemY,
-    trace_project (sX, [{| l := lX;  input := inX; destination := sX'; output := outX |}])
-      = Some (sY, [itemY]) ->
-    input_valid Y (l itemY) (sY, input itemY)
   := VLSM_weak_partial_projection_input_valid VLSM_partial_projection_weaken.
 
 End partial_projection_properties.
@@ -832,9 +823,6 @@ Definition VLSM_projection_input_valid_transition
   := VLSM_weak_projection_input_valid_transition VLSM_projection_weaken.
 
 Definition VLSM_projection_input_valid
-  : forall lX lY, label_project lX = Some lY ->
-    forall s im,
-    input_valid X lX (s, im) -> input_valid Y lY (state_project s, im)
   := VLSM_weak_projection_input_valid VLSM_projection_weaken.
 
 Definition VLSM_projection_finite_valid_trace_from_to

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -686,7 +686,7 @@ Proof.
   eapply proj1, VLSM_weak_projection_input_valid_transition, input_valid_can_transition
   ; [eassumption|assumption|exact HtX].
 Qed.
- 
+
 Lemma VLSM_weak_projection_finite_valid_trace_from_to
   : forall sX s'X trX,
     finite_valid_trace_from_to X sX s'X trX -> finite_valid_trace_from_to Y (state_project sX) (state_project s'X) (VLSM_weak_projection_trace_project Hsimul trX).

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -1,147 +1,73 @@
 From stdpp Require Import prelude.
 From Coq Require Import FinFun.
-From VLSM Require Import Lib.Preamble Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces.
+From VLSM.Lib Require Import Preamble ListExtras.
+From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.
 
 (** * VLSM Projection Validators
 
-In the sequel we fix a composite VLSM <<X>> obtained from an indexed family
-of VLSMs <<IM>> and a <<constraint>>, and an index <<i>>, corresponding to
-component <<IM i>>.
+In the sequel we fix a VLSMs <<X>> and <<Y>> and a [VLSM_projection]
+of <<X>> into <<PreY>>, the [pre_loaded_with_all_messages_vlsm] of <<Y>>.
 *)
 
 Section projection_validator.
 
 Context
-    {message : Type}
-    {index : Type}
-    {IndEqDec : EqDecision index}
-    (IM : index -> VLSM message)
-    (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-    (X := composite_vlsm IM constraint)
-    (i : index)
-    (Xi := composite_vlsm_constrained_projection IM constraint i)
-    .
+  {message : Type}
+  {X Y : VLSM message}
+  {label_project : vlabel X -> option (vlabel Y)}
+  {state_project : vstate X -> vstate Y}
+  (PreY := pre_loaded_with_all_messages_vlsm Y)
+  (Hproj : VLSM_projection X PreY label_project state_project)
+  .
 
 (**
-We say that the component <<i>> of X is a validator for received messages if
-non-[projection_valid]itiy implied non-component-[valid]ity (or non-reachability).
+We say that <<Y>> is a validator for received messages if
+non-[projection_induced_valid]itiy implied non-component-[valid]ity
+(or non-reachability).
 *)
 
-Definition projection_validator_received_messages_prop
-    :=
-    forall (li : vlabel (IM i)) (si : vstate (IM i)) (mi : message),
-        ~ vvalid Xi li (si, Some mi)
-        -> ~ input_valid (pre_loaded_with_all_messages_vlsm (IM i)) li (si, Some mi).
+Definition projection_validator_received_messages_prop :=
+  forall (li : vlabel Y) (si : vstate Y) (mi : message),
+    ~ projection_induced_valid X (type Y) label_project state_project li (si, Some mi)
+    -> ~ input_valid PreY li (si, Some mi).
 
 (**
 We can slightly generalize the definition above to also include empty messages
 and state it in a positive manner as the [projection_validator_prop]erty below,
 requiring that [valid]ity in the component (for reachable states) implies
-[projection_valid]ity.
+[projection_induced_valid]ity.
 *)
 
 Definition projection_validator_prop :=
-    forall (li : vlabel (IM i)) (siomi : vstate (IM i) * option message),
-        input_valid (pre_loaded_with_all_messages_vlsm (IM i)) li siomi ->
-        vvalid Xi li siomi.
-
-(** An alternative formulation of the above property with a seemingly
-stronger hypothesis, states that component (IM i) is a validator for the composition constraint
-if for any <<si>> a valid state in the projection <<Xi>>, <<li valid (IM i) (si, om)>>
-implies  that there exists a state <<s>> whose ith  component is <<si>>,
-and <<s>> and <<om>> are valid in <<X>>, and <<(i,li) valid (s,om)>> in <<X>>, that is,
-we have that <<li valid (si, om)>> in the projection <<Xi>>.
-*)
-Definition projection_validator_prop_alt :=
-    forall (li : vlabel (IM i)) (siom : vstate (IM i) * option message),
-        let (si, om) := siom in
-        vvalid (IM i) li siom ->
-        valid_state_prop Xi si ->
-        vvalid Xi li siom.
-
-(** Under validator assumptions, all reachable states for component <<IM i>> are
-valid states in the projection <<Xi>>.
-*)
-Lemma validator_alt_free_states_are_projection_states
-    : projection_validator_prop_alt ->
-    forall s,
-        valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) s ->
-        valid_state_prop Xi s.
-Proof.
-    intros Hvalidator s Hs.
-    induction Hs using valid_state_prop_ind;
-    [apply initial_state_is_valid;assumption|].
-    change s' with (fst (s',om')).
-    destruct Ht as [[_ [_ Hvalid]] Htrans].
-    apply (projection_valid_implies_destination_projection_valid_state IM constraint i) with l s om om'
-    ; [|assumption].
-    apply (Hvalidator l (s,om));assumption.
-Qed.
-
-(** Below we show that the two definitions above are actually equivalent.
-*)
-Lemma projection_validator_prop_alt_iff
-    : projection_validator_prop_alt <-> projection_validator_prop.
-Proof.
-    split.
-    - intros Hvalidator l (si, om) Hvalid.
-      destruct Hvalid as [Hsi [_ Hvalid]].
-      apply validator_alt_free_states_are_projection_states in Hsi
-      ; [|assumption].
-      exact (Hvalidator l (si,om) Hvalid Hsi).
-    - intros Hvalidator l (si, om) Hvalid HXisi.
-      specialize (Hvalidator l (si, om)).
-      apply Hvalidator.
-      repeat split; [| apply any_message_is_valid_in_preloaded | assumption].
-      revert HXisi.
-      apply VLSM_incl_valid_state.
-      apply proj_pre_loaded_with_all_messages_incl.
-Qed.
-
-Lemma validator_free_states_are_projection_states
-    : projection_validator_prop ->
-    forall s,
-        valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) s ->
-        valid_state_prop Xi s.
-Proof.
-    rewrite <- projection_validator_prop_alt_iff.
-    apply validator_alt_free_states_are_projection_states.
-Qed.
+  forall li si omi,
+    input_valid PreY li (si,omi) ->
+    projection_induced_valid X (type Y) label_project state_project li (si,omi).
 
 (**
 It is easy to see that the [projection_validator_prop]erty includes the
 [projection_validator_received_messages_prop]erty.
 *)
 Lemma projection_validator_messages_received
-    : projection_validator_prop -> projection_validator_received_messages_prop.
+  : projection_validator_prop -> projection_validator_received_messages_prop.
 Proof.
-    unfold projection_validator_prop. unfold projection_validator_received_messages_prop. intros.
-    intro Hvalid. elim H0. clear H0.
-    specialize (H li (si, Some mi) Hvalid). assumption.
+  unfold projection_validator_prop, projection_validator_received_messages_prop.
+  intuition.
 Qed.
 
 (**
-We say that component <<i>> is a [transition_validator] if any [valid]
-transition (from a reachable state) in component <<i>> can be "lifted" to
+We say that <<Y>> is a [transition_validator] if any [valid]
+transition (from a reachable state) in <<Y>> can be "lifted" to
 an [input_valid_transition] in <<X>>.
 
 *)
 
 Definition transition_validator :=
-    forall
-        (si : vstate (IM i))
-        (omi : option message)
-        (li : vlabel (IM i))
-        ,
-        input_valid (pre_loaded_with_all_messages_vlsm (IM i)) li (si, omi)
-        ->
-        (exists
-            (s s' : vstate X)
-            (om' : option message),
-            si = s i
-            /\
-            input_valid_transition X (existT i li) (s, omi) (s', om')
-        ).
+  forall lY sY omi, input_valid PreY lY (sY, omi) ->
+  exists lX sX sX' om',
+   input_valid_transition X lX (sX, omi) (sX', om') /\
+   label_project lX = Some lY /\
+   state_project sX = sY.
+   
 
 (**
 Next two results show that the (simpler) [projection_validator_prop]erty
@@ -149,91 +75,320 @@ is equivalent with the [transition_validator] property.
 *)
 
 Lemma projection_validator_messages_transitions
-    : projection_validator_prop -> transition_validator.
+  : projection_validator_prop -> transition_validator.
 Proof.
-    intros Hvalidator si omi li Hpvi.
-    specialize (Hvalidator li (si, omi) Hpvi). clear Hpvi.
-    destruct Hvalidator as [s [Hsi [Hps [Hopm [Hvalid Hctr]]]]].
-    destruct (vtransition X (existT i li) (s, omi)) as (s', om') eqn:Heqt.
-    exists s. exists s'. exists om'.
-    subst si.
-    repeat split; assumption.
+  intros Hvalidator li si omi Hpvi.
+  specialize (Hvalidator _ _ _ Hpvi)
+    as [l [s [Hli [Hsi [Hps [Hopm Hvalid]]]]]].
+  exists l, s.
+  unfold input_valid_transition.
+  destruct (transition _ _ ) as (s', om').
+  exists s', om'.
+  repeat split; assumption.
 Qed.
 
 Lemma transition_validator_messages
-    : transition_validator -> projection_validator_prop.
+  : transition_validator -> projection_validator_prop.
 Proof.
-    intros Hvalidator li (si,omi) Hpvi.
-    specialize (Hvalidator si omi li Hpvi). clear Hpvi.
-    destruct Hvalidator as [s [s' [om' [Hsi [Hvalid Htransition]]]]].
-    symmetry in Hsi.
-    exists s. split; assumption.
+  intros Hvalidator li si omi Hpvi.
+  specialize (Hvalidator _ _ _ Hpvi)
+    as [l [s [s' [om' [[Hvalid Htransition] [Hli Hsi]]]]]].
+  exists l, s.
+  intuition.
 Qed.
 
 (** ** Projection validators and Byzantine behavior
 
-In the sequel we assume that <<X>> has the [projection_validator_prop]erty for
-component <<i>>.  Let <<Xi>> be the projection of <<X>> to component <<i>>
-and <<Preloaded>> be the [pre_loaded_with_all_messages_vlsm] associated to component <<i>>.
+In the sequel we assume that the [projection_induced_vlsm_is_projection] and
+that initial states of <<Y>> can be lifted to <<X>>.
 *)
+
+Section induced_projection_validators.
+
+Context
+  (Htransition_None : weak_projection_transition_consistency_None _ _ label_project state_project)
+  (label_lift : vlabel Y -> vlabel X)
+  (state_lift : vstate Y -> vstate X)
+  (Xi := projection_induced_vlsm X (type Y)
+    label_project state_project label_lift state_lift)
+  (Hlabel_lift : induced_projection_label_lift_prop _ _ label_project label_lift)
+  (Hstate_lift : induced_projection_state_lift_prop _ _ state_project state_lift)
+  (Hinitial_lift : strong_full_projection_initial_state_preservation Y X state_lift)
+  (Htransition_consistency : induced_projection_transition_consistency_Some _ _ label_project state_project)
+  (Htransition_Some  : weak_projection_transition_consistency_Some _ _ label_project state_project label_lift state_lift
+    := basic_weak_projection_transition_consistency_Some _ _ _ _ _ _ Hlabel_lift Hstate_lift Htransition_consistency)
+  (Hproji := projection_induced_vlsm_is_projection _ _ _ _ _ _ Htransition_None Htransition_Some)
+  .
+
+(** If there is a [VLSM_projection] from <<X>> to <<PreY>> and the
+[projection_induced_vlsm_is_projection], then a [transition] [valid] for the
+[projection_induced_vlsm] has the same output as the transition on <<Y>>.
+*)
+Lemma projection_induced_valid_transition_eq
+  : forall l s om, vvalid Xi l (s, om) ->
+    vtransition Xi l (s, om) = vtransition Y l (s, om).
+Proof.
+  intros l s im [lX [sX [Hlx [<- Hv]]]].
+  replace (vtransition Y _ _) with
+    (state_project (vtransition X lX (sX, im)).1, (vtransition X lX (sX, im)).2).
+  - eapply proj2, (VLSM_projection_input_valid_transition Hproji) with (lY := l)
+    ; [eassumption|].
+    split; [assumption|].
+    apply injective_projections; reflexivity.
+  - symmetry.
+    eapply proj2, (VLSM_projection_input_valid_transition Hproj) with (lY := l)
+    ; [eassumption|].
+    split; [assumption|].
+    apply injective_projections; reflexivity.
+Qed.
+
+Lemma induced_projection_incl_preloaded_with_all_messages
+  : VLSM_incl Xi PreY.
+Proof.
+  apply basic_VLSM_incl.
+  - intros is [s [<- Hs]].
+    apply (VLSM_projection_initial_state Hproj).
+    assumption.
+  - intro; intros. apply any_message_is_valid_in_preloaded.
+  - intros l s om [_ [_ [lX [sX [Hlx [<- Hv]]]]]] _ _.
+    simpl.
+    eapply proj2, proj2, (VLSM_projection_input_valid Hproj); eassumption.
+  - intros l s im s' om [[_ [_ HvXi]] HtXi].
+    setoid_rewrite <- HtXi.
+    symmetry.
+    apply projection_induced_valid_transition_eq.
+    assumption.
+Qed.
+
+(** An alternative formulation of the [projection_validator_prop]erty with a
+seemingly stronger hypothesis, states that <<Y>> is a validator for <<X>>
+if for any <<sY>> a valid state in the projection <<Xi>>, <<li valid Y (sY, om)>>
+implies that <<li valid (si, om)>> in the projection <<Xi>> (i.e.,
+[projection_induced_valid]ity).
+*)
+Definition projection_validator_prop_alt :=
+  forall li si iom,
+    vvalid Y li (si, iom) ->
+    valid_state_prop Xi si ->
+    vvalid Xi li (si, iom).
+
+(** Under validator assumptions, all reachable states for component <<Y>> are
+valid states in the induced projection <<Xi>>.
+*)
+Lemma validator_alt_free_states_are_projection_states
+  : projection_validator_prop_alt ->
+  forall s,
+    valid_state_prop (pre_loaded_with_all_messages_vlsm Y) s ->
+    valid_state_prop Xi s.
+Proof.
+  intros Hvalidator sY Hs.
+  induction Hs using valid_state_prop_ind.
+  - apply initial_state_is_valid.
+    exists (state_lift s).
+    split; [apply Hstate_lift|].
+    apply Hinitial_lift.
+    assumption.
+  - destruct Ht as [[_ [_ Hvalid]] Htrans].
+    specialize (Hvalidator _ _ _ Hvalid IHHs)
+      as [lX [sX [HlX [HsX HvX]]]].
+    replace s' with (state_project (vtransition X lX (sX, om)).1).
+    + eapply input_valid_transition_destination,
+        (VLSM_projection_input_valid_transition Hproji);
+      [exact HlX|].
+      split; [exact HvX|].
+      apply injective_projections; reflexivity.
+    + assert (HivtX : input_valid_transition X lX (sX, om) (vtransition X lX (sX, om)))
+        by (split; [assumption|reflexivity]).
+      destruct (vtransition _ _ _) as (sX', _om').
+      apply (VLSM_projection_input_valid_transition Hproj) with (lY := l)
+        in HivtX as [_ Hs']
+      ; [|assumption].
+      rewrite HsX in Hs'.
+      destruct Y as (TY, (SY, MY)).
+      cbv in Htrans, Hs'.
+      rewrite Htrans in Hs'.
+      inversion Hs'.
+      reflexivity.
+Qed.
+
+(** Below we show that the two definitions above are actually equivalent.
+*)
+Lemma projection_validator_prop_alt_iff
+  : projection_validator_prop_alt <-> projection_validator_prop.
+Proof.
+  split.
+  - intros Hvalidator l si om Hvalid.
+    apply Hvalidator; [apply Hvalid|].
+    apply validator_alt_free_states_are_projection_states; [assumption..|].
+    apply Hvalid.
+  - intros Hvalidator l si om Hvalid HXisi.
+    apply Hvalidator.
+    repeat split; [| apply any_message_is_valid_in_preloaded | assumption].
+    revert HXisi.
+    apply VLSM_incl_valid_state.
+    apply induced_projection_incl_preloaded_with_all_messages.
+Qed.
+
+Lemma validator_free_states_are_projection_states
+  : projection_validator_prop ->
+  forall s,
+    valid_state_prop (pre_loaded_with_all_messages_vlsm Y) s ->
+    valid_state_prop Xi s.
+Proof.
+  rewrite <- projection_validator_prop_alt_iff by assumption.
+  apply validator_alt_free_states_are_projection_states.
+Qed.
 
 Section pre_loaded_with_all_messages_validator_proj.
-    Context
-        (Hvalidator : projection_validator_prop)
-        (PreLoaded := pre_loaded_with_all_messages_vlsm (IM i))
-        .
+  Context
+    (Hvalidator : projection_validator_prop)
+    .
 
 (**
-We can show that <<Preloaded>> is included in <<Xi>> by applying the meta-lemma
+We can show that <<PreY>> is included in <<Xi>> by applying the meta-lemma
 [VLSM_incl_finite_traces_characterization], and by induction on the length
 of a trace. The [projection_validator_prop]erty is used to translate
-[input_valid]ity for the preloaded machine into the [projection_valid]ity.
+[input_valid]ity for the PreY machine into the [projection_valid]ity.
 *)
-
-    Lemma pre_loaded_with_all_messages_validator_proj_incl
-        : VLSM_incl PreLoaded Xi.
-    Proof.
-        (* reduce inclusion to inclusion of finite traces. *)
-        apply VLSM_incl_finite_traces_characterization.
-        intros.
-        split; [|apply H].
-        induction H using finite_valid_trace_rev_ind.
-        - apply (finite_valid_trace_from_empty Xi). apply initial_state_is_valid. assumption.
-        - apply (extend_right_finite_trace_from Xi);[assumption|].
-          destruct Hx as [Hvx Htx].
-          split; [|assumption].
-          apply projection_valid_input_valid.
-          apply Hvalidator.
-          assumption.
-    Qed.
+Lemma pre_loaded_with_all_messages_validator_proj_incl
+  : VLSM_incl PreY Xi.
+Proof.
+  (* reduce inclusion to inclusion of finite traces. *)
+  apply VLSM_incl_finite_traces_characterization.
+  intros sY trY HtrY.
+  split; cycle 1.
+  - exists (state_lift sY).
+    split; [apply Hstate_lift|].
+    apply Hinitial_lift.
+    apply HtrY.
+  - induction HtrY using finite_valid_trace_rev_ind.
+    + apply (finite_valid_trace_from_empty Xi).
+      apply initial_state_is_valid.
+      exists (state_lift si).
+      split; [apply Hstate_lift|].
+      apply Hinitial_lift.
+      assumption.
+    + apply (extend_right_finite_trace_from Xi);[assumption|].
+      split.
+      * apply induced_projection_valid_is_input_valid; [assumption|].
+        apply Hvalidator.
+        apply Hx.
+      * replace (sf, _) with (vtransition Y l (finite_trace_last si tr, iom))
+          by apply Hx.
+        apply projection_induced_valid_transition_eq.
+        apply Hvalidator.
+        apply Hx.
+Qed.
 
 (**
 Given that any projection is included in the [pre_loaded_with_all_messages_vlsm]
 of its component (Lemma [proj_pre_loaded_with_all_messages_incl]), we conclude
-that <<Preloaded>> and <<Xi>> are trace-equal.  This means that all the
+that <<PreY>> and <<Xi>> are trace-equal.  This means that all the
 byzantine behavior of a component which is a validator
 is exhibited by its corresponding projection.
 *)
-    Lemma pre_loaded_with_all_messages_validator_proj_eq
-        : VLSM_eq PreLoaded Xi.
-    Proof.
-        split.
-        - apply pre_loaded_with_all_messages_validator_proj_incl.
-        - apply proj_pre_loaded_with_all_messages_incl.
-    Qed.
+Lemma pre_loaded_with_all_messages_validator_proj_eq
+  : VLSM_eq PreY Xi.
+Proof.
+  apply VLSM_eq_incl_iff.
+  split.
+  - apply pre_loaded_with_all_messages_validator_proj_incl.
+  - apply induced_projection_incl_preloaded_with_all_messages.
+Qed.
 
 End pre_loaded_with_all_messages_validator_proj.
 
+End induced_projection_validators.
+
 End projection_validator.
+
+(** ** Validator properties for the [component_projection].
+
+In this section we specialize the validator-related results to the
+components of a composition.
+*)
+
+Section component_projection_validator.
+
+Context
+  {message : Type}
+  {index : Type}
+  {IndEqDec : EqDecision index}
+  (IM : index -> VLSM message)
+  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
+  (X := composite_vlsm IM constraint)
+  (i : index)
+  (Xi := composite_vlsm_constrained_projection IM constraint i)
+  (PreXi := pre_loaded_with_all_messages_vlsm (IM i))
+  .
+
+(**
+We say that the component <<i>> of X is a validator for received messages if
+if [valid]ity in the component (for reachable states) implies [projection_valid]ity.
+*)
+Definition component_projection_validator_prop :=
+  forall (li : vlabel (IM i)) (siomi : vstate (IM i) * option message),
+    input_valid (pre_loaded_with_all_messages_vlsm (IM i)) li siomi ->
+    vvalid Xi li siomi.
+
+Lemma component_projection_to_preloaded
+  : VLSM_projection X PreXi (composite_project_label IM i) (fun s => s i).
+Proof.
+  constructor.
+  - apply component_projection.
+  - intros sX trX HtrX.
+    apply (VLSM_projection_finite_valid_trace (preloaded_component_projection IM i)).
+    revert HtrX.
+    apply VLSM_incl_finite_valid_trace.
+    apply constraint_preloaded_free_incl with (constraint0 := constraint).
+Qed.
+
+(** Assuming the [component_projection_validator_prop]erty, the component
+[pre_loaded_with_all_messages_vlsm] is [VLSM_eq]ual (trace-equivalent) with
+its corresponding [projection_induced_vlsm].
+*)
+Lemma pre_loaded_with_all_messages_validator_component_proj_eq
+  (Hvalidator : component_projection_validator_prop)
+  : VLSM_eq PreXi Xi.
+Proof.
+  apply VLSM_eq_trans with
+    (machine (projection_induced_vlsm X (type (IM i))
+      (composite_project_label IM i) (fun s => s i)
+      (lift_to_composite_label IM i) (lift_to_composite_state IM i)))
+  ; [|apply VLSM_eq_sym; apply composite_vlsm_constrained_projection_is_induced].
+  apply pre_loaded_with_all_messages_validator_proj_eq.
+  - apply component_projection_to_preloaded.
+  - apply component_transition_projection_None.
+  - apply component_label_projection_lift.
+  - apply component_state_projection_lift.
+  - intro s. apply (lift_to_composite_state_initial IM).
+  - apply component_transition_projection_Some.
+  - intros li si omi Hiv.
+    apply Hvalidator in Hiv as [sX [<- HivX]].
+    exists (existT i li), sX.
+    intuition.
+    unfold composite_project_label.
+    simpl.
+    case_decide as Hi; [|contradiction].
+    replace Hi with (@eq_refl index i) by (apply Eqdep_dec.UIP_dec; assumption).
+    reflexivity.
+Qed.
+
+Definition pre_loaded_with_all_messages_validator_component_proj_incl
+  (Hvalidator : component_projection_validator_prop)
+  : VLSM_incl PreXi Xi :=
+  VLSM_eq_proj1 (pre_loaded_with_all_messages_validator_component_proj_eq Hvalidator).
+
+End component_projection_validator.
 
 (** ** VLSM self-validation *)
 
 Section self_validator_vlsm.
 
 Context
-    {message : Type}
-    (X : VLSM message)
-    .
+  {message : Type}
+  (X : VLSM message)
+  .
 
 (**
 Let us fix a (regular) VLSM <<X>>. <<X>> is a self-validator if for any
@@ -242,11 +397,10 @@ arguments satisfying [valid] where the state is reachable in the
 a [valid_state] and [valid_message] for the original VLSM.
 *)
 
-Definition self_validator_vlsm_prop
-    :=
-    forall (l : label) (s : state) (om : option message),
-        input_valid (pre_loaded_with_all_messages_vlsm X) l (s, om) ->
-        input_valid X l (s, om).
+Definition self_validator_vlsm_prop :=
+  forall (l : label) (s : state) (om : option message),
+    input_valid (pre_loaded_with_all_messages_vlsm X) l (s, om) ->
+    input_valid X l (s, om).
 
 (**
 In the sequel we will show that a VLSM with the [self_validator_vlsm_prop]erty
@@ -258,58 +412,58 @@ byzantine behavior.
 *)
 
 Context
-    (Hvalidator : self_validator_vlsm_prop)
-    (PreLoaded := pre_loaded_with_all_messages_vlsm X)
-    .
+  (Hvalidator : self_validator_vlsm_prop)
+  (PreX := pre_loaded_with_all_messages_vlsm X)
+  .
 
 (**
-Let <<PreLoaded>> be the [pre_loaded_with_all_messages_vlsm] associated to X.
+Let <<PreX>> be the [pre_loaded_with_all_messages_vlsm] associated to X.
 From Lemma [vlsm_incl_pre_loaded_with_all_messages_vlsm] we know that <<X>> is
-included in <<PreLoaded>>.
+included in <<PreX>>.
 
 To prove the converse we use the [self_validator_vlsm_prop]erty to
 verify the conditions of meta-lemma [VLSM_incl_finite_traces_characterization].
 *)
 
-    Lemma pre_loaded_with_all_messages_self_validator_vlsm_incl
-        : VLSM_incl PreLoaded X.
-    Proof.
-        unfold self_validator_vlsm_prop  in Hvalidator.
-        destruct X as [T [S M]]. simpl in *.
-        (* redcuction to inclusion of finite traces. *)
-        apply VLSM_incl_finite_traces_characterization.
-        intros.
-        split; [|apply H].
-        destruct H as [Htr Hs].
-        (* reverse induction on the length of a trace. *)
-        induction tr using rev_ind.
-        - constructor. apply initial_state_is_valid. assumption.
-        - apply finite_valid_trace_from_app_iff in Htr.
-          destruct Htr as [Htr Hx].
-          specialize (IHtr Htr).
-          apply (finite_valid_trace_from_app_iff (mk_vlsm M)).
-          split; [assumption|].
-          apply (first_transition_valid (mk_vlsm M)).
-          apply first_transition_valid in Hx.
-          destruct Hx as [Hvx Htx].
-          split; [|assumption].
-          (* using the [self_validator_vlsm_prop]erty. *)
-          revert Hvx.
-          apply Hvalidator.
-    Qed.
+Lemma pre_loaded_with_all_messages_self_validator_vlsm_incl
+  : VLSM_incl PreX X.
+Proof.
+  unfold self_validator_vlsm_prop  in Hvalidator.
+  destruct X as [T [S M]]. simpl in *.
+  (* redcuction to inclusion of finite traces. *)
+  apply VLSM_incl_finite_traces_characterization.
+  intros.
+  split; [|apply H].
+  destruct H as [Htr Hs].
+  (* reverse induction on the length of a trace. *)
+  induction tr using rev_ind.
+  - constructor. apply initial_state_is_valid. assumption.
+  - apply finite_valid_trace_from_app_iff in Htr.
+    destruct Htr as [Htr Hx].
+    specialize (IHtr Htr).
+    apply (finite_valid_trace_from_app_iff (mk_vlsm M)).
+    split; [assumption|].
+    apply (first_transition_valid (mk_vlsm M)).
+    apply first_transition_valid in Hx.
+    destruct Hx as [Hvx Htx].
+    split; [|assumption].
+    (* using the [self_validator_vlsm_prop]erty. *)
+    revert Hvx.
+    apply Hvalidator.
+Qed.
 
 (**
-We conclude that <<X>> and <<Preloaded>> are trace-equal.
+We conclude that <<X>> and <<PreX>> are trace-equal.
 *)
 
-    Lemma pre_loaded_with_all_messages_self_validator_vlsm_eq
-        : VLSM_eq PreLoaded X.
-    Proof.
-        split.
-        - apply pre_loaded_with_all_messages_self_validator_vlsm_incl.
-        - pose (vlsm_incl_pre_loaded_with_all_messages_vlsm X) as Hincl.
-          destruct X as (T, (S, M)).
-          apply Hincl.
-    Qed.
+Lemma pre_loaded_with_all_messages_self_validator_vlsm_eq
+  : VLSM_eq PreX X.
+Proof.
+  split.
+  - apply pre_loaded_with_all_messages_self_validator_vlsm_incl.
+  - pose (vlsm_incl_pre_loaded_with_all_messages_vlsm X) as Hincl.
+    destruct X as (T, (S, M)).
+    apply Hincl.
+Qed.
 
 End self_validator_vlsm.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -127,12 +127,12 @@ Proof.
   intros l s im (lX & sX & Hlx & <- & Hv).
   replace (vtransition Y _ _) with
     (state_project (vtransition X lX (sX, im)).1, (vtransition X lX (sX, im)).2).
-  - eapply (VLSM_projection_input_valid_transition Hproji) with (lY := l)
+  - eapply (VLSM_projection_input_valid_transition Hproji)
     ; [eassumption|].
     split; [assumption|].
     apply injective_projections; reflexivity.
   - symmetry.
-    eapply (VLSM_projection_input_valid_transition Hproj) with (lY := l)
+    eapply (VLSM_projection_input_valid_transition Hproj)
     ; [eassumption|].
     split; [assumption|].
     apply injective_projections; reflexivity.
@@ -145,7 +145,7 @@ Proof.
   - intros is (s & <- & Hs).
     apply (VLSM_projection_initial_state Hproj).
     assumption.
-  - intro; intros. apply any_message_is_valid_in_preloaded.
+  - intros l s m Hv HsY HmX. apply any_message_is_valid_in_preloaded.
   - intros l s om (_ & _ & lX & sX & Hlx & <- & Hv) _ _.
     simpl.
     eapply (VLSM_projection_input_valid Hproj); eassumption.
@@ -195,11 +195,10 @@ Proof.
     + assert (HivtX : input_valid_transition X lX (sX, om) (vtransition X lX (sX, om)))
         by firstorder.
       destruct (vtransition _ _ _) as (sX', _om').
-      apply (VLSM_projection_input_valid_transition Hproj) with (lY := l)
-        in HivtX as [_ Hs']
-      ; [|assumption].
+      eapply (VLSM_projection_input_valid_transition Hproj) in HivtX as [_ Hs']
+      ; [|eassumption].
       rewrite HsX in Hs'.
-      destruct Y as (TY, (SY, MY)).
+      destruct Y as (TY & SY & MY).
       cbv in Htrans, Hs'.
       rewrite Htrans in Hs'.
       inversion Hs'.
@@ -251,15 +250,11 @@ Proof.
   split; cycle 1.
   - exists (state_lift sY).
     split; [apply Hstate_lift|].
-    apply Hinitial_lift.
-    apply HtrY.
+    apply Hinitial_lift, HtrY.
   - induction HtrY using finite_valid_trace_rev_ind.
-    + apply (finite_valid_trace_from_empty Xi).
-      apply initial_state_is_valid.
+    + apply (finite_valid_trace_from_empty Xi), initial_state_is_valid.
       exists (state_lift si).
-      split; [apply Hstate_lift|].
-      apply Hinitial_lift.
-      assumption.
+      auto.
     + apply (extend_right_finite_trace_from Xi);[assumption|].
       split.
       * apply induced_projection_valid_is_input_valid; [assumption|].
@@ -353,7 +348,7 @@ Proof.
   - intro s. apply (lift_to_composite_state_initial IM).
   - apply component_transition_projection_Some.
   - intros li si omi Hiv.
-    apply Hvalidator in Hiv as [sX [<- HivX]].
+    apply Hvalidator in Hiv as (sX & <- & HivX).
     exists (existT i li), sX.
     intuition.
     unfold composite_project_label.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -5,7 +5,7 @@ From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.
 
 (** * VLSM Projection Validators
 
-In the sequel we fix a VLSMs <<X>> and <<Y>> and a [VLSM_projection]
+In the sequel we fix VLSMs <<X>> and <<Y>> and a [VLSM_projection]
 of <<X>> into <<PreY>>, the [pre_loaded_with_all_messages_vlsm] of <<Y>>.
 *)
 
@@ -22,19 +22,7 @@ Context
 
 (**
 We say that <<Y>> is a validator for received messages if
-non-[projection_induced_valid]itiy implied non-component-[valid]ity
-(or non-reachability).
-*)
-
-Definition projection_validator_received_messages_prop :=
-  forall (li : vlabel Y) (si : vstate Y) (mi : message),
-    ~ projection_induced_valid X (type Y) label_project state_project li (si, Some mi)
-    -> ~ input_valid PreY li (si, Some mi).
-
-(**
-We can slightly generalize the definition above to also include empty messages
-and state it in a positive manner as the [projection_validator_prop]erty below,
-requiring that [valid]ity in the component (for reachable states) implies
+[valid]ity in the component (for reachable states) implies
 [projection_induced_valid]ity.
 *)
 
@@ -42,17 +30,6 @@ Definition projection_validator_prop :=
   forall li si omi,
     input_valid PreY li (si,omi) ->
     projection_induced_valid X (type Y) label_project state_project li (si,omi).
-
-(**
-It is easy to see that the [projection_validator_prop]erty includes the
-[projection_validator_received_messages_prop]erty.
-*)
-Lemma projection_validator_messages_received
-  : projection_validator_prop -> projection_validator_received_messages_prop.
-Proof.
-  unfold projection_validator_prop, projection_validator_received_messages_prop.
-  intuition.
-Qed.
 
 (**
 We say that <<Y>> is a [transition_validator] if any [valid]

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -58,16 +58,13 @@ Qed.
 We say that <<Y>> is a [transition_validator] if any [valid]
 transition (from a reachable state) in <<Y>> can be "lifted" to
 an [input_valid_transition] in <<X>>.
-
 *)
-
 Definition transition_validator :=
   forall lY sY omi, input_valid PreY lY (sY, omi) ->
   exists lX sX sX' om',
    input_valid_transition X lX (sX, omi) (sX', om') /\
    label_project lX = Some lY /\
    state_project sX = sY.
-   
 
 (**
 Next two results show that the (simpler) [projection_validator_prop]erty
@@ -109,8 +106,7 @@ Context
   (Htransition_None : weak_projection_transition_consistency_None _ _ label_project state_project)
   (label_lift : vlabel Y -> vlabel X)
   (state_lift : vstate Y -> vstate X)
-  (Xi := projection_induced_vlsm X (type Y)
-    label_project state_project label_lift state_lift)
+  (Xi := projection_induced_vlsm X (type Y) label_project state_project label_lift state_lift)
   (Hlabel_lift : induced_projection_label_lift_prop _ _ label_project label_lift)
   (Hstate_lift : induced_projection_state_lift_prop _ _ state_project state_lift)
   (Hinitial_lift : strong_full_projection_initial_state_preservation Y X state_lift)
@@ -161,10 +157,11 @@ Proof.
 Qed.
 
 (** An alternative formulation of the [projection_validator_prop]erty with a
-seemingly stronger hypothesis, states that <<Y>> is a validator for <<X>>
-if for any <<sY>> a valid state in the projection <<Xi>>, <<li valid Y (sY, om)>>
-implies that <<li valid (si, om)>> in the projection <<Xi>> (i.e.,
-[projection_induced_valid]ity).
+seemingly stronger hypothesis, states that <<Y>> is a validator for <<X>> if
+for any <<li>>, <<si>>, <<iom>> such that <<li valid (si, iom)>> in <<Y>>
+and <<si>> is a valid state in the induced projection <<Xi>>,
+implies that <<li valid (si, om)>> in the induced projection <<Xi>>
+(i.e., [projection_induced_valid]ity).
 *)
 Definition projection_validator_prop_alt :=
   forall li si iom,
@@ -177,9 +174,7 @@ valid states in the induced projection <<Xi>>.
 *)
 Lemma validator_alt_free_states_are_projection_states
   : projection_validator_prop_alt ->
-  forall s,
-    valid_state_prop (pre_loaded_with_all_messages_vlsm Y) s ->
-    valid_state_prop Xi s.
+    forall s, valid_state_prop PreY s -> valid_state_prop Xi s.
 Proof.
   intros Hvalidator sY Hs.
   induction Hs using valid_state_prop_ind.
@@ -211,8 +206,7 @@ Proof.
       reflexivity.
 Qed.
 
-(** Below we show that the two definitions above are actually equivalent.
-*)
+(** Below we show that the two definitions above are actually equivalent. *)
 Lemma projection_validator_prop_alt_iff
   : projection_validator_prop_alt <-> projection_validator_prop.
 Proof.
@@ -231,9 +225,7 @@ Qed.
 
 Lemma validator_free_states_are_projection_states
   : projection_validator_prop ->
-  forall s,
-    valid_state_prop (pre_loaded_with_all_messages_vlsm Y) s ->
-    valid_state_prop Xi s.
+    forall s, valid_state_prop PreY s -> valid_state_prop Xi s.
 Proof.
   rewrite <- projection_validator_prop_alt_iff by assumption.
   apply validator_alt_free_states_are_projection_states.


### PR DESCRIPTION
Abstracting validators to allow defining the validation property for generic projections, not just those of a constrained composition.