### PR TITLE
Full message dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ deps.map
 *.dpd
 *.dot
 .coq-native/
+.vscode

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -369,14 +369,14 @@ Lemma validator_component_byzantine_fault_tolerance
     (IM : index -> VLSM message)
     (constraint : composite_label IM -> composite_state IM  * option message -> Prop)
     (i : index)
-    (Hvalidator: projection_validator_prop IM constraint i)
+    (Hvalidator: component_projection_validator_prop IM constraint i)
     : forall tr, byzantine_trace_prop (IM i) tr ->
         valid_trace_prop (composite_vlsm_constrained_projection IM constraint i) tr.
 Proof.
     intros tr Htr.
     apply
         (VLSM_incl_valid_trace
-            (pre_loaded_with_all_messages_validator_proj_incl _ _ _ Hvalidator)).
+            (pre_loaded_with_all_messages_validator_component_proj_incl _ _ _ Hvalidator)).
     revert Htr.
     apply byzantine_pre_loaded_with_all_messages.
 Qed.
@@ -399,7 +399,7 @@ Section composite_validator_byzantine_traces.
             (X := composite_vlsm IM constraint)
             (PreLoadedX := pre_loaded_with_all_messages_vlsm X)
             (FreeX := free_composite_vlsm IM)
-            (Hvalidator: forall i : index, projection_validator_prop IM constraint i)
+            (Hvalidator: forall i : index, component_projection_validator_prop IM constraint i)
             .
 
 (**

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -64,9 +64,9 @@ Section fixed_byzantine_traces.
 
 Context
   {message : Type}
-  `{EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
+  `{forall i : index, HasBeenSentCapability (IM i)}
   (byzantine : set index)
   {validator : Type}
   (A : validator -> index)
@@ -128,20 +128,14 @@ Proof.
 Defined.
 
 Context
-  {finite_index : finite.Finite index}
   (non_byzantine : set index := set_diff (enum index) byzantine)
   .
-
-Definition sub_fixed_byzantine_IM_Hbs
-  : forall sub_i : sub_index non_byzantine,
-    HasBeenSentCapability (sub_IM fixed_byzantine_IM non_byzantine sub_i)
-  := update_IM_complement_Hbs IM byzantine _ Hbs.
 
 (** Constraint requiring only that the non-byzantine nodes are not equivocating.
 *)
 Definition non_byzantine_not_equivocating_constraint
   : composite_label fixed_byzantine_IM -> composite_state fixed_byzantine_IM * option message -> Prop :=
-  sub_IM_not_equivocating_constraint fixed_byzantine_IM non_byzantine A sender sub_fixed_byzantine_IM_Hbs.
+  sub_IM_not_equivocating_constraint fixed_byzantine_IM non_byzantine A sender.
 
 (** The first definition of the [fixed_byzantine_trace_prop]erty:
 
@@ -185,13 +179,12 @@ Qed.
 Lemma fixed_non_byzantine_projection_incl_preloaded
   : VLSM_incl fixed_non_byzantine_projection (pre_loaded_with_all_messages_vlsm (free_composite_vlsm (sub_IM fixed_byzantine_IM non_byzantine))).
 Proof.
-  apply basic_VLSM_strong_incl; intro; intros.
-  - apply fixed_non_byzantine_projection_initial_state_preservation. assumption.
-  - exact I.
-  - split; [|exact I].
-    revert H.
-    apply induced_sub_projection_valid_preservation.
-  - revert H. apply induced_sub_projection_transition_preservation.
+  apply basic_VLSM_strong_incl.
+  - intro; intros. apply fixed_non_byzantine_projection_initial_state_preservation. assumption.
+  - intro; intros; cbv; trivial.
+  - split; [|cbv; trivial].
+    eapply induced_sub_projection_valid_preservation; eassumption.
+  - intros l s om s' om'. apply induced_sub_projection_transition_preservation.
 Qed.
 
 (** The induced projection from the composition of [fixed_byzantine_IM] under
@@ -259,10 +252,10 @@ equivalent to each-other using the generic Lemma [same_IM_full_projection].
 *)
 
 Definition pre_loaded_fixed_non_byzantine_vlsm' : VLSM message :=
-  composite_no_equivocation_vlsm_with_pre_loaded (sub_IM fixed_byzantine_IM non_byzantine) (free_constraint _) sub_fixed_byzantine_IM_Hbs fixed_set_signed_message.
+  composite_no_equivocation_vlsm_with_pre_loaded (sub_IM fixed_byzantine_IM non_byzantine) (free_constraint _) fixed_set_signed_message.
 
 Definition pre_loaded_fixed_non_byzantine_vlsm : VLSM message :=
-  composite_no_equivocation_vlsm_with_pre_loaded (sub_IM IM non_byzantine) (free_constraint _) (sub_has_been_sent_capabilities IM non_byzantine Hbs) fixed_set_signed_message.
+  composite_no_equivocation_vlsm_with_pre_loaded (sub_IM IM non_byzantine) (free_constraint _) fixed_set_signed_message.
 
 Lemma non_byzantine_nodes_same
   : forall sub_i, sub_IM fixed_byzantine_IM non_byzantine sub_i = sub_IM IM non_byzantine sub_i.
@@ -291,15 +284,12 @@ Lemma pre_loaded_fixed_non_byzantine_vlsm_full_projection
     (same_IM_state_rew non_byzantine_nodes_same).
 Proof.
   apply same_IM_full_projection.
-  intros s1 H l1 om H0.
-  apply proj1 in H0.
-  split; [|exact I].
-  destruct om as [m|]; [|exact I].
-  destruct H0 as [Hsent | Hseeded]; [|right; assumption].
-  cbn. left.
-  revert Hsent.
-  apply same_IM_composite_has_been_sent_preservation; [|assumption].
-  apply stdpp_finite_sub_index; assumption.
+  intros s1 Hs1 l1 om [Hom _].
+  split; [|cbv; trivial].
+  destruct om as [m|]; [|cbv; trivial].
+  destruct Hom as [Hsent | Hseeded]; [|right; assumption].
+  left.
+  eapply same_IM_composite_has_been_sent_preservation; eassumption.
 Qed.
 
 Lemma pre_loaded_fixed_non_byzantine_vlsm_full_projection'
@@ -310,15 +300,12 @@ Lemma pre_loaded_fixed_non_byzantine_vlsm_full_projection'
     (same_IM_state_rew non_byzantine_nodes_same_sym).
 Proof.
   apply same_IM_full_projection.
-  intros s1 H l1 om H0.
-  apply proj1 in H0.
-  split; [|exact I].
-  destruct om as [m|]; [|exact I].
-  destruct H0 as [Hsent | Hseeded]; [|right; assumption].
-  cbn. left.
-  revert Hsent.
-  apply same_IM_composite_has_been_sent_preservation; [|assumption].
-  apply stdpp_finite_sub_index; assumption.
+  intros s1 Hs1 l1 om [Hom _].
+  split; [|cbv; trivial].
+  destruct om as [m|]; [|cbv; trivial].
+  destruct Hom as [Hsent | Hseeded]; [|right; assumption].
+  left.
+  eapply same_IM_composite_has_been_sent_preservation; eassumption.
 Qed.
 
 (**
@@ -333,13 +320,13 @@ Lemma fixed_non_byzantine_projection_valid_no_equivocations
   : forall l s om, vvalid fixed_non_byzantine_projection l (s, om) ->
     composite_no_equivocations_except_from
       (sub_IM fixed_byzantine_IM non_byzantine)
-      sub_fixed_byzantine_IM_Hbs fixed_set_signed_message
+      fixed_set_signed_message
       l (s, om).
 Proof.
   intros l s om Hv.
   apply
     (sub_IM_no_equivocation_preservation fixed_byzantine_IM non_byzantine
-      A sender fixed_byzantine_IM_sender_safety sub_fixed_byzantine_IM_Hbs
+      A sender fixed_byzantine_IM_sender_safety
       fixed_byzantine_IM_no_initial_messages fixed_byzantine_IM_preserves_channel_authentication)
     in Hv as Hnoequiv.
   destruct om as [m|]; [|exact I].
@@ -362,27 +349,25 @@ Qed.
 Lemma fixed_non_byzantine_pre_loaded_incl
   : VLSM_incl fixed_non_byzantine_projection pre_loaded_fixed_non_byzantine_vlsm'.
 Proof.
-  apply basic_VLSM_incl; intro; intros.
-  - apply fixed_non_byzantine_projection_initial_state_preservation; assumption.
-  - destruct Hv as [Hs [_ Hv]].
+  apply basic_VLSM_incl.
+  - intro; intros; apply fixed_non_byzantine_projection_initial_state_preservation; assumption.
+  - intros l s m (Hs & _ & Hv) HsY _.
     apply fixed_non_byzantine_projection_valid_no_equivocations in Hv as
       [Hsent | Hseeded].
     + simpl in Hsent.
       simpl in HsY.
       apply
         (preloaded_composite_sent_valid (sub_IM fixed_byzantine_IM non_byzantine)
-          (finite_sub_index non_byzantine (listing_from_finite index))
-          sub_fixed_byzantine_IM_Hbs _ _ _ HsY _ Hsent).
-    + apply initial_message_is_valid. cbn. right. assumption.
-  - split.
-    + apply proj2,proj2 in Hv.
-      revert Hv.
-      apply induced_sub_projection_valid_preservation.
-    + split; [|exact I].
-      apply fixed_non_byzantine_projection_valid_no_equivocations. apply Hv.
-  - apply proj2 in H.
-    revert H.
-    apply induced_sub_projection_transition_preservation.
+          _ _ _ HsY _ Hsent).
+    + apply initial_message_is_valid. right. assumption.
+  - intros l s om (_ & _ & Hv) _ _.
+    split.
+    + eapply induced_sub_projection_valid_preservation; eassumption.
+    + split; [|cbv; trivial].
+      apply fixed_non_byzantine_projection_valid_no_equivocations. assumption.
+  - intros l s om s' om' [_ Ht].
+    revert Ht.
+    eapply induced_sub_projection_transition_preservation.
 Qed.
 
 Lemma pre_loaded_fixed_non_byzantine_vlsm_lift_valid
@@ -405,26 +390,25 @@ Proof.
     cbn. destruct om as [m|]; [|exact I].
     destruct (sender m) as [v|] eqn:Hsender; [|exact I].
     simpl.
-    case_decide; [|exact I].
+    case_decide as HAv; [|exact I].
     cbn in Hc.
     destruct Hc as [Hsent | Hseeded].
     + unfold lift_sub_state.
-      rewrite lift_sub_state_to_eq with (Hi0 := H).
+      rewrite lift_sub_state_to_eq with (Hi0 := HAv).
       revert Hsent.
       apply (sub_IM_has_been_sent_iff_by_sender fixed_byzantine_IM non_byzantine
-              A sender fixed_byzantine_IM_sender_safety sub_fixed_byzantine_IM_Hbs).
+              A sender fixed_byzantine_IM_sender_safety).
       * apply (VLSM_incl_valid_state
                 (composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages
                   (sub_IM fixed_byzantine_IM non_byzantine) _ _))
         in HsX. assumption.
       * assumption.
-    + exfalso.
-      clear -Hseeded Hsender H.
-      destruct Hseeded as [[i [Hi Hm]] Hvalid].
+    + contradict HAv.
+      clear -Hseeded Hsender.
+      destruct Hseeded as [(i & Hi & Hm) _].
       unfold channel_authenticated_message in Hm.
       rewrite Hsender in Hm.
-      inversion Hm.
-      rewrite H1 in H; contradiction.
+      inversion Hm; subst; assumption.
 Qed.
 
 Lemma pre_loaded_fixed_non_byzantine_vlsm_lift_initial_message
@@ -488,32 +472,33 @@ Lemma pre_loaded_fixed_non_byzantine_vlsm_lift
       (lift_sub_label fixed_byzantine_IM non_byzantine)
       (lift_sub_state fixed_byzantine_IM non_byzantine).
 Proof.
-  apply basic_VLSM_full_projection; intro; intros.
-  - apply pre_loaded_fixed_non_byzantine_vlsm_lift_valid; assumption.
-  - apply lift_sub_transition. apply H.
-  - apply (lift_sub_state_initial fixed_byzantine_IM); assumption.
-  - apply (pre_loaded_fixed_non_byzantine_vlsm_lift_initial_message l s m); assumption.
+  apply basic_VLSM_full_projection.
+  - intro; intros; apply pre_loaded_fixed_non_byzantine_vlsm_lift_valid; assumption.
+  - intros ls s om s' om' [_ Ht]. apply lift_sub_transition. assumption.
+  - intro; intros; apply (lift_sub_state_initial fixed_byzantine_IM); assumption.
+  - intro; intros; apply (pre_loaded_fixed_non_byzantine_vlsm_lift_initial_message l s m); assumption.
 Qed.
 
 Lemma pre_loaded_fixed_non_byzantine_incl
   : VLSM_incl pre_loaded_fixed_non_byzantine_vlsm' fixed_non_byzantine_projection.
 Proof.
-  apply basic_VLSM_incl; intro; intros.
-  - apply fixed_non_byzantine_projection_initial_state_preservation; assumption.
-  - apply initial_message_is_valid.
+  apply basic_VLSM_incl.
+  - intro; intros; apply fixed_non_byzantine_projection_initial_state_preservation; assumption.
+  - intros l s m Hv _ Him.
+    apply initial_message_is_valid.
     apply (pre_loaded_fixed_non_byzantine_vlsm_lift_initial_message l s m).
-    + assumption.
-    + apply proj1 in Hv. revert Hv.
-      apply (VLSM_full_projection_valid_state pre_loaded_fixed_non_byzantine_vlsm_lift).
-    + assumption.
-  - exists (lift_sub_label fixed_byzantine_IM non_byzantine l).
+    1,3: assumption.
+    apply (VLSM_full_projection_valid_state pre_loaded_fixed_non_byzantine_vlsm_lift).
+    exact (proj1 Hv).
+  - intro; intros.
+    exists (lift_sub_label fixed_byzantine_IM non_byzantine l).
     exists (lift_sub_state fixed_byzantine_IM non_byzantine s).
     split; [apply composite_label_sub_projection_option_lift|].
     split; [apply composite_state_sub_projection_lift|].
     revert Hv.
     apply (VLSM_full_projection_input_valid pre_loaded_fixed_non_byzantine_vlsm_lift).
-  - apply proj2 in H.
-    revert H.
+  - intros l s om s' om' [_ Ht].
+    revert Ht.
     apply induced_sub_projection_transition_preservation.
 Qed.
 
@@ -558,20 +543,18 @@ Section fixed_non_equivocating_vs_byzantine.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  `{forall i : index, HasBeenReceivedCapability (IM i)}
   (selection : set index)
   {validator : Type}
   (A : validator -> index)
   (sender : message -> option validator)
-  {finite_index : finite.Finite index}
   (selection_complement := set_diff (enum index) selection)
-  (PreNonByzantine : VLSM message := pre_loaded_fixed_non_byzantine_vlsm IM Hbs selection A sender)
-  (Fixed : VLSM message := fixed_equivocation_vlsm_composition IM Hbs Hbr selection)
-  (FixedNonEquivocating : VLSM message := induced_sub_projection IM selection_complement (fixed_equivocation_constraint IM Hbs Hbr selection))
+  (PreNonByzantine : VLSM message := pre_loaded_fixed_non_byzantine_vlsm IM selection A sender)
+  (Fixed : VLSM message := fixed_equivocation_vlsm_composition IM selection)
+  (FixedNonEquivocating : VLSM message := induced_sub_projection IM selection_complement (fixed_equivocation_constraint IM selection))
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   (can_emit_signed : channel_authentication_prop IM A sender)
   (Hsender_safety : sender_safety_alt_prop IM A sender :=
@@ -582,85 +565,66 @@ Lemma fixed_non_equivocating_incl_sub_non_equivocating
   : VLSM_incl FixedNonEquivocating
       (induced_sub_projection IM (set_diff (enum index) selection)
         (sub_IM_not_equivocating_constraint IM
-          (set_diff (enum index) selection) A sender
-          (sub_has_been_sent_capabilities IM
-            (set_diff (enum index) selection) Hbs))).
+          (set_diff (enum index) selection) A sender)).
 Proof.
   apply induced_sub_projection_constraint_subsumption_incl.
   intros l (s, om) Hv.
-  apply (fixed_strong_equivocation_subsumption IM Hbs Hbr (listing_from_finite index) selection)
+  apply (fixed_strong_equivocation_subsumption IM selection)
     in Hv as Hstrong_v.
   destruct Hv as [Hs [Hom [Hv Hc]]].
   destruct om; [|exact I].
   simpl.
   destruct (sender m) as [v|] eqn:Hsender; [|exact I].
   simpl.
-  case_decide; [|exact I].
+  case_decide as HAv; [|exact I].
   unfold sub_IM. simpl.
-  apply (VLSM_incl_valid_state (constraint_free_incl IM (fixed_equivocation_constraint IM Hbs Hbr selection))) in Hs.
+  apply (VLSM_incl_valid_state (constraint_free_incl IM (fixed_equivocation_constraint IM selection))) in Hs.
   apply (VLSM_incl_valid_state (vlsm_incl_pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM))) in Hs.
   assert (Hpre_si : forall i, valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i)).
   { intro i.
     revert Hs.
     apply valid_state_project_preloaded_to_preloaded.
   }
-  cut (@has_been_sent _ _ (Hbs (A v)) (s (A v)) m).
-  { apply has_been_sent_irrelevance; intuition. }
-  apply set_diff_elim2 in H.
-  destruct Hstrong_v as [Hsent | Hemitted].
-  - destruct Hsent as [i [Hi Hsent]].
-    apply valid_state_has_trace in Hs as [is [tr Htr]].
-    apply (has_been_sent_iff_by_sender IM Hbs Hsender_safety Htr Hsender).
+  apply set_diff_elim2 in HAv.
+  destruct Hstrong_v as [(i & Hi & Hsent) | Hemitted].
+  - apply valid_state_has_trace in Hs as (is & tr & Htr).
+    eapply has_been_sent_iff_by_sender. 1-3: eassumption.
     exists i; assumption.
-  - elim H.
-    apply (sub_can_emit_sender IM selection A sender Hsender_safety _ _ _ Hsender Hemitted).
+  - contradict HAv.
+    eapply sub_can_emit_sender; eassumption.
 Qed.
 
 Lemma fixed_non_equivocating_incl_fixed_non_byzantine
   : VLSM_incl FixedNonEquivocating PreNonByzantine.
 Proof.
-  apply basic_VLSM_incl; intro; intros.
-  - intros sub_i.
-    destruct H as [sX [HeqsX Hinitial]].
-    subst.
+  apply basic_VLSM_incl.
+  - intros s (sX & <- & Hinitial) sub_i.
     apply Hinitial.
-  - apply (VLSM_incl_input_valid fixed_non_equivocating_incl_sub_non_equivocating) in Hv.
-    destruct Hv as [Hs [_ Hv]].
-    specialize
-      (sub_IM_no_equivocation_preservation IM (set_diff (enum index) selection)
-        A sender Hsender_safety (sub_has_been_sent_capabilities IM (set_diff (enum index) selection) Hbs)
-        no_initial_messages_in_IM can_emit_signed _ _ _ Hv)
-      as [Hsent | Hseeded].
-    + simpl in Hsent.
-      simpl in HsY.
-      apply
-        (preloaded_composite_sent_valid (sub_IM IM (set_diff (enum index) selection))
-          (finite_sub_index (set_diff (enum index) selection) (listing_from_finite index))
-          (sub_has_been_sent_capabilities IM (set_diff (enum index) selection) Hbs)
-          _ _ _ HsY _ Hsent).
+  - intro; intros.
+    apply (VLSM_incl_input_valid fixed_non_equivocating_incl_sub_non_equivocating)
+      in Hv as [Hs [_ Hv]].
+    apply sub_IM_no_equivocation_preservation in Hv as Hnoeqv. 2-4:assumption.
+    destruct Hnoeqv as [Hsent | Hseeded].
+    + eapply preloaded_composite_sent_valid; eassumption.
     + apply initial_message_is_valid.
       right.
       split; [assumption|].
-      clear -Hv.
-      apply induced_sub_projection_valid_projection in Hv; assumption.
-  - apply (VLSM_incl_input_valid fixed_non_equivocating_incl_sub_non_equivocating),
+      eapply induced_sub_projection_valid_projection. apply Hv.
+  - intros l s om Hv.
+    apply (VLSM_incl_input_valid fixed_non_equivocating_incl_sub_non_equivocating),
       proj2, proj2 in Hv.
     split.
     + revert Hv.
       apply induced_sub_projection_valid_preservation.
     + split; [|exact I].
-      apply
-        (sub_IM_no_equivocation_preservation IM (set_diff (enum index) selection)
-          A sender Hsender_safety (sub_has_been_sent_capabilities IM (set_diff (enum index) selection) Hbs)
-          no_initial_messages_in_IM can_emit_signed)
-        in Hv as Hnoequiv.
+      apply sub_IM_no_equivocation_preservation in Hv as Hnoequiv. 2-4:assumption.
       destruct om as [m|]; [|exact I].
       destruct Hnoequiv as [Hsent|Hseeded]; [left; assumption|].
       right.
       split; [assumption|].
-      apply induced_sub_projection_valid_projection in Hv; assumption.
-  - apply proj2 in H.
-    revert H.
+      eapply induced_sub_projection_valid_projection. apply Hv.
+  - intros l s om s' om' [_ Ht].
+    revert Ht.
     apply induced_sub_projection_transition_preservation.
 Qed.
 
@@ -670,13 +634,13 @@ traces for the composition with <<Fixed>> equivocation have the
 *)
 Corollary fixed_equivocating_traces_are_byzantine is tr
   : finite_valid_trace Fixed is tr ->
-    fixed_byzantine_trace_alt_prop IM Hbs selection A sender is tr.
+    fixed_byzantine_trace_alt_prop IM selection A sender is tr.
 Proof.
   intro Htr.
   apply (VLSM_incl_finite_valid_trace fixed_non_equivocating_incl_fixed_non_byzantine).
   specialize
     (induced_sub_projection_is_projection
-      IM (set_diff (enum index) selection) (fixed_equivocation_constraint IM Hbs Hbr selection))
+      IM (set_diff (enum index) selection) (fixed_equivocation_constraint IM selection))
     as Hproj.
   apply (VLSM_projection_finite_valid_trace Hproj); assumption.
 Qed.
@@ -684,9 +648,8 @@ Qed.
 Section validator_fixed_set_byzantine.
 
 Context
-  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
   (message_dependencies : message -> set message)
-  (HMsgDep : forall i, MessageDependencies message_dependencies (IM i))
+  `{forall i, MessageDependencies message_dependencies (IM i)}
   (Hfull : forall i, message_dependencies_full_node_condition_prop message_dependencies (IM i))
   .
 
@@ -725,11 +688,10 @@ Proof.
       apply Some_inj in Hsigned.
       specialize (Hsender_safety _ _ Hsender _ Hiom) as Heq_v.
       rewrite Hsigned in Heq_v. subst _v.
-      destruct (HMsgDep i) as [_ Hsufficient].
-      apply Hsufficient in Hiom. clear Hsufficient.
+      eapply message_dependencies_are_sufficient in Hiom; [|typeclasses eauto].
       revert Hiom.
       rewrite set_diff_iff in Hi.
-      apply not_and_r in Hi as [Hi | Hi]; [elim Hi; apply finite_index|].
+      apply not_and_r in Hi as [Hi | Hi]; [elim Hi; apply elem_of_enum|].
       apply dec_stable in Hi.
       apply can_emit_with_more; [assumption|].
       intros dm Hdm.
@@ -750,13 +712,13 @@ Lemma preloaded_non_byzantine_vlsm_lift
       (lift_sub_label IM (set_diff (enum index) selection))
       (lift_sub_state IM (set_diff (enum index) selection)).
 Proof.
-  apply basic_VLSM_strong_full_projection; intro; intros.
-  - split; [|exact I].
-    apply proj1 in H.
+  apply basic_VLSM_strong_full_projection. 
+  - intros l s om [Hv _].
+    split; [|exact I].
     apply lift_sub_valid; assumption.
-  - apply lift_sub_transition; assumption.
-  - apply (lift_sub_state_initial IM); assumption.
-  - exact I.
+  - intro; intros. apply lift_sub_transition; assumption.
+  - intro; intros. apply (lift_sub_state_initial IM); assumption.
+  - intro; intros. cbv; trivial.
 Qed.
 
 Section assuming_initial_messages_lift.
@@ -776,34 +738,37 @@ Lemma fixed_non_byzantine_vlsm_lift_from_initial
       (lift_sub_label IM (set_diff (enum index) selection))
       (lift_sub_state IM (set_diff (enum index) selection)).
 Proof.
-  apply basic_VLSM_full_projection; intro; intros.
-  - apply fixed_non_byzantine_vlsm_lift_valid; assumption.
-  - apply lift_sub_transition. apply H.
-  - apply (lift_sub_state_initial IM); assumption.
-  - apply (Hfixed_non_byzantine_vlsm_lift_initial_message l s m); assumption.
+  apply basic_VLSM_full_projection.
+  - intro; intros; apply fixed_non_byzantine_vlsm_lift_valid; assumption.
+  - intros l s om s' om' [_ Ht]. apply lift_sub_transition. assumption.
+  - intro; intros; apply (lift_sub_state_initial IM); assumption.
+  - intros l s om. apply Hfixed_non_byzantine_vlsm_lift_initial_message.
 Qed.
 
 Lemma fixed_non_byzantine_incl_fixed_non_equivocating_from_initial
   : VLSM_incl PreNonByzantine FixedNonEquivocating.
 Proof.
-  apply basic_VLSM_incl; intro; intros.
-  - exists (lift_sub_state IM (set_diff (enum index) selection) s).
+  apply basic_VLSM_incl.
+  - intro; intros.
+    exists (lift_sub_state IM (set_diff (enum index) selection) s).
     split; [apply composite_state_sub_projection_lift_to|].
-    by apply (lift_sub_state_initial IM).
-  - apply initial_message_is_valid.
-    apply (Hfixed_non_byzantine_vlsm_lift_initial_message l s m).
-    + assumption.
-    + apply proj1 in Hv. revert Hv.
-      apply (VLSM_full_projection_valid_state fixed_non_byzantine_vlsm_lift_from_initial).
-    + assumption.
-  - exists (lift_sub_label IM (set_diff (enum index) selection) l).
+    apply (lift_sub_state_initial IM); assumption.
+  - intro; intros.
+    apply initial_message_is_valid.
+    eapply Hfixed_non_byzantine_vlsm_lift_initial_message. 1,3:eassumption.
+    apply proj1 in Hv.
+    eapply VLSM_full_projection_valid_state in Hv; [eassumption|].
+    apply fixed_non_byzantine_vlsm_lift_from_initial.
+  - intro; intros.
+    exists (lift_sub_label IM (set_diff (enum index) selection) l).
     exists (lift_sub_state IM (set_diff (enum index) selection) s).
     split; [apply composite_label_sub_projection_option_lift|].
     split; [apply composite_state_sub_projection_lift|].
     revert Hv.
-    apply (VLSM_full_projection_input_valid fixed_non_byzantine_vlsm_lift_from_initial).
-  - apply proj2 in H.
-    revert H.
+    apply VLSM_full_projection_input_valid.
+    apply fixed_non_byzantine_vlsm_lift_from_initial.
+  - intros l s om s' om' [_ Ht].
+    revert Ht.
     apply induced_sub_projection_transition_preservation.
 Qed.
 
@@ -821,7 +786,7 @@ End assuming_initial_messages_lift.
 Context
   (Hvalidator:
     forall i : index, i ∉ selection ->
-    component_projection_validator_prop IM (fixed_equivocation_constraint IM Hbs Hbr selection) i)
+    component_projection_validator_prop IM (fixed_equivocation_constraint IM selection) i)
   .
 
 Lemma validator_fixed_non_byzantine_vlsm_lift_initial_message
@@ -868,7 +833,7 @@ equivocation composition the projections of the two traces to the non-byzantine
 nodes, i.e., the nodes in the <<selection_complement>> coincide.
 *)
 Lemma validator_fixed_byzantine_traces_equivocation_char bis btr
-  : fixed_byzantine_trace_alt_prop IM Hbs selection A sender bis btr <->
+  : fixed_byzantine_trace_alt_prop IM selection A sender bis btr <->
     exists eis etr,
       finite_valid_trace Fixed eis etr /\
       composite_state_sub_projection IM selection_complement eis = composite_state_sub_projection IM selection_complement bis /\

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -821,7 +821,7 @@ End assuming_initial_messages_lift.
 Context
   (Hvalidator:
     forall i : index, i ∉ selection ->
-    projection_validator_prop IM (fixed_equivocation_constraint IM Hbs Hbr selection) i)
+    component_projection_validator_prop IM (fixed_equivocation_constraint IM Hbs Hbr selection) i)
   .
 
 Lemma validator_fixed_non_byzantine_vlsm_lift_initial_message

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -180,11 +180,11 @@ Lemma fixed_non_byzantine_projection_incl_preloaded
   : VLSM_incl fixed_non_byzantine_projection (pre_loaded_with_all_messages_vlsm (free_composite_vlsm (sub_IM fixed_byzantine_IM non_byzantine))).
 Proof.
   apply basic_VLSM_strong_incl.
-  - intro; intros. apply fixed_non_byzantine_projection_initial_state_preservation. assumption.
-  - intro; intros; cbv; trivial.
-  - split; [|cbv; trivial].
+  - intros s H1; apply fixed_non_byzantine_projection_initial_state_preservation; assumption.
+  - intros m H1; cbv; trivial.
+  - split; [| cbv; trivial].
     eapply induced_sub_projection_valid_preservation; eassumption.
-  - intros l s om s' om'. apply induced_sub_projection_transition_preservation.
+  - intros l s om s' om'; apply induced_sub_projection_transition_preservation.
 Qed.
 
 (** The induced projection from the composition of [fixed_byzantine_IM] under
@@ -285,10 +285,9 @@ Lemma pre_loaded_fixed_non_byzantine_vlsm_full_projection
 Proof.
   apply same_IM_full_projection.
   intros s1 Hs1 l1 om [Hom _].
-  split; [|cbv; trivial].
-  destruct om as [m|]; [|cbv; trivial].
-  destruct Hom as [Hsent | Hseeded]; [|right; assumption].
-  left.
+  split; [| cbv; trivial].
+  destruct om as [m |]; [| cbv; trivial].
+  destruct Hom as [Hsent | Hseeded]; [left | right; assumption].
   eapply same_IM_composite_has_been_sent_preservation; eassumption.
 Qed.
 
@@ -301,9 +300,9 @@ Lemma pre_loaded_fixed_non_byzantine_vlsm_full_projection'
 Proof.
   apply same_IM_full_projection.
   intros s1 Hs1 l1 om [Hom _].
-  split; [|cbv; trivial].
-  destruct om as [m|]; [|cbv; trivial].
-  destruct Hom as [Hsent | Hseeded]; [left |right; assumption].
+  split; [| cbv; trivial].
+  destruct om as [m |]; [| cbv; trivial].
+  destruct Hom as [Hsent | Hseeded]; [left | right; assumption].
   eapply same_IM_composite_has_been_sent_preservation; eassumption.
 Qed.
 
@@ -353,14 +352,13 @@ Proof.
   - intros l s m (Hs & _ & Hv) HsY _.
     apply fixed_non_byzantine_projection_valid_no_equivocations
        in Hv as [Hsent | Hseeded].
-    + simpl in Hsent.
-      simpl in HsY.
+    + simpl in Hsent, HsY.
       eapply preloaded_composite_sent_valid; eassumption.
-    + apply initial_message_is_valid. right. assumption.
+    + apply initial_message_is_valid; right; assumption.
   - intros l s om (_ & _ & Hv) _ _; split.
     + eapply induced_sub_projection_valid_preservation; eassumption.
     + split; [|cbv; trivial].
-      apply fixed_non_byzantine_projection_valid_no_equivocations. assumption.
+      apply fixed_non_byzantine_projection_valid_no_equivocations; assumption.
   - intros l s om s' om' [_ Ht].
     revert Ht.
     eapply induced_sub_projection_transition_preservation.
@@ -387,11 +385,8 @@ Proof.
       apply (sub_IM_has_been_sent_iff_by_sender fixed_byzantine_IM non_byzantine
               A sender fixed_byzantine_IM_sender_safety)
       ; [| assumption | assumption].
-      apply (VLSM_incl_valid_state
-              (composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages
-                (sub_IM fixed_byzantine_IM non_byzantine) _ _))
-         in HsX.
-      assumption.
+      eapply (VLSM_incl_valid_state); [| eassumption].
+      eapply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
     + contradict HAv; clear -Hseeded Hsender.
       destruct Hseeded as [(i & Hi & Hm) _].
       unfold channel_authenticated_message in Hm.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -57,7 +57,7 @@ Context
   {is_equivocating_tracewise_no_has_been_sent_dec : RelDecision (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
   (limited_constraint := limited_equivocation_constraint IM (listing_from_finite index) sender)
   (Limited : VLSM message := composite_vlsm IM limited_constraint)
-  (Hvalidator: forall i : index, projection_validator_prop IM limited_constraint i)
+  (Hvalidator: forall i : index, component_projection_validator_prop IM limited_constraint i)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   (can_emit_signed : channel_authentication_prop IM Datatypes.id sender)
   (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -22,12 +22,11 @@ Section limited_byzantine_traces.
 
 Context
   {message : Type}
-  `{EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  `{forall i : index, HasBeenReceivedCapability (IM i)}
   (sender : message -> option index)
-  {finite_index : finite.Finite index}
   `{ReachableThreshold index}
   .
 
@@ -42,7 +41,7 @@ Definition fixed_limited_byzantine_trace_prop
   (byzantine : set index)
   : Prop
   := (sum_weights (remove_dups byzantine) <= `threshold)%R /\
-     fixed_byzantine_trace_alt_prop IM Hbs byzantine (fun i => i) sender s tr.
+     fixed_byzantine_trace_alt_prop IM byzantine (fun i => i) sender s tr.
 
 (** The union of traces with the [fixed_limited_byzantine_trace_prop]erty over
 all possible selections of (limited) byzantine nodes.
@@ -55,12 +54,11 @@ Definition limited_byzantine_trace_prop
 
 Context
   {is_equivocating_tracewise_no_has_been_sent_dec : RelDecision (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
-  (limited_constraint := limited_equivocation_constraint IM (listing_from_finite index) sender)
+  (limited_constraint := limited_equivocation_constraint IM sender)
   (Limited : VLSM message := composite_vlsm IM limited_constraint)
   (Hvalidator: forall i : index, component_projection_validator_prop IM limited_constraint i)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   (can_emit_signed : channel_authentication_prop IM Datatypes.id sender)
-  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
   (message_dependencies : message -> set message)
   (HMsgDep : forall i, MessageDependencies message_dependencies (IM i))
   (Hfull : forall i, message_dependencies_full_node_condition_prop message_dependencies (IM i))
@@ -78,9 +76,9 @@ Context
   (byzantine: set index)
   (non_byzantine : set index := set_diff (enum index) byzantine)
   (Hlimit: (sum_weights (remove_dups byzantine) <= `threshold)%R)
-  (PreNonByzantine := pre_loaded_fixed_non_byzantine_vlsm IM Hbs byzantine (λ i : index, i) sender)
+  (PreNonByzantine := pre_loaded_fixed_non_byzantine_vlsm IM byzantine (λ i : index, i) sender)
   (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) index
-    := equivocation_dec_tracewise IM (fun i => i) sender (listing_from_finite index))
+    := equivocation_dec_tracewise IM (fun i => i) sender)
   (tracewise_not_heavy := @not_heavy _ _ _ _ Htracewise_BasicEquivocation)
   (tracewise_equivocating_validators := @equivocating_validators _ _ _ _ Htracewise_BasicEquivocation)
   .
@@ -103,7 +101,7 @@ Proof.
     - intros i Hi. apply elem_of_remove_dups, Hincl, Hi.
   }
   apply valid_state_has_trace in Hs as [is [tr Htr]].
-  specialize (preloaded_non_byzantine_vlsm_lift IM Hbs byzantine (fun i => i) sender)
+  specialize (preloaded_non_byzantine_vlsm_lift IM byzantine (fun i => i) sender)
     as Hproj.
   apply (VLSM_full_projection_finite_valid_trace_init_to Hproj) in Htr as Hpre_tr.
   intros v Hv.
@@ -125,14 +123,14 @@ Proof.
   destruct Ht as [[_ [_ [_ [Hc _]]]] _].
   destruct Hc as [[sub_i Hsenti] | Hemit].
   + destruct_dec_sig sub_i i Hi Heqsub_i; subst sub_i.
-    assert (Hsent : composite_has_been_sent IM Hbs
+    assert (Hsent : composite_has_been_sent IM
                       (lift_sub_state IM non_byzantine (finite_trace_last is pre)) m0).
     { exists i.
       unfold lift_sub_state.
       rewrite lift_sub_state_to_eq with (Hi0 := Hi).
       assumption.
     }
-    apply (composite_proper_sent IM (listing_from_finite index)) in Hsent; [|assumption].
+    apply (composite_proper_sent IM) in Hsent; [|assumption].
     apply (VLSM_full_projection_initial_state Hproj) in Hinit.
     specialize (Hsent _ _ (conj Hpre_pre Hinit)).
     contradiction.
@@ -144,7 +142,7 @@ Proof.
         apply Some_inj in Hsigned.
         subst. assumption.
       * elim Hi.
-        apply set_diff_intro; [apply finite_index|assumption].
+        apply set_diff_intro; [apply elem_of_enum|assumption].
 Qed.
 
 (** When replacing the byzantine components of a composite [valid_state] with
@@ -179,11 +177,12 @@ Lemma limited_PreNonByzantine_vlsm_lift
       (lift_sub_label IM non_byzantine)
       (lift_sub_state IM non_byzantine).
 Proof.
-  apply basic_VLSM_full_projection; intro; intros.
-  - apply limited_PreNonByzantine_lift_valid; assumption.
-  - apply lift_sub_transition. apply H0.
-  - apply (lift_sub_state_initial IM); assumption.
-  - destruct HmX as [[sub_i [[im Him] Heqm]] | Hseeded].
+  apply basic_VLSM_full_projection; intros ? *.
+  - intros; apply limited_PreNonByzantine_lift_valid; assumption.
+  - intros [_ Ht]. apply lift_sub_transition. assumption.
+  - intros; apply (lift_sub_state_initial IM); assumption.
+  - intros.
+    destruct HmX as [[sub_i [[im Him] Heqm]] | Hseeded].
     + simpl in Heqm. subst.
       destruct_dec_sig sub_i i Hi Heqsub_i.
       subst. unfold sub_IM in Him. simpl in Him.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -179,20 +179,17 @@ Lemma limited_PreNonByzantine_vlsm_lift
 Proof.
   apply basic_VLSM_full_projection; intros ? *.
   - intros; apply limited_PreNonByzantine_lift_valid; assumption.
-  - intros [_ Ht]. apply lift_sub_transition. assumption.
+  - intros * []; apply lift_sub_transition; assumption.
   - intros; apply (lift_sub_state_initial IM); assumption.
-  - intros.
-    destruct HmX as [[sub_i [[im Him] Heqm]] | Hseeded].
-    + simpl in Heqm. subst.
-      destruct_dec_sig sub_i i Hi Heqsub_i.
-      subst. unfold sub_IM in Him. simpl in Him.
-      clear -Him.
+  - intros Hv HsY [[sub_i [[im Him] Heqm]] | Hseeded].
+    + cbn in Heqm; subst.
+      destruct_dec_sig sub_i i Hi Heqsub_i; subst.
+      unfold sub_IM in Him; cbn in Him; clear -Him.
       apply initial_message_is_valid.
-      exists i, (exist _ m Him); intuition.
-    + destruct Hseeded as [Hsigned [i [Hi [li [si Hpre_valid]]]]].
+      exists i, (exist _ m Him). reflexivity.
+    + destruct Hseeded as (Hsigned & i & Hi & li & si & Hpre_valid).
       apply set_diff_elim2 in Hi.
-      specialize (Hvalidator i _ _ Hpre_valid)
-        as [_ [_ [_ [Hmsg _]]]].
+      specialize (Hvalidator i _ _ Hpre_valid) as (_ & _ & _ & Hmsg & _).
       assumption.
 Qed.
 

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -551,8 +551,7 @@ Lemma [basic_VLSM_incl]
       apply basic_VLSM_incl; intro; intros.
       - assumption.
       - apply initial_message_is_valid. assumption.
-      - split; [apply Hv|].
-        apply Hsubsumption; assumption.
+      - split; [apply Hv | auto].
       - apply H.
     Qed.
 
@@ -616,7 +615,7 @@ Lemma [basic_VLSM_incl]
       (Hsubsumption : input_valid_constraint_subsumption constraint1 constraint2)
       : weak_input_valid_constraint_subsumption constraint1 constraint2.
     Proof.
-      intros l som Hv _ _. apply Hsubsumption. assumption.
+      intros l som Hv _ _. auto.
     Qed.
 
     Lemma preloaded_constraint_subsumption_stronger

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -515,6 +515,19 @@ and/or the message being valid (e.g., Lemma [Fixed_incl_StrongFixed]).
         forall (l : composite_label) (som : composite_state * option message),
           input_valid (composite_vlsm constraint1) l som -> constraint2 l som.
 
+(**
+The weakest form [constraint_subsumption] also requires that the input
+state and message are valid for the composition under the second constraint.
+*)
+    Definition weak_input_valid_constraint_subsumption
+        (constraint1 constraint2 : composite_label -> composite_state * option message -> Prop)
+        :=
+        forall (l : composite_label) (som : composite_state * option message),
+          input_valid (composite_vlsm constraint1) l som ->
+          valid_state_prop (composite_vlsm constraint2) som.1 ->
+          option_valid_message_prop (composite_vlsm constraint2) som.2 ->
+          constraint2 l som.
+
     Context
       (constraint1 constraint2 : composite_label -> composite_state * option message -> Prop)
       (X1 := composite_vlsm constraint1)
@@ -531,6 +544,18 @@ Lemma [basic_VLSM_incl]
 *)
 
 (* begin hide *)
+    Lemma weak_constraint_subsumption_incl
+      (Hsubsumption : weak_input_valid_constraint_subsumption constraint1 constraint2)
+      : VLSM_incl X1 X2.
+    Proof.
+      apply basic_VLSM_incl; intro; intros.
+      - assumption.
+      - apply initial_message_is_valid. assumption.
+      - split; [apply Hv|].
+        apply Hsubsumption; assumption.
+      - apply H.
+    Qed.
+
     Lemma constraint_subsumption_input_valid
       (Hsubsumption : input_valid_constraint_subsumption constraint1 constraint2)
       (l : label)
@@ -585,6 +610,13 @@ Lemma [basic_VLSM_incl]
       apply basic_VLSM_incl; intro; intros; [assumption| | |apply H].
       - apply initial_message_is_valid. assumption.
       - apply preloaded_constraint_subsumption_input_valid; assumption.
+    Qed.
+
+    Lemma weak_constraint_subsumption_weakest
+      (Hsubsumption : input_valid_constraint_subsumption constraint1 constraint2)
+      : weak_input_valid_constraint_subsumption constraint1 constraint2.
+    Proof.
+      intros l som Hv _ _. apply Hsubsumption. assumption.
     Qed.
 
     Lemma preloaded_constraint_subsumption_stronger

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -548,11 +548,11 @@ Lemma [basic_VLSM_incl]
       (Hsubsumption : weak_input_valid_constraint_subsumption constraint1 constraint2)
       : VLSM_incl X1 X2.
     Proof.
-      apply basic_VLSM_incl; intro; intros.
-      - assumption.
-      - apply initial_message_is_valid. assumption.
+      apply basic_VLSM_incl.
+      - intros s Hs. assumption.
+      - intros _ _ m _ _ Hm. apply initial_message_is_valid. assumption.
       - split; [apply Hv | auto].
-      - apply H.
+      - intros l s om s' om' Ht. apply Ht.
     Qed.
 
     Lemma constraint_subsumption_input_valid

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1448,7 +1448,7 @@ Proof.
   apply has_been_observed_stepwise_props.
 Qed.
 
-Lemma proper_not_observed {message} (vlsm : VLSM message) `{HasBeenObservedCapability message vlsm}:
+Lemma proper_not_observed `(vlsm : VLSM message) `{HasBeenObservedCapability message vlsm}:
   forall (s:state),
     valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s ->
     forall m,

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -998,6 +998,7 @@ Proof.
   clear -H H0. tauto.
 Qed.
 
+(* TODO(wkolowski): make notation uniform accross the file. *)
 Lemma oracle_stepwise_props_change_selector
       [message] [vlsm: VLSM message]
       [selector]
@@ -1529,7 +1530,7 @@ Proof.
     (prove_all_have_message_from_stepwise message vlsm  item_sends_or_receives
     (has_been_observed vlsm) (has_been_observed_stepwise_props _) _ Hs m) as Hall.
   split; [intro Hobs | intros [Hreceived | Hsent]].
-  - apply proj1 in Hall. specialize (Hall Hobs).
+  - destruct Hall as [Hall _]. specialize (Hall Hobs).
     apply consistency_from_valid_state_proj2 in Hall; [|assumption].
     destruct Hall as [is [tr [Htr Hexists]]].
     apply Exists_or_inv in Hexists.
@@ -1570,21 +1571,20 @@ Qed.
 Lemma has_been_observed_from_sent_received_stepwise_props
   : oracle_stepwise_props item_sends_or_receives has_been_observed_from_sent_received.
 Proof.
-  apply stepwise_props_from_trace; [apply has_been_observed_from_sent_received_dec|..]
+  apply stepwise_props_from_trace
+  ; [apply has_been_observed_from_sent_received_dec|..]
   ; intros; split.
-  - intros Hobs start tr Htr.
-    destruct Hobs as [Hsent | Hreceived].
+  - intros [Hsent | Hreceived] start tr Htr.
     + apply proper_sent in Hsent; [|assumption].
-      apply Exists_or. right.
+      apply Exists_or; right.
       eapply Hsent; eassumption.
     + apply proper_received in Hreceived; [|assumption].
-      apply Exists_or. left.
+      apply Exists_or; left.
       eapply Hreceived; eassumption.
   - intros Hobs.
     apply consistency_from_valid_state_proj2 in Hobs; [|assumption].
     destruct Hobs as (is & tr & Htr & Hexists).
-    apply Exists_or_inv in Hexists.
-    destruct Hexists as [Hsent | Hreceived].
+    apply Exists_or_inv in Hexists as [Hsent | Hreceived].
     + right. apply proper_received; [assumption|].
       apply has_been_received_consistency; [assumption|assumption|].
       exists is, tr, Htr. assumption.
@@ -1757,7 +1757,6 @@ Section Composite.
         - (* initial states not claim *)
           intros s Hs m [i Horacle].
           revert Horacle.
-          fold (~ oracles i (s i) m).
           apply (oracle_no_inits (stepwise_props i)).
           apply Hs.
         - (* step update property *)
@@ -2047,9 +2046,7 @@ Section Composite.
     destruct (sender m) as [v|] eqn: Hsender; [|inversion can_emit_signed].
     apply Some_inj in can_emit_signed.
     exists v.
-    split; [reflexivity|].
-    subst. cbn in Ht.
-  unfold can_emit; eauto.
+    subst; cbn in Ht; unfold can_emit; eauto.
   Qed.
 
   Lemma composite_no_initial_valid_messages_have_sender

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1248,13 +1248,7 @@ Lemma preloaded_has_been_sent_stepwise_props
   has_been_sent_stepwise_props (vlsm := X) (has_been_sent vlsm).
 Proof.
   destruct (has_been_sent_stepwise_from_trace Hhbs) as [Hinit Hupdate].
-  split.
-  - intros s Hs. apply Hinit. assumption.
-  - intros l s im s' om Ht msg.
-    apply (Hupdate l s im s' om).
-    revert Ht.
-    apply VLSM_incl_input_valid_transition.
-    apply basic_VLSM_incl_preloaded; cbv; intuition.
+  split; auto.
 Qed.
 
 Lemma preloaded_HasBeenSentCapability
@@ -1331,13 +1325,7 @@ Lemma preloaded_has_been_received_stepwise_props
   has_been_received_stepwise_props (vlsm := X) (has_been_received vlsm).
 Proof.
   destruct (has_been_received_stepwise_from_trace Hhbr) as [Hinit Hupdate].
-  split.
-  - intros s Hs. apply Hinit. assumption.
-  - intros l s im s' om Ht msg.
-    apply (Hupdate l s im s' om).
-    revert Ht.
-    apply VLSM_incl_input_valid_transition.
-    apply basic_VLSM_incl_preloaded; cbv; intuition.
+  split; auto.
 Qed.
 
 Lemma preloaded_HasBeenReceivedCapability
@@ -1654,7 +1642,9 @@ Lemma received_valid
     valid_message_prop X m.
 Proof.
   induction Hs using valid_state_prop_ind.
-  - contradict Hreceived. apply (oracle_no_inits (has_been_received_stepwise_from_trace Hhbr));assumption.
+  - contradict Hreceived.
+    eapply oracle_no_inits; [| eassumption].
+    apply has_been_received_stepwise_from_trace.
   - apply input_valid_transition_in in Ht as Hom'.
     apply preloaded_weaken_input_valid_transition in Ht.
     apply (oracle_step_update (has_been_received_stepwise_from_trace Hhbr) _ _ _ _ _ Ht) in Hreceived.
@@ -2102,12 +2092,11 @@ Section Composite.
       : forall (m : message) (Hm : valid_message_prop X m), sender m <> None.
   Proof.
     intros m Hm.
-    cut
-      (exists v, sender m = Some v /\
-        can_emit (pre_loaded_with_all_messages_vlsm (IM (A v))) m)
-    ; [intros [v [Hsender _]]; congruence|].
-    revert m Hm.
-    apply composite_no_initial_valid_messages_emitted_by_sender; assumption.
+    cut (exists v, sender m = Some v /\
+                   can_emit (pre_loaded_with_all_messages_vlsm (IM (A v))) m).
+    - intros (v & Hsender & _). congruence.
+    - revert m Hm.
+      apply composite_no_initial_valid_messages_emitted_by_sender; assumption.
   Qed.
 
   Lemma has_been_sent_iff_by_sender
@@ -2280,7 +2269,9 @@ Section Composite.
     : valid_message_prop X m.
   Proof.
     pose (Xhbr := preloaded_composite_HasBeenReceivedCapability has_been_received_capabilities constraint seed).
-    apply (received_valid X s). assumption. exists i;assumption.
+    apply (received_valid X s).
+    - assumption.
+    - exists i; assumption.
   Qed.
 
   Lemma composite_sent_valid

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -998,6 +998,25 @@ Proof.
   clear -H H0. tauto.
 Qed.
 
+Lemma oracle_stepwise_props_change_selector
+      [message] [vlsm: VLSM message]
+      [selector]
+      [oracle : state_message_oracle vlsm]
+      (Horacle: oracle_stepwise_props selector oracle)
+      selector'
+      (Heqv :
+        forall s item,
+          input_valid_transition_item (pre_loaded_with_all_messages_vlsm vlsm) s item ->
+          forall m, selector m item <-> selector' m item)
+      : oracle_stepwise_props selector' oracle.
+Proof.
+  destruct Horacle as [Hinits Hupdate].
+  constructor; [assumption|].
+  intros l s om s' om' Ht msg.
+  simpl; rewrite Hupdate, Heqv by eassumption.
+  reflexivity.
+Qed.
+
 (**
    Proving the trace properties from the stepwise properties
    begins with a lemma using induction along a trace to
@@ -2030,8 +2049,7 @@ Section Composite.
     exists v.
     split; [reflexivity|].
     subst. cbn in Ht.
-    eexists _, _, _.
-    eassumption.
+  unfold can_emit; eauto.
   Qed.
 
   Lemma composite_no_initial_valid_messages_have_sender
@@ -2043,7 +2061,7 @@ Section Composite.
   Proof.
     intros m Hm.
     cut (exists v, sender m = Some v /\
-                   can_emit (pre_loaded_with_all_messages_vlsm (IM (A v))) m).
+     can_emit (pre_loaded_with_all_messages_vlsm (IM (A v))) m).
     - intros (v & -> & _); congruence.
     - eapply composite_no_initial_valid_messages_emitted_by_sender; eassumption.
   Qed.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1,4 +1,4 @@
-From stdpp Require Import prelude.
+From stdpp Require Import prelude finite.
 From Coq Require Import Streams FinFun Rdefinitions Program.Tactics.
 From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet.
 From VLSM Require Import Lib.ListSetExtras Lib.Measurable Lib.FinFunExtras.
@@ -481,7 +481,7 @@ Section Simple.
     Qed.
 
     Lemma has_been_sent_consistency
-      {Hbs : HasBeenSentCapability}
+      `{HasBeenSentCapability}
       (s : state)
       (Hs : valid_state_prop pre_vlsm s)
       (m : message)
@@ -501,7 +501,7 @@ Section Simple.
     Qed.
 
     Lemma can_produce_has_been_sent
-      {Hbs : HasBeenSentCapability}
+      `{HasBeenSentCapability}
       (s : state)
       (m : message)
       (Hsm : can_produce pre_vlsm s m)
@@ -528,7 +528,7 @@ Section Simple.
     'pre_loaded_with_all_messages_vlsm'
     *)
     Lemma specialized_proper_sent
-      {Hbs : HasBeenSentCapability}
+      `{HasBeenSentCapability}
       (s : state)
       (Hs : valid_state_prop vlsm s)
       (m : message)
@@ -555,7 +555,7 @@ Section Simple.
     (avoiding 'pre_loaded_with_all_messages_vlsm')
     *)
     Lemma specialized_proper_sent_rev
-      {Hbs : HasBeenSentCapability}
+      `{HasBeenSentCapability}
       (s : state)
       (Hs : valid_state_prop vlsm s)
       (m : message)
@@ -618,7 +618,7 @@ Section Simple.
     }.
 
     Lemma has_been_received_consistency
-      {Hbs : HasBeenReceivedCapability}
+      `{HasBeenReceivedCapability}
       (s : state)
       (Hs : valid_state_prop pre_vlsm s)
       (m : message)
@@ -670,7 +670,7 @@ Section Simple.
       sig (fun m => selected_message_exists_in_some_preloaded_traces (field_selector output) s m).
 
     Lemma sent_messages_proper
-      (Hhbs : HasBeenSentCapability)
+      `{HasBeenSentCapability}
       (s : vstate vlsm)
       (Hs : valid_state_prop pre_vlsm s)
       (m : message)
@@ -691,7 +691,7 @@ Section Simple.
       sig (fun m => selected_message_exists_in_some_preloaded_traces (field_selector input) s m).
 
     Lemma received_messages_proper
-      (Hhbs : HasBeenReceivedCapability)
+      `{HasBeenReceivedCapability}
       (s : vstate vlsm)
       (Hs : valid_state_prop pre_vlsm s)
       (m : message)
@@ -922,6 +922,9 @@ Section Simple.
         proper_not_received := ComputableReceivedMessages_has_not_been_received_proper
       |}.
 End Simple.
+
+Global Hint Mode HasBeenSentCapability - ! : typeclass_instances.
+Global Hint Mode HasBeenReceivedCapability - ! : typeclass_instances.
 
 (** *** Stepwise consistency properties for [state_message_oracle]
 
@@ -1229,8 +1232,8 @@ Defined.
 
 Lemma has_been_sent_stepwise_from_trace
       [message : Type]
-      [vlsm: VLSM message]
-      (Hhbs: HasBeenSentCapability vlsm):
+      (vlsm: VLSM message)
+      `{HasBeenSentCapability message vlsm}:
   oracle_stepwise_props (field_selector output) (has_been_sent vlsm).
 Proof.
   apply stepwise_props_from_trace.
@@ -1241,47 +1244,49 @@ Defined.
 
 Lemma preloaded_has_been_sent_stepwise_props
       [message : Type]
-      [vlsm: VLSM message]
-      (Hhbs: HasBeenSentCapability vlsm)
+      (vlsm: VLSM message)
+      `{HasBeenSentCapability message vlsm}
       (seed : message -> Prop)
       (X := pre_loaded_vlsm vlsm seed):
   has_been_sent_stepwise_props (vlsm := X) (has_been_sent vlsm).
 Proof.
-  destruct (has_been_sent_stepwise_from_trace Hhbs); split; assumption.
+  destruct (has_been_sent_stepwise_from_trace vlsm); split; assumption.
 Qed.
 
-Lemma preloaded_HasBeenSentCapability
+Global Instance preloaded_HasBeenSentCapability
       [message : Type]
-      [vlsm: VLSM message]
-      (Hhbs: HasBeenSentCapability vlsm)
+      (vlsm: VLSM message)
+      `{HasBeenSentCapability message vlsm}
       (seed : message -> Prop):
   HasBeenSentCapability (pre_loaded_vlsm vlsm seed).
 Proof.
   eapply HasBeenSentCapability_from_stepwise.
-  - apply Hhbs.
+  - apply (has_been_sent_dec vlsm).
   - apply preloaded_has_been_sent_stepwise_props.
 Defined.
 
 Lemma has_been_sent_step_update
-      `{Hhbs: HasBeenSentCapability message vlsm}:
+      `{HasBeenSentCapability message vlsm}:
   forall [l s im s' om],
     input_valid_transition (pre_loaded_with_all_messages_vlsm vlsm) l (s,im) (s',om) ->
     forall m,
       has_been_sent vlsm s' m <-> (om = Some m \/ has_been_sent vlsm s m).
 Proof.
-  exact (oracle_step_update (has_been_sent_stepwise_from_trace Hhbs)).
+  exact (oracle_step_update (has_been_sent_stepwise_from_trace vlsm)).
 Qed.
 
 Lemma has_been_sent_examine_one_trace
-  `(Hhbs: HasBeenSentCapability message vlsm):
+  `{HasBeenSentCapability message vlsm}:
   forall is s tr,
     finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm vlsm) is s tr ->
   forall m,
     has_been_sent vlsm s m <->
     trace_has_message (field_selector output) m tr.
 Proof.
-  destruct Hhbs.
-  apply examine_one_trace; assumption.
+  apply examine_one_trace.
+  - apply has_been_sent_dec.
+  - apply proper_sent.
+  - apply proper_not_sent.
 Qed.
 
 (** ** Stepwise view of [HasBeenReceivedCapability] *)
@@ -1305,8 +1310,8 @@ Defined.
 
 Lemma has_been_received_stepwise_from_trace
       [message : Type]
-      [vlsm: VLSM message]
-      (Hhbr: HasBeenReceivedCapability vlsm):
+      (vlsm: VLSM message)
+      `{HasBeenReceivedCapability message vlsm}:
   oracle_stepwise_props (field_selector input) (has_been_received vlsm).
 Proof.
   apply stepwise_props_from_trace.
@@ -1317,51 +1322,54 @@ Defined.
 
 Lemma preloaded_has_been_received_stepwise_props
       {message : Type}
-      {vlsm: VLSM message}
-      (Hhbr: HasBeenReceivedCapability vlsm)
+      (vlsm: VLSM message)
+      `{HasBeenReceivedCapability message vlsm}
       (seed : message -> Prop)
       (X := pre_loaded_vlsm vlsm seed):
   has_been_received_stepwise_props (vlsm := X) (has_been_received vlsm).
 Proof.
-  destruct (has_been_received_stepwise_from_trace Hhbr); split; assumption.
+  destruct (has_been_received_stepwise_from_trace vlsm); split; assumption.
 Qed.
 
-Lemma preloaded_HasBeenReceivedCapability
+Global Instance preloaded_HasBeenReceivedCapability
       {message : Type}
-      {vlsm: VLSM message}
-      (Hhbr: HasBeenReceivedCapability vlsm)
+      (vlsm: VLSM message)
+      `{HasBeenReceivedCapability message vlsm}
       (seed : message -> Prop):
   HasBeenReceivedCapability (pre_loaded_vlsm vlsm seed).
 Proof.
   eapply HasBeenReceivedCapability_from_stepwise.
-  - apply Hhbr.
+  - apply (has_been_received_dec vlsm).
   - apply preloaded_has_been_received_stepwise_props.
 Defined.
 
 Lemma has_been_received_step_update
-      `{Hhbs: HasBeenReceivedCapability message vlsm}:
+      `{HasBeenReceivedCapability message vlsm}:
   forall [l s im s' om],
     input_valid_transition (pre_loaded_with_all_messages_vlsm vlsm) l (s,im) (s',om) ->
     forall m,
       has_been_received vlsm s' m <-> (im = Some m \/ has_been_received vlsm s m).
 Proof.
-  exact (oracle_step_update (has_been_received_stepwise_from_trace Hhbs)).
+  exact (oracle_step_update (has_been_received_stepwise_from_trace vlsm)).
 Qed.
 
 Lemma has_been_received_examine_one_trace
-  `(Hhbr: HasBeenReceivedCapability message vlsm):
+  `{HasBeenReceivedCapability message vlsm}:
   forall is s tr,
     finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm vlsm) is s tr ->
   forall m,
     has_been_received vlsm s m <->
     trace_has_message (field_selector input) m tr.
 Proof.
-  destruct Hhbr.
-  apply examine_one_trace; assumption.
+  apply examine_one_trace.
+  - apply has_been_received_dec.
+  - apply proper_received.
+  - apply proper_not_received.
 Qed.
 
 Lemma trace_to_initial_state_has_no_inputs
-  `{Hbr: HasBeenReceivedCapability message vlsm}
+  {message} vlsm
+  `{HasBeenReceivedCapability message vlsm}
   is s tr
   (Htr : finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm vlsm) is s tr)
   (Hs : vinitial_state_prop vlsm s)
@@ -1394,31 +1402,33 @@ Class HasBeenObservedCapability {message} (vlsm: VLSM message) :=
   }.
 Arguments has_been_observed {message} vlsm {_}.
 Arguments has_been_observed_dec {message} vlsm {_}.
+Arguments has_been_observed_stepwise_props {message} vlsm {_}.
 
-Definition has_been_observed_no_inits `{Hhbo: HasBeenObservedCapability message vlsm}
-  := oracle_no_inits has_been_observed_stepwise_props.
+Global Hint Mode HasBeenObservedCapability - ! : typeclass_instances.
 
-Definition has_been_observed_step_update `{Hhbo: HasBeenObservedCapability message vlsm} :
+Definition has_been_observed_no_inits `[HasBeenObservedCapability message vlsm]
+  := oracle_no_inits (has_been_observed_stepwise_props vlsm).
+
+Definition has_been_observed_step_update `{HasBeenObservedCapability message vlsm} :
   forall l s im s' om,
     input_valid_transition (pre_loaded_with_all_messages_vlsm vlsm) l (s, im) (s', om) ->
     forall msg,
       has_been_observed vlsm s' msg <->
       ((im = Some msg \/ om = Some msg) \/ has_been_observed vlsm s msg)
-  := oracle_step_update has_been_observed_stepwise_props.
+  := oracle_step_update (has_been_observed_stepwise_props vlsm).
 
-Lemma proper_observed `(Hhbo: HasBeenObservedCapability message vlsm):
+Lemma proper_observed {message} (vlsm : VLSM message) `{HasBeenObservedCapability message vlsm}:
   forall (s:state),
     valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s ->
     forall m,
       all_traces_have_message_prop vlsm item_sends_or_receives (has_been_observed vlsm) s m.
 Proof.
   intros.
-  apply prove_all_have_message_from_stepwise.
-  apply Hhbo.
-  assumption.
+  apply prove_all_have_message_from_stepwise; [|assumption].
+  apply has_been_observed_stepwise_props.
 Qed.
 
-Lemma proper_not_observed `(Hhbo: HasBeenObservedCapability message vlsm):
+Lemma proper_not_observed {message} (vlsm : VLSM message) `{HasBeenObservedCapability message vlsm}:
   forall (s:state),
     valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s ->
     forall m,
@@ -1426,13 +1436,12 @@ Lemma proper_not_observed `(Hhbo: HasBeenObservedCapability message vlsm):
                                   (fun s m => ~has_been_observed vlsm s m) s m.
 Proof.
   intros.
-  apply prove_none_have_message_from_stepwise.
-  apply Hhbo.
-  assumption.
+  apply prove_none_have_message_from_stepwise; [|assumption].
+  apply has_been_observed_stepwise_props.
 Qed.
 
 Lemma has_been_observed_examine_one_trace
-  `(Hhbo: HasBeenObservedCapability message vlsm):
+  {message} (vlsm : VLSM message) `{HasBeenObservedCapability message vlsm}:
   forall is s tr,
     finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm vlsm) is s tr ->
   forall m,
@@ -1451,7 +1460,7 @@ Qed.
 Definition no_additional_equivocations
   {message : Type}
   (vlsm : VLSM message)
-  {Hbo : HasBeenObservedCapability vlsm}
+  `{HasBeenObservedCapability message vlsm}
   (s : state)
   (m : message)
   : Prop
@@ -1464,7 +1473,7 @@ Definition no_additional_equivocations
 Lemma no_additional_equivocations_dec
   {message : Type}
   (vlsm : VLSM message)
-  {Hbo : HasBeenObservedCapability vlsm}
+  `{HasBeenObservedCapability message vlsm}
   : RelDecision (no_additional_equivocations vlsm).
 Proof.
   apply has_been_observed_dec.
@@ -1473,7 +1482,7 @@ Qed.
 Definition no_additional_equivocations_constraint
   {message : Type}
   (vlsm : VLSM message)
-  {Hbo : HasBeenObservedCapability vlsm}
+  `{HasBeenObservedCapability message vlsm}
   (l : vlabel vlsm)
   (som : state * option message)
   : Prop
@@ -1486,12 +1495,12 @@ Section sent_received_observed_capabilities.
 Context
   {message : Type}
   (vlsm : VLSM message)
-  {Hbr : HasBeenReceivedCapability vlsm}
-  {Hbs : HasBeenSentCapability vlsm}
+  `{HasBeenReceivedCapability message vlsm}
+  `{HasBeenSentCapability message vlsm}
   .
 
 Lemma has_been_observed_sent_received_iff
-  {Hbo : HasBeenObservedCapability vlsm}
+  `{HasBeenObservedCapability message vlsm}
   (s : state)
   (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s)
   (m : message)
@@ -1499,9 +1508,9 @@ Lemma has_been_observed_sent_received_iff
 Proof.
   specialize
     (prove_all_have_message_from_stepwise message vlsm  item_sends_or_receives
-    (has_been_observed vlsm) has_been_observed_stepwise_props _ Hs m) as Hall.
-  split; [intro H | intros [H | H]].
-  - apply proj1 in Hall. specialize (Hall H).
+    (has_been_observed vlsm) (has_been_observed_stepwise_props _) _ Hs m) as Hall.
+  split; [intro Hobs | intros [Hreceived | Hsent]].
+  - apply proj1 in Hall. specialize (Hall Hobs).
     apply consistency_from_valid_state_proj2 in Hall; [|assumption].
     destruct Hall as [is [tr [Htr Hexists]]].
     apply Exists_or_inv in Hexists.
@@ -1514,12 +1523,14 @@ Proof.
       apply Hcons. exists is, tr, Htr. assumption.
   - apply Hall.
     intro is; intros.
-    apply proper_received in H; [|assumption]. specialize (H is tr Htr).
-    apply Exists_or. left. assumption.
+    apply proper_received in Hreceived; [|assumption].
+    apply Exists_or. left.
+    eapply Hreceived; eassumption.
   - apply Hall.
     intro is; intros.
-    apply proper_sent in H; [|assumption]. specialize (H is tr Htr).
-    apply Exists_or. right. assumption.
+    apply proper_sent in Hsent; [|assumption].
+    apply Exists_or. right.
+    eapply Hsent; eassumption.
 Qed.
 
 Definition has_been_observed_from_sent_received
@@ -1541,15 +1552,18 @@ Lemma has_been_observed_from_sent_received_stepwise_props
   : oracle_stepwise_props item_sends_or_receives has_been_observed_from_sent_received.
 Proof.
   apply stepwise_props_from_trace; [apply has_been_observed_from_sent_received_dec|..]
-  ; intros; split; intros.
-  - intro; intros.
-    destruct H as [H | H].
-    + apply proper_sent in H; [|apply Hs]. specialize (H _ _ Htr).
-      apply Exists_or. right. assumption.
-    + apply proper_received in H; [|apply Hs]. specialize (H _ _ Htr).
-      apply Exists_or. left. assumption.
-  - apply consistency_from_valid_state_proj2 in H; [|assumption].
-    destruct H as [is [tr [Htr Hexists]]].
+  ; intros; split.
+  - intros Hobs start tr Htr.
+    destruct Hobs as [Hsent | Hreceived].
+    + apply proper_sent in Hsent; [|assumption].
+      apply Exists_or. right.
+      eapply Hsent; eassumption.
+    + apply proper_received in Hreceived; [|assumption].
+      apply Exists_or. left.
+      eapply Hreceived; eassumption.
+  - intros Hobs.
+    apply consistency_from_valid_state_proj2 in Hobs; [|assumption].
+    destruct Hobs as (is & tr & Htr & Hexists).
     apply Exists_or_inv in Hexists.
     destruct Hexists as [Hsent | Hreceived].
     + right. apply proper_received; [assumption|].
@@ -1558,7 +1572,8 @@ Proof.
     + left. apply proper_sent; [assumption|].
       apply has_been_sent_consistency; [assumption|assumption|].
       exists is, tr, Htr. assumption.
-  - intro; intros. intro Hexists. elim H.
+  - intros Hnobs start tr Htr Hexists.
+    contradict Hnobs.
     apply Exists_or_inv in Hexists.
     destruct Hexists as [Hexists| Hexists].
     + right. apply proper_received; [assumption|].
@@ -1567,18 +1582,20 @@ Proof.
     + left. apply proper_sent; [assumption|].
       apply has_been_sent_consistency; [assumption|assumption|].
       exists start, tr, Htr. assumption.
-  - intros [Hobs | Hobs].
+  - intros Hnobs  [Hobs | Hobs].
     + apply proper_sent in Hobs; [|assumption].
       apply has_been_sent_consistency in Hobs; [|assumption|assumption].
       destruct Hobs as [is [tr [Htr Hexists]]].
-      specialize (H _ _ Htr). elim H. apply Exists_or. right. assumption.
+      eapply Hnobs; [eassumption|].
+      apply Exists_or. right. assumption.
     + apply proper_received in Hobs; [|assumption].
       apply has_been_received_consistency in Hobs; [|assumption|assumption].
       destruct Hobs as [is [tr [Htr Hexists]]].
-      specialize (H _ _ Htr). elim H. apply Exists_or. left. assumption.
+      eapply Hnobs; [eassumption|].
+      apply Exists_or. left. assumption.
 Qed.
 
-Local Program Instance HasBeenObservedCapability_from_sent_received
+Global Program Instance HasBeenObservedCapability_from_sent_received
   : HasBeenObservedCapability vlsm
   :=
   { has_been_observed := has_been_observed_from_sent_received;
@@ -1588,7 +1605,7 @@ Local Program Instance HasBeenObservedCapability_from_sent_received
   }.
 
   Lemma has_been_observed_consistency
-    {Hbo : HasBeenObservedCapability vlsm}
+    `{HasBeenObservedCapability message vlsm}
     (s : state)
     (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s)
     (m : message)
@@ -1597,8 +1614,8 @@ Local Program Instance HasBeenObservedCapability_from_sent_received
     split.
     - intro Hsome.
       destruct (decide (has_been_observed vlsm s m)) as [Hsm|Hsm].
-      apply (proper_observed Hbo) in Hsm;assumption.
-      apply (proper_not_observed Hbo) in Hsm;[|assumption].
+      apply proper_observed in Hsm;assumption.
+      apply proper_not_observed in Hsm;[|assumption].
       exfalso.
       destruct Hsome as [is [tr [Htr Hmsg]]].
       elim (Hsm _ _ Htr).
@@ -1612,7 +1629,7 @@ End sent_received_observed_capabilities.
 Lemma sent_valid
     [message]
     (X : VLSM message)
-    {Hhbs: HasBeenSentCapability X}
+    `{HasBeenSentCapability message X}
     (s : state)
     (Hs : valid_state_prop X s)
     (m : message)
@@ -1620,19 +1637,22 @@ Lemma sent_valid
     valid_message_prop X m.
 Proof.
   induction Hs using valid_state_prop_ind.
-  - contradict Hsent. apply (oracle_no_inits (has_been_sent_stepwise_from_trace Hhbs));assumption.
+  - contradict Hsent.
+    eapply oracle_no_inits; [|assumption].
+    apply has_been_sent_stepwise_from_trace.
   - apply input_valid_transition_out in Ht as Hom'.
     apply preloaded_weaken_input_valid_transition in Ht.
-    apply (oracle_step_update (has_been_sent_stepwise_from_trace Hhbs) _ _ _ _ _ Ht) in Hsent.
-    destruct Hsent.
-    + simpl in H. subst om'. assumption.
+    erewrite oracle_step_update in Hsent
+    ; [|apply has_been_sent_stepwise_from_trace |eassumption].
+    destruct Hsent as [Hnow | Hsent].
+    + simpl in Hnow. subst om'. assumption.
     + auto.
 Qed.
 
 Lemma received_valid
     [message]
     (X : VLSM message)
-    {Hhbr: HasBeenReceivedCapability X}
+    `{HasBeenReceivedCapability message X}
     (s : state)
     (Hs : valid_state_prop X s)
     (m : message)
@@ -1645,17 +1665,17 @@ Proof.
     apply has_been_received_stepwise_from_trace.
   - apply input_valid_transition_in in Ht as Hom'.
     apply preloaded_weaken_input_valid_transition in Ht.
-    apply (oracle_step_update (has_been_received_stepwise_from_trace Hhbr) _ _ _ _ _ Ht) in Hreceived.
-    destruct Hreceived; [| auto].
-    simpl in H. subst om. assumption.
+    erewrite oracle_step_update in Hreceived
+    ; [|apply has_been_received_stepwise_from_trace|eassumption].
+    destruct Hreceived as [Hnow|]; [| auto].
+    simpl in Hnow. subst om. assumption.
 Qed.
 
 Lemma observed_valid
     [message]
     (X : VLSM message)
-    {Hhbs: HasBeenSentCapability X}
-    {Hhbr: HasBeenReceivedCapability X}
-    (Hhbo: HasBeenObservedCapability X := HasBeenObservedCapability_from_sent_received X)
+    `{HasBeenSentCapability message X}
+    `{HasBeenReceivedCapability message X}
     (s : state)
     (Hs : valid_state_prop X s)
     (m : message)
@@ -1685,14 +1705,11 @@ Qed.
 Section Composite.
 
   Context {message : Type}
-          {index : Type}
-          {IndEqDec : EqDecision index}
+          `{finite.Finite index}
           (IM : index -> VLSM message)
           (Free := free_composite_vlsm IM)
-          {index_listing : list index}
-          (finite_index : Listing index_listing)
-          (has_been_sent_capabilities : forall i : index, (HasBeenSentCapability (IM i)))
-          (has_been_observed_capabilities : forall i : index, (HasBeenObservedCapability (IM i)))
+          `{forall i : index, (HasBeenSentCapability (IM i))}
+          `{forall i : index, (HasBeenReceivedCapability (IM i))}
           .
 
   Section StepwiseProps.
@@ -1719,8 +1736,8 @@ Section Composite.
       Proof.
         split.
         - (* initial states not claim *)
-          intros s Hs m [i H].
-          revert H.
+          intros s Hs m [i Horacle].
+          revert Horacle.
           fold (~ oracles i (s i) m).
           apply (oracle_no_inits (stepwise_props i)).
           apply Hs.
@@ -1728,19 +1745,17 @@ Section Composite.
           intros l s im s' om Hproto msg.
           destruct l as [i li].
           simpl.
-          assert (forall j, s j = s' j \/ j = i).
+          assert (Hsj : forall j, s j = s' j \/ j = i).
           {
             intro j.
             apply (input_valid_transition_preloaded_project_any j) in Hproto.
-            destruct Hproto;[left;assumption|right].
-            destruct H as [lj [Hlj _]].
-            congruence.
+            destruct Hproto as [|(lj & Hlj & _)];[left;assumption|right; congruence].
           }
           apply input_valid_transition_preloaded_project_active in Hproto;simpl in Hproto.
           apply (oracle_step_update (stepwise_props i)) with (msg:=msg) in Hproto.
           split.
           + intros [j Hj].
-            destruct (H j) as [Hunchanged|Hji].
+            destruct (Hsj j) as [Hunchanged|Hji].
             * right;exists j;rewrite Hunchanged;assumption.
             * subst j.
               apply Hproto in Hj.
@@ -1750,7 +1765,7 @@ Section Composite.
               apply Hproto.
               left;assumption.
             * exists j.
-              destruct (H j) as [Hunchanged| ->].
+              destruct (Hsj j) as [Hunchanged| ->].
               -- rewrite <- Hunchanged;assumption.
               -- apply Hproto.
                  right.
@@ -1770,8 +1785,8 @@ Section Composite.
   Lemma composite_has_been_sent_dec : RelDecision composite_has_been_sent.
   Proof.
     intros s m.
-    apply (Decision_iff (P:=List.Exists (fun i => has_been_sent (IM i) (s i) m) index_listing)).
-    - rewrite <- exists_finite by (apply finite_index). reflexivity.
+    apply (Decision_iff (P:=List.Exists (fun i => has_been_sent (IM i) (s i) m) (enum index))).
+    - rewrite Exists_finite. reflexivity.
     - typeclasses eauto.
   Qed.
 
@@ -1783,7 +1798,7 @@ Section Composite.
     unfold has_been_sent_stepwise_props.
     pose proof (composite_stepwise_props
                   (fun i => has_been_sent_stepwise_from_trace
-                              (has_been_sent_capabilities i)))
+                              (IM i)))
          as [Hinits Hstep].
     split;[exact Hinits|].
     (* <<exact Hstep>> doesn't work because [composite_message_selector]
@@ -1793,44 +1808,13 @@ Section Composite.
     exact Hstep.
   Qed.
 
-  Definition composite_HasBeenSentCapability
+  Global Instance composite_HasBeenSentCapability
     (constraint : composite_label IM -> composite_state IM * option message -> Prop)
     (X := composite_vlsm IM constraint)
     : HasBeenSentCapability X :=
     HasBeenSentCapability_from_stepwise (vlsm := X)
       composite_has_been_sent_dec
       (composite_has_been_sent_stepwise_props constraint).
-
-  Global Instance free_composite_HasBeenSentCapability : HasBeenSentCapability Free :=
-    composite_HasBeenSentCapability (free_constraint IM).
-
-  Lemma preloaded_composite_has_been_sent_stepwise_props
-    (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-    (seed : message -> Prop)
-    (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
-    : has_been_sent_stepwise_props (vlsm := X) composite_has_been_sent.
-  Proof.
-    unfold has_been_sent_stepwise_props.
-    pose proof (composite_stepwise_props
-                  (fun i => has_been_sent_stepwise_from_trace
-                              (has_been_sent_capabilities i)))
-         as [Hinits Hstep].
-    split;[exact Hinits|].
-    (* <<exact Hstep>> doesn't work because [composite_message_selector]
-       pattern matches on the label l, so we instantiate and destruct
-       to let that simplify *)
-    intros l;specialize (Hstep l);destruct l.
-    exact Hstep.
-  Qed.
-
-  Definition preloaded_composite_HasBeenSentCapability
-    (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-    (seed : message -> Prop)
-    (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
-    : HasBeenSentCapability X :=
-    HasBeenSentCapability_from_stepwise (vlsm := X)
-      composite_has_been_sent_dec
-      (preloaded_composite_has_been_sent_stepwise_props constraint seed).
 
   Lemma composite_proper_sent
     (s : state)
@@ -1845,10 +1829,6 @@ Section Composite.
 
   Section composite_has_been_received.
 
-  Context
-        (has_been_received_capabilities : forall i : index, (HasBeenReceivedCapability (IM i)))
-        .
-
   (** A message 'has_been_received' for a composite state if it 'has_been_received' for any of
   its components.*)
   Definition composite_has_been_received
@@ -1861,8 +1841,8 @@ Section Composite.
   Lemma composite_has_been_received_dec : RelDecision composite_has_been_received.
   Proof.
     intros s m.
-    apply (Decision_iff (P:=List.Exists (fun i => has_been_received (IM i) (s i) m) index_listing)).
-    - rewrite <- exists_finite by (apply finite_index). reflexivity.
+    apply (Decision_iff (P:=List.Exists (fun i => has_been_received (IM i) (s i) m) (enum index))).
+    - rewrite Exists_finite. reflexivity.
     - typeclasses eauto.
   Qed.
 
@@ -1874,7 +1854,7 @@ Section Composite.
     unfold has_been_received_stepwise_props.
     pose proof (composite_stepwise_props
                   (fun i => has_been_received_stepwise_from_trace
-                              (has_been_received_capabilities i)))
+                              (IM i)))
          as [Hinits Hstep].
     split;[exact Hinits|].
     (* <<exact Hstep>> doesn't work because [composite_message_selector]
@@ -1884,7 +1864,7 @@ Section Composite.
     exact Hstep.
   Qed.
 
-  Definition composite_HasBeenReceivedCapability
+  Global Instance composite_HasBeenReceivedCapability
     (constraint : composite_label IM -> composite_state IM * option message -> Prop)
     (X := composite_vlsm IM constraint)
     : HasBeenReceivedCapability X :=
@@ -1892,36 +1872,11 @@ Section Composite.
       composite_has_been_received_dec
       (composite_has_been_received_stepwise_props constraint).
 
-  Global Instance free_composite_HasBeenReceivedCapability : HasBeenReceivedCapability Free :=
-    composite_HasBeenReceivedCapability (free_constraint IM).
-
-  Lemma preloaded_composite_has_been_received_stepwise_props
+  Global Instance composite_HasBeenObservedCapability
     (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-    (seed : message -> Prop)
-    (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
-    : has_been_received_stepwise_props (vlsm := X) composite_has_been_received.
-  Proof.
-    unfold has_been_received_stepwise_props.
-    pose proof (composite_stepwise_props
-                  (fun i => has_been_received_stepwise_from_trace
-                              (has_been_received_capabilities i)))
-         as [Hinits Hstep].
-    split;[assumption |].
-    (* <<exact Hstep>> doesn't work because [composite_message_selector]
-       pattern matches on the label l, so we instantiate and destruct
-       to let that simplify *)
-    intros l;specialize (Hstep l);destruct l.
-    assumption.
-  Qed.
-
-  Definition preloaded_composite_HasBeenReceivedCapability
-    (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-    (seed : message -> Prop)
-    (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
-    : HasBeenReceivedCapability X :=
-    HasBeenReceivedCapability_from_stepwise (vlsm := X)
-      composite_has_been_received_dec
-      (preloaded_composite_has_been_received_stepwise_props constraint seed).
+    (X := composite_vlsm IM constraint)
+    : HasBeenObservedCapability X :=
+    HasBeenObservedCapability_from_sent_received X.
 
   End composite_has_been_received.
 
@@ -1938,8 +1893,8 @@ Section Composite.
   Lemma composite_has_been_observed_dec : RelDecision composite_has_been_observed.
   Proof.
     intros s m.
-    apply (Decision_iff (P:=List.Exists (fun i => has_been_observed (IM i) (s i) m) index_listing)).
-    - rewrite <- exists_finite by (apply finite_index). reflexivity.
+    apply (Decision_iff (P:=List.Exists (fun i => has_been_observed (IM i) (s i) m) (enum index))).
+    - rewrite Exists_finite. reflexivity.
     - typeclasses eauto.
   Qed.
 
@@ -1949,14 +1904,14 @@ Section Composite.
     : oracle_stepwise_props (vlsm := X) item_sends_or_receives composite_has_been_observed.
   Proof.
     pose proof (composite_stepwise_props
-                  (fun i => has_been_observed_stepwise_props))
+                  (fun i => (has_been_observed_stepwise_props (IM i))))
          as [Hinits Hstep].
     split;[exact Hinits|].
     intros l;specialize (Hstep l);destruct l.
     exact Hstep.
   Qed.
 
-  Definition composite_HasBeenObservedCapability
+  Definition composite_HasBeenObservedCapability_from_stepwise
     (constraint : composite_label IM -> composite_state IM * option message -> Prop)
     (X := composite_vlsm IM constraint)
     : HasBeenObservedCapability X.
@@ -1965,9 +1920,6 @@ Section Composite.
     - apply composite_has_been_observed_dec.
     - apply (composite_has_been_observed_stepwise_props constraint).
   Defined.
-
-  Global Instance free_composite_HasBeenObservedCapability : HasBeenObservedCapability Free :=
-    composite_HasBeenObservedCapability (free_constraint IM).
 
   Context
         {validator : Type}
@@ -2104,26 +2056,20 @@ Section Composite.
   Proof.
     split;[|exists (A v);assumption].
     intros [i Hi].
-    rewrite (Hsender_safety _ _ Hsender i);[assumption|].
-    assert (finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm (IM i)) (is i) (s i)
-                                          (VLSM_projection_trace_project (preloaded_component_projection IM i) tr)).
+    erewrite Hsender_safety. 1,2: eassumption.
+    assert
+      (Htr_pr : finite_valid_trace_init_to
+        (pre_loaded_with_all_messages_vlsm (IM i))
+        (is i) (s i) (VLSM_projection_trace_project (preloaded_component_projection IM i) tr)).
     {
-      rewrite <- (valid_trace_get_last Htr).
-      apply valid_trace_forget_last in Htr.
-      destruct Htr as [Htr Hinit].
-      apply valid_trace_add_last.
-      split. revert Htr;apply preloaded_finite_valid_trace_projection.
-      exact (Hinit i).
-      symmetry.
-      apply (VLSM_projection_finite_trace_last (preloaded_component_projection IM i)).
+      apply (VLSM_projection_finite_valid_trace_init_to (preloaded_component_projection IM i)).
       assumption.
     }
-    apply (can_emit_from_valid_trace (pre_loaded_with_all_messages_vlsm (IM i)) (is i) m
-                                        (VLSM_projection_trace_project (preloaded_component_projection IM i) tr)).
-    exact (valid_trace_forget_last H).
-    apply (oracle_initial_trace_update (has_been_sent_stepwise_from_trace (has_been_sent_capabilities i)) (is i) (s i)).
-    assumption.
-    assumption.
+    eapply can_emit_from_valid_trace.
+    - eapply valid_trace_forget_last. eassumption.
+    - eapply proper_sent. 2,3:eassumption.
+      revert Htr_pr.
+      apply valid_trace_last_pstate.
   Qed.
 
   Lemma no_additional_equivocations_constraint_dec
@@ -2133,10 +2079,6 @@ Section Composite.
     destruct om; [|left; exact I].
     apply no_additional_equivocations_dec.
   Qed.
-
-  Context
-        (has_been_received_capabilities : forall i : index, (HasBeenReceivedCapability (IM i)))
-        .
 
    (** We say that a validator <v> (with associated component <i>) is equivocating wrt.
    to another component <j>, if there exists a message which [has_been_received] by
@@ -2221,7 +2163,6 @@ Section Composite.
     (Hsent : has_been_sent (IM i) (s i) m) :
     valid_message_prop X m.
   Proof.
-    pose (Xhbs := composite_HasBeenSentCapability constraint).
     apply (sent_valid X s). assumption. exists i;assumption.
   Qed.
 
@@ -2236,8 +2177,9 @@ Section Composite.
     (Hsent : has_been_sent (IM i) (s i) m) :
     valid_message_prop X m.
   Proof.
-    pose (Xhbs := preloaded_composite_HasBeenSentCapability constraint seed).
-    apply (sent_valid X s). assumption. exists i;assumption.
+    eapply sent_valid.
+    - eassumption.
+    - exists i;assumption.
   Qed.
 
   Lemma messages_received_from_component_of_valid_state_are_valid
@@ -2250,8 +2192,9 @@ Section Composite.
     (Hreceived : has_been_received (IM i) (s i) m)
     : valid_message_prop X m.
   Proof.
-    pose (Xhbr := composite_HasBeenReceivedCapability has_been_received_capabilities constraint).
-    apply (received_valid X s). assumption. exists i;assumption.
+    eapply received_valid.
+    - eassumption.
+    - exists i;assumption.
   Qed.
 
   Lemma preloaded_messages_received_from_component_of_valid_state_are_valid
@@ -2265,9 +2208,8 @@ Section Composite.
     (Hreceived : has_been_received (IM i) (s i) m)
     : valid_message_prop X m.
   Proof.
-    pose (Xhbr := preloaded_composite_HasBeenReceivedCapability has_been_received_capabilities constraint seed).
-    apply (received_valid X s).
-    - assumption.
+    eapply received_valid.
+    - eassumption.
     - exists i; assumption.
   Qed.
 
@@ -2306,7 +2248,7 @@ Section Composite.
     (s : composite_state IM)
     (Hs : valid_state_prop X s)
     (m : message)
-    (Hreceived : composite_has_been_received has_been_received_capabilities s m)
+    (Hreceived : composite_has_been_received s m)
     : valid_message_prop X m.
   Proof.
     destruct Hreceived as [i Hreceived].
@@ -2321,7 +2263,7 @@ Section Composite.
     (s : composite_state IM)
     (Hs : valid_state_prop X s)
     (m : message)
-    (Hreceived : composite_has_been_received has_been_received_capabilities s m)
+    (Hreceived : composite_has_been_received s m)
     : valid_message_prop X m.
   Proof.
     destruct Hreceived as [i Hreceived].
@@ -2370,15 +2312,13 @@ End Composite.
 
   Lemma composite_has_been_observed_sent_received_iff
     {message}
-    `{IndEqDec : EqDecision index}
+    `{EqDecision index}
     (IM : index -> VLSM message)
-    (Hbs : forall i : index, HasBeenSentCapability (IM i))
-    (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
-    (Hbo : forall i : index, HasBeenObservedCapability (IM i)
-      := fun i => HasBeenObservedCapability_from_sent_received (IM i))
+    `{forall i : index, HasBeenSentCapability (IM i)}
+    `{forall i : index, HasBeenReceivedCapability (IM i)}
     (s : composite_state IM)
     (m : message)
-    : composite_has_been_observed IM Hbo s m <-> composite_has_been_sent IM Hbs s m \/ composite_has_been_received IM Hbr s m.
+    : composite_has_been_observed IM s m <-> composite_has_been_sent IM s m \/ composite_has_been_received IM s m.
   Proof.
     split.
     - intros [i [Hs|Hr]]; [left|right]; exists i; assumption.
@@ -2389,16 +2329,11 @@ End Composite.
     {message}
     `{finite.Finite index}
     (IM : index -> VLSM message)
-    (Hbs : forall i : index, HasBeenSentCapability (IM i))
-    (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
-    (Hbo : forall i : index, HasBeenObservedCapability (IM i)
-      := fun i => HasBeenObservedCapability_from_sent_received (IM i))
-    (Free_Hbs := free_composite_HasBeenSentCapability IM (listing_from_finite index) Hbs)
-    (Free_Hbr := free_composite_HasBeenReceivedCapability IM (listing_from_finite index) Hbr)
-    (Free_Hbo := HasBeenObservedCapability_from_sent_received (free_composite_vlsm IM))
+    `{forall i : index, HasBeenSentCapability (IM i)}
+    `{forall i : index, HasBeenReceivedCapability (IM i)}
     (s : vstate (free_composite_vlsm IM))
     (m : message)
-    : composite_has_been_observed IM Hbo s m <-> has_been_observed (free_composite_vlsm IM) s m.
+    : composite_has_been_observed IM s m <-> has_been_observed (free_composite_vlsm IM) s m.
   Proof.
     unfold has_been_observed; cbn; unfold has_been_observed_from_sent_received; cbn.
     apply composite_has_been_observed_sent_received_iff.
@@ -2406,51 +2341,38 @@ End Composite.
 
   Lemma composite_has_been_observed_from_component
     {message}
-    `{IndEqDec : EqDecision index}
+    `{finite.Finite index}
     (IM : index -> VLSM message)
-    (Hbs : forall i : index, HasBeenSentCapability (IM i))
-    (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
-    (Hbo : forall i : index, HasBeenObservedCapability (IM i)
-      := fun i => HasBeenObservedCapability_from_sent_received (IM i))
+    `{forall i : index, HasBeenSentCapability (IM i)}
+    `{forall i : index, HasBeenReceivedCapability (IM i)}
     (s : composite_state IM)
     (i : index)
     (m : message)
-    : has_been_observed (IM i) (s i) m -> composite_has_been_observed IM Hbo s m.
+    : has_been_observed (IM i) (s i) m -> composite_has_been_observed IM s m.
   Proof.
     exists i. assumption.
   Qed.
 
-(* Make also A and sender implicit, because they are inferrable from Hsender_safety *)
-Arguments has_been_sent_iff_by_sender {message index}%type_scope {IndEqDec} _%function_scope
-  _%function_scope {validator}%type_scope {A sender}%function_scope Hsender_safety [is s] [tr]%list_scope _ [m v].
-
   Lemma lift_to_composite_state_observed
     {message}
-    `{IndEqDec : EqDecision index}
+    `{finite.Finite index}
     (IM : index -> VLSM message)
-    (Hbs : forall i : index, HasBeenSentCapability (IM i))
-    (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
-    (Hbo : forall i : index, HasBeenObservedCapability (IM i)
-      := fun i => HasBeenObservedCapability_from_sent_received (IM i))
-    {index_listing : list index}
-    (finite_index : Listing index_listing)
+    `{forall i : index, HasBeenSentCapability (IM i)}
+    `{forall i : index, HasBeenReceivedCapability (IM i)}
     (i : index)
     (s : vstate (IM i))
     (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) s)
     (m : message)
-    : composite_has_been_observed IM Hbo (lift_to_composite_state IM i s) m <-> has_been_observed (HasBeenObservedCapability := Hbo i) (IM i) s m.
+    : composite_has_been_observed IM (lift_to_composite_state IM i s) m <-> has_been_observed (IM i) s m.
   Proof.
     pose (free_composite_vlsm IM) as Free.
-    pose (free_composite_HasBeenObservedCapability IM finite_index Hbo) as Free_Hbo.
-    pose (free_composite_HasBeenReceivedCapability IM finite_index Hbr) as Free_Hbr.
-    pose (free_composite_HasBeenSentCapability IM finite_index Hbs) as Free_Hbs.
     assert
       (Hlift_s : valid_state_prop (pre_loaded_with_all_messages_vlsm Free) (lift_to_composite_state IM i s)).
     { revert Hs.  apply valid_state_preloaded_composite_free_lift. }
     split; intros Hobs.
-    - apply (proper_observed (Hbo i)); [assumption|].
+    - apply (proper_observed (IM i)); [assumption|].
       intros is tr Htr.
-      apply (proper_observed Free_Hbo) in Hobs
+      apply composite_has_been_observed_free_iff, proper_observed in Hobs
       ; [|assumption].
       apply (VLSM_full_projection_finite_valid_trace_init_to (lift_to_composite_preloaded_vlsm_full_projection IM i)) in Htr as Hpre_tr.
       specialize (Hobs _ _ Hpre_tr).
@@ -2466,10 +2388,10 @@ Arguments has_been_sent_iff_by_sender {message index}%type_scope {IndEqDec} _%fu
       subst composite_item.
       destruct item. simpl in *.
       assumption.
-    - apply (proper_observed Free_Hbo); [assumption|].
-      apply has_been_observed_consistency; [assumption|assumption|].
-      apply (proper_observed (Hbo i)) in Hobs ; [|assumption].
-      apply has_been_observed_consistency in Hobs; [|apply Hbo|assumption].
+    - apply composite_has_been_observed_free_iff, proper_observed; [assumption|].
+      apply has_been_observed_consistency; [typeclasses eauto|assumption|].
+      apply proper_observed in Hobs ; [|assumption].
+      apply has_been_observed_consistency in Hobs; [|typeclasses eauto|assumption].
       destruct Hobs as [is [tr [Htr Hobs]]].
       apply (VLSM_full_projection_finite_valid_trace_init_to (lift_to_composite_preloaded_vlsm_full_projection IM i)) in Htr as Hpre_tr.
       eexists. eexists. exists Hpre_tr.
@@ -2491,8 +2413,8 @@ Context
   `{EqDecision message}
   (X : VLSM message)
   (PreX := pre_loaded_with_all_messages_vlsm X)
-  {Hbs : HasBeenSentCapability X}
-  {Hbr : HasBeenReceivedCapability X}
+  `{HasBeenSentCapability message X}
+  `{HasBeenReceivedCapability message X}
   .
 
 Definition state_received_not_sent (s : state) (m : message) : Prop :=
@@ -2734,18 +2656,14 @@ Section all_traces_to_valid_state_are_valid.
 Context
   {message : Type}
   {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
+  `{forall i : index, (HasBeenReceivedCapability (IM i))}
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
   (PreX := pre_loaded_with_all_messages_vlsm X)
-  (has_been_received_capabilities : forall i : index, (HasBeenReceivedCapability (IM i)))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
-  (X_HasBeenReceivedCapability : HasBeenReceivedCapability X
-    := composite_HasBeenReceivedCapability IM finite_index has_been_received_capabilities constraint).
+  .
 
-Existing Instance X_HasBeenReceivedCapability.
 
 (**
 Under [HasBeenReceivedCapability] assumptions, and given the fact that
@@ -2766,13 +2684,10 @@ Proof.
   apply pre_traces_with_valid_inputs_are_valid in Htr; [assumption|].
   apply valid_trace_last_pstate in Htr as Hspre.
   intros.
-  apply
-    (composite_received_valid IM finite_index
-      has_been_received_capabilities _ _ Hs
-    ).
+  eapply composite_received_valid; [eassumption|].
   specialize (proper_received _ s Hspre m) as Hproper.
   apply proj2 in Hproper. apply Hproper.
-  apply has_been_received_consistency; [assumption|assumption|].
+  apply has_been_received_consistency; [typeclasses eauto|assumption|].
   exists is, tr, Htr. assumption.
 Qed.
 
@@ -2783,7 +2698,7 @@ Section has_been_received_in_state.
   Context
     {message : Type}
     (X : VLSM message)
-    (Hbr : HasBeenReceivedCapability X)
+    `{HasBeenReceivedCapability message X}
   .
 
   Lemma has_been_received_in_state s1 m:

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -1,4 +1,4 @@
-From stdpp Require Import prelude.
+From stdpp Require Import prelude finite.
 From Coq Require Import FinFun FunctionalExtensionality.
 From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces Core.SubProjectionTraces Core.Equivocation Core.Equivocation.NoEquivocation.
@@ -20,20 +20,12 @@ Section fixed_equivocation_without_fullnode.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
-  (Hbo : forall i : index, HasBeenObservedCapability (IM i)
-    := fun i => HasBeenObservedCapability_from_sent_received (IM i))
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  `{forall i : index, HasBeenReceivedCapability (IM i)}
   (equivocating : set index)
   (Free := free_composite_vlsm IM)
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
-  (Free_HasBeenSentCapability : HasBeenSentCapability Free := free_composite_HasBeenSentCapability IM finite_index Hbs)
-  (Free_HasBeenReceivedCapability : HasBeenReceivedCapability Free := free_composite_HasBeenReceivedCapability IM finite_index Hbr)
-  (Free_HasBeenObservedCapability : HasBeenObservedCapability Free := free_composite_HasBeenObservedCapability IM finite_index Hbo)
   (index_equivocating_prop : index -> Prop := sub_index_prop equivocating)
   (equivocating_index : Type := sub_index equivocating)
   (equivocating_IM := sub_IM IM equivocating)
@@ -60,7 +52,7 @@ Given a composite state <<s>>, we define the composition of equivocators
 preloaded with the messages observed in s.
 *)
 Definition equivocators_composition_for_observed s
-  := pre_loaded_free_equivocating_vlsm_composition (composite_has_been_observed IM Hbo s).
+  := pre_loaded_free_equivocating_vlsm_composition (composite_has_been_observed IM s).
 
 (**
 The fixed equivocation constraint for the regular composition of nodes
@@ -69,7 +61,7 @@ or it can be emited by the free composition of equivocators pre-loaded with
 the messages observed in the current state.
 *)
 Definition fixed_equivocation s m
-  := composite_has_been_observed IM Hbo s m \/
+  := composite_has_been_observed IM s m \/
     can_emit (equivocators_composition_for_observed s) m.
 
 Definition fixed_equivocation_constraint
@@ -120,24 +112,24 @@ Definition sent_by_non_equivocating s m
 Global Instance sent_by_non_equivocating_dec : RelDecision sent_by_non_equivocating.
 Proof.
   intros s m.
-  apply @Decision_iff with (P := Exists (fun i => has_been_sent (IM i) (s i) m) (filter (fun i => i ∉ equivocating) index_listing)).
+  apply @Decision_iff with (P := Exists (fun i => has_been_sent (IM i) (s i) m) (filter (fun i => i ∉ equivocating) (enum index))).
   - rewrite Exists_exists. apply exist_proper. intro i.
     rewrite elem_of_list_filter. apply and_iff_compat_r.
     split; [intros [Hi Hl]; assumption|split; [assumption|]].
-    apply elem_of_list_In, finite_index.
+    apply elem_of_enum.
   - apply Exists_dec. intro i. apply has_been_sent_dec.
 Qed.
 
 Lemma sent_by_non_equivocating_are_sent s m
   (Hsent : sent_by_non_equivocating s m)
-  : composite_has_been_sent IM Hbs s m.
+  : composite_has_been_sent IM s m.
 Proof.
   destruct Hsent as [i [Hi Hsent]]. exists i. assumption.
 Qed.
 
 Lemma sent_by_non_equivocating_are_observed s m
   (Hsent : sent_by_non_equivocating s m)
-  : composite_has_been_observed IM Hbo s m.
+  : composite_has_been_observed IM s m.
 Proof.
   apply composite_has_been_observed_sent_received_iff.
   left. apply sent_by_non_equivocating_are_sent. assumption.
@@ -219,15 +211,10 @@ Section fixed_equivocation_index_incl.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
-  (Hbo : forall i : index, HasBeenObservedCapability (IM i)
-    := fun i => HasBeenObservedCapability_from_sent_received (IM i))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  `{forall i : index, HasBeenReceivedCapability (IM i)}
   (indices1 indices2 : list index)
   (Hincl : indices1 ⊆ indices2)
   .
@@ -235,8 +222,8 @@ Context
 Lemma equivocators_composition_for_observed_index_incl_full_projection
   (s: state)
   : VLSM_full_projection
-    (equivocators_composition_for_observed IM Hbs Hbr indices1 s)
-    (equivocators_composition_for_observed IM Hbs Hbr indices2 s)
+    (equivocators_composition_for_observed IM indices1 s)
+    (equivocators_composition_for_observed IM indices2 s)
     (lift_sub_incl_label IM _ _ Hincl) (lift_sub_incl_state IM _ _).
 Proof.
   apply lift_sub_incl_preloaded_full_projection. intro. exact id.
@@ -244,8 +231,8 @@ Qed.
 
 Lemma fixed_equivocation_index_incl_subsumption
   : forall s m,
-    fixed_equivocation IM Hbs Hbr indices1 s m ->
-    fixed_equivocation IM Hbs Hbr indices2 s m.
+    fixed_equivocation IM indices1 s m ->
+    fixed_equivocation IM indices2 s m.
 Proof.
   intros s m [Hobs | Hemit]; [left; assumption|].
   right.
@@ -258,8 +245,8 @@ Qed.
 
 Lemma fixed_equivocation_constraint_index_incl_subsumption
   : strong_constraint_subsumption IM
-    (fixed_equivocation_constraint IM Hbs Hbr indices1)
-    (fixed_equivocation_constraint IM Hbs Hbr indices2).
+    (fixed_equivocation_constraint IM indices1)
+    (fixed_equivocation_constraint IM indices2).
 Proof.
   intros l (s, [m|]); [|exact id].
   apply fixed_equivocation_index_incl_subsumption.
@@ -267,8 +254,8 @@ Qed.
 
 Lemma fixed_equivocation_vlsm_composition_index_incl
   : VLSM_incl
-    (fixed_equivocation_vlsm_composition IM Hbs Hbr indices1)
-    (fixed_equivocation_vlsm_composition IM Hbs Hbr indices2).
+    (fixed_equivocation_vlsm_composition IM indices1)
+    (fixed_equivocation_vlsm_composition IM indices2).
 Proof.
   apply constraint_subsumption_incl.
   apply preloaded_constraint_subsumption_stronger.
@@ -294,19 +281,14 @@ Section fixed_equivocator_sub_projection.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i, HasBeenSentCapability (IM i))
-  (Hbr : forall i, HasBeenReceivedCapability (IM i))
-  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
+  `{forall i, HasBeenSentCapability (IM i)}
+  `{forall i, HasBeenReceivedCapability (IM i)}
   (equivocators : list index)
-  (Fixed := fixed_equivocation_vlsm_composition IM Hbs Hbr equivocators)
-  (StrongFixed := strong_fixed_equivocation_vlsm_composition IM Hbs equivocators)
+  (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
+  (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
   (Free := free_composite_vlsm IM)
-  (Free_hbo := free_composite_HasBeenObservedCapability IM finite_index Hbo)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
@@ -332,13 +314,13 @@ Qed.
 Lemma in_futures_preserves_strong_fixed_equivocation s base_s
   (Hfuture_s : in_futures PreFree s base_s)
   m
-  (Hstrong : strong_fixed_equivocation IM Hbs equivocators s m)
-  : strong_fixed_equivocation IM Hbs equivocators base_s m.
+  (Hstrong : strong_fixed_equivocation IM equivocators s m)
+  : strong_fixed_equivocation IM equivocators base_s m.
 Proof.
   assert
     (Hpreserve : forall m0,
-      sent_by_non_equivocating IM Hbs equivocators s m0 ->
-      sent_by_non_equivocating IM Hbs equivocators base_s m0).
+      sent_by_non_equivocating IM equivocators s m0 ->
+      sent_by_non_equivocating IM equivocators base_s m0).
   { clear -Hfuture_s. intros m Hsent.
     destruct Hsent as [i [Hi Hsent]]. exists i. split; [assumption|].
     revert Hsent.
@@ -357,8 +339,8 @@ Proof.
 Qed.
 
 Lemma strong_fixed_equivocation_eqv_valid_message base_s m
-  (Hstrong : strong_fixed_equivocation IM Hbs equivocators base_s m)
-  : valid_message_prop (equivocators_composition_for_sent IM Hbs equivocators base_s) m.
+  (Hstrong : strong_fixed_equivocation IM equivocators base_s m)
+  : valid_message_prop (equivocators_composition_for_sent IM equivocators base_s) m.
 Proof.
    destruct Hstrong as [Hobs | Hemit].
   - apply initial_message_is_valid. right. assumption.
@@ -368,8 +350,8 @@ Qed.
 Lemma strong_fixed_equivocation_eqv_valid_message_in_futures base_s s
   (Hfuture_s : in_futures PreFree s base_s)
   m
-  (Hstrong : strong_fixed_equivocation IM Hbs equivocators s m)
-  : valid_message_prop (equivocators_composition_for_sent IM Hbs equivocators base_s) m.
+  (Hstrong : strong_fixed_equivocation IM equivocators s m)
+  : valid_message_prop (equivocators_composition_for_sent IM equivocators base_s) m.
 Proof.
   destruct (in_futures_preserves_strong_fixed_equivocation _ _ Hfuture_s _ Hstrong)
     as [Hobs | Hemit].
@@ -392,15 +374,15 @@ We then restate (some of) these lemmas without the extra assumption.
 
 Context
   (base_s s : composite_state IM)
-  (Hobs_s_protocol : forall m, composite_has_been_observed IM Hbo s m ->
-    strong_fixed_equivocation IM Hbs equivocators base_s m)
+  (Hobs_s_protocol : forall m, composite_has_been_observed IM s m ->
+    strong_fixed_equivocation IM equivocators base_s m)
   .
 
 (** See Lemma [fixed_input_has_strong_fixed_equivocation] below. *)
 Local Lemma fixed_input_has_strong_fixed_equivocation_helper
   l m
   (Hv : input_valid Fixed l (s, Some m))
-  : strong_fixed_equivocation IM Hbs equivocators base_s m.
+  : strong_fixed_equivocation IM equivocators base_s m.
 Proof.
   destruct Hv as [_ [_ [_ [Hobs | Hemit]]]].
   - apply Hobs_s_protocol. assumption.
@@ -416,13 +398,13 @@ Proof.
 Qed.
 
 Local Lemma fixed_input_valid_transition_sub_projection_helper
-  (Hs_pr: valid_state_prop (equivocators_composition_for_sent IM Hbs equivocators base_s)
+  (Hs_pr: valid_state_prop (equivocators_composition_for_sent IM equivocators base_s)
     (composite_state_sub_projection IM equivocators s))
   l
   (e : sub_index_prop equivocators (projT1 l))
   iom oom sf
   (Ht : input_valid_transition Fixed l (s, iom) (sf, oom))
-  : input_valid_transition (equivocators_composition_for_sent IM Hbs equivocators base_s)
+  : input_valid_transition (equivocators_composition_for_sent IM equivocators base_s)
       (composite_label_sub_projection IM equivocators l e)
       (composite_state_sub_projection IM equivocators s, iom)
       (composite_state_sub_projection IM equivocators sf, oom).
@@ -452,13 +434,13 @@ Qed.
 
 (** See Lemma [fixed_output_has_strong_fixed_equivocation] below. *)
 Local Lemma fixed_output_has_strong_fixed_equivocation_helper
-  (Hs_pr: valid_state_prop (equivocators_composition_for_sent IM Hbs equivocators base_s)
+  (Hs_pr: valid_state_prop (equivocators_composition_for_sent IM equivocators base_s)
     (composite_state_sub_projection IM equivocators s))
   sf
   (Hfuture : in_futures PreFree sf base_s)
   l iom om
   (Ht : input_valid_transition Fixed l (s, iom) (sf, Some om))
-  : strong_fixed_equivocation IM Hbs equivocators base_s om.
+  : strong_fixed_equivocation IM equivocators base_s om.
 Proof.
   destruct (decide (projT1 l ∈ equivocators)).
   - apply
@@ -495,20 +477,22 @@ Lemma fixed_finite_valid_trace_sub_projection_helper
   (Htr: finite_valid_trace_init_to Fixed si s tr)
   base_s
   (Hfuture: in_futures PreFree s base_s)
-  : finite_valid_trace_from_to (equivocators_composition_for_sent IM Hbs equivocators base_s)
+  : finite_valid_trace_from_to (equivocators_composition_for_sent IM equivocators base_s)
     (composite_state_sub_projection IM equivocators si)
     (composite_state_sub_projection IM equivocators s)
     (finite_trace_sub_projection IM equivocators tr) /\
-    forall m, composite_has_been_observed IM Hbo s m ->
-      strong_fixed_equivocation IM Hbs equivocators base_s m.
+    forall m, composite_has_been_observed IM s m ->
+      strong_fixed_equivocation IM equivocators base_s m.
 Proof.
   induction Htr using finite_valid_trace_init_to_rev_ind.
   - split.
     + apply finite_valid_trace_from_to_empty.
       apply (composite_initial_state_sub_projection IM equivocators si) in Hsi.
       apply initial_state_is_valid. assumption.
-    + intros m Hobs. apply @has_been_observed_no_inits with (m := m) (Hhbo := Free_hbo) in Hsi.
-      contradiction.
+    + intros m Hobs.
+      exfalso.
+      eapply (@has_been_observed_no_inits _ Free); [eassumption|].
+      apply composite_has_been_observed_free_iff; eassumption.
   - apply (VLSM_incl_input_valid_transition Fixed_incl_Preloaded) in Ht as Hpre_t.
     assert (Hfuture_s : in_futures PreFree s base_s).
     { destruct Hfuture as [tr' Htr'].
@@ -518,9 +502,10 @@ Proof.
     specialize (IHHtr Hfuture_s) as [Htr_pr Htr_obs].
     split.
     2: {
-      intros m Hobs. apply @has_been_observed_step_update with (msg := m) (Hhbo := Free_hbo) in Hpre_t.
-      apply Hpre_t in Hobs. destruct Hobs as [Hitem | Hobs]
-      ; [| apply Htr_obs in Hobs; assumption].
+      intros m Hobs.
+      eapply @has_been_observed_step_update with (msg := m) (vlsm := Free) in Hpre_t.
+      apply composite_has_been_observed_free_iff,Hpre_t in Hobs. destruct Hobs as [Hitem | Hobs]
+      ; [| apply composite_has_been_observed_free_iff,Htr_obs in Hobs; assumption].
       apply valid_trace_last_pstate in Htr.
       apply valid_trace_last_pstate in Htr_pr.
       destruct Hitem as [Hm | Hm];  subst.
@@ -530,23 +515,23 @@ Proof.
     rewrite (finite_trace_sub_projection_app IM equivocators). simpl.
     unfold pre_VLSM_projection_transition_item_project. simpl.
     unfold composite_label_sub_projection_option.
-    case_decide.
+    case_decide as Hl.
     + eapply finite_valid_trace_from_to_app; [apply Htr_pr|].
       apply finite_valid_trace_from_to_singleton. simpl.
       apply valid_trace_last_pstate in Htr_pr.
-      apply (fixed_input_valid_transition_sub_projection_helper _ _ Htr_obs Htr_pr _ H _ _ _ Ht).
+      apply (fixed_input_valid_transition_sub_projection_helper _ _ Htr_obs Htr_pr _ Hl _ _ _ Ht).
     + rewrite app_nil_r.
       replace (composite_state_sub_projection _ _ sf) with (composite_state_sub_projection IM equivocators s)
       ; [assumption|].
       apply proj2 in Ht. simpl in Ht.
       destruct l as (i, li). destruct (vtransition _ _ _) as (si', om').
-      inversion Ht. unfold from_sub_projection in H. simpl in H.
-      clear -H.
-      apply functional_extensionality_dep. intro sub_j.
-      destruct_dec_sig sub_j j Hj Heqsub_j. subst.
+      inversion_clear Ht.
+      clear -Hl.
+      extensionality sub_j; destruct_dec_sig sub_j j Hj Heqsub_j; subst.
       unfold composite_state_sub_projection. simpl.
       rewrite state_update_neq; [reflexivity|].
-      intro. subst. contradiction.
+      contradict Hl.
+      simpl; subst; assumption.
 Qed.
 
 (**
@@ -561,7 +546,7 @@ proved above.
 Lemma fixed_finite_valid_trace_sub_projection is f tr
   (Htr : finite_valid_trace_init_to Fixed is f tr)
   : finite_valid_trace_init_to
-              (equivocators_composition_for_sent IM Hbs equivocators f)
+              (equivocators_composition_for_sent IM equivocators f)
               (composite_state_sub_projection IM equivocators is)
               (composite_state_sub_projection IM equivocators f)
               (finite_trace_sub_projection IM equivocators tr).
@@ -583,8 +568,8 @@ using only the messages sent by the non-equivocating nodes.
 Lemma fixed_observed_has_strong_fixed_equivocation f
   (Hf : valid_state_prop Fixed f)
   m
-  (Hobs: composite_has_been_observed IM Hbo f m)
-  : strong_fixed_equivocation IM Hbs equivocators f m.
+  (Hobs: composite_has_been_observed IM f m)
+  : strong_fixed_equivocation IM equivocators f m.
 Proof.
   apply (VLSM_incl_valid_state Fixed_incl_Preloaded) in Hf as Hfuture.
   apply in_futures_refl in Hfuture.
@@ -598,7 +583,7 @@ Qed.
 Lemma fixed_valid_state_sub_projection s f
   (Hsf : in_futures Fixed s f)
   : valid_state_prop
-    (equivocators_composition_for_sent IM Hbs equivocators f)
+    (equivocators_composition_for_sent IM equivocators f)
     (composite_state_sub_projection IM equivocators s).
 Proof.
   destruct Hsf as [tr Htr].
@@ -618,7 +603,7 @@ property.
 Lemma fixed_input_has_strong_fixed_equivocation
   l s m
   (Ht : input_valid Fixed l (s, Some m))
-  : strong_fixed_equivocation IM Hbs equivocators s m.
+  : strong_fixed_equivocation IM equivocators s m.
 Proof.
   apply fixed_input_has_strong_fixed_equivocation_helper with (base_s := s) in Ht
   ; [assumption|].
@@ -632,7 +617,7 @@ property for its destination.
 Lemma fixed_output_has_strong_fixed_equivocation
   l s iom sf om
   (Ht : input_valid_transition Fixed l (s, iom) (sf, Some om))
-  : strong_fixed_equivocation IM Hbs equivocators sf om.
+  : strong_fixed_equivocation IM equivocators sf om.
 Proof.
   apply input_valid_transition_origin in Ht as Hs.
   apply fixed_output_has_strong_fixed_equivocation_helper with s sf l iom.
@@ -666,17 +651,13 @@ Section Fixed_eq_StrongFixed.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i, HasBeenSentCapability (IM i))
-  (Hbr : forall i, HasBeenReceivedCapability (IM i))
-  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
+  `{forall i, HasBeenSentCapability (IM i)}
+  `{forall i, HasBeenReceivedCapability (IM i)}
   (equivocators : list index)
-  (Fixed := fixed_equivocation_vlsm_composition IM Hbs Hbr equivocators)
-  (StrongFixed := strong_fixed_equivocation_vlsm_composition IM Hbs equivocators)
+  (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
+  (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
   (Free := free_composite_vlsm IM)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
   .
@@ -689,26 +670,26 @@ than that preloaded with only the messages sent by non-equivocators.
 Lemma Equivocators_Fixed_Strong_incl base_s
   (Hbase_s : valid_state_prop Fixed base_s)
   : VLSM_incl
-      (equivocators_composition_for_observed IM Hbs Hbr equivocators base_s)
-      (equivocators_composition_for_sent IM Hbs equivocators base_s).
+      (equivocators_composition_for_observed IM equivocators base_s)
+      (equivocators_composition_for_sent IM equivocators base_s).
 Proof.
-  apply basic_VLSM_incl; intro; intros.
-  - assumption.
-  - destruct HmX as [Hinit | Hobs]
+  apply basic_VLSM_incl.
+  - intro; intros; assumption.
+  - intro; intros. destruct HmX as [Hinit | Hobs]
     ; [apply initial_message_is_valid; left; assumption|].
     apply strong_fixed_equivocation_eqv_valid_message.
     revert Hobs.
-    apply (fixed_observed_has_strong_fixed_equivocation IM Hbs Hbr finite_index).
+    apply fixed_observed_has_strong_fixed_equivocation.
     assumption.
-  - apply Hv.
-  - apply H.
+  - intros l s om (_ & _ & Hv) _ _; assumption.
+  - intros l s om s' om' [_ Ht]; assumption.
 Qed.
 
 Lemma Equivocators_Fixed_Strong_eq base_s
   (Hbase_s : valid_state_prop Fixed base_s)
   : VLSM_eq
-      (equivocators_composition_for_observed IM Hbs Hbr equivocators base_s)
-      (equivocators_composition_for_sent IM Hbs equivocators base_s).
+      (equivocators_composition_for_observed IM equivocators base_s)
+      (equivocators_composition_for_sent IM equivocators base_s).
 Proof.
   apply VLSM_eq_incl_iff. split.
   - apply Equivocators_Fixed_Strong_incl. assumption.
@@ -720,13 +701,13 @@ Qed.
 *)
 Lemma fixed_strong_equivocation_subsumption
   : input_valid_constraint_subsumption IM
-    (fixed_equivocation_constraint IM Hbs Hbr equivocators)
-    (strong_fixed_equivocation_constraint IM Hbs equivocators).
+    (fixed_equivocation_constraint IM equivocators)
+    (strong_fixed_equivocation_constraint IM equivocators).
 Proof.
   intros l (s, om) Hv.
   destruct om as [m|]; [|exact I].
   apply proj1 in Hv as Hs.
-  revert Hv. apply (fixed_input_has_strong_fixed_equivocation _ _ _ finite_index).
+  eapply fixed_input_has_strong_fixed_equivocation; eassumption.
 Qed.
 
 Lemma Fixed_incl_StrongFixed : VLSM_incl Fixed StrongFixed.
@@ -762,30 +743,23 @@ Section fixed_equivocator_lifting.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i, HasBeenSentCapability (IM i))
-  (Hbr : forall i, HasBeenReceivedCapability (IM i))
-  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
+  `{forall i, HasBeenSentCapability (IM i)}
+  `{forall i, HasBeenReceivedCapability (IM i)}
   (equivocators : list index)
   (Free := free_composite_vlsm IM)
-  (Fixed := fixed_equivocation_vlsm_composition IM Hbs Hbr equivocators)
-  (StrongFixed := strong_fixed_equivocation_vlsm_composition IM Hbs equivocators)
+  (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
+  (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
-  (Free_hbo := free_composite_HasBeenObservedCapability IM finite_index Hbo)
-  (Free_hbr := free_composite_HasBeenReceivedCapability IM finite_index Hbr)
-  (Free_hbs := free_composite_HasBeenSentCapability IM finite_index Hbs)
   .
 
 (** Replacing the state corresponding to the equivocators does not affect the
 [sent_by_non_equivocating] property.
 *)
 Lemma lift_sub_state_to_sent_by_non_equivocating_iff s eqv_is m
-  : sent_by_non_equivocating IM Hbs equivocators s m <->
-    sent_by_non_equivocating IM Hbs equivocators (lift_sub_state_to IM equivocators s eqv_is) m.
+  : sent_by_non_equivocating IM equivocators s m <->
+    sent_by_non_equivocating IM equivocators (lift_sub_state_to IM equivocators s eqv_is) m.
 Proof.
   split; intros [i [Hi Hsent]]; exists i; split; [assumption| | assumption| ]
   ; revert Hsent
@@ -797,8 +771,8 @@ Qed.
 *)
 Lemma restrict_observed_to_non_equivocating_incl s eqv_is
   : VLSM_incl
-    (equivocators_composition_for_sent IM Hbs equivocators s)
-    (equivocators_composition_for_sent IM Hbs equivocators
+    (equivocators_composition_for_sent IM equivocators s)
+    (equivocators_composition_for_sent IM equivocators
       (lift_sub_state_to IM equivocators s eqv_is)).
 Proof.
   apply pre_loaded_vlsm_incl.
@@ -807,9 +781,9 @@ Qed.
 
 Lemma restrict_observed_to_non_equivocating_incl_rev s eqv_is
   : VLSM_incl
-    (equivocators_composition_for_sent IM Hbs equivocators
+    (equivocators_composition_for_sent IM equivocators
       (lift_sub_state_to IM equivocators s eqv_is))
-    (equivocators_composition_for_sent IM Hbs equivocators s).
+    (equivocators_composition_for_sent IM equivocators s).
 Proof.
   apply pre_loaded_vlsm_incl.
   apply lift_sub_state_to_sent_by_non_equivocating_iff.
@@ -819,8 +793,8 @@ Qed.
 [strong_fixed_equivocation] property.
 *)
 Lemma lift_sub_state_to_strong_fixed_equivocation s eqv_is m
-  : strong_fixed_equivocation IM Hbs equivocators s m <->
-    strong_fixed_equivocation IM Hbs equivocators (lift_sub_state_to IM equivocators s eqv_is) m.
+  : strong_fixed_equivocation IM equivocators s m <->
+    strong_fixed_equivocation IM equivocators (lift_sub_state_to IM equivocators s eqv_is) m.
 Proof.
   split; intros [Hs | Hs]; [left|right|left|right]; revert Hs.
   - apply lift_sub_state_to_sent_by_non_equivocating_iff.
@@ -840,56 +814,61 @@ Lemma remove_equivocating_transitions_fixed_projection eqv_is
   (Heqv_is : composite_initial_state_prop (sub_IM IM equivocators) eqv_is)
   : VLSM_projection StrongFixed StrongFixed (remove_equivocating_label_project IM equivocators) (remove_equivocating_state_project IM equivocators eqv_is).
 Proof.
-  apply basic_VLSM_strong_projection; intro; intros.
-  - destruct lX as [i liX].
+  apply basic_VLSM_strong_projection.
+  - intros (i, liX) lY.
     unfold remove_equivocating_state_project.
-    unfold remove_equivocating_label_project in H.
-    simpl in H.
-    destruct (decide _); [congruence|]. inversion H. subst. clear H.
-    destruct H0 as [Hv Hc]. cbn in Hv.
+    unfold remove_equivocating_label_project.
+    simpl.
+    case_decide as Hi; [congruence|].
+    inversion_clear 1.
+    intros s om [Hv Hc].
     split.
     + cbn. rewrite lift_sub_state_to_neq; assumption.
     + destruct om as [m|]; [|exact I].
       apply lift_sub_state_to_strong_fixed_equivocation. assumption.
-  - destruct lX as [i liX].
+  - intros [i liX] lY.
     unfold remove_equivocating_state_project.
-    unfold remove_equivocating_label_project in H.
-    simpl in H.
-    destruct (decide _); [congruence|]. inversion H. subst. clear H.
-    revert H0. cbn.
+    unfold remove_equivocating_label_project.
+    cbn.
+    case_decide as Hi; [congruence|].
+    inversion_clear 1.
+    intros s om s' om'.
     rewrite lift_sub_state_to_neq by assumption.
     destruct (vtransition _ _ _) as (si', _om').
-    inversion_clear 1. f_equal.
-    apply functional_extensionality_dep. intro j.
+    inversion_clear 1.
+    f_equal.
+    extensionality j.
     destruct (decide (i = j)).
     + subst. rewrite lift_sub_state_to_neq by assumption.
       rewrite !state_update_eq. reflexivity.
     + rewrite state_update_neq by congruence.
       unfold lift_sub_state_to. destruct (decide _); [reflexivity|].
       rewrite state_update_neq by congruence. reflexivity.
-  - destruct lX as [i liX].
+  - intros (i, liX).
     unfold remove_equivocating_state_project.
-    unfold remove_equivocating_label_project in H.
-    simpl in H.
-    destruct (decide _); [|congruence]. clear H.
-    cbn in H0. destruct (vtransition _ _ _) as (si', _om') eqn:Hti.
-    inversion_clear H0.
-    apply functional_extensionality_dep. intro j.
+    unfold remove_equivocating_label_project.
+    cbn.
+    case_decide as Hi; [|congruence].
+    intros _ s om s' om'.
+    destruct (vtransition _ _ _) as (si', _om') eqn:Hti.
+    inversion_clear 1.
+    extensionality j.
     unfold lift_sub_state_to.
-    destruct (decide _); [reflexivity|].
-    destruct (decide (i = j)); [subst; contradiction|].
+    case_decide as Hj; [reflexivity|].
+    destruct (decide (i = j)); [contradict Hj; subst; assumption|].
     apply state_update_neq. congruence.
-  - intro i. unfold remove_equivocating_state_project, lift_sub_state_to.
-    destruct (decide _).
-    + exact (Heqv_is (dec_exist _ i s0)).
-    + exact (H i).
-  - assumption.
+  - intros s Hs i.
+    unfold remove_equivocating_state_project, lift_sub_state_to.
+    case_decide as Hi.
+    + exact (Heqv_is (dexist i Hi)).
+    + exact (Hs i).
+  - intro; intros; assumption.
 Qed.
 
 Context
   (base_s : composite_state IM)
   (Hbase_s : valid_state_prop Fixed base_s)
-  (EquivPreloadedBase := equivocators_composition_for_sent IM Hbs equivocators base_s)
+  (EquivPreloadedBase := equivocators_composition_for_sent IM equivocators base_s)
   .
 
 (**
@@ -901,15 +880,15 @@ Lemma fixed_equivocator_lifting_initial_state
   : weak_full_projection_initial_state_preservation EquivPreloadedBase Fixed (lift_sub_state_to IM equivocators base_s).
 Proof.
   intros eqv_is Heqv_is.
-  apply (VLSM_incl_valid_state (StrongFixed_incl_Fixed IM Hbs Hbr equivocators)).
+  apply (VLSM_incl_valid_state (StrongFixed_incl_Fixed IM equivocators)).
   apply (VLSM_projection_valid_state (remove_equivocating_transitions_fixed_projection _ Heqv_is)).
   revert Hbase_s.
-  apply (VLSM_incl_valid_state (Fixed_incl_StrongFixed IM Hbs Hbr finite_index equivocators)).
+  apply (VLSM_incl_valid_state (Fixed_incl_StrongFixed IM equivocators)).
 Qed.
 
 Lemma lift_sub_state_to_sent_are_observed s
-  : forall m, sent_by_non_equivocating IM Hbs equivocators base_s m ->
-    composite_has_been_observed IM Hbo (lift_sub_state_to IM equivocators base_s s) m.
+  : forall m, sent_by_non_equivocating IM equivocators base_s m ->
+    composite_has_been_observed IM (lift_sub_state_to IM equivocators base_s s) m.
 Proof.
   intros m Hsent.
   apply (lift_sub_state_to_sent_by_non_equivocating_iff base_s s m) in Hsent.
@@ -917,12 +896,13 @@ Proof.
 Qed.
 
 Lemma strong_fixed_equivocation_lift_sub_state_to s
-  : forall m, strong_fixed_equivocation IM Hbs equivocators base_s m ->
-    fixed_equivocation IM Hbs Hbr equivocators (lift_sub_state_to IM equivocators base_s s) m.
+  : forall m, strong_fixed_equivocation IM equivocators base_s m ->
+    fixed_equivocation IM equivocators (lift_sub_state_to IM equivocators base_s s) m.
 Proof.
   intros.
   apply strong_fixed_equivocation_subsumption.
-  revert H. apply lift_sub_state_to_strong_fixed_equivocation.
+  apply lift_sub_state_to_strong_fixed_equivocation.
+  assumption.
 Qed.
 
 (** *** Main result of the section
@@ -946,8 +926,8 @@ Lemma EquivPreloadedBase_Fixed_weak_full_projection
   (no_initial_messages_for_equivocators : forall i m, i ∈ equivocators -> ~vinitial_message_prop (IM i) m)
   : VLSM_weak_full_projection EquivPreloadedBase Fixed (lift_sub_label IM equivocators) (lift_sub_state_to IM equivocators base_s).
 Proof.
-  apply basic_VLSM_weak_full_projection; intro; intros.
-  - split.
+  apply basic_VLSM_weak_full_projection.
+  - intro; intros. split.
     + destruct Hv as [_ [_ [Hv _]]]. revert Hv. destruct l as (i, li).
       destruct_dec_sig i j Hj Heq. subst i.
       simpl. unfold sub_IM. simpl.
@@ -963,14 +943,15 @@ Proof.
         elim (no_initial_messages_for_equivocators j im); assumption.
       * apply strong_fixed_equivocation_lift_sub_state_to. left. assumption.
       * apply strong_fixed_equivocation_lift_sub_state_to. right. assumption.
-  - destruct l as (i, li). destruct H as [Hpv Ht].
-    destruct_dec_sig i j Hj Heq. subst i.
-    revert Ht. cbn. unfold sub_IM at 2. simpl.
+  - intros (sub_i, li) s om s' om'.
+    destruct_dec_sig sub_i j Hj Heq; subst.
+    unfold input_valid_transition. cbn. unfold sub_IM. simpl.
     rewrite lift_sub_state_to_eq with (Hi := Hj).
     destruct (vtransition _ _ _) as (si', _om').
-    inversion_clear 1.
+    intros [_ Ht].
+    inversion_clear Ht.
     f_equal.
-    apply functional_extensionality_dep. intro i.
+    extensionality i.
     destruct (decide (i = j)).
     + subst.
       rewrite lift_sub_state_to_eq with (Hi := Hj).
@@ -981,14 +962,13 @@ Proof.
         rewrite state_update_neq; [reflexivity|].
         intro Hcontra. apply dsig_eq in Hcontra. contradiction.
       * rewrite !lift_sub_state_to_neq by assumption. reflexivity.
-  - apply fixed_equivocator_lifting_initial_state. assumption.
-  - destruct HmX as [Hm | Hm].
+  - intro; intros. apply fixed_equivocator_lifting_initial_state. assumption.
+  - intro; intros. destruct HmX as [Hm | Hm].
     + destruct Hm as [(i, Hi) [[im Him] Heqm]].
       apply initial_message_is_valid.
       exists i. exists (exist _ im Him). subst. reflexivity.
-    + apply (composite_observed_valid IM finite_index Hbs Hbo Hbr _ _ Hbase_s).
-      revert Hm.
-      apply sent_by_non_equivocating_are_observed.
+    + clear HsY. eapply composite_observed_valid; [eassumption|].
+      eapply sent_by_non_equivocating_are_observed; eassumption.
 Qed.
 
 End fixed_equivocator_lifting.
@@ -1003,20 +983,15 @@ Section fixed_equivocation_no_equivocators.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
-  (Hbo : forall i : index, HasBeenObservedCapability (IM i)
-    := fun i => HasBeenObservedCapability_from_sent_received (IM i))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  `{forall i : index, HasBeenReceivedCapability (IM i)}
   .
 
 Lemma strong_fixed_equivocation_no_equivocators
   : forall s m,
-  strong_fixed_equivocation IM Hbs [] s m <-> composite_has_been_sent IM Hbs s m.
+  strong_fixed_equivocation IM [] s m <-> composite_has_been_sent IM s m.
 Proof.
   intros s m.
   split.
@@ -1034,8 +1009,8 @@ Qed.
 
 Lemma strong_fixed_equivocation_constraint_no_equivocators
   : forall l som,
-    strong_fixed_equivocation_constraint IM Hbs [] l som <->
-    composite_no_equivocations IM Hbs l som.
+    strong_fixed_equivocation_constraint IM [] l som <->
+    composite_no_equivocations IM l som.
 Proof.
   intros.
   destruct som as (s, [m|]); [|split; exact id].
@@ -1046,18 +1021,18 @@ Proof.
 Qed.
 
 Lemma strong_fixed_equivocation_vlsm_composition_no_equivocators
-  : VLSM_eq (strong_fixed_equivocation_vlsm_composition IM Hbs [])
-      (composite_vlsm IM (composite_no_equivocations IM Hbs)).
+  : VLSM_eq (strong_fixed_equivocation_vlsm_composition IM [])
+      (composite_vlsm IM (composite_no_equivocations IM)).
 Proof.
   apply VLSM_eq_incl_iff.
   split.
-  - apply (constraint_subsumption_incl IM (strong_fixed_equivocation_constraint IM Hbs []) (composite_no_equivocations IM Hbs)).
+  - apply (constraint_subsumption_incl IM (strong_fixed_equivocation_constraint IM []) (composite_no_equivocations IM)).
     apply preloaded_constraint_subsumption_stronger.
     apply strong_constraint_subsumption_strongest.
     intros l som.
     rewrite strong_fixed_equivocation_constraint_no_equivocators by assumption.
     exact id.
-  - apply (constraint_subsumption_incl IM (composite_no_equivocations IM Hbs) (strong_fixed_equivocation_constraint IM Hbs [])).
+  - apply (constraint_subsumption_incl IM (composite_no_equivocations IM) (strong_fixed_equivocation_constraint IM [])).
     apply preloaded_constraint_subsumption_stronger.
     apply strong_constraint_subsumption_strongest.
     intros l som.
@@ -1066,12 +1041,12 @@ Proof.
 Qed.
 
 Lemma fixed_equivocation_vlsm_composition_no_equivocators
-  : VLSM_eq (fixed_equivocation_vlsm_composition IM Hbs Hbr [])
-      (composite_vlsm IM (composite_no_equivocations IM Hbs)).
+  : VLSM_eq (fixed_equivocation_vlsm_composition IM [])
+      (composite_vlsm IM (composite_no_equivocations IM)).
 Proof.
-  specialize strong_fixed_equivocation_vlsm_composition_no_equivocators.
-  specialize (Fixed_eq_StrongFixed IM Hbs Hbr finite_index []).
-  apply VLSM_eq_trans.
+  eapply VLSM_eq_trans.
+  - apply Fixed_eq_StrongFixed.
+  - apply strong_fixed_equivocation_vlsm_composition_no_equivocators.
 Qed.
 
 End fixed_equivocation_no_equivocators.
@@ -1080,29 +1055,20 @@ Section fixed_non_equivocator_lifting.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
-  {finite_index : finite.Finite index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i, HasBeenSentCapability (IM i))
-  (Hbr : forall i, HasBeenReceivedCapability (IM i))
-  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
+  `{forall i, HasBeenSentCapability (IM i)}
+  `{forall i, HasBeenReceivedCapability (IM i)}
   (equivocators : list index)
   (non_equivocators := set_diff (finite.enum index) equivocators)
   (Free := free_composite_vlsm IM)
-  (Fixed := fixed_equivocation_vlsm_composition IM Hbs Hbr equivocators)
+  (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
   (FixedNonEquivocating:= induced_sub_projection IM non_equivocators
-                                (fixed_equivocation_constraint IM Hbs Hbr
-                                   equivocators))
-  (StrongFixed := strong_fixed_equivocation_vlsm_composition IM Hbs equivocators)
+                                (fixed_equivocation_constraint IM equivocators))
+  (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
   (StrongFixedNonEquivocating:= induced_sub_projection IM non_equivocators
-                                (strong_fixed_equivocation_constraint IM Hbs
-                                   equivocators))
+                                (strong_fixed_equivocation_constraint IM equivocators))
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
-  (finite_listing := FinFunExtras.listing_from_finite index)
-  (Free_hbo := free_composite_HasBeenObservedCapability IM finite_listing Hbo)
-  (Free_hbr := free_composite_HasBeenReceivedCapability IM finite_listing Hbr)
-  (Free_hbs := free_composite_HasBeenSentCapability IM finite_listing Hbs)
   .
 
 (** All valid traces in the induced projection of the composition under the
@@ -1118,8 +1084,8 @@ Proof.
   intros s1 s2 Heq l om.
   destruct om as [m|]; [|intuition].
   cut
-    (forall m, sent_by_non_equivocating IM Hbs equivocators s1 m ->
-      sent_by_non_equivocating IM Hbs equivocators s2 m).
+    (forall m, sent_by_non_equivocating IM equivocators s1 m ->
+      sent_by_non_equivocating IM equivocators s2 m).
   {
     intros Hsent_impl [[j [Hj Hsent]] | Hemit].
     - left. apply Hsent_impl. exists j; split; assumption.
@@ -1131,11 +1097,11 @@ Proof.
   clear -Heq.
   intros m [i [Hi Hsent]].
   exists i. split; [assumption|].
+  replace (s2 i) with (s1 i); [assumption|].
   assert (Hi' : i ∈ non_equivocators)
-    by (apply set_diff_intro; [apply finite_index|assumption]).
-  apply f_equal_dep with (x := dexist i Hi') in Heq.
+    by (apply set_diff_intro; [apply elem_of_enum|assumption]).
+  eapply f_equal_dep with (x := dexist i Hi') in Heq.
   cbv in Heq.
-  rewrite <- Heq.
   assumption.
 Qed.
 
@@ -1152,19 +1118,18 @@ Proof.
   intros sX trX Htr.
   apply
     (VLSM_incl_finite_valid_trace
-      (StrongFixed_incl_Fixed IM Hbs Hbr equivocators)).
+      (StrongFixed_incl_Fixed IM equivocators)).
   apply (VLSM_full_projection_finite_valid_trace lift_strong_fixed_non_equivocating).
   revert Htr.
   apply VLSM_incl_finite_valid_trace.
   apply induced_sub_projection_constraint_subsumption_incl.
-  apply fixed_strong_equivocation_subsumption with (finite.enum index).
-  apply FinFunExtras.listing_from_finite.
+  apply fixed_strong_equivocation_subsumption.
 Qed.
 
 Lemma fixed_non_equivocating_projection_friendliness
   : projection_friendly_prop
       (induced_sub_projection_is_projection IM non_equivocators
-        (fixed_equivocation_constraint IM Hbs Hbr equivocators)).
+        (fixed_equivocation_constraint IM equivocators)).
 Proof.
   apply induced_sub_projection_friendliness.
   apply lift_fixed_non_equivocating.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -117,7 +117,7 @@ Section strong_fixed_equivocation.
 Definition sent_by_non_equivocating s m
   := exists i, i ∉ equivocating /\ has_been_sent (IM i) (s i) m.
 
-Local Instance sent_by_non_equivocating_dec : RelDecision sent_by_non_equivocating.
+Global Instance sent_by_non_equivocating_dec : RelDecision sent_by_non_equivocating.
 Proof.
   intros s m.
   apply @Decision_iff with (P := Exists (fun i => has_been_sent (IM i) (s i) m) (filter (fun i => i ∉ equivocating) index_listing)).

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -100,10 +100,10 @@ any message that tests as [has_been_observed] in a state also tests as
       destruct Henforced; [|contradiction].
       right. assumption.
     - left. reflexivity.
-    - specialize (Hprev Hobs).
-      right. assumption.
+    - right. apply Hprev. assumption.
   Qed.
 
+  (* TODO(wkolowski): make notation uniform accross the file. *)
   Lemma observed_were_sent_invariant s:
     valid_state_prop X s ->
     observed_were_sent s.
@@ -220,17 +220,11 @@ Section CompositeNoEquivocationInvariants.
   Proof.
     intros Hs m.
     rewrite composite_has_been_observed_sent_received_iff.
-    specialize (observed_were_sent_invariant message X) as Hinv.
-    spec Hinv.
-    {
-      intros l s0 om Hv.
-      apply Hsubsumed in Hv.
-      assumption.
-    }
-    spec Hinv s Hs.
     intros Hobs.
-    apply Hinv.
-    assumption.
+    cut (has_been_sent X s m); [intro; assumption|].
+    apply (observed_were_sent_invariant message X); [|assumption|assumption].
+    intros l s0 om.
+    apply Hsubsumed.
   Qed.
 End CompositeNoEquivocationInvariants.
 

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -56,8 +56,8 @@ Section NoEquivocationInvariants.
   Context
     message
     (X: VLSM message)
-    (Hhbs: HasBeenSentCapability X)
-    (Hhbo: HasBeenObservedCapability X)
+    `{HasBeenSentCapability message X}
+    `{HasBeenObservedCapability message X}
     (Henforced: forall l s om, input_valid (pre_loaded_with_all_messages_vlsm X) l (s,om) -> no_equivocations X l (s,om))
   .
 
@@ -77,7 +77,7 @@ any message that tests as [has_been_observed] in a state also tests as
   Proof.
     intros Hinitial msg Hsend.
     contradict Hsend.
-    apply (oracle_no_inits has_been_observed_stepwise_props).
+    apply has_been_observed_no_inits.
     assumption.
   Qed.
 
@@ -89,19 +89,18 @@ any message that tests as [has_been_observed] in a state also tests as
     intros Hptrans Hprev msg Hobs.
     specialize (Hprev msg).
     apply preloaded_weaken_input_valid_transition in Hptrans.
-    apply (oracle_step_update has_been_observed_stepwise_props _ _ _ _ _ Hptrans) in Hobs.
+    eapply (oracle_step_update (has_been_observed_stepwise_props X) _ _ _ _ _ Hptrans) in Hobs.
     simpl in Hobs.
     specialize (Henforced l s (Some msg)).
-    rewrite (oracle_step_update (has_been_sent_stepwise_from_trace Hhbs) _ _ _ _ _ Hptrans).
+    rewrite (oracle_step_update (has_been_sent_stepwise_from_trace X) _ _ _ _ _ Hptrans).
     destruct Hptrans as [Hv _].
-    destruct Hobs as [[|]|].
+    destruct Hobs as [[Hin|Hout]|Hobs]; subst.
     - (* by [no_equivocations], the incoming message [im] was previously sent *)
-      rewrite H in Hv.
       specialize (Henforced Hv).
       destruct Henforced; [|contradiction].
       right. assumption.
-    - left. assumption.
-    - specialize (Hprev H).
+    - left. reflexivity.
+    - specialize (Hprev Hobs).
       right. assumption.
   Qed.
 
@@ -170,14 +169,14 @@ Section CompositeNoEquivocation.
 
 Context
   {message : Type}
-  `{IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
+  `{forall i, HasBeenSentCapability (IM i)}
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (Hbs : forall i, HasBeenSentCapability (IM i))
   .
 
 Definition sent_except_from exception es iom : Prop :=
-  from_option (fun im => composite_has_been_sent IM Hbs es im \/ exception im) True iom.
+  from_option (fun im => composite_has_been_sent IM es im \/ exception im) True iom.
 
 Definition composite_no_equivocations_except_from
   (exception : message -> Prop)
@@ -207,27 +206,30 @@ in the same state.
  *)
 Section CompositeNoEquivocationInvariants.
   Context
-    (Hbo : forall i, HasBeenObservedCapability (IM i))
-    {index_listing : list index}
-    (finite_index : Listing index_listing)
+    `{forall i, HasBeenReceivedCapability (IM i)}
     (X := composite_vlsm IM constraint)
     (Hsubsumed: preloaded_constraint_subsumption IM constraint composite_no_equivocations)
     .
 
   Definition composite_observed_were_sent (s: state) : Prop :=
-    forall msg, composite_has_been_observed IM Hbo s msg -> composite_has_been_sent IM Hbs s msg.
+    forall msg, composite_has_been_observed IM s msg -> composite_has_been_sent IM s msg.
 
   Lemma composite_observed_were_sent_invariant s:
     valid_state_prop X s ->
     composite_observed_were_sent s.
   Proof.
-    intro Hs.
-    apply (observed_were_sent_invariant _ _
-           (composite_HasBeenSentCapability IM finite_index Hbs _)
-           (composite_HasBeenObservedCapability IM finite_index Hbo constraint))
-    ; [|assumption].
-    intros l s' om Hv.
-    apply Hsubsumed in Hv.
+    intros Hs m.
+    rewrite composite_has_been_observed_sent_received_iff.
+    specialize (observed_were_sent_invariant message X) as Hinv.
+    spec Hinv.
+    {
+      intros l s0 om Hv.
+      apply Hsubsumed in Hv.
+      assumption.
+    }
+    spec Hinv s Hs.
+    intros Hobs.
+    apply Hinv.
     assumption.
   Qed.
 End CompositeNoEquivocationInvariants.
@@ -244,8 +246,6 @@ the newly added initial messages are safe to be received at all times.
 
   Context
     (X := free_composite_vlsm IM)
-    {index_listing : list index}
-    (finite_index : Listing index_listing)
     .
 
 Section seeded_composite_vlsm_no_equivocation_definition.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -142,14 +142,14 @@ Lemma input_valid_transition_reflects_trace_witnessing_equivocation_prop
   : trace_witnessing_equivocation_prop is tr.
 Proof.
   apply finite_valid_trace_init_to_last in Htr as Hlst.
-  simpl in Hlst.
-  intros v. split; intros *; simpl in *; rewrite Hlst in *.
+  intros v; split; simpl in *; rewrite Hlst in *.
   - intros Hv.
     apply equivocating_validators_is_equivocating_tracewise_iff in Hv.
-    apply (Hv is). assumption.
+    eapply Hv; eassumption.
   - intros (msg & Hsender & Heqv).
     apply Hincl.
-    spec Hwitness v. rewrite finite_trace_last_is_last in Hwitness.
+    spec Hwitness v;
+    rewrite finite_trace_last_is_last in Hwitness;
     apply Hwitness.
     exists msg. split; [assumption|].
     apply equivocation_in_trace_prefix.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -29,39 +29,22 @@ induced by its set of equivocators.
 Section witnessed_equivocation.
 
 Context
-  {message : Type}
-  {MsgEqDec : EqDecision message}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{EqDecision message}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
-  (Hbo : forall i : index, HasBeenObservedCapability (IM i)
-    := fun i => HasBeenObservedCapability_from_sent_received (IM i))
-  {validator : Type}
-  {ValEqDec : EqDecision validator}
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  `{forall i : index, HasBeenReceivedCapability (IM i)}
+  `{finite.Finite validator}
   (A : validator -> index)
   (sender : message -> option validator)
   (Free := free_composite_vlsm IM)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
-  (Hbs_free : HasBeenSentCapability Free
-    := free_composite_HasBeenSentCapability IM finite_index Hbs)
-  (Hbr_free : HasBeenReceivedCapability Free
-    := free_composite_HasBeenReceivedCapability IM finite_index Hbr)
-  {measurable_V : Measurable validator}
-  {threshold_V : ReachableThreshold validator}
-  {is_equivocating_tracewise_no_has_been_sent_dec : RelDecision (is_equivocating_tracewise_no_has_been_sent IM A sender)}
-  {validator_listing : list validator}
-  (finite_validator : Listing validator_listing)
+  `{ReachableThreshold validator}
+  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM A sender)}
   (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) validator
-    := equivocation_dec_tracewise IM A sender finite_validator)
+    := equivocation_dec_tracewise IM A sender)
   (equivocating_validators := equivocating_validators (BasicEquivocation := Htracewise_BasicEquivocation))
   .
-
-Existing Instance Hbs_free.
-Existing Instance Hbr_free.
 
 (** A trace witnesses the equivocation of its final state <<s>> if its set of
 equivocators is precisely that of the [equivocating_validators] of <<s>>.
@@ -108,13 +91,13 @@ Lemma initial_state_witnessing_equivocation_prop
   (Hs : composite_initial_state_prop IM s)
   : trace_witnessing_equivocation_prop s [].
 Proof.
-  specialize (equivocating_validators_empty_in_initial_state IM A sender finite_validator s Hs) as Hempty.
+  specialize (equivocating_validators_empty_in_initial_state IM A sender s Hs) as Hempty.
   intros v.
   unfold finite_trace_last. simpl.
   replace (equivocating_validators s) with (@nil validator).
   simpl.
   split; [inversion 1|].
-  intros [m [_ Hm]].
+  intros [m [_ Hmsg]].
   elim (no_equivocation_in_empty_trace PreFree m).
   assumption.
 Qed.
@@ -136,7 +119,7 @@ Proof.
   rewrite finite_trace_last_is_last in Hwitness.
   apply Hwitness.
   apply equivocating_validators_is_equivocating_tracewise_iff in Hv.
-  specialize (Hv _ _ Htr) as [m [Hm Heqv]].
+  specialize (Hv _ _ Htr) as [m [Hmsg Heqv]].
   exists m. split; [assumption|].
   apply equivocation_in_trace_prefix. assumption.
 Qed.
@@ -160,13 +143,14 @@ Lemma input_valid_transition_reflects_trace_witnessing_equivocation_prop
 Proof.
   apply finite_valid_trace_init_to_last in Htr as Hlst.
   simpl in Hlst.
-  intros v. split; intros; simpl in *; rewrite Hlst in *.
-  - apply equivocating_validators_is_equivocating_tracewise_iff in H.
-    spec H is tr Htr. assumption.
-  - apply Hincl.
+  intros v. split; intros *; simpl in *; rewrite Hlst in *.
+  - intros Hv.
+    apply equivocating_validators_is_equivocating_tracewise_iff in Hv.
+    apply (Hv is). assumption.
+  - intros (msg & Hsender & Heqv).
+    apply Hincl.
     spec Hwitness v. rewrite finite_trace_last_is_last in Hwitness.
     apply Hwitness.
-    destruct H as [msg [Hsender Heqv]].
     exists msg. split; [assumption|].
     apply equivocation_in_trace_prefix.
     assumption.
@@ -196,8 +180,8 @@ Proof.
   ; [left; assumption|].
   right. apply equivocating_validators_is_equivocating_tracewise_iff in Hv.
   destruct (transition_is_equivocating_tracewise_char IM A sender  _ _ _ _ _ Ht _ Hv)
-    as [H | Hom]
-  ; [elim Hnv; apply (equivocating_validators_is_equivocating_tracewise_iff IM A sender finite_validator); assumption|].
+    as [| Hom]
+  ; [elim Hnv; apply (equivocating_validators_is_equivocating_tracewise_iff IM A sender); assumption|].
   destruct om as [m|]; simpl in Hom; [|congruence].
   exists m. repeat split; [assumption|].
   intros is tr [Htr Hinit] Hwitness.
@@ -265,7 +249,7 @@ Proof.
   apply equivocating_validators_witness_monotonicity with (s := (finite_trace_last is tr))
     in Hwitness as Hincl
   ; [| split; assumption].
-  specialize (input_valid_transition_receiving_no_sender_reflects_equivocating_validators IM A sender finite_validator _ _ _  _ _ Ht)
+  specialize (input_valid_transition_receiving_no_sender_reflects_equivocating_validators IM A sender _ _ _  _ _ Ht)
     as Hreflect.
   remember (finite_trace_last is tr) as s.
   destruct (option_bind _ _ sender om) as [v|] eqn:Heq_v.
@@ -289,7 +273,7 @@ Proof.
       }
       destruct Hv as [v' [Heqv Hneqv]].
       apply Honly_v in Heqv as Heq_v'.
-      destruct Heq_v' as [H|[_m [Heq_m [Heq_v' Hweqv]]]]; [subst; contradiction|].
+      destruct Heq_v' as [|[_m [Heq_m [Heq_v' Hweqv]]]]; [subst; contradiction|].
       inversion Heq_m. subst _m. clear Heq_m.
       assert (v' = v) by congruence. subst v'. clear Heq_v'.
       split; [assumption|]. split; [|subst; assumption].
@@ -298,7 +282,7 @@ Proof.
         ; [apply set_add_intro1; assumption|].
         apply set_add_intro2.
         apply Honly_v in Hv'.
-        destruct Hv' as [H|[_m [Heq_m [Heq_v' _]]]]; [subst; contradiction|].
+        destruct Hv' as [|[_m [Heq_m [Heq_v' _]]]]; [subst; contradiction|].
         congruence.
       * apply set_add_elim in Hv' as [Heq_v' | Hs'0]
         ; [subst v'; assumption|].
@@ -390,11 +374,11 @@ Proof.
     + intros Hv. apply Heq in Hv.
       rewrite <- Hlst' in Hv.
       apply Hprefix in Hv.
-      destruct Hv as [m [Hm Heqv]].
+      destruct Hv as [m [Hmsg Heqv]].
       exists m. split; [assumption|].
       apply equivocation_in_trace_prefix.
       assumption.
-    + intros [m [Hm Heqv]].
+    + intros [m [Hmsg Heqv]].
       apply equivocation_in_trace_last_char in Heqv.
       destruct Heqv as [Heqv | Heqv].
       * apply Heq. rewrite <- Hlst'.
@@ -460,11 +444,11 @@ Proof.
         eexists tr, _, [].
         repeat split; assumption.
       * apply Hprefix in Hv'.
-        destruct Hv' as [m [Hm Heqv]].
+        destruct Hv' as [m [? Heqv]].
         exists m. split; [assumption|].
         apply equivocation_in_trace_prefix.
         assumption.
-    + intros [m [Hm Heqv]].
+    + intros [m [? Heqv]].
       apply equivocation_in_trace_last_char in Heqv.
       apply Hneq. apply set_add_iff.
       destruct Heqv as [Heqv | Heqv].
@@ -536,7 +520,7 @@ Proof.
       apply app_eq_nil  in Heq_tr. destruct Heq_tr. subst.
       apply initial_state_witnessing_equivocation_prop. apply Htr.
   - rewrite finite_trace_last_is_last.
-    intros Hm Hn Htr'_item Hwitness.
+    intros ? Hn Htr'_item Hwitness.
     apply finite_valid_trace_init_add_last
       with (sf := destination item)
       in Htr'_item
@@ -646,7 +630,7 @@ Proof.
     in Hs as Hpre_s.
   apply preloaded_has_strong_trace_witnessing_equivocation_prop in Hpre_s.
   destruct Hpre_s as [is [tr [Htr Hwitness]]].
-  apply (all_pre_traces_to_valid_state_are_valid IM _ Hbr finite_index) in Htr
+  apply (all_pre_traces_to_valid_state_are_valid IM) in Htr
   ; [|assumption].
   exists is, tr. split; assumption.
 Qed.
@@ -666,29 +650,20 @@ by the [equivocating_validators] of its final state.
 Section witnessed_equivocation_fixed_set.
 
 Context
-  {message : Type}
-  {MsgEqDec : EqDecision message}
-  {index : Type}
-  {IndEqDec : EqDecision index}
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
+  `{EqDecision message}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i, HasBeenSentCapability (IM i))
-  (Hbr : forall i, HasBeenReceivedCapability (IM i))
-  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
+  `{forall i, HasBeenSentCapability (IM i)}
+  `{forall i, HasBeenReceivedCapability (IM i)}
   (Free := free_composite_vlsm IM)
-  (Free_HasBeenSentCapability : HasBeenSentCapability Free := free_composite_HasBeenSentCapability IM finite_index Hbs)
-  (Free_HasBeenReceivedCapability : HasBeenReceivedCapability Free := free_composite_HasBeenReceivedCapability IM finite_index Hbr)
-  (Free_HasBeenObservedCapability : HasBeenObservedCapability Free := free_composite_HasBeenObservedCapability IM finite_index Hbo)
   (sender : message -> option index)
-  {measurable_V : Measurable index}
-  {threshold_V : ReachableThreshold index}
-  {is_equivocating_tracewise_no_has_been_sent_dec : RelDecision (is_equivocating_tracewise_no_has_been_sent IM id sender)}
+  `{ReachableThreshold index}
+  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM id sender)}
   (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) index
-    := equivocation_dec_tracewise IM id sender finite_index)
-  (Hke : WitnessedEquivocationCapability IM id sender finite_index)
+    := equivocation_dec_tracewise IM id sender)
+  (Hke : WitnessedEquivocationCapability IM id sender)
   (message_dependencies : message -> set message)
-  (HMsgDep : forall i, MessageDependencies message_dependencies (IM i))
+  `{forall i, MessageDependencies message_dependencies (IM i)}
   (Hfull : forall i, message_dependencies_full_node_condition_prop message_dependencies (IM i))
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   (can_emit_signed : channel_authentication_prop IM id sender)
@@ -697,12 +672,10 @@ Context
   (Free_has_sender :=
     composite_no_initial_valid_messages_have_sender IM id sender
       can_emit_signed no_initial_messages_in_IM (free_constraint IM))
+  (equivocating_validators := equivocating_validators (BasicEquivocation := Htracewise_BasicEquivocation))
   .
 
 Existing Instance Htracewise_BasicEquivocation.
-Existing Instance Free_HasBeenSentCapability.
-Existing Instance Free_HasBeenReceivedCapability.
-Existing Instance Free_HasBeenObservedCapability.
 
 (**
 Given the fact that the set of [equivocating_validators] can be empty,
@@ -714,10 +687,10 @@ when there are no [equivocating_validators].
 Definition equivocating_validators_fixed_equivocation_constraint
   (s : composite_state IM)
   :=
-  fixed_equivocation_constraint IM Hbs Hbr (equivocating_validators s).
+  fixed_equivocation_constraint IM (equivocating_validators s).
 
 Lemma equivocators_can_emit_free m
-  (Hm : valid_message_prop Free m)
+  (Hmsg : valid_message_prop Free m)
   v
   (Hsender: sender m = Some v)
   sf
@@ -725,25 +698,24 @@ Lemma equivocators_can_emit_free m
   l s
   (Hv : composite_valid IM l (s, Some m))
   : can_emit
-    (equivocators_composition_for_observed IM Hbs Hbr (equivocating_validators sf) s)
+    (equivocators_composition_for_observed IM (equivocating_validators sf) s)
     m.
 Proof.
-    apply emitted_messages_are_valid_iff in Hm.
-    destruct Hm as [[_v [[_im Him] Heqim]] | Hiom]
+    apply emitted_messages_are_valid_iff in Hmsg
+      as [(_v & [_im Him] & Heqim) | Hiom]
     ; [elim (no_initial_messages_in_IM _v _im); assumption|].
     apply (VLSM_incl_can_emit (vlsm_incl_pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)))
       in Hiom.
     apply can_emit_composite_project in Hiom as [_v Hiom].
     specialize (Hsender_safety _ _ Hsender _ Hiom) as Heq_v. simpl in Heq_v.
     subst _v.
-    destruct (HMsgDep v) as [_ Hsufficient].
-    apply Hsufficient in Hiom.
+    eapply message_dependencies_are_sufficient in Hiom; [|typeclasses eauto].
     unfold pre_loaded_free_equivocating_vlsm_composition, free_equivocating_vlsm_composition.
       specialize
         (@lift_to_composite_generalized_preloaded_vlsm_full_projection
           message (sub_index (equivocating_validators sf)) _ (sub_IM IM (equivocating_validators sf))
           (λ msg : message, msg ∈ message_dependencies m)
-          (composite_has_been_observed IM Hbo s))
+          (composite_has_been_observed IM s))
         as Hproj.
       spec Hproj.
       { intros dm Hdm.
@@ -771,12 +743,12 @@ induction hypothesis in terms of the final state after the last transition.
 *)
 Lemma strong_witness_has_fixed_equivocation is s tr
   (Htr : finite_valid_trace_init_to (free_composite_vlsm IM) is s tr)
-  (Heqv: strong_trace_witnessing_equivocation_prop IM id sender finite_index is tr)
-  : finite_valid_trace_init_to (fixed_equivocation_vlsm_composition IM Hbs Hbr (equivocating_validators s)) is s tr.
+  (Heqv: strong_trace_witnessing_equivocation_prop IM id sender is tr)
+  : finite_valid_trace_init_to (fixed_equivocation_vlsm_composition IM (equivocating_validators s)) is s tr.
 Proof.
   split; [|apply Htr].
   induction Htr using finite_valid_trace_init_to_rev_ind.
-  - eapply (finite_valid_trace_from_to_empty (fixed_equivocation_vlsm_composition IM Hbs Hbr (equivocating_validators si))).
+  - eapply (finite_valid_trace_from_to_empty (fixed_equivocation_vlsm_composition IM (equivocating_validators si))).
     apply initial_state_is_valid. assumption.
   - spec IHHtr.
     { intros prefix. intros.
@@ -786,7 +758,7 @@ Proof.
     apply (VLSM_incl_finite_valid_trace_init_to (vlsm_incl_pre_loaded_with_all_messages_vlsm Free))
       in Htr as Hpre_tr.
     specialize
-      (equivocating_validators_witness_monotonicity IM id sender finite_index
+      (equivocating_validators_witness_monotonicity IM id sender
         _ _ _ Hpre_tr {| l := l; input := iom; destination := sf; output := oom |})
       as Hincl.
     simpl in Hincl.
@@ -799,7 +771,7 @@ Proof.
     }
     assert
       (Htr_sf : finite_valid_trace_from_to
-        (fixed_equivocation_vlsm_composition IM Hbs Hbr (equivocating_validators sf)) si s tr).
+        (fixed_equivocation_vlsm_composition IM (equivocating_validators sf)) si s tr).
     { revert IHHtr.
       apply VLSM_incl_finite_valid_trace_from_to.
       apply fixed_equivocation_vlsm_composition_index_incl.
@@ -827,10 +799,10 @@ Proof.
     simpl in Heqv.
     assert (Hpre_s : valid_state_prop (pre_loaded_with_all_messages_vlsm Free) s).
     { apply proj1, finite_valid_trace_from_to_last_pstate in Hpre_tr. assumption. }
-    destruct (@decide _ (composite_has_been_observed_dec IM finite_index Hbo s im)).
+    destruct (@decide _ (composite_has_been_observed_dec IM s im)).
     { repeat split
       ; [assumption| apply option_valid_message_Some | assumption| | assumption].
-      - apply (composite_observed_valid IM finite_index Hbs Hbo Hbr _ s); assumption.
+      - apply (composite_observed_valid IM _ s); assumption.
       - left. assumption.
     }
     assert (Hequivocating_v : v ∈ equivocating_validators sf).
@@ -852,11 +824,11 @@ Proof.
     ; [assumption|  | assumption| right; assumption | assumption].
     apply emitted_messages_are_valid.
     specialize
-      (EquivPreloadedBase_Fixed_weak_full_projection IM Hbs Hbr _ finite_index _ Hs') as Hproj.
+      (EquivPreloadedBase_Fixed_weak_full_projection IM _ _ Hs') as Hproj.
     spec Hproj.
     { intros.  apply no_initial_messages_in_IM. }
     apply (VLSM_weak_full_projection_can_emit Hproj).
-    apply (VLSM_incl_can_emit (Equivocators_Fixed_Strong_incl IM Hbs Hbr finite_index _  _ Hs')).
+    apply (VLSM_incl_can_emit (Equivocators_Fixed_Strong_incl IM _  _ Hs')).
     assumption.
 Qed.
 
@@ -873,7 +845,7 @@ Lemma equivocating_validators_fixed_equivocation_characterization
 Proof.
   intros s Hs.
   destruct
-    (free_has_strong_trace_witnessing_equivocation_prop IM finite_index Hbs Hbr id sender finite_index _ s Hs)
+    (free_has_strong_trace_witnessing_equivocation_prop IM id sender _ s Hs)
     as [is [tr [Htr Heqv]]].
   cut (finite_valid_trace_from_to (composite_vlsm IM (equivocating_validators_fixed_equivocation_constraint s)) is s tr).
   { intro Htr'. apply finite_valid_trace_from_to_last_pstate in Htr'.

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -68,46 +68,44 @@ Qed.
 End selectors.
 
 Lemma VLSM_projection_has_been_sent_reflect
-  {HbsX : HasBeenSentCapability X}
-  {HbsY : HasBeenSentCapability Y}
+  `{HasBeenSentCapability message X}
+  `{HasBeenSentCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_sent Y (state_project s) m -> has_been_sent X s m.
 Proof.
   apply VLSM_projection_oracle_reflect with (field_selector output) (field_selector output).
   - intros. destruct itemX, itemY. simpl in *. subst.
     split; exact id.
-  - apply (has_been_sent_stepwise_from_trace HbsX).
-  - apply (has_been_sent_stepwise_from_trace HbsY).
+  - apply (has_been_sent_stepwise_from_trace X).
+  - apply (has_been_sent_stepwise_from_trace Y).
 Qed.
 
 Lemma VLSM_projection_has_been_received_reflect
-  {HbrX : HasBeenReceivedCapability X}
-  {HbrY : HasBeenReceivedCapability Y}
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenReceivedCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_received Y (state_project s) m -> has_been_received X s m.
 Proof.
   apply VLSM_projection_oracle_reflect with (field_selector input) (field_selector input).
   - intros. destruct itemX, itemY. simpl in *. subst.
     split; exact id.
-  - apply (has_been_received_stepwise_from_trace HbrX).
-  - apply (has_been_received_stepwise_from_trace HbrY).
+  - apply (has_been_received_stepwise_from_trace X).
+  - apply (has_been_received_stepwise_from_trace Y).
 Qed.
 
 Lemma VLSM_projection_has_been_observed_reflect
-  {HbsX : HasBeenSentCapability X}
-  {HbrX : HasBeenReceivedCapability X}
-  (HboX := HasBeenObservedCapability_from_sent_received X)
-  {HbsY : HasBeenSentCapability Y}
-  {HbrY : HasBeenReceivedCapability Y}
-  (HboY := HasBeenObservedCapability_from_sent_received Y)
+  `{HasBeenSentCapability message X}
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenSentCapability message Y}
+  `{HasBeenReceivedCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_observed Y (state_project s) m -> has_been_observed X s m.
 Proof.
   apply VLSM_projection_oracle_reflect with item_sends_or_receives item_sends_or_receives.
   - intros. destruct itemX, itemY. simpl in *. subst.
     split; exact id.
-  - apply HboX.
-  - apply HboY.
+  - apply has_been_observed_stepwise_props.
+  - apply has_been_observed_stepwise_props.
 Qed.
 
 End projection_oracle.
@@ -184,52 +182,50 @@ Qed.
 End selectors.
 
 Lemma VLSM_weak_full_projection_has_been_sent
-  {HbsX : HasBeenSentCapability X}
-  {HbsY : HasBeenSentCapability Y}
+  `{HasBeenSentCapability message X}
+  `{HasBeenSentCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_sent X s m -> has_been_sent Y (state_project s) m.
 Proof.
   apply VLSM_weak_full_projection_oracle with (field_selector output) (field_selector output).
-  - intros. destruct itemX, itemY. simpl in H0. subst. simpl.
+  - intros itemX itemY Hin Hout. destruct itemX, itemY. simpl in Hout. subst. simpl.
     split; exact id.
-  - apply (has_been_sent_stepwise_from_trace HbsX).
-  - apply (has_been_sent_stepwise_from_trace HbsY).
-  - apply HbsX.
-  - apply HbsY.
+  - apply (has_been_sent_stepwise_from_trace X).
+  - apply (has_been_sent_stepwise_from_trace Y).
+  - apply has_been_sent_dec.
+  - apply has_been_sent_dec.
 Qed.
 
 Lemma VLSM_weak_full_projection_has_been_received
-  {HbrX : HasBeenReceivedCapability X}
-  {HbrY : HasBeenReceivedCapability Y}
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenReceivedCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_received X s m -> has_been_received Y (state_project s) m.
 Proof.
   apply VLSM_weak_full_projection_oracle with (field_selector input) (field_selector input).
-  - intros. destruct itemX, itemY. simpl in H. subst. simpl.
+  - intros itemX itemY Hin Hout. destruct itemX, itemY. simpl in Hin. subst. simpl.
     split; exact id.
-  - apply (has_been_received_stepwise_from_trace HbrX).
-  - apply (has_been_received_stepwise_from_trace HbrY).
-  - apply HbrX.
-  - apply HbrY.
+  - apply (has_been_received_stepwise_from_trace X).
+  - apply (has_been_received_stepwise_from_trace Y).
+  - apply has_been_received_dec.
+  - apply has_been_received_dec.
 Qed.
 
 Lemma VLSM_weak_full_projection_has_been_observed
-  {HbsX : HasBeenSentCapability X}
-  {HbrX : HasBeenReceivedCapability X}
-  (HboX := HasBeenObservedCapability_from_sent_received X)
-  {HbsY : HasBeenSentCapability Y}
-  {HbrY : HasBeenReceivedCapability Y}
-  (HboY := HasBeenObservedCapability_from_sent_received Y)
+  `{HasBeenSentCapability message X}
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenSentCapability message Y}
+  `{HasBeenReceivedCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_observed X s m -> has_been_observed Y (state_project s) m.
 Proof.
   apply VLSM_weak_full_projection_oracle with item_sends_or_receives item_sends_or_receives.
   - intros. destruct itemX, itemY. simpl in *. subst.
     split; exact id.
-  - apply HboX.
-  - apply HboY.
-  - apply HboX.
-  - apply HboY.
+  - apply has_been_observed_stepwise_props.
+  - apply has_been_observed_stepwise_props.
+  - apply has_been_observed_dec.
+  - apply has_been_observed_dec.
 Qed.
 
 End weak_full_projection_oracle.
@@ -246,81 +242,169 @@ Context
   .
 
 Definition VLSM_full_projection_has_been_sent
-  {HbsX : HasBeenSentCapability X}
-  {HbsY : HasBeenSentCapability Y}
+  `{HasBeenSentCapability message X}
+  `{HasBeenSentCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_sent X s m -> has_been_sent Y (state_project s) m
   := VLSM_weak_full_projection_has_been_sent (VLSM_full_projection_weaken Hsimul).
 
 Definition VLSM_full_projection_has_been_received
-  {HbsX : HasBeenReceivedCapability X}
-  {HbsY : HasBeenReceivedCapability Y}
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenReceivedCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_received X s m -> has_been_received Y (state_project s) m
   := VLSM_weak_full_projection_has_been_received (VLSM_full_projection_weaken Hsimul).
 
 Definition VLSM_full_projection_has_been_observed
-  {HbsX : HasBeenSentCapability X}
-  {HbrX : HasBeenReceivedCapability X}
-  (HboX := HasBeenObservedCapability_from_sent_received X)
-  {HbsY : HasBeenSentCapability Y}
-  {HbrY : HasBeenReceivedCapability Y}
-  (HboY := HasBeenObservedCapability_from_sent_received Y)
+  `{HasBeenSentCapability message X}
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenSentCapability message Y}
+  `{HasBeenReceivedCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_observed X s m -> has_been_observed Y (state_project s) m
   := VLSM_weak_full_projection_has_been_observed (VLSM_full_projection_weaken Hsimul).
 
 Definition VLSM_full_projection_has_been_sent_reflect
-  {HbsX : HasBeenSentCapability X}
-  {HbsY : HasBeenSentCapability Y}
+  `{HasBeenSentCapability message X}
+  `{HasBeenSentCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_sent Y (state_project s) m -> has_been_sent X s m
   := VLSM_projection_has_been_sent_reflect  (VLSM_full_projection_is_projection Hsimul).
 
 Definition VLSM_full_projection_has_been_received_reflect
-  {HbrX : HasBeenReceivedCapability X}
-  {HbrY : HasBeenReceivedCapability Y}
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenReceivedCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_received Y (state_project s) m -> has_been_received X s m
   := VLSM_projection_has_been_received_reflect  (VLSM_full_projection_is_projection Hsimul).
 
 Definition VLSM_full_projection_has_been_observed_reflect
-  {HbsX : HasBeenSentCapability X}
-  {HbrX : HasBeenReceivedCapability X}
-  (HboX := HasBeenObservedCapability_from_sent_received X)
-  {HbsY : HasBeenSentCapability Y}
-  {HbrY : HasBeenReceivedCapability Y}
-  (HboY := HasBeenObservedCapability_from_sent_received Y)
+  `{HasBeenSentCapability message X}
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenSentCapability message Y}
+  `{HasBeenReceivedCapability message Y}
   : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
     forall m, has_been_observed Y (state_project s) m -> has_been_observed X s m
   := VLSM_projection_has_been_observed_reflect  (VLSM_full_projection_is_projection Hsimul).
 
 End full_projection_oracle.
 
+Section incl_oracle.
+(** ** [VLSM_incl]usions both preserve and reflect message properties *)
+
+Context
+  {message : Type}
+  {T : VLSMType message}
+  {SX SY : VLSMSign T}
+  {MX : VLSMClass SX}
+  {MY : VLSMClass SY}
+  (X := mk_vlsm MX)
+  (Y := mk_vlsm MY)
+  (Hincl : VLSM_incl (pre_loaded_with_all_messages_vlsm X) (pre_loaded_with_all_messages_vlsm Y))
+  .
+
+Lemma VLSM_incl_has_been_sent
+  `{HasBeenSentCapability message X}
+  `{HasBeenSentCapability message Y}
+  : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
+    forall m, has_been_sent X s m -> has_been_sent Y s m.
+Proof.
+  intros s Hs m Hm.
+  eapply
+    (@VLSM_full_projection_has_been_sent _ X Y _ _
+      (VLSM_incl_is_full_projection Hincl))
+  ; assumption.
+Qed.
+
+Lemma VLSM_incl_has_been_received
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenReceivedCapability message Y}
+  : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
+    forall m, has_been_received X s m -> has_been_received Y s m.
+Proof.
+  intros s Hs m Hm.
+  eapply
+    (@VLSM_full_projection_has_been_received _ X Y _ _
+      (VLSM_incl_is_full_projection Hincl))
+  ; assumption.
+Qed.
+
+Lemma VLSM_incl_has_been_observed
+  `{HasBeenSentCapability message X}
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenSentCapability message Y}
+  `{HasBeenReceivedCapability message Y}
+  : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
+    forall m, has_been_observed X s m -> has_been_observed Y s m.
+Proof.
+  intros s Hs m Hm.
+  eapply
+    (@VLSM_full_projection_has_been_observed _ X Y _ _
+      (VLSM_incl_is_full_projection Hincl))
+  ; assumption.
+Qed.
+
+Lemma VLSM_incl_has_been_sent_reflect
+  `{HasBeenSentCapability message X}
+  `{HasBeenSentCapability message Y}
+  : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
+    forall m, has_been_sent Y s m -> has_been_sent X s m.
+Proof.
+  intros s Hs m Hm.
+  eapply
+    (@VLSM_full_projection_has_been_sent_reflect _ X Y _ _
+      (VLSM_incl_is_full_projection Hincl))
+  ; assumption.
+Qed.
+
+Lemma VLSM_incl_has_been_received_reflect
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenReceivedCapability message Y}
+  : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
+    forall m, has_been_received Y s m -> has_been_received X s m.
+Proof.
+  intros s Hs m Hm.
+  eapply
+    (@VLSM_full_projection_has_been_received_reflect _ X Y _ _
+      (VLSM_incl_is_full_projection Hincl))
+  ; assumption.
+Qed.
+
+Lemma VLSM_incl_has_been_observed_reflect
+  `{HasBeenSentCapability message X}
+  `{HasBeenReceivedCapability message X}
+  `{HasBeenSentCapability message Y}
+  `{HasBeenReceivedCapability message Y}
+  : forall s, valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
+    forall m, has_been_observed Y s m -> has_been_observed X s m.
+Proof.
+  intros s Hs m Hm.
+  eapply
+    (@VLSM_full_projection_has_been_observed_reflect _ X Y _ _
+      (VLSM_incl_is_full_projection Hincl))
+  ; assumption.
+Qed.
+
+End incl_oracle.
+
 Section same_IM_oracle_properties.
 
 Context
   {message : Type}
-  `{EqDecision index}
+  `{finite.Finite index}
   (IM1 IM2 : index -> VLSM message)
-  (Hbs1 : forall i, HasBeenSentCapability (IM1 i))
-  (Hbs2 : forall i, HasBeenSentCapability (IM2 i))
+  `{forall i, HasBeenSentCapability (IM1 i)}
+  `{forall i, HasBeenSentCapability (IM2 i)}
   (Heq : forall i, IM1 i = IM2 i)
-  (finite_index : finite.Finite index)
-  (HbsFree1 := free_composite_HasBeenSentCapability IM1 (listing_from_finite index) Hbs1)
-  (HbsFree2 := free_composite_HasBeenSentCapability IM2 (listing_from_finite index) Hbs2)
   .
-
-Existing Instance HbsFree1.
-Existing Instance HbsFree2.
 
 (** If two indexed sets of VLSMs are extensionally-equal, then the
 [has_been_sent] predicate is preserved through the [same_IM_state_rew] map.
 *)
 Lemma same_IM_composite_has_been_sent_preservation s1 m
   (Hs1 : valid_state_prop (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM1)) s1)
-  : composite_has_been_sent IM1 Hbs1 s1 m ->
-    composite_has_been_sent IM2 Hbs2 (same_IM_state_rew Heq s1) m.
+  : composite_has_been_sent IM1 s1 m ->
+    composite_has_been_sent IM2 (same_IM_state_rew Heq s1) m.
 Proof.
   specialize (same_IM_preloaded_free_full_projection IM1 IM2 Heq) as Hproj.
   intros Hbs1_m.

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -362,12 +362,7 @@ Proof.
   specialize (preloaded_component_projection IM i) as Hproj.
   specialize (VLSM_projection_input_valid_transition Hproj (existT i li) li)
     as Htransition.
-  spec Htransition.
-  { clear. unfold composite_project_label. simpl.
-    case_decide; [|congruence].
-    replace H with (@eq_refl index i) by (apply Eqdep_dec.UIP_dec; assumption).
-    reflexivity.
-  }
+  spec Htransition; [apply (composite_project_label_eq IM)|].
   apply Htransition in Hemitted. clear Htransition.
   remember (s0 i) as s0i. clear s0 Heqs0i.
   remember (s1 i) as s1i. clear s1 Heqs1i.

--- a/theories/VLSM/Core/Equivocators/Common.v
+++ b/theories/VLSM/Core/Equivocators/Common.v
@@ -101,7 +101,7 @@ Definition is_equivocating_state
   : Prop
   := not (is_singleton_state s).
 
-Lemma is_equivocating_state_dec
+Global Instance is_equivocating_state_dec
   (s : equivocator_state)
   : Decision (is_equivocating_state s).
 Proof.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -691,8 +691,9 @@ Proof.
   { apply (finite_valid_trace_last_pstate (pre_loaded_with_all_messages_vlsm Free)).
     apply HtrX_Pre.
   }
-
-  rewrite has_been_observed_sent_received_iff; [|assumption].
+  rewrite has_been_observed_sent_received_iff
+    with (Hbr0 := Free_HasBeenReceivedCapability) (Hbs0 := Free_HasBeenSentCapability)
+  ; [|assumption].
   right. apply proper_sent; [assumption|].
   apply has_been_sent_consistency; [assumption| assumption |].
   exists (equivocators_state_project IM initial_descriptors is), trX,
@@ -765,9 +766,6 @@ Proof.
   inversion Hpr. subst. clear Hpr.
   inversion Hpr_pre_item. subst. clear Hpr_pre_item.
   constructor. reflexivity.
-Unshelve.
-  - assumption.
-  - assumption.
 Qed.
 
 (**

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -765,7 +765,7 @@ Proof.
   inversion Hpr. subst. clear Hpr.
   inversion Hpr_pre_item. subst. clear Hpr_pre_item.
   constructor. reflexivity.
-  Unshelve.
+Unshelve.
   - assumption.
   - assumption.
 Qed.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -1,4 +1,4 @@
-From stdpp Require Import prelude.
+From stdpp Require Import prelude finite.
 From Coq Require Import FinFun Lia.
 From VLSM.Lib Require Import Preamble ListExtras StdppListSet FinExtras.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.Equivocation.
@@ -11,17 +11,14 @@ From VLSM Require Import Core.Equivocators.Composition.Projections.
 
 (** * VLSM Equivocators Fixed Equivocation *)
 
-Section equivocators_fixed_equivocations_vlsm.
+Section sec_equivocators_fixed_equivocations_vlsm.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
+  `{forall i : index, HasBeenSentCapability (IM i)}
   (equivocator_IM := equivocator_IM IM)
-  (index_listing : list index)
-  (finite_index : Listing index_listing)
   (equivocating : set index)
   .
 
@@ -30,14 +27,14 @@ Definition state_has_fixed_equivocation
   (s : composite_state equivocator_IM)
   : Prop
   :=
-  (equivocating_indices IM index_listing s) ⊆ equivocating.
+  (equivocating_indices IM (enum index) s) ⊆ equivocating.
 
 Definition equivocators_fixed_equivocations_constraint
   (l : composite_label equivocator_IM)
   (som : composite_state equivocator_IM * option message)
   (som' := composite_transition equivocator_IM l som)
   : Prop
-  := equivocators_no_equivocations_constraint IM Hbs l som
+  := equivocators_no_equivocations_constraint IM l som
   /\ state_has_fixed_equivocation (fst som').
 
 (** If the starting [state_has_fixed_equivocation] and the transition is made
@@ -60,7 +57,7 @@ Proof.
   apply Hs.
   apply elem_of_list_filter.
   split; [assumption|].
-  apply elem_of_list_In. apply finite_index.
+  apply elem_of_enum.
 Qed.
 
 (** If the starting [state_has_fixed_equivocation] and the transition is made
@@ -76,7 +73,7 @@ Proof.
   intros i Hi. apply Hs.
   apply elem_of_list_filter, proj1 in Hi.
   apply elem_of_list_filter.
-  split; [|apply elem_of_list_In; apply finite_index].
+  split; [|apply elem_of_enum].
   cbn in Ht.
   destruct l as (eqv, leqv).
   destruct (equivocator_transition _ _ _) as (si', _om') eqn:Hti.
@@ -136,8 +133,7 @@ Proof.
     destruct (decide (equivocator_state_n (s i) = 1)); [assumption|].
     elim Hi. apply Hfixed.
     apply elem_of_list_filter.
-    split; [|apply elem_of_list_In; apply finite_index].
-    assumption.
+    split; [assumption|apply elem_of_enum].
 Qed.
 
 Lemma valid_state_has_fixed_equivocation
@@ -185,8 +181,10 @@ Qed.
 Lemma preloaded_equivocators_fixed_equivocations_vlsm_incl_free
   : VLSM_incl (pre_loaded_with_all_messages_vlsm equivocators_fixed_equivocations_vlsm) (pre_loaded_with_all_messages_vlsm (free_composite_vlsm equivocator_IM)).
 Proof.
-  apply basic_VLSM_incl_preloaded; intro; intros; [assumption| |assumption].
-  split; [|exact I]. apply H.
+  apply basic_VLSM_incl_preloaded.
+  1,3: intro; intros; assumption.
+  intros l s om [Hv _].
+  split; [assumption|exact I].
 Qed.
 
 (**
@@ -194,13 +192,13 @@ Inclusion in the composition of equivocators with no message equivocation
 (no restriction on state equivocation).
 *)
 Lemma equivocators_fixed_equivocations_vlsm_incl_no_equivocations
-  : VLSM_incl equivocators_fixed_equivocations_vlsm (equivocators_no_equivocations_vlsm IM Hbs).
+  : VLSM_incl equivocators_fixed_equivocations_vlsm (equivocators_no_equivocations_vlsm IM).
 Proof.
   apply constraint_subsumption_incl.
   intros l (s,om) Hv. apply Hv.
 Qed.
 
-End equivocators_fixed_equivocations_vlsm.
+End sec_equivocators_fixed_equivocations_vlsm.
 
 Section fixed_equivocation_with_fullnode.
 
@@ -219,22 +217,18 @@ It requires that the nodes have [has_been_sent] and [has_been_received]
 capabilities, that the number of nodes is finite
 *)
   Context
-    {message : Type}
-    {index : Type}
-    {IndEqDec : EqDecision index}
+    `{EqDecision message}
+    `{finite.Finite index}
     (IM : index -> VLSM message)
-    (Hbs : forall i : index, HasBeenSentCapability (IM i))
-    (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
-    (Hbo : forall i : index, HasBeenObservedCapability (IM i) := fun i : index => HasBeenObservedCapability_from_sent_received (IM i))
+    `{forall i : index, HasBeenSentCapability (IM i)}
+    `{forall i : index, HasBeenReceivedCapability (IM i)}
     (equivocator_IM := equivocator_IM IM)
-    (index_listing : list index)
-    (finite_index : Listing index_listing)
     (equivocating : set index)
     (admissible_index := fun s i => i ∈ equivocating)
     (full_node_constraint
-      := full_node_condition_for_admissible_equivocators IM Hbs Hbr admissible_index)
+      := full_node_condition_for_admissible_equivocators IM admissible_index)
     (full_node_constraint_alt
-      := full_node_condition_for_admissible_equivocators_alt IM Hbs Hbr admissible_index)
+      := full_node_condition_for_admissible_equivocators_alt IM admissible_index)
     .
 
 
@@ -245,18 +239,12 @@ allowed to equivocate is non-empty.
 *)
 
   Context
-    `{EqDecision message}
     (equivocating_index : Type := sub_index equivocating)
     (equivocating_IM := sub_IM IM equivocating)
     (fixed_equivocation_constraint : composite_label IM  -> composite_state IM * option message -> Prop
-      := fixed_equivocation_constraint IM Hbs Hbr equivocating)
+      := fixed_equivocation_constraint IM equivocating)
     (Free := free_composite_vlsm IM)
-    (Free_HasBeenSentCapability : HasBeenSentCapability Free := free_composite_HasBeenSentCapability IM finite_index Hbs)
-    (Free_HasBeenReceivedCapability : HasBeenReceivedCapability Free := free_composite_HasBeenReceivedCapability IM finite_index Hbr)
-    (Free_HasBeenObservedCapability : HasBeenObservedCapability Free := free_composite_HasBeenObservedCapability IM finite_index Hbo)
     .
-
-  Existing Instance Free_HasBeenObservedCapability.
 
   (**
   The [full_node_constraint_alt] is stronger than the [fixed_equivocation_constraint].
@@ -268,12 +256,8 @@ allowed to equivocate is non-empty.
     destruct Hc as [Hno_equiv | [i [Hi Hm]]]; [left; assumption|].
     unfold node_generated_without_further_equivocation_alt in Hm.
     right.
-    remember (composite_has_been_observed IM _ _) as P.
-    specialize (can_emit_composite_free_lift equivocating_IM P P) as Hemit.
-    spec Hemit. { intro. apply id. }
-    specialize (Hemit (dec_exist _  i Hi) m). subst P.
-    apply Hemit.
-    assumption.
+    eapply can_emit_composite_free_lift with (j := dexist i Hi); [|eassumption].
+    intuition.
   Qed.
 
   (** If all nodes have the [cannot_resend_message_stepwise_prop]erty, then the
@@ -287,10 +271,7 @@ allowed to equivocate is non-empty.
   Proof.
     intros l (s, om) Hv.
     apply fixed_equivocation_constraint_subsumption_alt.
-    apply
-      (full_node_condition_for_admissible_equivocators_subsumption
-        IM Hbs Hbr admissible_index Hno_resend).
-    assumption.
+    eapply full_node_condition_for_admissible_equivocators_subsumption; eassumption.
   Qed.
 
 End fixed_equivocation_with_fullnode.
@@ -306,29 +287,18 @@ equivocation constraint.
 *)
 
 Context
-  {message : Type}
   `{EqDecision message}
   {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
-  (Hbo : forall i : index, HasBeenObservedCapability (IM i)
-    := fun i => HasBeenObservedCapability_from_sent_received (IM i))
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  `{forall i : index, HasBeenReceivedCapability (IM i)}
   (equivocating : set index)
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
-  (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM Hbs index_listing equivocating)
-  (X : VLSM message := fixed_equivocation_vlsm_composition IM Hbs Hbr equivocating)
-  (equivocators_free_Hbs := free_composite_HasBeenSentCapability (equivocator_IM IM) finite_index (equivocator_Hbs IM Hbs))
+  (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM equivocating)
+  (X : VLSM message := fixed_equivocation_vlsm_composition IM equivocating)
   (FreeE : VLSM message := free_composite_vlsm (equivocator_IM IM))
-  (FreeE_HasBeenSentCapability : HasBeenSentCapability FreeE := free_composite_HasBeenSentCapability (equivocator_IM IM) finite_index (equivocator_Hbs IM Hbs))
   (Hdec_init : forall i, vdecidable_initial_messages_prop (IM i))
   (Free := free_composite_vlsm IM)
-  (Free_HasBeenSentCapability : HasBeenSentCapability Free := free_composite_HasBeenSentCapability IM finite_index Hbs)
-  (Free_HasBeenReceivedCapability : HasBeenReceivedCapability Free := free_composite_HasBeenReceivedCapability IM finite_index Hbr)
-  (Free_HasBeenObservedCapability : HasBeenObservedCapability Free := free_composite_HasBeenObservedCapability IM finite_index Hbo)
-  (Free_no_additional_equivocation_decidable := no_additional_equivocations_dec Free)
   (index_equivocating_prop : index -> Prop := sub_index_prop equivocating)
   (equivocating_index : Type := sub_index equivocating)
   (equivocating_IM := sub_IM IM equivocating)
@@ -362,7 +332,7 @@ Proof.
   apply not_equivocating_equivocator_descriptors_proper in Heqv_descriptors as Hproper.
   split; [assumption|].
   intros i Hi.
-  specialize (not_equivocating_index_has_singleton_state IM Hbs _ finite_index equivocating _ Hs _ Hi)
+  specialize (not_equivocating_index_has_singleton_state IM equivocating _ Hs _ Hi)
     as Hzero.
   unfold is_singleton_state in Hzero.
   specialize (Heqv_descriptors i). unfold existing_descriptor in Heqv_descriptors.
@@ -400,8 +370,6 @@ Proof.
   ; assumption.
 Qed.
 
-Existing Instance equivocators_free_Hbs.
-
 Lemma fixed_equivocators_initial_state_project
   (es : vstate XE)
   (Hes : vinitial_state_prop XE es)
@@ -418,9 +386,6 @@ Proof.
   simpl. rewrite Heqsi.
   apply equivocator_vlsm_initial_state_preservation_rev with (es eqv) i; assumption.
 Qed.
-
-Existing Instance Free_HasBeenObservedCapability.
-Existing Instance Free_HasBeenSentCapability.
 
 (**
 This is a property of the [fixed_equivocation_constraint] which also
@@ -441,7 +406,7 @@ Definition constraint_has_been_sent_prop
     (Hs : valid_state_prop XE s)
     (descriptors : equivocator_descriptors IM)
     (Hdescriptors : proper_fixed_equivocator_descriptors descriptors s)
-    (sX := @equivocators_state_project _ _ IndEqDec IM descriptors s)
+    (sX := equivocators_state_project IM descriptors s)
     (m: message)
     (Hm : has_been_sent FreeE s m)
     l,
@@ -487,27 +452,27 @@ Lemma _equivocators_valid_trace_project
     finite_valid_trace X' isX trX.
 Proof.
   remember (length tr) as len_tr.
-  generalize dependent final_descriptors. generalize dependent tr.
-  induction len_tr using (well_founded_induction Wf_nat.lt_wf); intros.
+  revert tr Htr Heqlen_tr final_state final_descriptors Hproper.
+  induction len_tr as [len_tr IHlen] using (well_founded_induction Wf_nat.lt_wf); intros.
   subst len_tr.
   destruct_list_last tr tr' lst Htr_lst.
-  - clear H. subst. unfold final_state in *. exists [], final_descriptors.
+  - clear IHlen. subst. exists [], final_descriptors.
     split; [assumption|]. split; [reflexivity|]. split; [reflexivity|].
     remember (equivocators_state_project IM final_descriptors is) as isx.
     cut (vinitial_state_prop X' isx).
-    { intro. split; [|assumption]. constructor.
+    { intro His. split; [|assumption]. constructor.
       apply valid_state_prop_iff. left.
-      exists (exist _ _ H). reflexivity.
+      exists (exist _ _ His). reflexivity.
     }
     subst.
     apply fixed_equivocators_initial_state_project; [|apply Hproper].
     apply Htr.
-  - specialize (H (length tr')) as H'.
-    spec H'. { rewrite app_length. simpl. lia. }
+  - specialize (IHlen (length tr')) as IH'.
+    spec IH'. { rewrite app_length. simpl. lia. }
     destruct Htr as [Htr Hinit].
     apply finite_valid_trace_from_app_iff in Htr.
     destruct Htr as [Htr Hlst].
-    specialize (H' tr' (conj Htr Hinit) eq_refl).
+    specialize (IH' tr' (conj Htr Hinit) eq_refl).
     specialize (equivocators_transition_item_project_proper_characterization IM final_descriptors lst) as Hproperx.
     specialize
       (equivocators_transition_item_project_preserves_zero_descriptors IM final_descriptors lst)
@@ -535,8 +500,8 @@ Proof.
       apply Hzero. assumption.
     }
     clear _Hproper' Hzero.
-    specialize (H' _ Hproper').
-    destruct H' as [trX' [initial_descriptors [_ [Htr_project [Hstate_project HtrX']]]]].
+    specialize (IH' _ Hproper')
+      as (trX' & initial_descriptors & _ & Htr_project & Hstate_project & HtrX').
     assert
       (Htr' : finite_valid_trace FreeE is tr').
     {  split; [|assumption].
@@ -606,23 +571,21 @@ Proof.
       { apply not_equivocating_equivocator_descriptors_proper_fixed; [|assumption].
         apply finite_valid_trace_last_pstate. assumption.
       }
-      specialize (H (length tr')).
-      spec H. { rewrite app_length. simpl. lia. }
-      specialize (H tr' (conj Htr Hinit) eq_refl final_descriptors_m Hfinal_descriptors_m).
-      destruct H as [trXm' [initial_descriptors_m' [Hproper_initial_m [Hproject_trXm' [Hpr_fin_tr' HtrXm]]]]].
+      specialize (IHlen (length tr')).
+      spec IHlen. { rewrite app_length. simpl. lia. }
+      specialize (IHlen tr' (conj Htr Hinit) eq_refl final_descriptors_m Hfinal_descriptors_m)
+        as (trXm' & initial_descriptors_m' & Hproper_initial_m & Hproject_trXm' & Hpr_fin_tr' & HtrXm).
       simpl in *. rewrite Hproject_trXm in Hproject_trXm'.
       inversion Hproject_trXm'. subst trXm' initial_descriptors_m'. clear Hproject_trXm'.
-      repeat split; [assumption| |assumption| |assumption]
-      ; [ apply option_valid_message_Some
-        ; apply (valid_trace_output_is_valid X' _ _ (proj1 HtrXm) _ Hex)
-        |].
-      rewrite <- Hstate_project.
-      apply Hconstraint_hbs; [assumption| apply Hproper'|].
-      assert (Hlst'pre : valid_state_prop (pre_loaded_with_all_messages_vlsm FreeE) (finite_trace_last is tr')).
-      { apply finite_valid_trace_last_pstate. apply Htr'pre. }
-      apply proper_sent; [assumption|].
-      apply has_been_sent_consistency; [assumption| assumption| ].
-      exists is, tr', (valid_trace_add_default_last Htr'pre). assumption.
+      repeat split. 1,3,5: assumption.
+      * eapply valid_trace_output_is_valid; [apply HtrXm|assumption].
+      * rewrite <- Hstate_project.
+        apply Hconstraint_hbs; [assumption| apply Hproper'|].
+        assert (Hlst'pre : valid_state_prop (pre_loaded_with_all_messages_vlsm FreeE) (finite_trace_last is tr')).
+        { apply finite_valid_trace_last_pstate. apply Htr'pre. }
+        apply proper_sent; [assumption|].
+        apply has_been_sent_consistency; [typeclasses eauto| assumption| ].
+        exists is, tr', (valid_trace_add_default_last Htr'pre). assumption.
     + exists trX'. exists initial_descriptors. subst foldx. split; [assumption|].
       split; [apply Htr_project|]. split; [|assumption].
       subst tr. clear -Hstate_project Hx.
@@ -691,11 +654,9 @@ Proof.
   { apply (finite_valid_trace_last_pstate (pre_loaded_with_all_messages_vlsm Free)).
     apply HtrX_Pre.
   }
-  rewrite has_been_observed_sent_received_iff
-    with (Hbr0 := Free_HasBeenReceivedCapability) (Hbs0 := Free_HasBeenSentCapability)
-  ; [|assumption].
+  rewrite (has_been_observed_sent_received_iff Free) by assumption.
   right. apply proper_sent; [assumption|].
-  apply has_been_sent_consistency; [assumption| assumption |].
+  apply has_been_sent_consistency; [typeclasses eauto| assumption |].
   exists (equivocators_state_project IM initial_descriptors is), trX,
     (valid_trace_add_default_last HtrX_Pre).
 
@@ -706,7 +667,7 @@ Proof.
 
   assert (Hsingleton_d_item : is_singleton_state (IM (projT1 (VLSM.l item))) (destination item (projT1 (VLSM.l item)))).
   {
-    apply (not_equivocating_index_has_singleton_state IM Hbs _ finite_index equivocating); [|assumption].
+    apply (not_equivocating_index_has_singleton_state IM equivocating); [|assumption].
     apply proj1 in Htr.
     rewrite app_assoc in Htr.
     apply finite_valid_trace_from_app_iff in Htr.
@@ -793,7 +754,7 @@ Lemma equivocators_trace_sub_item_input_is_seeded_or_sub_previously_sent
   (lst_trX := equivocators_state_project IM descriptors s)
   : trace_sub_item_input_is_seeded_or_sub_previously_sent
     (equivocator_IM IM) equivocating
-    (no_additional_equivocations (free_composite_vlsm IM) lst_trX) tr.
+    (composite_has_been_observed IM lst_trX) tr.
 Proof.
   intros pre item suf m Heq Hm Hitem.
   destruct (free_equivocators_valid_trace_project descriptors is tr Hproper Htr)
@@ -819,9 +780,8 @@ Proof.
   apply finite_valid_trace_from_app_iff in Htr as Hpre. destruct Hpre as [Hpre _].
   apply finite_valid_trace_from_app_iff in Hpre. destruct Hpre as [Hpre Hivt].
   apply first_transition_valid in Hivt.
-  destruct (Free_no_additional_equivocation_decidable lst_trX m)
+  destruct (composite_has_been_observed_dec IM lst_trX m) as [|Heqv]
   ; [left; assumption|right].
-  unfold no_additional_equivocations in n.
   assert (Hsuf_free : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE) (finite_trace_last is pre) ([item] ++ suf)).
   { revert Hsuf. apply VLSM_incl_finite_valid_trace_from.
     apply VLSM_incl_trans with (machine FreeE)
@@ -887,35 +847,28 @@ Proof.
     apply valid_trace_add_last;[apply Hfuture|].
     rewrite finite_trace_last_is_last;reflexivity.
   }
-  apply (@in_futures_reflects_fixed_equivocation _ _ _ IM index_listing equivocating)
-    in Hfutures
-  ; [|assumption].
+  eapply (in_futures_reflects_fixed_equivocation) in Hfutures; [|eassumption].
   destruct (free_equivocators_valid_trace_project final_descriptors' is pre Hfinal' (conj Hpre His))
     as [_preX [_initial_descriptors [_ [_Htr_project [Hpre_final_state _]]]]].
   rewrite Htr_project in _Htr_project. inversion _Htr_project. subst _preX _initial_descriptors.
   clear _Htr_project.
   unfold from_sub_projection, pre_VLSM_projection_in_projection,
     composite_label_sub_projection_option.
-  case_decide; [eexists; reflexivity|].
-  elim n.
-  specialize
-    (not_equivocating_sent_message_has_been_observed_in_projection
-      is pre (conj Hpre His) pre_item Hpre_item H m Hpre_m final_descriptors'
-      Hfinal'
-    )
-    as Hobs_m.
-  rewrite Hpre_final_state in Hobs_m.
-
-  revert Hobs_m.
-  apply in_futures_preserving_oracle_from_stepwise with item_sends_or_receives.
-  - apply has_been_observed_stepwise_props.
+  case_decide as Hl; [eexists; reflexivity|].
+  contradict Heqv.
+  apply composite_has_been_observed_free_iff.
+  eapply in_futures_preserving_oracle_from_stepwise; cycle 2
+  ; [|apply has_been_observed_stepwise_props|].
+  - eapply not_equivocating_sent_message_has_been_observed_in_projection.
+    2-5:eassumption.
+    split; assumption.
   - subst lst_trX. subst s. simpl. simpl in Hfinal_state.
     rewrite Hfinal_state. subst trX.
     rewrite finite_trace_last_app.
     exists sufX.
-    clear -HtrXPre.
     apply proj1 in HtrXPre.
     apply finite_valid_trace_from_app_iff in HtrXPre.
+    simpl in *. rewrite Hpre_final_state.
     apply valid_trace_add_default_last.
     apply HtrXPre.
 Qed.
@@ -981,7 +934,7 @@ Proof.
     ) as Hex.
   spec Hex.
   {
-    apply (not_equivocating_index_has_singleton_state _ Hbs _ finite_index equivocating); [|assumption].
+    apply (not_equivocating_index_has_singleton_state _ equivocating); [|assumption].
     apply finite_valid_trace_last_pstate in Hitem. assumption.
   }
   destruct item as (l, iom, s, oom). apply first_transition_valid in Hitem. simpl in Hitem.
@@ -1008,7 +961,7 @@ Lemma projection_has_not_been_observed_is_equivocating
   (Hproper: proper_fixed_equivocator_descriptors descriptors s)
   (sX := equivocators_state_project IM descriptors s)
   (m: message)
-  (Hno: ~ composite_has_been_observed IM Hbo sX m)
+  (Hno: ~ composite_has_been_observed IM sX m)
   : forall item : composite_transition_item (equivocator_IM IM),
       item ∈ tr -> output item = Some m -> (projT1 (l item)) ∈ equivocating.
 Proof.
@@ -1028,9 +981,9 @@ Proof.
   subst sX s.
   simpl in *.
   rewrite Hlast_state.
-  apply (composite_proper_sent IM finite_index Hbs)
+  apply (composite_proper_sent IM)
   ; [assumption|].
-  apply has_been_sent_consistency; [assumption| assumption |].
+  apply has_been_sent_consistency; [typeclasses eauto| assumption |].
   exists (equivocators_state_project IM initial_descriptors is), trX, (valid_trace_add_default_last HtrX_free).
   clear HtrX HtrX_free Hfree_lst.
   apply equivocator_vlsm_trace_project_reflect_non_equivocating with is tr descriptors initial_descriptors item
@@ -1053,24 +1006,21 @@ Lemma pre_loaded_equivocators_composition_sub_projection_commute
     (composite_no_equivocation_vlsm_with_pre_loaded
       (sub_IM (equivocator_IM IM) equivocating)
       (free_constraint _)
-      (sub_has_been_sent_capabilities (equivocator_IM IM)
-        equivocating (equivocator_Hbs IM Hbs))
       seed1)
     (composite_no_equivocation_vlsm_with_pre_loaded
       (equivocator_IM (sub_IM IM equivocating))
       (free_constraint _)
-      (equivocator_Hbs (sub_IM IM equivocating)
-        (sub_has_been_sent_capabilities IM equivocating Hbs))
       seed2).
 Proof.
-  apply basic_VLSM_incl
-  ; intro; intros; [assumption|..].
-  - apply initial_message_is_valid.
+  apply basic_VLSM_incl.
+  - intro; intros; assumption.
+  - intro; intros.
+    apply initial_message_is_valid.
     simpl.
     destruct HmX.
     + left; assumption.
     + right. by apply Hseed12.
-  - destruct Hv as [Hs [_ [Hv Hc]]].
+  - intros l s om [Hs [_ [Hv Hc]]].
     split; [assumption|].
     destruct Hc as [Hc _].
     split; [|exact I].
@@ -1087,7 +1037,7 @@ Proof.
     revert Hs.
     apply VLSM_incl_valid_state.
     apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
-  - apply H.
+  - intros ? * [_ Ht]. assumption.
 Qed.
 
 Lemma pre_loaded_equivocators_composition_sub_projection_commute_inv
@@ -1098,24 +1048,21 @@ Lemma pre_loaded_equivocators_composition_sub_projection_commute_inv
     (composite_no_equivocation_vlsm_with_pre_loaded
       (equivocator_IM (sub_IM IM equivocating))
       (free_constraint _)
-      (equivocator_Hbs (sub_IM IM equivocating)
-        (sub_has_been_sent_capabilities IM equivocating Hbs))
       seed1)
     (composite_no_equivocation_vlsm_with_pre_loaded
       (sub_IM (equivocator_IM IM) equivocating)
       (free_constraint _)
-      (sub_has_been_sent_capabilities (equivocator_IM IM)
-        equivocating (equivocator_Hbs IM Hbs))
       seed2).
 Proof.
-  apply basic_VLSM_incl
-  ; intro; intros; [assumption|..].
-  - apply initial_message_is_valid.
+  apply basic_VLSM_incl; intros ? *.
+  - intro; assumption.
+  - intros.
+    apply initial_message_is_valid.
     simpl.
     destruct HmX; [left; assumption|].
     right.
     apply Hseed12; assumption.
-  - destruct Hv as [Hs [_ [Hv [Hc _]]]].
+  - intros (Hs & _ & Hv & Hc & _) _ _.
     split; [assumption|].
     split; [|exact I].
     destruct om; [| exact I].
@@ -1131,7 +1078,7 @@ Proof.
     revert Hs.
     apply VLSM_incl_valid_state.
     apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
-  - apply H.
+  - intros [_ Ht]; assumption.
 Qed.
 
 
@@ -1156,11 +1103,11 @@ the [seeded_equivocators_valid_trace_project] result to reach our conclusion.
 *)
 Lemma fixed_equivocation_constraint_has_constraint_has_been_sent_prop
   : constraint_has_been_sent_prop
-    (fixed_equivocation_constraint IM Hbs Hbr equivocating).
+    (fixed_equivocation_constraint IM equivocating).
 Proof.
   unfold constraint_has_been_sent_prop. intros.
   remember (equivocators_state_project _ _ _) as sX.
-  destruct (composite_has_been_observed_dec IM finite_index Hbo sX m)
+  destruct (composite_has_been_observed_dec IM sX m)
   ; [left; assumption|right].
   clear l.
   unfold no_additional_equivocations in n.
@@ -1175,8 +1122,7 @@ Proof.
   { revert Htr. apply VLSM_incl_finite_valid_trace_init_to.
     apply VLSM_incl_trans with (machine FreeE).
     - apply
-      (constraint_free_incl (equivocator_IM IM) (equivocators_fixed_equivocations_constraint IM Hbs
-        index_listing equivocating)).
+      (constraint_free_incl (equivocator_IM IM) (equivocators_fixed_equivocations_constraint IM equivocating)).
     - apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
   assert (Hplst : valid_state_prop (pre_loaded_with_all_messages_vlsm FreeE) s).
@@ -1191,10 +1137,8 @@ Proof.
 
   specialize
     (finite_valid_trace_sub_projection (equivocator_IM IM) equivocating
-      (equivocators_fixed_equivocations_constraint IM Hbs index_listing equivocating)
-      (equivocator_Hbs IM Hbs)
-      finite_index
-      (no_additional_equivocations (free_composite_vlsm IM) sX)
+      (equivocators_fixed_equivocations_constraint IM equivocating)
+      (composite_has_been_observed IM sX)
     ) as Hproject.
   spec Hproject is tr.
   spec Hproject.
@@ -1213,8 +1157,8 @@ Proof.
      Obtain a projection trXm of tr outputing m using a final_descriptor_m
   *)
 
-  apply (equivocators_trace_project_output_reflecting_iff _ _ _ (proj1 (valid_trace_forget_last Htr'pre))) in Hm.
-  destruct Hm as [final_descriptors_m [initial_descriptors_m [trXm [Hfinal_descriptors_m [Hproject_trXm Hex]]]]].
+  apply (equivocators_trace_project_output_reflecting_iff _ _ _ (proj1 (valid_trace_forget_last Htr'pre))) in Hm
+    as (final_descriptors_m & initial_descriptors_m & trXm & Hfinal_descriptors_m & Hproject_trXm & Hex).
 
   (* Identify the item outputing m in trXm an its corresponding item in tr.
   *)
@@ -1261,11 +1205,10 @@ Proof.
   and leverage the result from Phase II (a)
   to derive that the resulting projection is valid.
   *)
+  unfold equivocators_composition_for_observed, pre_loaded_free_equivocating_vlsm_composition.
 specialize
-    (seeded_equivocators_valid_trace_project IM Hbs finite_index equivocating
-      (fun m : message =>
-        no_additional_equivocations (free_composite_vlsm IM)
-          sX m)
+    (seeded_equivocators_valid_trace_project IM equivocating
+      (composite_has_been_observed IM sX)
       (composite_state_sub_projection (equivocator_IM IM) equivocating is)
       (finite_trace_sub_projection (equivocator_IM IM) equivocating tr)
       Hproject
@@ -1275,7 +1218,7 @@ specialize
   spec Hsub_project.
   { specialize
       (finite_trace_sub_projection_last_state (equivocator_IM IM) equivocating
-        (equivocators_fixed_equivocations_constraint IM Hbs index_listing equivocating) _ _ (proj1 (valid_trace_forget_last Htr)))
+        (equivocators_fixed_equivocations_constraint IM equivocating) _ _ (proj1 (valid_trace_forget_last Htr)))
       as Heq_lst.
     simpl in Heq_lst.
     match goal with
@@ -1312,8 +1255,7 @@ specialize
     (equivocators_state_project (sub_IM IM equivocating) initial_descriptors'
       (composite_state_sub_projection (equivocator_IM IM) equivocating is)
     ) as isX. clear HeqisX.
-  apply can_emit_from_valid_trace with isX trX'; [assumption|].
-  clear HtrX.
+  eapply can_emit_from_valid_trace; [eassumption|].
 
   subst.
   rewrite! (finite_trace_sub_projection_app IM).
@@ -1357,7 +1299,7 @@ Qed.
 
 Lemma fixed_equivocators_vlsm_partial_projection
   (final_descriptors : equivocator_descriptors IM)
-  : VLSM_partial_projection XE X (equivocators_partial_trace_project IM finite_index final_descriptors).
+  : VLSM_partial_projection XE X (equivocators_partial_trace_project IM final_descriptors).
 Proof.
   split; [split|].
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
@@ -1369,7 +1311,7 @@ Proof.
     clear Hpre_tr.  revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
     apply equivocators_partial_trace_project_extends_left.
   - intros s tr sX trX Hpr_tr Htr.
-    destruct (destruct_equivocators_partial_trace_project IM finite_index Hpr_tr)
+    destruct (destruct_equivocators_partial_trace_project IM Hpr_tr)
       as [Hnot_equiv [initial_descriptors [Htr_project Hs_project]]].
 
     specialize (finite_valid_trace_last_pstate XE _ _ (proj1 Htr)) as Hlst.
@@ -1384,12 +1326,14 @@ Qed.
 Lemma fixed_equivocators_vlsm_projection
   : VLSM_projection XE X (equivocators_total_label_project IM) (equivocators_total_state_project IM).
 Proof.
-  constructor; [constructor|]; intros.
-  - apply PreFreeE_Free_vlsm_projection_type.
-    revert H. apply VLSM_incl_finite_valid_trace_from.
+  constructor; [constructor|]; intros *.
+  - intro HtrX.
+    apply PreFreeE_Free_vlsm_projection_type.
+    revert HtrX. apply VLSM_incl_finite_valid_trace_from.
     apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
-  - assert (Hpre_tr : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) sX trX).
-    { revert H. apply VLSM_incl_finite_valid_trace.
+  - intro HtrX.
+    assert (Hpre_tr : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) sX trX).
+    { revert HtrX. apply VLSM_incl_finite_valid_trace.
       apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
     }
     specialize
@@ -1401,7 +1345,7 @@ Proof.
       rewrite (equivocators_total_trace_project_characterization IM (proj1 Hpre_tr)).
       reflexivity.
     }
-    apply Hsim in H.
+    apply Hsim in HtrX.
     remember (pre_VLSM_projection_trace_project _ _ _ _ _) as tr.
     replace tr with (equivocators_total_trace_project IM trX); [assumption|].
     subst. symmetry.
@@ -1422,29 +1366,26 @@ with only the no-message-equivocation constraint.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
-  (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM Hbs index_listing index_listing)
-  (NE : VLSM message := equivocators_no_equivocations_vlsm IM Hbs)
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM (enum index))
+  (NE : VLSM message := equivocators_no_equivocations_vlsm IM)
   .
 
 Lemma strong_constraint_subsumption_fixed_all
   : strong_constraint_subsumption (equivocator_IM IM)
-    (equivocators_no_equivocations_constraint IM Hbs)
-    (equivocators_fixed_equivocations_constraint IM Hbs index_listing index_listing).
+    (equivocators_no_equivocations_constraint IM)
+    (equivocators_fixed_equivocations_constraint IM (enum index)).
 Proof.
   split; [assumption|].
-  intro; intros. apply elem_of_list_In. apply finite_index.
+  intro; intros. apply elem_of_enum.
 Qed.
 
 Lemma strong_constraint_subsumption_all_fixed
   : strong_constraint_subsumption (equivocator_IM IM)
-    (equivocators_fixed_equivocations_constraint IM Hbs index_listing index_listing)
-    (equivocators_no_equivocations_constraint IM Hbs).
+    (equivocators_fixed_equivocations_constraint IM (enum index))
+    (equivocators_no_equivocations_constraint IM).
 Proof.
   intros l (s, om) Hv. apply Hv.
 Qed.
@@ -1459,8 +1400,8 @@ Proof.
     apply strong_constraint_subsumption_all_fixed.
   - apply
       (constraint_subsumption_incl (equivocator_IM IM)
-        (equivocators_no_equivocations_constraint IM Hbs)
-        (equivocators_fixed_equivocations_constraint IM Hbs index_listing index_listing)).
+        (equivocators_no_equivocations_constraint IM)
+        (equivocators_fixed_equivocations_constraint IM (enum index))).
     apply preloaded_constraint_subsumption_stronger.
     apply strong_constraint_subsumption_strongest.
     apply strong_constraint_subsumption_fixed_all.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -581,8 +581,8 @@ Proof.
       * eapply valid_trace_output_is_valid; [apply HtrXm|assumption].
       * rewrite <- Hstate_project.
         apply Hconstraint_hbs; [assumption| apply Hproper'|].
-        assert (Hlst'pre : valid_state_prop (pre_loaded_with_all_messages_vlsm FreeE) (finite_trace_last is tr')).
-        { apply finite_valid_trace_last_pstate. apply Htr'pre. }
+        assert (Hlst'pre : valid_state_prop (pre_loaded_with_all_messages_vlsm FreeE) (finite_trace_last is tr'))
+            by (apply finite_valid_trace_last_pstate, Htr'pre).
         apply proper_sent; [assumption|].
         apply has_been_sent_consistency; [typeclasses eauto| assumption| ].
         exists is, tr', (valid_trace_add_default_last Htr'pre). assumption.
@@ -1015,11 +1015,8 @@ Proof.
   apply basic_VLSM_incl.
   - intro; intros; assumption.
   - intro; intros.
-    apply initial_message_is_valid.
-    simpl.
-    destruct HmX.
-    + left; assumption.
-    + right. by apply Hseed12.
+    apply initial_message_is_valid; cbn.
+    destruct HmX; auto.
   - intros l s om [Hs [_ [Hv Hc]]].
     split; [assumption|].
     destruct Hc as [Hc _].
@@ -1057,11 +1054,8 @@ Proof.
   apply basic_VLSM_incl; intros ? *.
   - intro; assumption.
   - intros.
-    apply initial_message_is_valid.
-    simpl.
-    destruct HmX; [left; assumption|].
-    right.
-    apply Hseed12; assumption.
+    apply initial_message_is_valid; cbn.
+    destruct HmX; auto.
   - intros (Hs & _ & Hv & Hc & _) _ _.
     split; [assumption|].
     split; [|exact I].
@@ -1326,14 +1320,12 @@ Qed.
 Lemma fixed_equivocators_vlsm_projection
   : VLSM_projection XE X (equivocators_total_label_project IM) (equivocators_total_state_project IM).
 Proof.
-  constructor; [constructor|]; intros *.
-  - intro HtrX.
-    apply PreFreeE_Free_vlsm_projection_type.
-    revert HtrX. apply VLSM_incl_finite_valid_trace_from.
+  constructor; [constructor|]; intros sX trX HtrX.
+  - apply PreFreeE_Free_vlsm_projection_type.
+    apply VLSM_incl_finite_valid_trace_from; [| assumption].
     apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
-  - intro HtrX.
-    assert (Hpre_tr : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) sX trX).
-    { revert HtrX. apply VLSM_incl_finite_valid_trace.
+  - assert (Hpre_tr : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) sX trX).
+    { apply VLSM_incl_finite_valid_trace; [| assumption].
       apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
     }
     specialize

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -157,7 +157,7 @@ Lemma fixed_equivocation_replay_has_message
       (lift_equivocators_sub_state_to IM equivocating eqv_state_s s) im.
 Proof.
   apply non_empty_valid_trace_from_can_produce in Him
-    as [im_eis [im_etr [item [Him_etr [Hlast [Heqs Him]]]]]].
+     as (im_eis & im_etr & item & Him_etr & Hlast & Heqs & Him).
   specialize
     (PreFreeSubE_PreFreeE_weak_full_projection IM equivocating _ Heqv_state_s)
     as Hproj.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -29,27 +29,18 @@ Section fixed_equivocating.
 
 Context {message : Type}
   {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
   (Free := free_composite_vlsm IM)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
+  `{forall i : index, HasBeenSentCapability (IM i)}
   (equivocating : list index)
-  (X : VLSM message := strong_fixed_equivocation_vlsm_composition IM Hbs equivocating)
-  (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM Hbs index_listing equivocating)
+  (X : VLSM message := strong_fixed_equivocation_vlsm_composition IM equivocating)
+  (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM equivocating)
   (FreeE := free_composite_vlsm (equivocator_IM IM))
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   (SubFreeE := free_composite_vlsm (sub_IM (equivocator_IM IM) equivocating))
-  (Free_Hbs := free_composite_HasBeenSentCapability IM finite_index Hbs)
-  (FreeE_Hbs := free_composite_HasBeenSentCapability (equivocator_IM IM) finite_index (equivocator_Hbs IM Hbs))
-  (SubFreeE_Hbs := free_composite_HasBeenSentCapability (sub_IM (equivocator_IM IM) equivocating) (finite_sub_index equivocating finite_index) (sub_has_been_sent_capabilities (equivocator_IM IM) equivocating (equivocator_Hbs IM Hbs)))
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   .
-
-Existing Instance Free_Hbs.
-Existing Instance FreeE_Hbs.
-Existing Instance SubFreeE_Hbs.
 
 Lemma no_initial_messages_in_sub_IM
   : forall i m, ~vinitial_message_prop (sub_IM IM equivocating i) m.
@@ -69,23 +60,22 @@ Lemma fixed_equivocating_messages_sent_by_non_equivocating_are_valid
   (s := equivocators_total_state_project IM eqv_state_s)
   (Hs : valid_state_prop X s)
   m
-  (Hm : sent_by_non_equivocating IM Hbs equivocating s m)
+  (Hm : sent_by_non_equivocating IM equivocating s m)
   : valid_message_prop XE m.
 Proof.
-  specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM Hbs index_listing equivocating)
+  specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM equivocating)
     as HinclE.
   apply sent_by_non_equivocating_are_sent in Hm.
-  specialize (StrongFixed_incl_Preloaded IM Hbs equivocating)
+  specialize (StrongFixed_incl_Preloaded IM equivocating)
     as Hincl.
   apply (VLSM_incl_valid_state Hincl) in Hs.
   apply
-    (composite_sent_valid (equivocator_IM IM) finite_index (equivocator_Hbs IM Hbs)
-      _ _ Heqv_state_s).
+    (composite_sent_valid (equivocator_IM IM) _ _ Heqv_state_s).
   revert Hm.
   apply (VLSM_incl_valid_state HinclE) in Heqv_state_s.
   by specialize
     (VLSM_projection_has_been_sent_reflect
-      (preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection IM Hbs finite_index)
+      (preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection IM)
       _ Heqv_state_s m).
 Qed.
 
@@ -98,16 +88,15 @@ Lemma fixed_equivocating_non_equivocating_constraint_lifting
   l s om
   (Hv :
     input_valid
-      (seeded_equivocators_no_equivocation_vlsm IM Hbs equivocating
-        (sent_by_non_equivocating IM Hbs equivocating (equivocators_total_state_project IM eqv_state_s)))
+      (seeded_equivocators_no_equivocation_vlsm IM equivocating
+        (sent_by_non_equivocating IM equivocating (equivocators_total_state_project IM eqv_state_s)))
         l (s, om))
   (Hlift_s : valid_state_prop XE (lift_equivocators_sub_state_to IM equivocating eqv_state_s s))
-  : equivocators_fixed_equivocations_constraint IM Hbs index_listing
-        equivocating
+  : equivocators_fixed_equivocations_constraint IM equivocating
         (lift_equivocators_sub_label_to IM equivocating eqv_state_s l)
         (lift_equivocators_sub_state_to IM equivocating eqv_state_s s, om).
 Proof.
-  specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM Hbs index_listing equivocating)
+  specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM equivocating)
     as HinclE.
   destruct Hv as [Hs [Hom [_ Hc]]].
   apply valid_state_has_fixed_equivocation in Hlift_s.
@@ -118,11 +107,10 @@ Proof.
     apply proj1 in Hc as [Hsent | Hseed].
     + revert Hsent. simpl.
       apply (VLSM_incl_valid_state HinclE) in Heqv_state_s.
-      apply (VLSM_incl_valid_state (seeded_no_equivocation_incl_preloaded IM Hbs equivocating _)) in Hs.
+      apply (VLSM_incl_valid_state (seeded_no_equivocation_incl_preloaded IM equivocating _)) in Hs.
       by specialize
         (VLSM_weak_full_projection_has_been_sent
-          (PreFreeSubE_PreFreeE_weak_full_projection IM _ finite_index equivocating
-            _ Heqv_state_s)
+          (PreFreeSubE_PreFreeE_weak_full_projection IM _ _ Heqv_state_s)
           _ Hs m
           ).
     + destruct Hseed as [i [Hi Hsent]].
@@ -135,14 +123,14 @@ Proof.
       revert Hsent.
       apply
         (VLSM_projection_has_been_sent_reflect
-          (preloaded_equivocator_zero_projection (IM i)) (HbsX := equivocator_HasBeenSentCapability (IM i))).
+          (preloaded_equivocator_zero_projection (IM i))).
       apply (VLSM_incl_valid_state HinclE) in Heqv_state_s.
       revert Heqv_state_s.
       apply (VLSM_projection_valid_state (preloaded_component_projection (equivocator_IM IM) i)).
   - destruct (composite_transition _ _ _) as (s', om') eqn:Ht'.
     apply
       (equivocating_transition_preserves_fixed_equivocation
-        IM _ finite_index equivocating _ _ _ _ _ Ht' Hlift_s).
+        IM equivocating _ _ _ _ _ Ht' Hlift_s).
     destruct l as (sub_i, li).
     destruct_dec_sig sub_i i Hi Hsub_i.
     by subst.
@@ -165,21 +153,14 @@ Lemma fixed_equivocation_replay_has_message
     (pre_loaded_with_all_messages_vlsm
       (free_composite_vlsm (equivocator_IM (sub_IM IM equivocating))))
     s im)
-  : composite_has_been_sent (equivocator_IM IM) (equivocator_Hbs IM Hbs)
+  : composite_has_been_sent (equivocator_IM IM)
       (lift_equivocators_sub_state_to IM equivocating eqv_state_s s) im.
 Proof.
   apply non_empty_valid_trace_from_can_produce in Him
     as [im_eis [im_etr [item [Him_etr [Hlast [Heqs Him]]]]]].
   specialize
-    (PreFreeSubE_PreFreeE_weak_full_projection IM index_listing finite_index
-      equivocating _ Heqv_state_s)
+    (PreFreeSubE_PreFreeE_weak_full_projection IM equivocating _ Heqv_state_s)
     as Hproj.
-  pose
-    (Hbs_sub_eqv := composite_HasBeenSentCapability
-      (sub_IM (equivocator_IM IM) equivocating)
-      (finite_sub_index equivocating finite_index)
-      (sub_has_been_sent_capabilities (equivocator_IM IM) equivocating (equivocator_Hbs IM Hbs))
-      (free_constraint _)).
   apply valid_trace_add_default_last in Him_etr.
   apply valid_trace_last_pstate in Him_etr as Him_etr_lst.
   specialize
@@ -187,8 +168,9 @@ Proof.
   unfold has_been_sent in Hsent. simpl in Hsent.
   replace s with (finite_trace_last im_eis im_etr).
   - apply Hsent.
-    apply
-      (has_been_sent_examine_one_trace Hbs_sub_eqv _ _ _ Him_etr im).
+    specialize (has_been_sent_examine_one_trace _ _ _ Him_etr im)
+      as Hrew.
+    unfold has_been_sent in Hrew; cbn; apply Hrew.
     apply Exists_exists. exists item. split; [|assumption].
     apply elem_of_list_lookup.
     rewrite StdppExtras.last_last_error in Hlast.
@@ -197,20 +179,20 @@ Proof.
     exists (pred (length im_etr)).
     by induction im_etr as [| ?[]].
   - apply last_error_destination_last.
-    rewrite Hlast. simpl. by f_equal.
+    rewrite Hlast. simpl. f_equal. assumption.
 Qed.
 
 (** Messages satisfying the [strong_fixed_equivocation_constraint] have the
 [replayable_message_prop]erty for the [equivocators_fixed_equivocations_constraint].
 *)
 Lemma fixed_equivocation_has_replayable_message_prop
-  : replayable_message_prop IM Hbs (λ _ : message, False)
-    (strong_fixed_equivocation_constraint IM Hbs equivocating)
-    (equivocators_fixed_equivocations_constraint IM Hbs index_listing equivocating).
+  : replayable_message_prop IM (λ _ : message, False)
+    (strong_fixed_equivocation_constraint IM equivocating)
+    (equivocators_fixed_equivocations_constraint IM equivocating).
 Proof.
   specialize (vlsm_is_pre_loaded_with_False XE) as HeqXE.
   specialize (vlsm_is_pre_loaded_with_False X) as HeqX.
-  specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM Hbs index_listing equivocating) as HinclE.
+  specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM equivocating) as HinclE.
   intro; intros.
   destruct iom as [im|]; swap 1 2; [|destruct HcX as [Hsent | Hemitted]].
   - exists []. exists eqv_state_s.
@@ -229,7 +211,7 @@ Proof.
     revert Hsent. subst.
     specialize
       (VLSM_projection_has_been_sent_reflect
-        (preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection IM Hbs finite_index)
+        (preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection IM)
         eqv_state_s Hstate_valid im) as Hsent.
     unfold has_been_sent in Hsent. simpl in Hsent.
     assumption.
@@ -245,10 +227,9 @@ Proof.
     rewrite finite_trace_last_is_last in Him_tr.
     apply
       (seeded_equivocators_finite_valid_trace_init_to_rev
-        (sub_IM IM equivocating) (sub_has_been_sent_capabilities IM equivocating Hbs)
-        (finite_sub_index equivocating finite_index) _ no_initial_messages_in_sub_IM)
+        (sub_IM IM equivocating) _ no_initial_messages_in_sub_IM)
       in Him_tr
-      as [im_eis [Him_eis [im_es [Him_es [im_etr [Him_etr_pr [Him_etr Him_output]]]]]]].
+      as (im_eis & Him_eis & im_es & Him_es & im_etr & Him_etr_pr & Him_etr & Him_output).
     rewrite finite_trace_last_output_is_last in Him_output.
     rewrite Him_item in Him_output.
     (*  We will use Lemma
@@ -261,20 +242,20 @@ Proof.
     *)
     specialize
       (sub_preloaded_replayed_trace_from_valid_equivocating
-        IM Hbs _ finite_index (sent_by_non_equivocating IM Hbs equivocating s)
+        IM (sent_by_non_equivocating IM equivocating s)
         equivocating
-        (equivocators_fixed_equivocations_constraint IM Hbs index_listing equivocating)
+        (equivocators_fixed_equivocations_constraint IM equivocating)
         (fun m => False))
       as Hreplay.
     spec Hreplay.
-    { clear -finite_index HeqXE. intros i ns s Hi Hs.
+    { clear -HeqXE. intros i ns s Hi Hs.
       split; [split; exact I|].
       apply (VLSM_eq_valid_state HeqXE) in Hs.
       apply valid_state_has_fixed_equivocation in Hs.
       destruct (composite_transition _ _ _) as (s', om') eqn:Ht.
       apply
         (equivocating_transition_preserves_fixed_equivocation
-          IM _ finite_index equivocating _ _ _ _ _ Ht Hs).
+          IM equivocating _ _ _ _ _ Ht Hs).
       assumption.
     }
     spec Hreplay.
@@ -291,7 +272,7 @@ Proof.
     { by apply (VLSM_eq_valid_state HeqXE), (VLSM_eq_valid_state HeqXE). }
     spec Hreplay.
     { subst s.
-      clear -finite_index FreeE_Hbs SubFreeE_Hbs HeqXE Hstate_valid.
+      clear -HeqXE Hstate_valid.
       intros l s om Hv Hlift_s.
       apply (VLSM_eq_valid_state HeqXE) in Hstate_valid.
       apply (VLSM_eq_valid_state HeqXE) in Hlift_s.
@@ -309,27 +290,23 @@ Proof.
     repeat split.
     + apply
       (equivocators_total_trace_project_replayed_trace_from
-        IM index_listing equivocating
-        eqv_state_s im_eis im_etr).
+        IM equivocating eqv_state_s im_eis im_etr).
     + subst s.
       apply
       (equivocators_total_state_project_replayed_trace_from
-        IM index_listing equivocating
-        eqv_state_s im_eis im_etr).
-    +
-      apply (VLSM_eq_valid_state HeqXE) in Hstate_valid.
+        IM equivocating eqv_state_s im_eis im_etr).
+    + apply (VLSM_eq_valid_state HeqXE) in Hstate_valid.
       apply (VLSM_incl_valid_state HinclE) in Hstate_valid as Hstate_pre.
       specialize
         (NoEquivocation.seeded_no_equivocation_incl_preloaded (equivocator_IM (sub_IM IM equivocating))
           (free_constraint _)
-          (sub_has_been_sent_capabilities (equivocator_IM IM) equivocating (equivocator_Hbs IM Hbs))
-          (sent_by_non_equivocating IM Hbs equivocating
+          (sent_by_non_equivocating IM equivocating
                     s)
         ) as Hsub_incl.
       apply (VLSM_incl_finite_valid_trace Hsub_incl) in Him_etr.
       left.
       specialize
-        (replayed_trace_from_finite_trace_last IM _ finite_index equivocating eqv_state_s im_eis im_etr (proj2 Him_etr)).
+        (replayed_trace_from_finite_trace_last IM equivocating eqv_state_s im_eis im_etr (proj2 Him_etr)).
       simpl. intro Hrew. rewrite Hrew. clear Hrew.
       apply fixed_equivocation_replay_has_message; [assumption|].
       clear -Him_etr Him_output.
@@ -379,8 +356,7 @@ Proof.
   apply (VLSM_eq_finite_valid_trace_init_to HeqX) in HtrX.
   apply
     (generalized_equivocators_finite_valid_trace_init_to_rev
-      IM Hbs finite_index _ _
-      (equivocators_fixed_equivocations_constraint IM Hbs index_listing equivocating))
+      IM _ _ (equivocators_fixed_equivocations_constraint IM equivocating))
     in HtrX
     as [is [His [s [Hs [tr [Htr [Hptr Houtput]]]]]]].
   - exists is. split; [assumption|].
@@ -400,7 +376,7 @@ Proof.
       simpl.
       apply
         (zero_descriptor_transition_preserves_fixed_equivocation
-          IM _ finite_index equivocating _ _ _ _ _ Het Hes li
+          IM equivocating _ _ _ _ _ Het Hes li
         ).
       reflexivity.
   - apply fixed_equivocation_has_replayable_message_prop.
@@ -418,24 +394,15 @@ no message-equivocation in which no component is allowed to state-equivocate.
 Section no_equivocation.
 
 Context {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  {i0 : Inhabited index}
   (Free := free_composite_vlsm IM)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
-  (X : VLSM message := composite_vlsm IM (composite_no_equivocations IM Hbs))
-  (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM Hbs index_listing [])
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  (X : VLSM message := composite_vlsm IM (composite_no_equivocations IM))
+  (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM [])
   (FreeE := free_composite_vlsm (equivocator_IM IM))
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
-  (Free_Hbs := free_composite_HasBeenSentCapability IM finite_index Hbs)
-  (FreeE_Hbs := free_composite_HasBeenSentCapability (equivocator_IM IM) finite_index (equivocator_Hbs IM Hbs))
   .
-
-Existing Instance Free_Hbs.
-Existing Instance FreeE_Hbs.
 
 Lemma no_equivocating_equivocators_finite_valid_trace_init_to_rev
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
@@ -458,8 +425,7 @@ Proof.
   apply (VLSM_eq_finite_valid_trace_init_to HeqX) in HtrX.
   apply
     (generalized_equivocators_finite_valid_trace_init_to_rev
-      IM Hbs finite_index _ _
-      (equivocators_fixed_equivocations_constraint IM Hbs index_listing []))
+      IM _ _ (equivocators_fixed_equivocations_constraint IM []))
     in HtrX
     as [is [His [s [Hs [tr [Htr [Hptr Houtput]]]]]]].
   - exists is. split; [assumption|].
@@ -479,11 +445,11 @@ Proof.
       simpl.
       apply
         (zero_descriptor_transition_preserves_fixed_equivocation
-          IM _ finite_index [] _ _ _ _ _ Het Hes li
+          IM [] _ _ _ _ _ Het Hes li
         ).
       reflexivity.
   - clear isX sX trX HtrX. intro; intros.
-    specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM Hbs index_listing []) as HinclE.
+    specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM []) as HinclE.
     destruct iom as [im|].
     2: {
       exists []. exists eqv_state_s.
@@ -502,7 +468,7 @@ Proof.
     revert Hsent. subst.
     specialize
       (VLSM_projection_has_been_sent_reflect
-        (preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection IM Hbs finite_index)
+        (preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection IM)
         eqv_state_s Hstate_valid im) as Hsent.
     unfold has_been_sent in Hsent. simpl in Hsent.
     assumption.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocation.v
@@ -1,4 +1,4 @@
-From stdpp Require Import prelude.
+From stdpp Require Import prelude finite.
 From Coq Require Import FinFun Lia Reals Lra.
 From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras FinExtras Measurable.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces.
@@ -30,8 +30,8 @@ Proof.
 Qed.
 
 Lemma composite_equivocators_initial_state_project
-  {index message}
-  {Hindex_eq: EqDecision index}
+  {message}
+  `{EqDecision index}
   (IM : index -> VLSM message)
   (es : composite_state (equivocator_IM IM))
   (eqv_descriptors : equivocator_descriptors IM)
@@ -47,36 +47,33 @@ Qed.
 Section limited_state_equivocation.
 
 Context {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  (Hbr : forall i : index, HasBeenReceivedCapability (IM i))
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  `{forall i : index, HasBeenReceivedCapability (IM i)}
   (Free := free_composite_vlsm IM)
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
   (equivocator_descriptors := equivocator_descriptors IM)
   (equivocators_state_project := equivocators_state_project IM)
   (equivocator_IM := equivocator_IM IM)
   (equivocator_descriptors_update := equivocator_descriptors_update IM)
   (proper_equivocator_descriptors := proper_equivocator_descriptors IM)
   (sender : message -> option index)
-  {Hmeasurable : Measurable index}
-  {reachable_threshold : ReachableThreshold index}
+  `{ReachableThreshold index}
   (Heqv_idx_BasicEquivocation : BasicEquivocation (composite_state equivocator_IM) index
-    := equivocating_indices_BasicEquivocation IM _ finite_index Hmeasurable reachable_threshold)
+    := equivocating_indices_BasicEquivocation IM)
   (FreeE : VLSM message := free_composite_vlsm equivocator_IM)
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
+  (not_heavy := @not_heavy _ _ _ _ Heqv_idx_BasicEquivocation)
+  (equivocating_validators := @equivocating_validators _ _ _ _ Heqv_idx_BasicEquivocation)
+  (equivocation_fault := @equivocation_fault _ _ _ _ Heqv_idx_BasicEquivocation)
   .
-
-Existing Instance Heqv_idx_BasicEquivocation.
 
 Definition equivocators_limited_equivocations_constraint
   (l : composite_label equivocator_IM)
   (som : composite_state equivocator_IM * option message)
   (som' := composite_transition equivocator_IM l som)
   : Prop
-  := equivocators_no_equivocations_constraint IM Hbs l som
+  := equivocators_no_equivocations_constraint IM l som
   /\ not_heavy (fst som').
 
 Definition equivocators_limited_equivocations_vlsm
@@ -107,8 +104,9 @@ Qed.
 Lemma preloaded_equivocators_limited_equivocations_vlsm_incl_free
   : VLSM_incl (pre_loaded_with_all_messages_vlsm equivocators_limited_equivocations_vlsm) PreFreeE.
 Proof.
-  apply basic_VLSM_incl_preloaded; intro; intros; [assumption| |assumption].
-  split; [|exact I]. apply H.
+  apply basic_VLSM_incl_preloaded; intros ? *.
+  1, 3: intuition.
+  intros [Hv _]. split; [assumption|exact I].
 Qed.
 
 (**
@@ -116,10 +114,10 @@ Inclusion in the composition of equivocators with no message equivocation
 (no restriction on state equivocation).
 *)
 Lemma equivocators_limited_equivocations_vlsm_incl_no_equivocations
-  : VLSM_incl equivocators_limited_equivocations_vlsm (equivocators_no_equivocations_vlsm IM Hbs).
+  : VLSM_incl equivocators_limited_equivocations_vlsm (equivocators_no_equivocations_vlsm IM).
 Proof.
   apply constraint_subsumption_incl.
-  intros l (s,om) Hv. apply Hv.
+  intros l (s,om) (_ & _ & _ & Hc & _). assumption.
 Qed.
 
 (** A valid state for a VLSM satisfying the limited equivocation assumption
@@ -132,11 +130,13 @@ Lemma valid_state_limited_equivocation
 Proof.
   apply valid_state_prop_iff in Hs.
   destruct Hs as [[(is, His) Heq_s] | [l [(s0, oim) [oom' [[_ [_ [_ [_ Hlimited]]]] Ht]]]]].
-  - subst s. simpl. unfold not_heavy, equivocation_fault.
-    replace (equivocating_validators is) with (@nil index).
+  - subst s.
+    unfold not_heavy, Equivocation.not_heavy,
+      equivocation_fault, Equivocation.equivocation_fault.
+    replace (Equivocation.equivocating_validators is) with (@nil index).
     + destruct threshold as [t Ht]. simpl. apply Rge_le. assumption.
     + symmetry. apply set_eq_empty_iff.
-      specialize (equivocating_indices_equivocating_validators IM _ finite_index _ _ is).
+      specialize (equivocating_indices_equivocating_validators IM is).
       rewrite equivocating_indices_initially_empty; [|assumption].
       intro. assumption.
   - replace s with
@@ -153,45 +153,45 @@ measured for the final state of the trace.
 Lemma equivocators_limited_valid_trace_is_fixed is s tr
   : finite_valid_trace_init_to equivocators_limited_equivocations_vlsm is s tr ->
   finite_valid_trace_init_to
-   (equivocators_fixed_equivocations_vlsm IM Hbs index_listing
-    (equivocating_validators s)) is s tr.
+   (equivocators_fixed_equivocations_vlsm IM (equivocating_validators s))
+   is s tr.
 Proof.
-  intro H.
-  split; [| apply H].
+  intro Htr.
+  split; [| exact (proj2  Htr)].
   cut
     (forall equivocating, equivocating_validators s ⊆ equivocating ->
-      finite_valid_trace_from_to (equivocators_fixed_equivocations_vlsm IM Hbs index_listing equivocating) is s tr).
+      finite_valid_trace_from_to (equivocators_fixed_equivocations_vlsm IM equivocating) is s tr).
   { intros H'. apply H'. reflexivity. }
-  induction H using finite_valid_trace_init_to_rev_ind; intros equivocating Hincl.
-  - apply (finite_valid_trace_from_to_empty (equivocators_fixed_equivocations_vlsm IM Hbs index_listing equivocating)).
+  induction Htr using finite_valid_trace_init_to_rev_ind; intros equivocating Hincl.
+  - apply (finite_valid_trace_from_to_empty (equivocators_fixed_equivocations_vlsm IM equivocating)).
     apply initial_state_is_valid. assumption.
-  - specialize (equivocating_indices_equivocating_validators IM _ finite_index _ reachable_threshold)
+  - specialize (equivocating_indices_equivocating_validators IM)
       as Heq.
     destruct (Heq sf) as [_ Hsf_incl].
-    specialize (IHfinite_valid_trace_init_to equivocating).
-    spec IHfinite_valid_trace_init_to.
+    specialize (IHHtr equivocating).
+    spec IHHtr.
     { apply proj2 in Ht.
-      specialize (equivocators_transition_preserves_equivocating_indices IM index_listing _ _ _ _ _ Ht)
+      specialize (equivocators_transition_preserves_equivocating_indices IM (enum index)  _ _ _ _ _ Ht)
         as Hincl'.
       clear -Hincl Hincl' Heq Hsf_incl.
       specialize (Heq s) as [Hincl_s _].
       transitivity (equivocating_validators sf); [|assumption].
-      transitivity (equivocating_indices IM index_listing sf); [|assumption].
-      transitivity (equivocating_indices IM index_listing s); assumption.
+      transitivity (equivocating_indices IM (enum index) sf); [|assumption].
+      transitivity (equivocating_indices IM (enum index) s); assumption.
     }
     apply
       (finite_valid_trace_from_to_app
-        (equivocators_fixed_equivocations_vlsm IM Hbs index_listing equivocating))
+        (equivocators_fixed_equivocations_vlsm IM equivocating))
       with s; [assumption|].
     apply valid_trace_add_last; [|reflexivity].
-      apply (finite_valid_trace_singleton (equivocators_fixed_equivocations_vlsm IM Hbs index_listing equivocating)).
-      apply valid_trace_last_pstate in IHfinite_valid_trace_init_to.
+      apply (finite_valid_trace_singleton (equivocators_fixed_equivocations_vlsm IM equivocating)).
+      apply valid_trace_last_pstate in IHHtr.
       destruct Ht as [[_ [_ [Hv [[Hno_equiv _] Hno_heavy]]]] Ht].
       repeat split; [assumption| |assumption|assumption| |assumption].
       + destruct iom as [m|]; [|apply option_valid_message_None].
         destruct Hno_equiv as [Hsent | Hfalse]; [|contradiction].
         simpl in Hsent.
-        apply composite_sent_valid with index_listing (equivocator_Hbs IM Hbs) s; assumption.
+        eapply composite_sent_valid; eassumption.
       + replace (composite_transition _ _ _) with (sf, oom).
         unfold state_has_fixed_equivocation.
         transitivity (equivocating_validators sf); assumption.
@@ -216,15 +216,15 @@ Lemma equivocators_limited_valid_trace_projects_to_fixed_limited_equivocation
     proper_equivocator_descriptors initial_descriptors is /\
     equivocators_trace_project IM final_descriptors tr = Some (trX, initial_descriptors) /\
     equivocators_state_project final_descriptors final_state = final_stateX /\
-    fixed_limited_equivocation_prop IM Hbs Hbr isX trX.
+    fixed_limited_equivocation_prop IM isX trX.
 Proof.
   apply valid_trace_add_default_last in Htr as Hfixed_tr.
   apply equivocators_limited_valid_trace_is_fixed in Hfixed_tr.
   apply valid_trace_last_pstate in Hfixed_tr as Hfixed_last.
   apply valid_trace_forget_last in Hfixed_tr.
   specialize
-    (fixed_equivocators_valid_trace_project IM Hbs Hbr (equivocating_validators (finite_trace_last is tr))
-      finite_index final_descriptors is tr) as Hpr.
+    (fixed_equivocators_valid_trace_project IM (equivocating_validators (finite_trace_last is tr))
+      final_descriptors is tr) as Hpr.
   feed specialize Hpr; [| assumption |].
   - eapply not_equivocating_equivocator_descriptors_proper_fixed; eassumption.
   - destruct Hpr as [trX [initial_descriptors [Hinitial_descriptors [Hpr [Hlst_pr Hpr_fixed]]]]].
@@ -234,10 +234,8 @@ Proof.
     + exists (equivocating_validators (finite_trace_last is tr)).
       split; [| assumption].
       apply valid_trace_add_default_last, valid_trace_last_pstate, valid_state_limited_equivocation in Htr.
-      unfold not_heavy in Htr.
       transitivity (equivocation_fault (finite_trace_last is tr)); [|assumption].
-      unfold equivocation_fault.
-      specialize (equivocating_indices_equivocating_validators IM _ finite_index _ reachable_threshold
+      specialize (equivocating_indices_equivocating_validators IM
                    (finite_trace_last is tr)) as Heq.
       apply sum_weights_subseteq.
       * apply NoDup_remove_dups.
@@ -246,10 +244,9 @@ Proof.
 Qed.
 
 Context
-  {is_equivocating_tracewise_no_has_been_sent_dec : RelDecision (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
-  (Limited : VLSM message := limited_equivocation_vlsm_composition IM finite_index sender)
+  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
+  (Limited : VLSM message := limited_equivocation_vlsm_composition IM sender)
   (Hsender_safety : sender_safety_alt_prop IM (fun i => i) sender)
-  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
   (message_dependencies : message -> set message)
   (Hfull : forall i, message_dependencies_full_node_condition_prop message_dependencies (IM i))
   .
@@ -293,7 +290,7 @@ composite VLSMs. It yields a [VLSM_partial_projection] because for invalid
 *)
 Lemma limited_equivocators_vlsm_partial_projection
   (final_descriptors : equivocator_descriptors)
-  : VLSM_partial_projection equivocators_limited_equivocations_vlsm Limited (equivocators_partial_trace_project IM finite_index final_descriptors).
+  : VLSM_partial_projection equivocators_limited_equivocations_vlsm Limited (equivocators_partial_trace_project IM final_descriptors).
 Proof.
   split; [split|].
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
@@ -305,11 +302,11 @@ Proof.
     clear Hpre_tr.  revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
     apply equivocators_partial_trace_project_extends_left.
   - intros s tr sX trX Hpr_tr Htr.
-    destruct (destruct_equivocators_partial_trace_project IM finite_index Hpr_tr)
+    destruct (destruct_equivocators_partial_trace_project IM Hpr_tr)
       as [Hnot_equiv [initial_descriptors [Htr_project Hs_project]]].
 
     destruct (limited_equivocators_valid_trace_project _ _ _ Hnot_equiv Htr)
-      as [_trX [_initial_descriptors [_ [_Htr_project [_ HtrX]]]]].
+      as (_trX & _initial_descriptors & _ & _Htr_project & _ & HtrX).
     rewrite Htr_project in _Htr_project.
     inversion _Htr_project. subst.  assumption.
 Qed.
@@ -321,12 +318,12 @@ above strengthens to a [VLSM_projection].
 Lemma limited_equivocators_vlsm_projection
   : VLSM_projection equivocators_limited_equivocations_vlsm Limited (equivocators_total_label_project IM) (equivocators_total_state_project IM).
 Proof.
-  constructor; [constructor|]; intros.
-  - apply PreFreeE_Free_vlsm_projection_type.
-    revert H. apply VLSM_incl_finite_valid_trace_from.
+  constructor; [constructor|]; intros ? *.
+  - intros HtrX. apply PreFreeE_Free_vlsm_projection_type.
+    revert HtrX. apply VLSM_incl_finite_valid_trace_from.
     apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
-  - assert (Hpre_tr : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) sX trX).
-    { revert H. apply VLSM_incl_finite_valid_trace.
+  - intro HtrX. assert (Hpre_tr : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) sX trX).
+    { revert HtrX. apply VLSM_incl_finite_valid_trace.
       apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
     }
     specialize
@@ -338,7 +335,7 @@ Proof.
       rewrite (equivocators_total_trace_project_characterization IM (proj1 Hpre_tr)).
       reflexivity.
     }
-    apply Hsim in H.
+    apply Hsim in HtrX.
     remember (pre_VLSM_projection_trace_project _ _ _ _ _) as tr.
     replace tr with (equivocators_total_trace_project IM trX); [assumption|].
     subst. symmetry.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
@@ -92,23 +92,19 @@ Lemma limited_equivocators_finite_valid_trace_init_to_rev
     finite_valid_trace_init_to XE is s tr /\
     finite_trace_last_output trX = finite_trace_last_output tr.
 Proof.
-  destruct HtrX as [equivocating [Hlimited HtrX]].
-  pose proof (VLSM_eq_proj1 (Fixed_eq_StrongFixed IM equivocating))  as Hincl.
-  apply (VLSM_incl_finite_valid_trace Hincl) in HtrX.
-  clear Hincl.
-  apply valid_trace_add_default_last in HtrX.
+  destruct HtrX as (equivocating & Hlimited & HtrX).
+  eapply VLSM_incl_finite_valid_trace, valid_trace_add_default_last in HtrX
+  ; [|eapply VLSM_eq_proj1,Fixed_eq_StrongFixed].
   specialize
     (fixed_equivocators_finite_valid_trace_init_to_rev IM _
       no_initial_messages_in_IM _ _ _ HtrX)
-    as [is [His [s [Hs [tr [Htr [Hptr Houtput]]]]]]].
-  exists is. split; [assumption|].
-  exists s. split; [assumption|].
-  exists tr. split; [assumption|].
+    as (is & His & s & Hs & tr & Htr & Hptr & Houtput).
+  exists is; split; [assumption|].
+  exists s; split; [assumption|].
+  exists tr; split; [assumption|].
   split; [|assumption].
-  revert Hptr.
-  apply VLSM_incl_finite_valid_trace_init_to.
-  apply equivocators_Fixed_incl_Limited.
-  assumption.
+  revert Hptr; apply VLSM_incl_finite_valid_trace_init_to.
+  apply equivocators_Fixed_incl_Limited; assumption.
 Qed.
 
 Context

--- a/theories/VLSM/Core/Equivocators/Composition/Projections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/Projections.v
@@ -1,4 +1,4 @@
-From stdpp Require Import prelude.
+From stdpp Require Import prelude finite.
 From Coq Require Import FinFun FunctionalExtensionality Program.
 From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet Lib.FinExtras.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces.
@@ -12,27 +12,20 @@ From VLSM Require Import Core.Equivocators.Composition.Common.
 Section equivocators_composition_projections.
 
 Context {message : Type}
-  {equiv_index : Type}
-  (index := equiv_index)
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
+  `{forall i : index, HasBeenSentCapability (IM i)}
   (equivocator_descriptors := equivocator_descriptors IM)
-  (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM Hbs)
+  (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM)
   (equivocators_state_project := equivocators_state_project IM)
   (equivocator_IM := equivocator_IM IM)
   (equivocator_descriptors_update := equivocator_descriptors_update IM)
   (proper_equivocator_descriptors := proper_equivocator_descriptors IM)
   (FreeE := free_composite_vlsm equivocator_IM)
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
-  (equivocators_free_Hbs : HasBeenSentCapability FreeE := free_composite_HasBeenSentCapability equivocator_IM finite_index (equivocator_Hbs IM Hbs))
   (Free := free_composite_vlsm IM)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
   .
-
-Existing Instance equivocators_free_Hbs.
 
 (** Given a [transition_item] <<item>> in the compositions of equivocators
 of components [IM] and an [equivocator_descriptors], if the descriptors
@@ -76,10 +69,9 @@ Lemma equivocators_transition_item_project_preserves_equivocating_indices
   (Hv : composite_valid equivocator_IM (l item) (s, input item))
   (Hpr : equivocators_transition_item_project descriptors item = Some (oitem, idescriptors))
   :
-    (set_union (equivocating_indices IM index_listing s) (newmachine_descriptors_list IM index_listing idescriptors)) ⊆
-    (set_union (equivocating_indices IM index_listing (destination item)) (newmachine_descriptors_list IM index_listing descriptors)).
+    (set_union (equivocating_indices IM (enum index) s) (newmachine_descriptors_list IM (enum index) idescriptors)) ⊆
+    (set_union (equivocating_indices IM (enum index) (destination item)) (newmachine_descriptors_list IM (enum index) descriptors)).
 Proof.
-
   unfold equivocators_transition_item_project
     , composite_transition_item_projection
     , composite_transition_item_projection_from_eq  in Hpr; simpl in Hpr.
@@ -95,7 +87,6 @@ Proof.
   inversion Ht. subst. clear Ht.
   replace idescriptors with (equivocator_descriptors_update descriptors i deqv')
     by (destruct oitemx;congruence);clear oitem Hpr.
-
   intros eqv Heqv. apply set_union_iff in Heqv. apply set_union_iff.
   destruct (decide (eqv = i)).
   - subst i.
@@ -359,7 +350,7 @@ Proof.
     (equivocator_transition_item_project_proper_characterization (IM i)
       (composite_transition_item_projection equivocator_IM item)
       (eqv_descriptors i) Hproper)
-    as [oitemi [eqv_descriptorsi' [Hoitemi [Hitemx H]]]].
+    as (oitemi & eqv_descriptorsi' & Hoitemi & Hitemx & Hchar).
   subst i.
   unfold equivocators_transition_item_project.
   rewrite Hoitemi. clear Hoitemi.
@@ -376,33 +367,32 @@ Proof.
       destruct t as (si', om') eqn:Ht'
     end
   ; inversion Ht; subst; clear Ht
-  ; rewrite state_update_eq in H
-  ; specialize (H _ Hv Ht')
+  ; rewrite state_update_eq in Hchar
+  ; specialize (Hchar _ Hv Ht')
   ; simpl in *
-  ; destruct H as [Hproper' [Hex_new H]]
+  ; destruct Hchar as (Hproper' & Hex_new & Hchar)
   .
   - repeat split.
     + unfold equivocator_descriptors_update. rewrite equivocator_descriptors_update_eq. assumption.
     + unfold equivocator_descriptors_update. rewrite equivocator_descriptors_update_eq. reflexivity.
-    + apply functional_extensionality_dep. intro j.
+    + extensionality j.
       destruct (decide (j = i)).
       * subst. rewrite state_update_eq. reflexivity.
       * repeat (rewrite state_update_neq; [| assumption]). reflexivity.
     + unfold equivocator_descriptors_update.
       rewrite equivocator_descriptors_update_eq.
       assumption.
-    + subst. specialize (H _ eq_refl). destruct H as [Hvx Htx].
+    + subst. specialize (Hchar _ eq_refl) as [Hvx Htx].
       unfold equivocators_state_project. unfold Common.equivocators_state_project.
       unfold equivocator_descriptors_update.
       rewrite equivocator_descriptors_update_eq.
       rewrite Hli in Hvx. assumption.
-    + subst. specialize (H _ eq_refl). destruct H as [Hvx Htx].
+    + subst. specialize (Hchar _ eq_refl) as [Hvx Htx].
       unfold equivocators_state_project. unfold Common.equivocators_state_project.
       unfold equivocator_descriptors_update.
       rewrite equivocator_descriptors_update_eq.
       simpl in *. rewrite Hli in Htx. rewrite Htx. f_equal.
-      apply functional_extensionality_dep.
-      intro eqv.
+      extensionality eqv.
       destruct (decide (eqv = i)).
       * subst. repeat rewrite state_update_eq.
         rewrite state_update_eq in Hdestinationi. symmetry. assumption.
@@ -412,15 +402,14 @@ Proof.
   - repeat split.
     + unfold equivocator_descriptors_update. rewrite equivocator_descriptors_update_eq. assumption.
     + unfold equivocator_descriptors_update. rewrite equivocator_descriptors_update_eq. reflexivity.
-    + apply functional_extensionality_dep. intro j.
+    + extensionality j.
       destruct (decide (j = i)).
       * subst. rewrite state_update_eq. reflexivity.
       * repeat (rewrite state_update_neq; [| assumption]). reflexivity.
     + unfold equivocator_descriptors_update.
       rewrite equivocator_descriptors_update_eq.
       assumption.
-    + apply functional_extensionality_dep.
-      intro eqv.
+    + extensionality eqv.
       unfold equivocators_state_project. unfold Common.equivocators_state_project.
       unfold equivocator_descriptors_update.
       destruct (decide (eqv = i)).
@@ -464,13 +453,13 @@ Lemma equivocators_transition_item_project_proper_characterization
 Proof.
   destruct
     (equivocators_transition_item_project_proper_descriptor_characterization eqv_descriptors item (Hproper (projT1 (l item))))
-    as [oitem [eqv_descriptors' [Hoitem [Hitemx H]]]].
+    as [oitem [eqv_descriptors' [Hoitem [Hitemx Hchar]]]].
   exists oitem, eqv_descriptors'. split; [assumption|].
   split; [assumption|].
   intros.
-  specialize (H s Hv Ht). clear Hv Ht Hoitem.
-  destruct H as [Hproperi' [Heqv' [Hs [Hex_new H]]]].
-  split; [|repeat split; assumption]. clear H.
+  specialize (Hchar s Hv Ht) as (Hproperi' & Heqv' & Hs & Hex_new & Hchar).
+  clear Hv Ht Hoitem.
+  split; [|repeat split; assumption]; clear Hchar.
   intro eqv.
   destruct (decide (eqv = (projT1 (l item)))).
   - subst. assumption.
@@ -660,9 +649,12 @@ Lemma equivocators_trace_project_app_inv_item
 Proof.
   generalize dependent sufX. generalize dependent eqv_descriptors.
   induction tr using rev_ind; intros eqv_descriptors sufX.
-  - simpl. intro H. inversion H as [[Hnil Heq]]. destruct preX; inversion Hnil.
-  - intro H. apply equivocators_trace_project_app_iff in H.
-    destruct H as [trX' [xX [eqv_descriptors' [Hpr_x [Hpr_tr Heq]]]]].
+  - simpl.
+    intro Hsome; inversion Hsome as [[Hnil Heq]].
+    clear -Hnil; destruct preX; inversion Hnil.
+  - intro Hsome.
+    apply equivocators_trace_project_app_iff in Hsome
+      as (trX' & xX & eqv_descriptors' & Hpr_x & Hpr_tr & Heq).
     simpl in Hpr_x.
     destruct (equivocators_transition_item_project eqv_descriptors x)
       as [(ox, descriptorx)|] eqn:Hpr_x_item
@@ -741,8 +733,8 @@ Lemma equivocators_trace_project_preserves_equivocating_indices
   (Hdescriptors : proper_equivocator_descriptors descriptors s)
   (Hproject_tr : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   :
-    (set_union (equivocating_indices IM index_listing is) (newmachine_descriptors_list IM index_listing idescriptors)) ⊆
-    (set_union (equivocating_indices IM index_listing s) (newmachine_descriptors_list IM index_listing descriptors)).
+    (set_union (equivocating_indices IM (enum index) is) (newmachine_descriptors_list IM (enum index) idescriptors)) ⊆
+    (set_union (equivocating_indices IM (enum index) s) (newmachine_descriptors_list IM (enum index) descriptors)).
 Proof.
   generalize dependent trX. generalize dependent descriptors.
   induction Htr using finite_valid_trace_from_to_rev_ind.
@@ -839,8 +831,8 @@ Lemma equivocators_trace_project_preserves_equivocating_indices_final
   (Hdescriptors : not_equivocating_equivocator_descriptors IM descriptors s)
   (Hproject_tr : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   :
-    (set_union (equivocating_indices IM index_listing is) (newmachine_descriptors_list IM index_listing idescriptors)) ⊆
-    (equivocating_indices IM index_listing s).
+    (set_union (equivocating_indices IM (enum index) is) (newmachine_descriptors_list IM (enum index) idescriptors)) ⊆
+    (equivocating_indices IM (enum index) s).
 Proof.
   apply not_equivocating_equivocator_descriptors_proper in Hdescriptors as Hproper.
   specialize
@@ -980,21 +972,22 @@ Proof.
   generalize dependent trX. generalize dependent descriptors.
   induction Htr using finite_valid_trace_from_rev_ind.
   - intros. inversion HtrX. subst. assumption.
-  - intros.
-    apply equivocators_trace_project_app_iff in HtrX.
-    destruct HtrX as [preX [sufX [descriptors' [Hproject_x [Hproject_tr _]]]]].
+  - intros descriptors trX HtrX i Hi.
+    apply equivocators_trace_project_app_iff in HtrX
+      as (preX & sufX & descriptors' & Hproject_x & Hproject_tr & _).
     simpl in Hproject_x.
     destruct
       (equivocators_transition_item_project descriptors x)
       as [(oitemx, _descriptors')|] eqn:Hpr_x ; [|congruence].
     assert (_descriptors' = descriptors') as -> by (destruct oitemx;injection Hproject_x;congruence).
     clear Hproject_x trX sufX.
-
-    destruct Hx as [[_ [_ [Hv _]]] Ht].
-    specialize
-      (equivocators_transition_item_project_preserves_zero_descriptors descriptors x
-         oitemx descriptors' _ Ht Hv Hpr_x _ H) as Hx_preserves.
-    apply (IHHtr _ _ Hproject_tr). assumption.
+    destruct Hx as [(_ & _  & Hv & _) Ht].
+    eapply IHHtr; [eassumption|].
+    revert Hi.
+    eapply equivocators_transition_item_project_preserves_zero_descriptors
+      with (item := x).
+    2,3:eassumption.
+    exact Ht.
 Qed.
 
 Lemma preloaded_equivocators_valid_trace_from_project
@@ -1390,7 +1383,7 @@ Definition equivocators_partial_trace_project
   : option (composite_state IM * list (composite_transition_item IM))
   :=
   let (s, tr) := str in
-  if (@decide _ (not_equivocating_equivocator_descriptors_dec IM finite_index final_descriptors (finite_trace_last s tr))) then
+  if (decide (not_equivocating_equivocator_descriptors IM final_descriptors (finite_trace_last s tr))) then
     match equivocators_trace_project final_descriptors tr with
     | None => None
     | Some (trX, initial_descriptors) =>
@@ -1520,7 +1513,7 @@ Lemma equivocators_total_trace_project_app
       (exists sX, finite_valid_trace_from (pre_loaded_with_all_messages_vlsm X) sX (tr1X ++ tr2X)) ->
       trace_project (tr1X ++ tr2X) = trace_project tr1X ++ trace_project tr2X.
 Proof.
-  intros.  destruct H as [sX Hpre_tr].
+  intros tr1X tr2X [sX Hpre_tr].
   specialize (equivocators_total_trace_project_characterization Hpre_tr) as Htr12_pr.
   apply equivocators_trace_project_app_iff in Htr12_pr.
   destruct Htr12_pr as [tr1Y [tr2Y [descriptors [Htr2_pr [Htr1_pr Htr12_eq]]]]].
@@ -1612,12 +1605,9 @@ Section equivocators_composition_sub_projections.
 
 Context
   {message : Type}
-  {index : Type}
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
+  `{forall i : index, HasBeenSentCapability (IM i)}
   (selection : list index)
   .
 
@@ -1662,7 +1652,7 @@ Proof.
   simpl in Heqpr_item_x.
   unfold pre_VLSM_projection_transition_item_project
     , composite_label_sub_projection_option in Hpr_sub_item.
-  case_decide.
+  case_decide as Hl.
   - simpl in Hpr_sub_item.
     unfold final_sub_descriptors in *.
     unfold equivocators_transition_item_project in Hpr_sub_item.
@@ -1689,7 +1679,7 @@ Proof.
       ; simpl
       ; destruct (decide ((proj1_sig i) = projT1 (l item))).
       * rewrite equivocator_descriptors_update_eq_rew with (Heq := e).
-        assert (e1 : i = (dec_exist (sub_index_prop selection) (projT1 (l item)) H)).
+        assert (e1 : i = (dec_exist (sub_index_prop selection) (projT1 (l item)) Hl)).
         { apply dec_sig_eq_iff. assumption. }
         subst i.
         rewrite equivocator_descriptors_update_eq_rew with (Heq := eq_refl).
@@ -1698,7 +1688,7 @@ Proof.
       * rewrite! equivocator_descriptors_update_neq; [reflexivity | assumption |].
         intro contra. elim n. apply dec_sig_eq_iff in contra. assumption.
       * rewrite equivocator_descriptors_update_eq_rew with (Heq := e).
-        assert (e1 : i = (dec_exist (sub_index_prop selection) (projT1 (l item)) H)).
+        assert (e1 : i = (dec_exist (sub_index_prop selection) (projT1 (l item)) Hl)).
         { apply dec_sig_eq_iff. assumption. }
         subst i.
         rewrite equivocator_descriptors_update_eq_rew with (Heq := eq_refl).
@@ -1714,15 +1704,15 @@ Proof.
       unfold pre_VLSM_projection_transition_item_project,
         composite_label_sub_projection_option.
       simpl.
-      case_decide; [|contradiction].
-      f_equal. f_equal.
+      case_decide as _Hl; [|contradiction].
+      do 2 f_equal.
       unfold composite_label_sub_projection.
       apply
         (@dec_sig_sigT_eq _
           (sub_index_prop selection)
           (sub_index_prop_dec selection)
           (fun n => vlabel (IM n))
-          (projT1 (l item)) (l item') (l item') H0 H
+          (projT1 (l item)) (l item') (l item') _Hl Hl
         ).
       reflexivity.
   - simpl in Hpr_sub_item. unfold final_sub_descriptors in *.
@@ -1730,7 +1720,7 @@ Proof.
     split.
     + extensionality i.
       assert (Hnot : proj1_sig i <> projT1 (l item)).
-      { intro Hnot. elim H. destruct i. simpl in Hnot. subst.
+      { intro Hnot. contradict Hl. destruct i. simpl in Hnot. subst.
         apply bool_decide_spec in i. assumption.
       }
       destruct oitem' as [item'|]
@@ -1803,14 +1793,13 @@ Section seeded_equivocators_valid_trace_project.
 
 Context
   (seed : message -> Prop)
-  (SeededXE := seeded_equivocators_no_equivocation_vlsm IM Hbs selection seed)
+  (SeededXE := seeded_equivocators_no_equivocation_vlsm IM selection seed)
   (sub_equivocator_IM := sub_IM (equivocator_IM IM) selection)
   (SubFreeE := free_composite_vlsm sub_equivocator_IM)
   (SubPreFreeE := pre_loaded_with_all_messages_vlsm SubFreeE)
   (sub_IM := sub_IM IM selection)
   (SubFree := free_composite_vlsm sub_IM)
   (SeededX := pre_loaded_vlsm SubFree seed)
-  (Hbs_sub : forall sub_i, HasBeenSentCapability (sub_IM sub_i) := sub_has_been_sent_capabilities IM selection Hbs)
   .
 
 Lemma seeded_equivocators_initial_message
@@ -1857,14 +1846,14 @@ Proof.
   apply pre_equivocators_valid_trace_project
     with (final_descriptors0 := final_descriptors)
     in Hpre_tr_to
-  ; [|assumption..].
+  ; [|typeclasses eauto|assumption].
   destruct Hpre_tr_to as [initial_descriptors [Hproper_initial [trX [Hpr_trX Hpre_trX]]]].
   exists trX, initial_descriptors.
   split; [assumption|]. split; [assumption|].
   apply finite_valid_trace_init_to_last in Hpre_trX as Hfinal_stateX.
   symmetry in Hfinal_stateX.
   split; [assumption|].
-  clear -SubPreFreeE Hbs_sub finite_index Htr Hproper Hpr_trX.
+  clear -SubPreFreeE Htr Hproper Hpr_trX.
   remember (length tr) as len_tr.
   generalize dependent trX.
   generalize dependent initial_descriptors.
@@ -1933,7 +1922,7 @@ Proof.
     apply pre_equivocators_valid_trace_project
       with (final_descriptors0 := final_descriptors')
       in Hpre_tr_to as Hpr_tr'
-    ; [|assumption..].
+    ; [|typeclasses eauto|assumption].
     destruct Hpr_tr' as [_initial_descriptors [_ [_trX' [_Hpr_trX' Heq_final_stateX']]]].
     replace (equivocators_trace_project _ _ _) with (Some (trX', initial_descriptors))
       in _Hpr_trX'.
@@ -1955,11 +1944,7 @@ Proof.
     { apply proj1, finite_valid_trace_from_to_last_pstate in Hpre_tr_to.
       assumption.
     }
-    apply
-      (composite_proper_sent sub_equivocator_IM
-        (finite_sub_index selection finite_index)
-        (equivocator_Hbs sub_IM Hbs_sub) _ Hs_free)
-        in Hno_equiv.
+    apply (composite_proper_sent sub_equivocator_IM _ Hs_free) in Hno_equiv.
     specialize (Hno_equiv is tr' Hpre_tr_to).
     apply finite_valid_trace_init_to_forget_last in Hpre_tr_to as Hpre_tr.
     destruct (equivocators_trace_project_output_reflecting_inv _ _ _ (proj1 Hpre_tr) _ Hno_equiv)
@@ -1974,7 +1959,7 @@ Proof.
     apply pre_equivocators_valid_trace_project
       with (final_descriptors0 := final_descriptors_m)
       in Hpre_tr_to as Hpr_tr'
-    ; [|assumption..].
+    ; [|typeclasses eauto|assumption].
 
     destruct Hpr_tr' as [initial_descriptors_m' [Hproper_initial_m [trXm' [Hproject_trXm' HtrXm]]]].
     specialize (H _ _ Hproject_trXm').
@@ -1987,21 +1972,23 @@ Qed.
 Lemma SeededXE_incl_PreFreeE
   : VLSM_incl SeededXE SubPreFreeE.
 Proof.
-  apply basic_VLSM_strong_incl; intro; intros; [assumption| | |assumption].
-  - exact I.
-  - split; [|exact I]. apply H.
+  apply basic_VLSM_strong_incl.
+  1,2,4:cbv; intuition.
+  - intros l s om [Hv _]. split; [|exact I]. assumption.
 Qed.
 
 Lemma PreSeededXE_incl_PreFreeE
   : VLSM_incl (pre_loaded_with_all_messages_vlsm SeededXE) SubPreFreeE.
 Proof.
-  apply basic_VLSM_incl_preloaded; intro; intros; [assumption| |assumption].
-  split; [|exact I]. apply H.
+  apply basic_VLSM_incl_preloaded.
+  1,3: intro; intros; assumption.
+  intros l s om [Hv _].
+  split; [assumption|exact I].
 Qed.
 
 Lemma SeededXE_SeededX_vlsm_partial_projection
   (final_descriptors : equivocator_descriptors sub_IM)
-  : VLSM_partial_projection SeededXE SeededX (equivocators_partial_trace_project sub_IM (finite_sub_index selection finite_index) final_descriptors).
+  : VLSM_partial_projection SeededXE SeededX (equivocators_partial_trace_project sub_IM final_descriptors).
 Proof.
   split; [split|].
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
@@ -2013,7 +2000,7 @@ Proof.
     clear Hpre_tr. revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
     apply equivocators_partial_trace_project_extends_left.
   - intros s tr sX trX Hpr_tr Htr.
-    destruct (destruct_equivocators_partial_trace_project sub_IM (finite_sub_index selection finite_index) Hpr_tr)
+    destruct (destruct_equivocators_partial_trace_project sub_IM  Hpr_tr)
       as [Hnot_equiv [initial_descriptors [Htr_project Hs_project]]].
     apply not_equivocating_equivocator_descriptors_proper in Hnot_equiv as Hproper.
     destruct (seeded_equivocators_valid_trace_project _ _ Htr _ Hproper)
@@ -2029,29 +2016,20 @@ End equivocators_composition_sub_projections.
 Section equivocators_composition_vlsm_projection.
 
 Context {message : Type}
-  {equiv_index : Type}
-  (index := equiv_index)
-  {IndEqDec : EqDecision index}
+  `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i : index, HasBeenSentCapability (IM i))
-  {index_listing : list index}
-  (finite_index : Listing index_listing)
-  (finite_index' : finite.Finite index := Listing_finite finite_index)
-  (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM Hbs)
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM)
   (equivocators_state_project := equivocators_state_project IM)
   (equivocator_IM := equivocator_IM IM)
   (equivocator_descriptors_update := equivocator_descriptors_update IM)
   (proper_equivocator_descriptors := proper_equivocator_descriptors IM)
   (FreeE := free_composite_vlsm equivocator_IM)
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
-  (equivocators_free_Hbs : HasBeenSentCapability FreeE := free_composite_HasBeenSentCapability equivocator_IM finite_index (equivocator_Hbs IM Hbs))
   (Free := free_composite_vlsm IM)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
   (sub_IM := sub_IM IM (finite.enum index))
-  (Hbs_sub : forall sub_i, HasBeenSentCapability (sub_IM sub_i) := sub_has_been_sent_capabilities IM (finite.enum index) Hbs)
   .
-
-Existing Instance finite_index'.
 
 Definition free_sub_free_equivocator_descriptors
   (descriptors : equivocator_descriptors IM)
@@ -2060,7 +2038,7 @@ Definition free_sub_free_equivocator_descriptors
 
 Lemma equivocators_no_equivocations_vlsm_X_vlsm_partial_projection
   (final_descriptors : equivocator_descriptors IM)
-  : VLSM_partial_projection equivocators_no_equivocations_vlsm Free (equivocators_partial_trace_project IM finite_index final_descriptors).
+  : VLSM_partial_projection equivocators_no_equivocations_vlsm Free (equivocators_partial_trace_project IM final_descriptors).
 Proof.
   split; [split|].
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
@@ -2072,27 +2050,25 @@ Proof.
     clear Hpre_tr.  revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
     apply equivocators_partial_trace_project_extends_left.
   - intros s tr sX trX Hpr_tr Htr.
-    destruct (destruct_equivocators_partial_trace_project IM finite_index Hpr_tr)
+    destruct (destruct_equivocators_partial_trace_project IM Hpr_tr)
       as [Hnot_equiv [initial_descriptors [Htr_project Hs_project]]].
     apply not_equivocating_equivocator_descriptors_proper in Hnot_equiv as Hproper.
 
-    specialize (sub_composition_all_full_projection equivocator_IM (equivocators_no_equivocations_constraint IM Hbs))
+    specialize (sub_composition_all_full_projection equivocator_IM (equivocators_no_equivocations_constraint IM))
       as Hproj.
     apply (VLSM_full_projection_finite_valid_trace Hproj) in Htr.
     specialize
       (false_composite_no_equivocation_vlsm_with_pre_loaded
-        (SubProjectionTraces.sub_IM equivocator_IM (finite.enum index))
-        (free_constraint (SubProjectionTraces.sub_IM equivocator_IM (finite.enum index)))
-        (equivocator_Hbs sub_IM Hbs_sub))
+        (SubProjectionTraces.sub_IM equivocator_IM (enum index))
+        (free_constraint _))
       as Heq.
     assert (Htr' :
       finite_valid_trace
         (composite_vlsm
-          (SubProjectionTraces.sub_IM equivocator_IM (finite.enum index))
+          (SubProjectionTraces.sub_IM equivocator_IM (enum index))
           (no_equivocations_additional_constraint
-            (SubProjectionTraces.sub_IM equivocator_IM (finite.enum index))
-            (free_constraint (SubProjectionTraces.sub_IM equivocator_IM (finite.enum index)))
-            (equivocator_Hbs sub_IM Hbs_sub)))
+            (SubProjectionTraces.sub_IM equivocator_IM (enum index))
+            (free_constraint _)))
         (composite_state_sub_projection equivocator_IM (finite.enum index) s)
         (VLSM_full_projection_finite_trace_project Hproj tr)
     ).
@@ -2117,8 +2093,8 @@ Proof.
     apply (VLSM_eq_finite_valid_trace Heq) in Htr'.
 
     specialize
-      (seeded_equivocators_valid_trace_project IM Hbs finite_index
-        (finite.enum index)
+      (seeded_equivocators_valid_trace_project IM
+        (enum index)
         (fun m => False)
         _ _ Htr'
         (free_sub_free_equivocator_descriptors final_descriptors)
@@ -2133,7 +2109,7 @@ Proof.
     destruct Hproject  as [_trX [_initial_descriptors [_ [_Htr_project [_ HtrX]]]]].
 
     specialize
-      (equivocators_trace_project_finite_trace_sub_projection_commute IM (finite.enum index)
+      (equivocators_trace_project_finite_trace_sub_projection_commute IM (enum index)
         final_descriptors initial_descriptors _initial_descriptors tr trX _trX
         Htr_project)
       as Hcommute.
@@ -2147,21 +2123,20 @@ Proof.
         composite_label_sub_projection_option,
         pre_VLSM_full_projection_trace_item_project.
       simpl.
-      case_decide.
-      - f_equal; [|assumption].
-        destruct a. destruct l as (i, li).
-        simpl.
-        f_equal.
-        unfold composite_label_sub_projection. simpl.
-        unfold free_sub_free_index.
-        apply
-          (@dec_sig_sigT_eq _ _
-            (sub_index_prop_dec (finite.enum index))
-            (fun n => vlabel (Common.equivocator_IM IM n))
-            i li li
-          ).
-        reflexivity.
-      - elim H. apply finite.elem_of_enum.
+      case_decide as Hla; [|contradict Hla; apply elem_of_enum].
+      f_equal; [|assumption].
+      destruct a. destruct l as (i, li).
+      simpl.
+      f_equal.
+      unfold composite_label_sub_projection. simpl.
+      unfold free_sub_free_index.
+      apply
+        (@dec_sig_sigT_eq _ _
+          (sub_index_prop_dec (enum index))
+          (fun n => vlabel (Common.equivocator_IM IM n))
+          i li li
+        ).
+      reflexivity.
     }
     destruct Hcommute as [Heq_initial Heq_trX].
     subst.
@@ -2197,11 +2172,10 @@ Proof.
     unfold pre_VLSM_projection_transition_item_project,
       composite_label_sub_projection_option.
     simpl.
-    case_decide.
-    + simpl. f_equal; [|assumption].
-      destruct a. destruct l as (i, li).
-      reflexivity.
-    + elim H. apply finite.elem_of_enum.
+    case_decide as Hla; [|contradict Hla; apply elem_of_enum].
+    simpl. f_equal; [|assumption].
+    destruct a. destruct l as (i, li).
+    reflexivity.
 Qed.
 
 Lemma equivocators_valid_trace_from_project
@@ -2270,14 +2244,14 @@ Qed.
 Lemma equivocators_no_equivocations_vlsm_X_vlsm_projection
   : VLSM_projection equivocators_no_equivocations_vlsm Free (equivocators_total_label_project IM) (equivocators_total_state_project IM).
 Proof.
-  constructor; [constructor; intros|].
-  - apply PreFreeE_Free_vlsm_projection_type.
-    revert H.
+  constructor; [constructor|].
+  - intros * Htr. apply PreFreeE_Free_vlsm_projection_type.
+    revert Htr.
     apply VLSM_incl_finite_valid_trace_from.
     apply equivocators_no_equivocations_vlsm_incl_PreFree.
-  - intros.
+  - intros * Htr.
     assert (Hpre_tr : finite_valid_trace PreFreeE sX trX).
-    { revert H. apply VLSM_incl_finite_valid_trace.
+    { revert Htr. apply VLSM_incl_finite_valid_trace.
       apply equivocators_no_equivocations_vlsm_incl_PreFree.
     }
     specialize
@@ -2289,7 +2263,7 @@ Proof.
       rewrite (equivocators_total_trace_project_characterization IM (proj1 Hpre_tr)).
       reflexivity.
     }
-    apply Hsim in H.
+    apply Hsim in Htr.
     remember (pre_VLSM_projection_trace_project _ _ _ _ _) as tr.
     replace tr with (equivocators_total_trace_project IM trX); [assumption|].
     subst. symmetry.
@@ -2302,21 +2276,21 @@ Proof.
   constructor; [constructor; intros|].
   - apply PreFreeE_Free_vlsm_projection_type.
     assumption.
-  - intros.
+  - intros * Htr.
     specialize
-     (VLSM_partial_projection_finite_valid_trace (PreFreeE_PreFree_vlsm_partial_projection IM Hbs finite_index (zero_descriptor IM))
+     (VLSM_partial_projection_finite_valid_trace (PreFreeE_PreFree_vlsm_partial_projection IM (zero_descriptor IM))
        sX trX (equivocators_total_state_project IM sX) (equivocators_total_trace_project IM trX)
      ) as Hsim.
     spec Hsim.
     { simpl. rewrite decide_True by apply zero_descriptor_not_equivocating.
-      rewrite (equivocators_total_trace_project_characterization IM (proj1 H)).
+      rewrite (equivocators_total_trace_project_characterization IM (proj1 Htr)).
       reflexivity.
     }
-    apply Hsim in H as Hpr.
+    apply Hsim in Htr as Hpr.
     remember (pre_VLSM_projection_trace_project _ _ _ _ _) as tr.
     replace tr with (equivocators_total_trace_project IM trX); [assumption|].
     subst. symmetry.
-    apply (equivocators_total_VLSM_projection_trace_project IM (proj1 H)).
+    apply (equivocators_total_VLSM_projection_trace_project IM (proj1 Htr)).
 Qed.
 
 End equivocators_composition_vlsm_projection.

--- a/theories/VLSM/Core/Equivocators/Composition/Projections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/Projections.v
@@ -649,9 +649,8 @@ Lemma equivocators_trace_project_app_inv_item
 Proof.
   generalize dependent sufX. generalize dependent eqv_descriptors.
   induction tr using rev_ind; intros eqv_descriptors sufX.
-  - simpl.
-    intro Hsome; inversion Hsome as [[Hnil Heq]].
-    clear -Hnil; destruct preX; inversion Hnil.
+  - cbn; inversion 1 as [[Hnil Heq]]; clear -Hnil.
+    destruct preX; inversion Hnil.
   - intro Hsome.
     apply equivocators_trace_project_app_iff in Hsome
       as (trX' & xX & eqv_descriptors' & Hpr_x & Hpr_tr & Heq).
@@ -983,11 +982,8 @@ Proof.
     clear Hproject_x trX sufX.
     destruct Hx as [(_ & _  & Hv & _) Ht].
     eapply IHHtr; [eassumption|].
-    revert Hi.
     eapply equivocators_transition_item_project_preserves_zero_descriptors
-      with (item := x).
-    2,3:eassumption.
-    exact Ht.
+      with (item := x); cycle 1; eassumption.
 Qed.
 
 Lemma preloaded_equivocators_valid_trace_from_project
@@ -1974,7 +1970,7 @@ Lemma SeededXE_incl_PreFreeE
 Proof.
   apply basic_VLSM_strong_incl.
   1,2,4:cbv; intuition.
-  - intros l s om [Hv _]. split; [|exact I]. assumption.
+  intros l s om [Hv _]; split; [assumption | exact I].
 Qed.
 
 Lemma PreSeededXE_incl_PreFreeE
@@ -1982,8 +1978,7 @@ Lemma PreSeededXE_incl_PreFreeE
 Proof.
   apply basic_VLSM_incl_preloaded.
   1,3: intro; intros; assumption.
-  intros l s om [Hv _].
-  split; [assumption|exact I].
+  intros l s om [Hv _]; split; [assumption| exact I].
 Qed.
 
 Lemma SeededXE_SeededX_vlsm_partial_projection
@@ -2125,11 +2120,9 @@ Proof.
       simpl.
       case_decide as Hla; [|contradict Hla; apply elem_of_enum].
       f_equal; [|assumption].
-      destruct a. destruct l as (i, li).
-      simpl.
-      f_equal.
-      unfold composite_label_sub_projection. simpl.
-      unfold free_sub_free_index.
+      destruct a, l as (i, li); cbn; f_equal.
+      unfold composite_label_sub_projection;
+      cbn; unfold free_sub_free_index.
       apply
         (@dec_sig_sigT_eq _ _
           (sub_index_prop_dec (enum index))
@@ -2173,8 +2166,8 @@ Proof.
       composite_label_sub_projection_option.
     simpl.
     case_decide as Hla; [|contradict Hla; apply elem_of_enum].
-    simpl. f_equal; [|assumption].
-    destruct a. destruct l as (i, li).
+    cbn; f_equal; [|assumption].
+    destruct a, l as (i, li).
     reflexivity.
 Qed.
 
@@ -2246,12 +2239,11 @@ Lemma equivocators_no_equivocations_vlsm_X_vlsm_projection
 Proof.
   constructor; [constructor|].
   - intros * Htr. apply PreFreeE_Free_vlsm_projection_type.
-    revert Htr.
-    apply VLSM_incl_finite_valid_trace_from.
+    apply VLSM_incl_finite_valid_trace_from; [| assumption].
     apply equivocators_no_equivocations_vlsm_incl_PreFree.
   - intros * Htr.
     assert (Hpre_tr : finite_valid_trace PreFreeE sX trX).
-    { revert Htr. apply VLSM_incl_finite_valid_trace.
+    { apply VLSM_incl_finite_valid_trace; [| assumption].
       apply equivocators_no_equivocations_vlsm_incl_PreFree.
     }
     specialize

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -422,7 +422,7 @@ Section has_been_received_lifting.
 (** ** Lifting the [HasBeenReceivedCapability] *)
 
 Context
-  {Hbr : HasBeenReceivedCapability X}
+  `{HasBeenReceivedCapability message X}
   .
 
 (** We define [has_been_received] for the [equivocator_vlsm] as being received by any
@@ -437,26 +437,29 @@ Global Instance equivocator_has_been_received_dec
 Lemma equivocator_has_been_received_stepwise_props
   : has_been_received_stepwise_props (vlsm := equivocator_vlsm) equivocator_has_been_received.
 Proof.
-  assert (Hreceived_stepwise : oracle_stepwise_props (field_selector input) (has_been_received X)).
-  { destruct Hbr.  apply stepwise_props_from_trace; assumption. }
-  specialize (equivocator_oracle_stepwise_props (field_selector input)) as Hlift.
-  spec Hlift. { intros. simpl. split; exact id. }
-  specialize (Hlift _ Hreceived_stepwise).
-  constructor; [apply Hlift|].
-  intros. simpl.
-  destruct Hlift as [_ Hlift].
-  specialize (Hlift _ _ _ _ _ H msg).
-  rewrite Hlift. clear -H.
-  unfold equivocator_selector. simpl.
+  assert
+    (Hlift :
+      oracle_stepwise_props
+        (equivocator_selector (field_selector input))
+        (equivocator_oracle (has_been_received X))).
+  {
+    apply equivocator_oracle_stepwise_props.
+    - cbv; intuition.
+    - apply has_been_received_stepwise_from_trace.
+  }
+  destruct Hlift as [Hinits Hupdate].
+  constructor; [assumption|].
+  intros l s om s' om' Ht msg.
+  simpl; rewrite Hupdate by eassumption.
+  unfold equivocator_selector; simpl.
   destruct l; [|intuition..].
-  destruct H as [[_ [_ [_ Him]]] _].
-  simpl in Him. subst.
-  intuition. congruence.
+  destruct Ht as [(_ & _ & _ & Him) _]; simpl in Him; subst.
+  intuition congruence.
 Qed.
 
 (** Finally we define the [HasBeenReceivedCapability] for the [equivocator_vlsm].
 *)
-Definition equivocator_HasBeenReceivedCapability
+Global Instance equivocator_HasBeenReceivedCapability
   : HasBeenReceivedCapability equivocator_vlsm
   := HasBeenReceivedCapability_from_stepwise (vlsm := equivocator_vlsm)
     equivocator_has_been_received_dec
@@ -469,7 +472,7 @@ Section has_been_sent_lifting.
 (** ** Lifting the [HasBeenSentCapability] *)
 
 Context
-  {Hbs : HasBeenSentCapability X}
+  `{HasBeenSentCapability message X}
   .
 
 (** We define [has_been_sent] for the [equivocator_vlsm] as being sent by any
@@ -484,26 +487,30 @@ Global Instance equivocator_has_been_sent_dec
 Lemma equivocator_has_been_sent_stepwise_props
   : has_been_sent_stepwise_props (vlsm := equivocator_vlsm) equivocator_has_been_sent.
 Proof.
-  assert (Hsent_stepwise : oracle_stepwise_props (field_selector output) (has_been_sent X)).
-  { destruct Hbs.  apply stepwise_props_from_trace; assumption. }
-  specialize (equivocator_oracle_stepwise_props (field_selector output)) as Hlift.
-  spec Hlift. { intros. simpl. split; exact id. }
-  specialize (Hlift _ Hsent_stepwise).
-  constructor; [apply Hlift|].
-  intros. simpl.
-  destruct Hlift as [_ Hlift].
-  specialize (Hlift _ _ _ _ _ H msg).
-  rewrite Hlift. clear -H.
-  unfold equivocator_selector. simpl.
+  assert
+    (Hlift :
+      oracle_stepwise_props
+        (equivocator_selector (field_selector output))
+        (equivocator_oracle (has_been_sent X))).
+  {
+    apply equivocator_oracle_stepwise_props.
+    - cbv; intuition.
+    - apply has_been_sent_stepwise_from_trace.
+  }
+  destruct Hlift as [Hinits Hupdate].
+  constructor; [assumption|].
+  intros l s om s' om' Ht msg.
+  simpl; rewrite Hupdate by eassumption.
+  unfold equivocator_selector; simpl.
   destruct l; [|intuition..].
-  destruct H as [_ Ht].
-  inversion Ht. subst.
-  intuition. congruence.
+  apply proj2 in Ht.
+  inversion_clear Ht.
+  intuition congruence.
 Qed.
 
 (** Finally we define the [HasBeenSentCapability] for the [equivocator_vlsm].
 *)
-Definition equivocator_HasBeenSentCapability
+Global Instance equivocator_HasBeenSentCapability
   : HasBeenSentCapability equivocator_vlsm
   := HasBeenSentCapability_from_stepwise (vlsm := equivocator_vlsm)
     equivocator_has_been_sent_dec
@@ -520,6 +527,8 @@ Context
   (message_eq : EqDecision message)
   (Hbeen_sent_X := @ComputableSentMessages_HasBeenSentCapability message X Hsent_messages message_eq)
   .
+
+Existing Instance Hbeen_sent_X.
 
 (** We define the [sent_messages_fn] for the [equivocator_vlsm] as the
 union of all [sent_messages_fn] for its internal machines.
@@ -631,8 +640,8 @@ Program Definition equivocator_ComputableSentMessages
 Next Obligation.
   intros.
   apply has_been_sent_consistency; [| assumption].
-  apply (equivocator_HasBeenSentCapability (Hbs := Hbeen_sent_X)).
-Defined.
+  eapply equivocator_HasBeenSentCapability.
+Qed.
 
 End ComputableSentMessages_lifting.
 

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -437,24 +437,14 @@ Global Instance equivocator_has_been_received_dec
 Lemma equivocator_has_been_received_stepwise_props
   : has_been_received_stepwise_props (vlsm := equivocator_vlsm) equivocator_has_been_received.
 Proof.
-  assert
-    (Hlift :
-      oracle_stepwise_props
-        (equivocator_selector (field_selector input))
-        (equivocator_oracle (has_been_received X))).
-  {
-    apply equivocator_oracle_stepwise_props.
-    - cbv; intuition.
-    - apply has_been_received_stepwise_from_trace.
-  }
-  destruct Hlift as [Hinits Hupdate].
-  constructor; [assumption|].
-  intros l s om s' om' Ht msg.
-  simpl; rewrite Hupdate by eassumption.
-  unfold equivocator_selector; simpl.
-  destruct l; [|intuition..].
-  destruct Ht as [(_ & _ & _ & Him) _]; simpl in Him; subst.
-  intuition congruence.
+  eapply oracle_stepwise_props_change_selector.
+  - apply equivocator_oracle_stepwise_props
+    ; [|apply has_been_received_stepwise_from_trace].
+    cbv; intuition.
+  - intros s item; destruct item, l; cbn.
+    2,3:intuition.
+    intros [(_ & _ & _ & Him) _]; simpl in Him; subst.
+    intuition congruence.
 Qed.
 
 (** Finally we define the [HasBeenReceivedCapability] for the [equivocator_vlsm].
@@ -487,25 +477,14 @@ Global Instance equivocator_has_been_sent_dec
 Lemma equivocator_has_been_sent_stepwise_props
   : has_been_sent_stepwise_props (vlsm := equivocator_vlsm) equivocator_has_been_sent.
 Proof.
-  assert
-    (Hlift :
-      oracle_stepwise_props
-        (equivocator_selector (field_selector output))
-        (equivocator_oracle (has_been_sent X))).
-  {
-    apply equivocator_oracle_stepwise_props.
-    - cbv; intuition.
-    - apply has_been_sent_stepwise_from_trace.
-  }
-  destruct Hlift as [Hinits Hupdate].
-  constructor; [assumption|].
-  intros l s om s' om' Ht msg.
-  simpl; rewrite Hupdate by eassumption.
-  unfold equivocator_selector; simpl.
-  destruct l; [|intuition..].
-  apply proj2 in Ht.
-  inversion_clear Ht.
-  intuition congruence.
+  eapply oracle_stepwise_props_change_selector.
+  - apply equivocator_oracle_stepwise_props
+    ; [|apply has_been_sent_stepwise_from_trace].
+    cbv; intuition.
+  - intros s item; destruct item, l; cbn.
+    2,3:intuition.
+    intros [_ Ht]; inversion_clear Ht.
+    intuition congruence.
 Qed.
 
 (** Finally we define the [HasBeenSentCapability] for the [equivocator_vlsm].

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -1,7 +1,7 @@
 From stdpp Require Import prelude.
-From Coq Require Import FinFun Relations.Relation_Operators.
+From Coq Require Import FinFun Relations.Relation_Operators Program.Equality.
 From VLSM.Lib Require Import Preamble ListExtras FinFunExtras StdppListSet Measurable.
-From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces SubProjectionTraces Equivocation.
+From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces SubProjectionTraces Equivocation EquivocationProjections.
 
 (** * VLSM Message Dependencies
 
@@ -16,12 +16,9 @@ Context
   {message : Type}
   (message_dependencies : message -> set message)
   (X : VLSM message)
-  {Hbs : HasBeenSentCapability X}
-  {Hbr : HasBeenReceivedCapability X}
-  (Hbo : HasBeenObservedCapability X := HasBeenObservedCapability_from_sent_received X)
+  `{HasBeenSentCapability message X}
+  `{HasBeenReceivedCapability message X}
   .
-
-Existing Instance Hbo.
 
 (**
 [MessageDependencies] characterize a <<message_dependencies>> function
@@ -84,7 +81,7 @@ Lemma msg_dep_happens_before_iff_one x z
 Proof.
   split.
   - inversion 1; subst; eauto.
-  - intros [H | [y [H1 H2]]]; econstructor; eassumption.
+  - intros [Hxz | [y [Hxy Hyz]]]; econstructor; eassumption.
 Qed.
 
 Global Instance msg_dep_happens_before_transitive : Transitive msg_dep_happens_before.
@@ -112,13 +109,10 @@ Qed.
 pre-loaded message property, then it also reflects the [valid_message_prop]erty.
 *)
 Lemma msg_dep_reflects_validity
-  (HMsgDep : MessageDependencies)
+  `{MessageDependencies}
   (no_initial_messages_in_X : forall m, ~ vinitial_message_prop X m)
   (P : message -> Prop)
   (Hreflects : forall dm m, msg_dep_rel dm m -> P m -> P dm)
-  (Hbr_pre := preloaded_HasBeenReceivedCapability Hbr)
-  (Hbs_pre := preloaded_HasBeenSentCapability Hbs)
-  (Hbo_pre := HasBeenObservedCapability_from_sent_received (pre_loaded_vlsm X P))
   : forall dm m, msg_dep_rel dm m ->
     valid_message_prop (pre_loaded_vlsm X P) m ->
     valid_message_prop (pre_loaded_vlsm X P) dm.
@@ -131,50 +125,48 @@ Proof.
     apply Hreflects with m; [assumption |].
     destruct Hinit as [Hinit | Hp]; [| assumption].
     contradict Hinit. apply no_initial_messages_in_X.
-  - apply (observed_valid (pre_loaded_vlsm X P)) with (s := s).
-    + exists (Some m). apply can_produce_valid. assumption.
-    + cut (has_been_observed X s dm).
-      {
-        intros [Hsent | Hreceived]; [left|right]; auto.
-      }
-      apply message_dependencies_are_necessary with m; [| assumption].
-      revert Hproduce.
-      apply VLSM_incl_can_produce, pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
+  - eapply (observed_valid (pre_loaded_vlsm X P))
+    ; [eexists; apply can_produce_valid; eassumption|].
+    apply (@message_dependencies_are_necessary _ m s) in Hdm
+    ; [|revert Hproduce; apply VLSM_incl_can_produce; apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages].
+    clear H1 no_initial_messages_in_X Hreflects.
+    revert H H0 s Hdm Hproduce; destruct X as (T & S & M); cbn; intros.
+    revert Hdm.
+    apply VLSM_incl_has_been_observed
+    ; [apply basic_VLSM_incl_preloaded; cbv;intuition|].
+    exists (Some m).
+    apply can_produce_valid.
+    revert Hproduce.
+    eapply VLSM_incl_can_produce.
+    apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
 Qed.
 
 (** Under [MessageDependencies] assumptions, if a message [has_been_sent]
 in a state <<s>>, then any of its direct dependencies [has_been_observed].
 *)
 Lemma msg_dep_has_been_sent
-  (HMsgDep : MessageDependencies)
+  `{MessageDependencies}
   s
   (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm X) s)
   m
   (Hsent : has_been_sent X s m)
   : forall dm, msg_dep_rel dm m -> has_been_observed X s dm.
 Proof.
-  intros dm Hdm.
-  cut (exists item, can_produce (pre_loaded_with_all_messages_vlsm X) (destination item) m /\
-                    in_futures (pre_loaded_with_all_messages_vlsm X) (destination item) s).
-  {
-    intros (s_dm & Hproduce & Hfutures).
-    eapply in_futures_preserving_oracle_from_stepwise; [|eassumption|].
-    - apply has_been_observed_from_sent_received_stepwise_props.
-    - apply message_dependencies_are_necessary with m; assumption.
-  }
   apply proper_sent in Hsent; [|assumption].
-  apply valid_state_has_trace in Hs as [is [tr Htr]].
+  apply valid_state_has_trace in Hs as (is & tr & Htr).
   specialize (Hsent _ _ Htr).
-  apply Exists_exists in Hsent as [item [Hitem Houtput]].
-  exists item.
-  split; cycle 1.
-  - eapply elem_of_trace_in_futures_left; [|eassumption].
-    apply Htr.
-  - unfold can_produce.
+  apply Exists_exists in Hsent as (item & Hitem & Houtput).
+  intros dm Hdm.
+  eapply in_futures_preserving_oracle_from_stepwise; cycle 2.
+  - eapply message_dependencies_are_necessary; [|eassumption].
+    unfold can_produce.
     rewrite <- Houtput.
     eapply can_produce_from_valid_trace; [|eassumption].
     eapply valid_trace_forget_last.
-    apply Htr.
+    exact (proj1 Htr).
+  - apply has_been_observed_from_sent_received_stepwise_props.
+  - eapply elem_of_trace_in_futures_left; [|eassumption].
+    exact (proj1 Htr).
 Qed.
 
 (** If the [valid]ity predicate has the [message_dependencies_full_node_condition_prop]erty,
@@ -200,21 +192,21 @@ Proof.
   - exists (item  :: suf).
     eapply finite_valid_trace_from_to_app_split.
     rewrite <- Heqtr.
-    apply Htr.
+    exact (proj1 Htr).
   - eapply Hfull; [|eassumption].
     replace (Some m) with (input item) by assumption.
     clear Hinput.
     eapply (input_valid_transition_is_valid (pre_loaded_with_all_messages_vlsm X)).
     eapply input_valid_transition_to; [|simpl; eassumption].
     eapply valid_trace_forget_last.
-    apply Htr.
+    exact (proj1 Htr).
 Qed.
 
 (** By combining Lemmas [msg_dep_has_been_sent] and [full_node_has_been_received],
 [msg_dep_rel] reflects the [has_been_observed] predicate.
 *)
 Lemma msg_dep_full_node_reflects_has_been_observed
-  (HMsgDep : MessageDependencies)
+  `{MessageDependencies}
   (Hfull : message_dependencies_full_node_condition_prop)
   s
   (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm X) s)
@@ -242,28 +234,22 @@ Context
   (message_dependencies : message -> set message)
   `{finite.Finite index}
   (IM : index -> VLSM message)
-  (Hbs : forall i, HasBeenSentCapability (IM i))
-  (Hbr : forall i, HasBeenReceivedCapability (IM i))
-  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
-  (HMsgDep : forall i, MessageDependencies message_dependencies (IM i))
-  (Free_Hbs := free_composite_HasBeenSentCapability IM (listing_from_finite index) Hbs)
-  (Free_Hbr := free_composite_HasBeenReceivedCapability IM (listing_from_finite index) Hbr)
+  `{forall i, HasBeenSentCapability (IM i)}
+  `{forall i, HasBeenReceivedCapability (IM i)}
+  `{forall i, MessageDependencies message_dependencies (IM i)}
   .
-
-Existing Instance Free_Hbs.
-Existing Instance Free_Hbr.
 
 (** If all of the components satisfy the [MessageDependencies] assumptions,
 then their free composition will also do so.
 *)
-Lemma composite_message_dependencies
+Global Instance composite_message_dependencies
   : MessageDependencies message_dependencies (free_composite_vlsm IM).
 Proof.
   split.
   - intros m s ((is, iom) & (i, li) & Ht) dm Hdm.
     apply composite_has_been_observed_free_iff.
     eapply composite_has_been_observed_from_component.
-    eapply message_dependencies_are_necessary; [apply HMsgDep| |eassumption].
+    eapply message_dependencies_are_necessary; [typeclasses eauto| |eassumption].
     exists (is i, iom), li.
     revert Ht.
     apply
@@ -275,7 +261,7 @@ Proof.
     reflexivity.
   - intros m Hemit.
     apply can_emit_composite_project in Hemit as [j Hemitj].
-    eapply message_dependencies_are_sufficient in Hemitj; [| apply HMsgDep].
+    eapply message_dependencies_are_sufficient in Hemitj; [|typeclasses eauto].
     revert Hemitj.
     eapply VLSM_full_projection_can_emit.
     apply lift_to_composite_generalized_preloaded_vlsm_full_projection.
@@ -356,27 +342,11 @@ Context
   (message_dependencies : message -> set message)
   `{EqDecision index}
   (IM : index -> VLSM message)
-  (Hbs : forall i, HasBeenSentCapability (IM i))
-  (Hbr : forall i, HasBeenReceivedCapability (IM i))
-  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
-  (HMsgDep : forall i, MessageDependencies message_dependencies (IM i))
+  `{forall i, HasBeenSentCapability (IM i)}
+  `{forall i, HasBeenReceivedCapability (IM i)}
+  `{forall i, MessageDependencies message_dependencies (IM i)}
   (indices : set index)
-  (SubFree_Hbs := free_composite_HasBeenSentCapability (sub_IM IM indices) (listing_from_finite (sub_index indices)) (sub_has_been_sent_capabilities IM indices Hbs))
-  (SubFree_Hbr := free_composite_HasBeenReceivedCapability (sub_IM IM indices) (listing_from_finite (sub_index indices)) (sub_has_been_received_capabilities IM indices Hbr))
   .
-
-Existing Instance SubFree_Hbs.
-Existing Instance SubFree_Hbr.
-
-Lemma sub_composite_message_dependencies
-  : MessageDependencies message_dependencies (free_composite_vlsm (sub_IM IM indices)).
-Proof.
-  apply composite_message_dependencies.
-  intro sub_i.
-  destruct_dec_sig sub_i i Hi Heqsub_i.
-  subst.
-  apply HMsgDep.
-Qed.
 
 Lemma msg_dep_reflects_sub_free_validity
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
@@ -388,7 +358,7 @@ Lemma msg_dep_reflects_sub_free_validity
     valid_message_prop (pre_loaded_vlsm X P) dm.
 Proof.
   eapply msg_dep_reflects_validity; [| |assumption].
-  - apply sub_composite_message_dependencies.
+  - typeclasses eauto.
   - intros m [sub_i [[im Him] Heqm]].
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
     contradict Him; apply no_initial_messages_in_IM.
@@ -426,7 +396,7 @@ Context
   {message : Type}
   (message_dependencies : message -> set message)
   (full_message_dependencies : message -> set message)
-  {HFullMsgDep : FullMessageDependencies message_dependencies full_message_dependencies}
+  `{FullMessageDependencies _ message_dependencies full_message_dependencies}
   .
 
 Global Instance msg_dep_happens_before_irrefl :
@@ -476,10 +446,10 @@ Lemma FullMessageDependencies_ind
     (forall dm0, dm0 ∈ full_message_dependencies dm -> P dm0) -> P dm)
   : forall dm, dm ∈ full_message_dependencies m -> P dm.
 Proof.
-  induction m using (well_founded_ind msg_dep_happens_before_wf).
+  induction m  as (m & Hm) using (well_founded_ind msg_dep_happens_before_wf).
   intros dm Hdm.
   apply IHm; [assumption|].
-  apply H; [apply full_message_dependencies_happens_before; assumption|].
+  apply Hm; [apply full_message_dependencies_happens_before; assumption|].
   intros dm0 Hdm0.
   apply IHm, full_message_dependencies_happens_before.
   transitivity dm; apply full_message_dependencies_happens_before; assumption.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -232,6 +232,12 @@ Qed.
 
 End sec_message_dependencies.
 
+(* Given the VLSM for which it's defined, the other arguments (message,
+message_dependencies function, [HasBeenSentCapability] and
+[HasBeenReceivedCapability]) can be inferred from that.
+*)
+Global Hint Mode MessageDependencies - - ! - - : typeclass_instances.
+
 Section sec_composite_message_dependencies.
 
 Context
@@ -419,20 +425,24 @@ Class FullMessageDependencies
 
 End sec_full_message_dependencies.
 
+(* given the message type, we can usually look up the functions for
+message dependencies *)
+Global Hint Mode FullMessageDependencies ! - - : typeclass_instances.
+
 Section full_message_dependencies_happens_before.
 
 Context
   {message : Type}
   (message_dependencies : message -> set message)
   (full_message_dependencies : message -> set message)
-  (HFullMsgDep : FullMessageDependencies message_dependencies full_message_dependencies)
+  {HFullMsgDep : FullMessageDependencies message_dependencies full_message_dependencies}
   .
 
 Global Instance msg_dep_happens_before_irrefl : Irreflexive (msg_dep_happens_before message_dependencies).
 Proof.
   intros m Hm.
   elim (full_message_dependencies_irreflexive m).
-  eapply full_message_dependencies_happens_before.
+  apply full_message_dependencies_happens_before.
   assumption.
 Qed.
 

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -1,7 +1,7 @@
 From stdpp Require Import prelude.
-From Coq Require Import FinFun.
-From VLSM Require Import Lib.Preamble Lib.StdppListSet Lib.Measurable.
-From VLSM Require Import Core.VLSM Core.Composition Core.Equivocation.
+From Coq Require Import FinFun Relations.Relation_Operators.
+From VLSM.Lib Require Import Preamble ListExtras FinFunExtras StdppListSet Measurable.
+From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces SubProjectionTraces Equivocation.
 
 (** * VLSM Message Dependencies
 
@@ -10,14 +10,18 @@ Assumes that each message has an associated set of [message_dependencies].
 
 *)
 
-Section message_dependencies.
+Section sec_message_dependencies.
 
 Context
   {message : Type}
   (message_dependencies : message -> set message)
   (X : VLSM message)
-  {Hbo : HasBeenObservedCapability X}
+  {Hbs : HasBeenSentCapability X}
+  {Hbr : HasBeenReceivedCapability X}
+  (Hbo : HasBeenObservedCapability X := HasBeenObservedCapability_from_sent_received X)
   .
+
+Existing Instance Hbo.
 
 (**
 [MessageDependencies] characterize a <<message_dependencies>> function
@@ -51,9 +55,8 @@ observed all of <<m>>'s dependencies.
 Definition message_dependencies_full_node_condition
   (s : vstate X)
   (m : message)
-  : Prop
-  := forall dm, dm ∈ message_dependencies m ->
-    has_been_observed X s dm.
+  : Prop :=
+  forall dm, dm ∈ message_dependencies m -> has_been_observed X s dm.
 
 (** A VLSM has the [message_dependencies_full_node_condition_prop]
 if the validity of receiving a message in a state implies the
@@ -63,4 +66,444 @@ Definition message_dependencies_full_node_condition_prop : Prop :=
   forall l s m,
   vvalid X l (s, Some m) -> message_dependencies_full_node_condition s m.
 
-End message_dependencies.
+(** Membership to the message_dependencies of a message induces a dependency
+relation.
+*)
+Definition msg_dep_rel : relation message :=
+  fun m1 m2 => m1 ∈ message_dependencies m2.
+
+(** The transitive closure of the [msg_dep_rel]ation is a happens-before
+relation.
+*)
+Definition msg_dep_happens_before : relation message := flip (clos_trans _ (flip msg_dep_rel)).
+
+(** Unrolling one the [msg_dep_happens_before] relation one step. *)
+Lemma msg_dep_happens_before_iff_one x z
+  : msg_dep_happens_before x z <->
+    msg_dep_rel x z \/ exists y, msg_dep_happens_before x y /\ msg_dep_rel y z.
+Proof.
+  split.
+  - intros Hhb.
+    apply Operators_Properties.clos_trans_t1n in Hhb.
+    inversion Hhb; subst.
+    + left. assumption.
+    + right.
+      exists y.
+      split; [|assumption].
+      apply Operators_Properties.clos_t1n_trans.
+      assumption.
+  - intros Hhb.
+    apply Operators_Properties.clos_t1n_trans.
+    destruct Hhb as [Hone | [y [Hhb Hone]]].
+    + apply t1n_step. assumption.
+    + apply t1n_trans with y; [assumption|].
+      apply Operators_Properties.clos_trans_t1n.
+      assumption.
+Qed.
+
+Global Instance msg_dep_happens_before_transitive : Transitive msg_dep_happens_before.
+Proof.
+  apply flip_Transitive.
+  intros m1 m2 m3.
+  apply t_trans.
+Qed.
+
+(** If the [msg_dep_rel]ation reflects a predicate <<P>> and the induced
+[msg_dep_happens_before] is [well_founded], then if <<P>> holds for a message,
+it will hold for all its dependencies. *)
+Lemma msg_dep_happens_before_reflect
+  (P : message -> Prop)
+  (Hreflects : forall dm m, msg_dep_rel dm m -> P m -> P dm)
+  : forall dm m, msg_dep_happens_before dm m -> P m -> P dm.
+Proof.
+  intros dm m Hdm.
+  apply Operators_Properties.clos_trans_t1n in Hdm.
+  induction Hdm; [apply Hreflects; assumption|].
+  intro Hpx.
+  apply IHHdm.
+  revert Hpx.
+  apply Hreflects.
+  assumption.
+Qed.
+
+(** In the absence of initial messages, and if [msg_dep_rel] reflects the
+pre-loaded message property, then it also reflects the [valid_message_prop]erty.
+*)
+Lemma msg_dep_reflects_validity
+  (HMsgDep : MessageDependencies)
+  (no_initial_messages_in_X : forall m, ~ vinitial_message_prop X m)
+  (P : message -> Prop)
+  (Hreflects : forall dm m, msg_dep_rel dm m -> P m -> P dm)
+  (Hbr_pre := preloaded_HasBeenReceivedCapability Hbr)
+  (Hbs_pre := preloaded_HasBeenSentCapability Hbs)
+  (Hbo_pre := HasBeenObservedCapability_from_sent_received (pre_loaded_vlsm X P))
+  : forall dm m, msg_dep_rel dm m ->
+    valid_message_prop (pre_loaded_vlsm X P) m ->
+    valid_message_prop (pre_loaded_vlsm X P) dm.
+Proof.
+  intros dm m Hdm.
+  rewrite emitted_messages_are_valid_iff.
+  rewrite can_emit_iff.
+  intros [Hinit | [s Hproduce]].
+  - rewrite emitted_messages_are_valid_iff.
+    left.
+    right.
+    apply Hreflects with m; [assumption|].
+    destruct Hinit as [Hinit | Hp]; [|assumption].
+    elim (no_initial_messages_in_X m).
+    assumption.
+  - apply (observed_valid (pre_loaded_vlsm X P)) with (s := s)
+    ; [exists (Some m); apply can_produce_valid; eassumption|].
+    cut (has_been_observed X s dm).
+    {
+      intros [Hsent | Hreceived]; [left|right].
+      - clear -Hsent. destruct Hbs. assumption.
+      - clear -Hreceived. destruct Hbr. assumption.
+    }
+    apply message_dependencies_are_necessary with m; [|assumption].
+    revert Hproduce.
+    apply VLSM_incl_can_produce.
+    apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
+Qed.
+
+(** Under [MessageDependencies] assumptions, if a message [has_been_sent]
+in a state <<s>>, then any of its direct dependencies [has_been_observed].
+*)
+Lemma msg_dep_has_been_sent
+  (HMsgDep : MessageDependencies)
+  s
+  (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm X) s)
+  m
+  (Hsent : has_been_sent X s m)
+  : forall dm, msg_dep_rel dm m -> has_been_observed X s dm.
+Proof.
+  intros dm Hdm.
+  cut (exists item, can_produce (pre_loaded_with_all_messages_vlsm X) (destination item) m /\ in_futures (pre_loaded_with_all_messages_vlsm X) (destination item) s).
+  {
+    intros [s_dm [Hproduce Hfutures]].
+    eapply in_futures_preserving_oracle_from_stepwise; [|eassumption|].
+    - apply has_been_observed_from_sent_received_stepwise_props.
+    - apply message_dependencies_are_necessary with m; assumption.
+  }
+  apply proper_sent in Hsent; [|assumption].
+  apply valid_state_has_trace in Hs as [is [tr Htr]].
+  specialize (Hsent _ _ Htr).
+  apply Exists_exists in Hsent as [item [Hitem Houtput]].
+  exists item.
+  split; cycle 1.
+  - eapply elem_of_trace_in_futures_left; [|eassumption].
+    apply Htr.
+  - unfold can_produce.
+    replace (Some m) with (output item) by assumption.
+    eapply can_produce_from_valid_trace; [|eassumption].
+    eapply valid_trace_forget_last.
+    apply Htr.
+Qed.
+
+(** If the [valid]ity predicate has the [message_dependencies_full_node_condition_prop]erty,
+then if a message [has_been_received] in a state <<s>>, any of its direct
+dependencies [has_been_observed].
+*)
+Lemma full_node_has_been_received
+  (Hfull : message_dependencies_full_node_condition_prop)
+  s
+  (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm X) s)
+  m
+  (Hreceived : has_been_received X s m)
+  : forall dm, msg_dep_rel dm m -> has_been_observed X s dm.
+Proof.
+  intros dm Hdm.
+  apply proper_received in Hreceived; [|assumption].
+  apply valid_state_has_trace in Hs as [is [tr Htr]].
+  specialize (Hreceived _ _ Htr).
+  apply Exists_exists in Hreceived as [item [Hitem Hinput]].
+  apply elem_of_list_split in Hitem as [pre [suf Heqtr]].
+  eapply in_futures_preserving_oracle_from_stepwise with (s1 := finite_trace_last is pre)
+  ; [apply has_been_observed_from_sent_received_stepwise_props|..].
+  - exists (item  :: suf).
+    eapply finite_valid_trace_from_to_app_split.
+    rewrite <- Heqtr.
+    apply Htr.
+  - eapply Hfull; [|eassumption].
+    replace (Some m) with (input item) by assumption.
+    clear Hinput.
+    eapply (input_valid_transition_is_valid (pre_loaded_with_all_messages_vlsm X)).
+    eapply input_valid_transition_to; [|simpl; eassumption].
+    eapply valid_trace_forget_last.
+    apply Htr.
+Qed.
+
+(** By combining Lemmas [msg_dep_has_been_sent] and [full_node_has_been_received],
+[msg_dep_rel] reflects the [has_been_observed] predicate.
+*)
+Lemma msg_dep_full_node_reflects_has_been_observed
+  (HMsgDep : MessageDependencies)
+  (Hfull : message_dependencies_full_node_condition_prop)
+  s
+  (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm X) s)
+  : forall dm m, msg_dep_rel dm m ->
+    has_been_observed X s m ->
+    has_been_observed X s dm.
+Proof.
+  intros dm m Hdm [Hsent|Hreceived].
+  - eapply msg_dep_has_been_sent; eassumption.
+  - eapply full_node_has_been_received; eassumption.
+Qed.
+
+End sec_message_dependencies.
+
+Section sec_composite_message_dependencies.
+
+Context
+  {message : Type}
+  (message_dependencies : message -> set message)
+  `{finite.Finite index}
+  (IM : index -> VLSM message)
+  (Hbs : forall i, HasBeenSentCapability (IM i))
+  (Hbr : forall i, HasBeenReceivedCapability (IM i))
+  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
+  (HMsgDep : forall i, MessageDependencies message_dependencies (IM i))
+  (Free_Hbs := free_composite_HasBeenSentCapability IM (listing_from_finite index) Hbs)
+  (Free_Hbr := free_composite_HasBeenReceivedCapability IM (listing_from_finite index) Hbr)
+  .
+
+Existing Instance Free_Hbs.
+Existing Instance Free_Hbr.
+
+(** If all of the components satisfy the [MessageDependencies] assumptions,
+then their free composition will also do so.
+*)
+Lemma composite_message_dependencies
+  : MessageDependencies message_dependencies (free_composite_vlsm IM).
+Proof.
+  split.
+  - intros m s Hproduce dm Hdm.
+    destruct Hproduce as [(is, iom) [(i, li) Ht]].
+    cut (@has_been_observed _ (IM i) (Hbo i) (s i) dm)
+    ; [intros [Hsent | Hreceived]; [left | right]; exists i; assumption|].
+    eapply message_dependencies_are_necessary; [apply HMsgDep| |eassumption].
+    exists (is i, iom), li.
+    revert Ht.
+    apply
+      (VLSM_projection_input_valid_transition (preloaded_component_projection IM _))
+      with (lY := li).
+    unfold composite_project_label.
+    cbn.
+    case_decide as Heqi; [|contradiction].
+    replace Heqi with (@eq_refl index i) by (apply Eqdep_dec.UIP_dec; assumption).
+    reflexivity.
+  - intros m Hemit.
+    apply can_emit_composite_project in Hemit as [j Hemitj].
+    eapply message_dependencies_are_sufficient in Hemitj; [| apply HMsgDep].
+    revert Hemitj.
+    eapply VLSM_full_projection_can_emit.
+    apply lift_to_composite_generalized_preloaded_vlsm_full_projection.
+    intuition.
+Qed.
+
+Lemma msg_dep_reflects_free_validity
+  (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
+  (X := free_composite_vlsm IM)
+  : forall dm m, msg_dep_rel message_dependencies dm m ->
+    valid_message_prop X m -> valid_message_prop X dm.
+Proof.
+  intros dm m Hdm.
+  rewrite !emitted_messages_are_valid_iff.
+  intros [[i [[im Him] Heqm]] | Hemit]
+  ; [elim (no_initial_messages_in_IM i im); assumption|].
+  right.
+  pose proof (vlsm_is_pre_loaded_with_False X) as XeqXFalse.
+  apply (VLSM_eq_can_emit XeqXFalse) in Hemit.
+  apply (VLSM_eq_can_emit XeqXFalse).
+  cut (valid_message_prop (pre_loaded_vlsm X (fun _ => False)) dm).
+  {
+    clear -no_initial_messages_in_IM.
+    rewrite emitted_messages_are_valid_iff.
+    intros [[[i [[im Him] Heqm]] | Hpreloaded] | Hemit]
+    ; [elim (no_initial_messages_in_IM i im); assumption|contradiction| assumption].
+  }
+  eapply msg_dep_reflects_validity.
+  - apply composite_message_dependencies.
+  - clear -no_initial_messages_in_IM.
+    intros m [i [[im Him] Heqm]].
+    elim (no_initial_messages_in_IM i im).
+    assumption.
+  - intuition.
+  - eassumption.
+  - apply emitted_messages_are_valid_iff.
+    right.
+    assumption.
+Qed.
+
+Lemma msg_dep_reflects_happens_before_free_validity
+  (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
+  (X := free_composite_vlsm IM)
+  : forall dm m, msg_dep_happens_before message_dependencies dm m ->
+    valid_message_prop X m -> valid_message_prop X dm.
+Proof.
+  apply msg_dep_happens_before_reflect.
+  apply msg_dep_reflects_free_validity.
+  assumption.
+Qed.
+
+Lemma msg_dep_happens_before_composite_no_initial_valid_messages_emitted_by_sender
+  {validator : Type}
+  (sender : message -> option validator)
+  (A : validator -> index)
+  (Hchannel : channel_authentication_prop  IM A sender)
+  (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
+  (X := free_composite_vlsm IM)
+  : forall m, valid_message_prop X m ->
+    forall dm, msg_dep_happens_before message_dependencies dm m ->
+    exists v, sender dm = Some v /\
+      can_emit (pre_loaded_with_all_messages_vlsm (IM (A v))) dm.
+Proof.
+  intros m Hm dm Hdm.
+  cut (valid_message_prop X dm).
+  {
+    clear Hdm.
+    revert dm.
+    apply composite_no_initial_valid_messages_emitted_by_sender; assumption.
+  }
+  revert dm m Hdm Hm.
+  apply msg_dep_reflects_happens_before_free_validity.
+  assumption.
+Qed.
+
+End sec_composite_message_dependencies.
+
+Section sec_sub_composite_message_dependencies.
+
+Context
+  {message : Type}
+  (message_dependencies : message -> set message)
+  `{EqDecision index}
+  (IM : index -> VLSM message)
+  (Hbs : forall i, HasBeenSentCapability (IM i))
+  (Hbr : forall i, HasBeenReceivedCapability (IM i))
+  (Hbo := fun i => HasBeenObservedCapability_from_sent_received (IM i))
+  (HMsgDep : forall i, MessageDependencies message_dependencies (IM i))
+  (indices : set index)
+  (SubFree_Hbs := free_composite_HasBeenSentCapability (sub_IM IM indices) (listing_from_finite (sub_index indices)) (sub_has_been_sent_capabilities IM indices Hbs))
+  (SubFree_Hbr := free_composite_HasBeenReceivedCapability (sub_IM IM indices) (listing_from_finite (sub_index indices)) (sub_has_been_received_capabilities IM indices Hbr))
+  .
+
+Existing Instance SubFree_Hbs.
+Existing Instance SubFree_Hbr.
+
+Lemma sub_composite_message_dependencies
+  : MessageDependencies message_dependencies (free_composite_vlsm (sub_IM IM indices)).
+Proof.
+  apply composite_message_dependencies.
+  intro sub_i.
+  destruct_dec_sig sub_i i Hi Heqsub_i.
+  subst.
+  apply HMsgDep.
+Qed.
+
+Lemma msg_dep_reflects_sub_free_validity
+  (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
+  (P : message -> Prop)
+  (Hreflects : forall dm m, msg_dep_rel message_dependencies dm m -> P m -> P dm)
+  (X := free_composite_vlsm (sub_IM IM indices))
+  : forall dm m, msg_dep_rel message_dependencies dm m ->
+    valid_message_prop (pre_loaded_vlsm X P) m ->
+    valid_message_prop (pre_loaded_vlsm X P) dm.
+Proof.
+  eapply msg_dep_reflects_validity; [..|assumption].
+  - apply sub_composite_message_dependencies.
+  - intros m [sub_i [[im Him] Heqm]].
+    destruct_dec_sig sub_i i Hi Heqsub_i.
+    subst.
+    elim (no_initial_messages_in_IM i im).
+    assumption.
+Qed.
+
+End sec_sub_composite_message_dependencies.
+
+Section sec_full_message_dependencies.
+
+Context
+  {message : Type}
+  .
+
+Class FullMessageDependencies
+  (message_dependencies : message -> set message)
+  (full_message_dependencies : message -> set message)
+  :=
+  { full_message_dependencies_happens_before
+      : forall dm m, dm ∈ full_message_dependencies m <-> msg_dep_happens_before message_dependencies dm m
+  ; full_message_dependencies_irreflexive
+      : forall m, m ∉ full_message_dependencies m
+  ; full_message_dependencies_nodups
+      : forall m, NoDup (full_message_dependencies m)
+  }.
+
+End sec_full_message_dependencies.
+
+Section full_message_dependencies_happens_before.
+
+Context
+  {message : Type}
+  (message_dependencies : message -> set message)
+  (full_message_dependencies : message -> set message)
+  (HFullMsgDep : FullMessageDependencies message_dependencies full_message_dependencies)
+  .
+
+Global Instance msg_dep_happens_before_irrefl : Irreflexive (msg_dep_happens_before message_dependencies).
+Proof.
+  intros m Hm.
+  elim (full_message_dependencies_irreflexive m).
+  eapply full_message_dependencies_happens_before.
+  assumption.
+Qed.
+
+Global Instance msg_dep_happens_before_strict : StrictOrder (msg_dep_happens_before message_dependencies) := {}.
+
+Lemma msg_dep_happens_before_wf : well_founded (msg_dep_happens_before message_dependencies).
+Proof.
+  cut (forall n m, length (full_message_dependencies m) < n -> Acc (msg_dep_happens_before message_dependencies) m).
+  {
+    intros Hn m.
+    apply (Hn (S (length (full_message_dependencies m)))).
+    lia.
+  }
+  induction n as [|n IHn]; [lia|].
+  intros m Hm.
+  constructor.
+  intros dm Hdm.
+  apply IHn.
+  unfold lt.
+  transitivity (length (full_message_dependencies m)); [|lia].
+  replace (S _) with (length (dm :: full_message_dependencies dm))
+    by reflexivity.
+  apply NoDup_subseteq_length.
+  - constructor; [apply full_message_dependencies_irreflexive| apply full_message_dependencies_nodups].
+  - intros m' Hm'.
+    inversion Hm'; subst; [apply full_message_dependencies_happens_before; assumption|].
+    revert H1.
+    setoid_rewrite full_message_dependencies_happens_before.
+    intro Hm'dm.
+    transitivity dm; assumption.
+Qed.
+
+Lemma FullMessageDependencies_ind
+  (P : message -> Prop)
+  m
+  (IHm : forall dm, dm ∈ full_message_dependencies m -> (forall dm0, dm0 ∈ full_message_dependencies dm -> P dm0) -> P dm)
+  : forall dm, dm ∈ full_message_dependencies m -> P dm.
+Proof.
+  induction m using (well_founded_ind msg_dep_happens_before_wf).
+  intros dm Hdm.
+  apply IHm; [assumption|].
+  apply H; [apply full_message_dependencies_happens_before; assumption|].
+  intros dm0 Hdm0.
+  apply IHm.
+  apply full_message_dependencies_happens_before in Hdm.
+  apply full_message_dependencies_happens_before in Hdm0.
+  apply full_message_dependencies_happens_before.
+  change _ with (msg_dep_happens_before message_dependencies dm0 m).
+  transitivity dm; assumption.
+Qed.
+
+End full_message_dependencies_happens_before.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -106,6 +106,7 @@ Lemma msg_dep_happens_before_reflect
 Proof.
   intros dm m Hdm.
   apply Operators_Properties.clos_trans_t1n in Hdm.
+  clear -Hdm Hreflects.
   induction Hdm; firstorder.
 Qed.
 

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -72,18 +72,16 @@ relation.
 Definition msg_dep_rel : relation message :=
   fun m1 m2 => m1 ∈ message_dependencies m2.
 
-(** The transitive closure of the [msg_dep_rel]ation is a happens-before
-relation.
+(** The transitive closure ([clos_trans_1n]) of the [msg_dep_rel]ation is a
+happens-before relation.
 *)
-Definition msg_dep_happens_before : relation message := flip (clos_trans _ (flip msg_dep_rel)).
+Definition msg_dep_happens_before : relation message := flip (clos_trans_1n _ (flip msg_dep_rel)).
 
 (** Unrolling one the [msg_dep_happens_before] relation one step. *)
 Lemma msg_dep_happens_before_iff_one x z
   : msg_dep_happens_before x z <->
     msg_dep_rel x z \/ exists y, msg_dep_happens_before x y /\ msg_dep_rel y z.
 Proof.
-  unfold msg_dep_happens_before; simpl.
-  setoid_rewrite Operators_Properties.clos_trans_t1n_iff.
   split.
   - inversion 1; subst; eauto.
   - intros [H | [y [H1 H2]]]; econstructor; eassumption.
@@ -92,7 +90,8 @@ Qed.
 Global Instance msg_dep_happens_before_transitive : Transitive msg_dep_happens_before.
 Proof.
   apply flip_Transitive.
-  intros m1 m2 m3.
+  intros m1 m2 m3 .
+  rewrite <- !Relations.Operators_Properties.clos_trans_t1n_iff.
   apply t_trans.
 Qed.
 
@@ -105,7 +104,6 @@ Lemma msg_dep_happens_before_reflect
   : forall dm m, msg_dep_happens_before dm m -> P m -> P dm.
 Proof.
   intros dm m Hdm.
-  apply Operators_Properties.clos_trans_t1n in Hdm.
   clear -Hdm Hreflects.
   induction Hdm; firstorder.
 Qed.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -20,6 +20,16 @@ Context
   `{HasBeenReceivedCapability message X}
   .
 
+(** The (local) full node condition for a given <<message_dependencies>> function
+requires that a state (receiving the message) has previously
+observed all of <<m>>'s dependencies.
+*)
+Definition message_dependencies_full_node_condition
+  (s : vstate X)
+  (m : message)
+  : Prop :=
+  forall dm, dm ∈ message_dependencies m -> has_been_observed X s dm.
+
 (**
 [MessageDependencies] characterize a <<message_dependencies>> function
 through two properties:
@@ -37,23 +47,11 @@ Class MessageDependencies
   :=
   { message_dependencies_are_necessary (m : message)
       `(can_produce (pre_loaded_with_all_messages_vlsm X) s m)
-      : forall (dm : message),
-        dm ∈ message_dependencies m ->
-        has_been_observed X s dm
+      : message_dependencies_full_node_condition s m
   ; message_dependencies_are_sufficient (m : message)
       `(can_emit (pre_loaded_with_all_messages_vlsm X) m)
       : can_emit (pre_loaded_vlsm X (fun msg => msg ∈ message_dependencies m)) m
   }.
-
-(** The (local) full node condition for a given <<message_dependencies>> function
-requires that a state (receiving the message) has previously
-observed all of <<m>>'s dependencies.
-*)
-Definition message_dependencies_full_node_condition
-  (s : vstate X)
-  (m : message)
-  : Prop :=
-  forall dm, dm ∈ message_dependencies m -> has_been_observed X s dm.
 
 (** A VLSM has the [message_dependencies_full_node_condition_prop]
 if the validity of receiving a message in a state implies the

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -129,9 +129,9 @@ Proof.
     ; [|revert Hproduce; apply VLSM_incl_can_produce; apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages].
     clear H1 no_initial_messages_in_X Hreflects.
     revert H H0 s Hdm Hproduce; destruct X as (T & S & M); cbn; intros.
-    revert Hdm.
-    apply VLSM_incl_has_been_observed
-    ; [apply basic_VLSM_incl_preloaded; cbv;intuition|].
+    eapply VLSM_incl_has_been_observed
+    ; [apply basic_VLSM_incl_preloaded; cbv;intuition | | eassumption].
+
     exists (Some m).
     apply can_produce_valid.
     revert Hproduce.
@@ -275,8 +275,7 @@ Proof.
   intros dm m Hdm.
   rewrite !emitted_messages_are_valid_iff.
   intros [[i [[im Him] _]] | Hemit]
-  ; [contradict Him; apply no_initial_messages_in_IM|].
-  right.
+  ; [contradict Him; apply no_initial_messages_in_IM | right].
   pose proof (vlsm_is_pre_loaded_with_False X) as XeqXFalse.
   apply (VLSM_eq_can_emit XeqXFalse).
   cut (valid_message_prop (pre_loaded_vlsm X (fun _ => False)) dm).
@@ -289,7 +288,7 @@ Proof.
   eapply msg_dep_reflects_validity.
   - apply composite_message_dependencies.
   - intros _ [i [[im Him] _]].
-    contradict Him. apply no_initial_messages_in_IM.
+    contradict Him; apply no_initial_messages_in_IM.
   - intuition.
   - eassumption.
   - apply emitted_messages_are_valid_iff.
@@ -322,13 +321,8 @@ Lemma msg_dep_happens_before_composite_no_initial_valid_messages_emitted_by_send
 Proof.
   intros m Hm dm Hdm.
   cut (valid_message_prop X dm).
-  {
-    clear Hdm; revert dm.
-    apply composite_no_initial_valid_messages_emitted_by_sender; assumption.
-  }
-  revert dm m Hdm Hm.
-  apply msg_dep_reflects_happens_before_free_validity.
-  assumption.
+  - apply composite_no_initial_valid_messages_emitted_by_sender; assumption.
+  - eapply msg_dep_reflects_happens_before_free_validity; eassumption.
 Qed.
 
 End sec_composite_message_dependencies.
@@ -428,8 +422,7 @@ Proof.
   - constructor.
     + apply full_message_dependencies_irreflexive.
     + apply full_message_dependencies_nodups.
-  - intros m' Hm'.
-apply elem_of_cons in Hm' as [-> | Hm'].
+  - intros m' Hm'. apply elem_of_cons in Hm' as [-> | Hm'].
     + apply full_message_dependencies_happens_before; assumption.
     + revert Hm'.
       setoid_rewrite full_message_dependencies_happens_before.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -267,10 +267,8 @@ Definition composite_project_label
 Lemma composite_project_label_eq lj
   : composite_project_label (existT j lj) = Some lj.
 Proof.
-  unfold composite_project_label.
-  cbn.
-  case_decide as Heqi; [|contradiction].
-  replace Heqi with (@eq_refl index j) by (apply Eqdep_dec.UIP_dec; assumption).
+  unfold composite_project_label; cbn.
+  rewrite decide_left with eq_refl; cbn.
   reflexivity.
 Qed.
 
@@ -289,48 +287,34 @@ Proof.
   apply VLSM_eq_incl_iff.
   split.
   - apply basic_VLSM_strong_incl.
-    + intros s Hs; cbn; red.
+    + intros s Hs; cbn in *; red.
       exists (lift_to_composite_state IM j s).
       split; [apply state_update_eq|].
       apply (lift_to_composite_state_initial IM).
       assumption.
-    + intros m [[im Him] <-]. assumption.
+    + intros m [[im Him] <-]; assumption.
     + intros l s iom [sX [<- Hv]].
       exists (existT j l), sX.
       intuition.
       apply composite_project_label_eq.
     + intros l s iom s' oom.
-      cbn.
-      unfold lift_to_composite_state at 1.
-      rewrite state_update_eq.
-      intros Ht.
-      setoid_rewrite Ht.
-      rewrite state_update_eq.
-      reflexivity.
-  - cbn. apply basic_VLSM_strong_incl.
-    + intros s [sX [<- HsX]].
-      apply (HsX j).
-    + intros m Him.
-      exists (exist _ m Him).
-      reflexivity.
-    + intros l s iom ((i, li) & sX & HlX & <- & Hv).
-      exists sX.
-      split; [reflexivity|].
-      unfold composite_project_label in HlX.
-      simpl in *.
-      case_decide; [|congruence].
-      subst i.
-      apply Some_inj in HlX.
-      cbv in HlX.
-      subst li.
+      cbn; unfold lift_to_composite_state at 1; rewrite state_update_eq.
+      intros Ht; setoid_rewrite Ht.
+      rewrite state_update_eq; reflexivity.
+  - cbn; apply basic_VLSM_strong_incl.
+    + intros s [sX [<- HsX]]; cbn. apply HsX.
+    + intros m Him; cbn. exists (exist _ m Him). reflexivity.
+    + intros l s iom ((i, li) & sX & HlX & <- & Hv); cbn.
+      exists sX; split; [reflexivity|].
+      unfold composite_project_label in HlX; cbn in *.
+      case_decide; [| congruence].
+      subst i; apply Some_inj in HlX; cbn in HlX; subst li.
       assumption.
-    + intros l s iom s' oom.
-      cbn.
-      unfold lift_to_composite_state at 1.
-      rewrite state_update_eq.
+    + intros l s iom s' oom; cbn.
+      unfold lift_to_composite_state at 1;
+      rewrite state_update_eq;
       destruct (vtransition _ _ _) as (si', om').
-      rewrite state_update_eq.
-      intuition.
+      rewrite state_update_eq; trivial.
 Qed.
 
 Lemma component_label_projection_lift

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -277,7 +277,7 @@ Proof.
   apply VLSM_eq_incl_iff.
   split.
   - apply basic_VLSM_strong_incl.
-    + intros s Hs.
+    + intros s Hs; cbn; red.
       exists (lift_to_composite_state IM j s).
       split; [apply state_update_eq|].
       apply (lift_to_composite_state_initial IM).
@@ -295,7 +295,6 @@ Proof.
       cbn.
       unfold lift_to_composite_state at 1.
       rewrite state_update_eq.
-      cbn.
       intros Ht.
       setoid_rewrite Ht.
       rewrite state_update_eq.
@@ -306,7 +305,7 @@ Proof.
     + intros m Him.
       exists (exist _ m Him).
       reflexivity.
-    + intros l s iom [[i li] [sX [HlX [<- Hv]]]].
+    + intros l s iom ((i, li) & sX & HlX & <- & Hv).
       exists sX.
       split; [reflexivity|].
       unfold composite_project_label in HlX.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -264,15 +264,27 @@ Definition composite_project_label
   | _ => None
   end.
 
+Lemma composite_project_label_eq lj
+  : composite_project_label (existT j lj) = Some lj.
+Proof.
+  unfold composite_project_label.
+  cbn.
+  case_decide as Heqi; [|contradiction].
+  replace Heqi with (@eq_refl index j) by (apply Eqdep_dec.UIP_dec; assumption).
+  reflexivity.
+Qed.
+
+Definition composite_vlsm_induced_projection : VLSM message :=
+  projection_induced_vlsm X (type (IM j))
+    composite_project_label (fun s => s j)
+    (lift_to_composite_label IM j) (lift_to_composite_state IM j).
+
 (** The [composite_vlsm_constraint_projection] is [VLSM_eq]ual (trace-equivalent)
 to the [projection_induced_vlsm] by the [composite_project_label] and the
 projection of the state to the component.
 *)
 Lemma composite_vlsm_constrained_projection_is_induced
-  : VLSM_eq Xj
-    (projection_induced_vlsm X (type (IM j))
-      composite_project_label (fun s => s j)
-      (lift_to_composite_label IM j) (lift_to_composite_state IM j)).
+  : VLSM_eq Xj composite_vlsm_induced_projection.
 Proof.
   apply VLSM_eq_incl_iff.
   split.
@@ -286,11 +298,7 @@ Proof.
     + intros l s iom [sX [<- Hv]].
       exists (existT j l), sX.
       intuition.
-      unfold composite_project_label.
-      case_decide; [|contradiction].
-      cbn in H |- *.
-      replace H with (@eq_refl index j) by (apply Eqdep_dec.UIP_dec; assumption).
-      reflexivity.
+      apply composite_project_label_eq.
     + intros l s iom s' oom.
       cbn.
       unfold lift_to_composite_state at 1.
@@ -330,11 +338,7 @@ Lemma component_label_projection_lift
     (lift_to_composite_label IM j).
 Proof.
   intros lj.
-  unfold composite_project_label.
-  case_decide as Hj; [|contradiction].
-  cbn in Hj |- *.
-  replace Hj with (@eq_refl index j) by (apply Eqdep_dec.UIP_dec; assumption).
-  reflexivity.
+  apply composite_project_label_eq.
 Qed.
 
 Lemma component_state_projection_lift

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -402,7 +402,7 @@ Proof.
     + apply component_label_projection_lift.
     + apply component_state_projection_lift.
     + apply component_transition_projection_Some.
-Qed. 
+Qed.
 
 (** The projection on component <<j>> of valid traces from <<X>> is valid
 for the <<j>>th projection.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1219,13 +1219,13 @@ Lemma induced_sub_projection_friendliness
     (lift_sub_state IM equivocators))
   : projection_friendly_prop (induced_sub_projection_is_projection IM equivocators constraint).
 Proof.
-  eapply (basic_projection_induces_friendliness (composite_vlsm IM constraint)).
+  apply (basic_projection_induces_friendliness (composite_vlsm IM constraint)) with
+    (Htransition_None := ltac: (eapply induced_sub_projection_transition_consistency_None))
+    (Hlabel_lift := ltac: (eapply composite_label_sub_projection_option_lift))
+    (Hstate_lift := ltac: (eapply composite_state_sub_projection_lift))
+    (Htransition_consistency := ltac:(eapply induced_sub_projection_transition_consistency_Some))
+    .
   assumption.
-Unshelve.
-  - apply induced_sub_projection_transition_consistency_None.
-  - apply composite_label_sub_projection_option_lift.
-  - apply composite_state_sub_projection_lift.
-  - apply induced_sub_projection_transition_consistency_Some.
 Qed.
 
 End lift_sub_state_to_preloaded.
@@ -2027,16 +2027,15 @@ Proof.
   apply projection_induced_vlsm_is_projection.
   - intros lX HlX s om s' om' [_ Ht].
     apply sub_transition_element_project_None with lX om om'; [assumption|].
-    setoid_rewrite <- induced_sub_projection_transition_is_composite.
-    eassumption.
+    setoid_rewrite <- induced_sub_projection_transition_is_composite
+      with (constraint0 := constraint).
+    assumption.
   - apply basic_weak_projection_transition_consistency_Some.
     + intro. apply sub_element_label_project.
     + intro. apply sub_element_state_project.
     + intro.
       setoid_rewrite induced_sub_projection_transition_is_composite.
       apply sub_transition_element_project_Some.
-Unshelve.
-  exact constraint.
 Qed.
 
 End sub_composition_element.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -63,7 +63,10 @@ Lemma sub_IM_state_update_neq
   (si : vstate (IM i))
   (j : index)
   (ej : sub_index_prop j)
-  : i <> j -> state_update sub_IM s (dec_exist _ i ei) si (dec_exist _ j ej) = s (dec_exist _ j ej).
+  : i <> j ->
+      state_update sub_IM s (dec_exist _ i ei) si (dec_exist _ j ej)
+        =
+      s (dec_exist _ j ej).
 Proof.
   intro Hneq.
   apply state_update_neq.
@@ -353,26 +356,18 @@ Lemma induced_sub_projection_transition_is_composite l s om
   : vtransition induced_sub_projection l (s, om) = composite_transition sub_IM l (s, om).
 Proof.
   destruct l as (sub_i, li).
-  destruct_dec_sig sub_i i Hi Heqsub_i.
-  subst.
-  cbn.
-  unfold sub_IM, lift_sub_state.
-  rewrite lift_sub_state_to_eq with (Hi := Hi).
-  cbn.
+  destruct_dec_sig sub_i i Hi Heqsub_i; subst.
+  cbn; unfold sub_IM, lift_sub_state;
+  rewrite lift_sub_state_to_eq with (Hi := Hi); cbn.
   destruct (vtransition _ _ _) as (si', om').
   f_equal.
   extensionality sub_k.
-  destruct_dec_sig sub_k k Hk Heqsub_k.
-  subst.
-  unfold composite_state_sub_projection.
-  simpl.
-  destruct (decide (i = k)).
-  + subst.
-    rewrite state_update_eq.
-    symmetry.
-    apply sub_IM_state_update_eq.
-  + setoid_rewrite sub_IM_state_update_neq; [|congruence].
-    rewrite state_update_neq by congruence.
+  destruct_dec_sig sub_k k Hk Heqsub_k; subst.
+  unfold composite_state_sub_projection; cbn.
+  destruct (decide (i = k)); subst.
+  + rewrite state_update_eq, sub_IM_state_update_eq.
+    reflexivity.
+  + rewrite sub_IM_state_update_neq, state_update_neq by congruence.
     apply lift_sub_state_to_eq.
 Qed.
 
@@ -511,9 +506,8 @@ Proof.
   - apply NoDup_remove_dups.
   - intro sub_x.
     apply elem_of_remove_dups, elem_of_list_annotate.
-    destruct_dec_sig sub_x x Hx Heqsub_x.
-    subst.
-    assumption.
+    destruct_dec_sig sub_x x Hx Heqsub_x; subst.
+    cbn; red in Hx. assumption.
 Qed.
 
 Local Instance Sub_Free_HasBeenSentCapability
@@ -1831,10 +1825,8 @@ Definition sub_element_state (s : vstate (IM j)) sub_i
 Lemma sub_element_state_eq s H_j
   : sub_element_state s (dexist j H_j) = s.
 Proof.
-  unfold sub_element_state.
-  simpl.
-  case_decide as Heq_j; [|contradiction].
-  replace Heq_j with (@eq_refl index j) by (apply Eqdep_dec.UIP_dec; assumption).
+  unfold sub_element_state; cbn.
+  rewrite decide_left with (HP := eq_refl); cbn.
   reflexivity.
 Qed.
 
@@ -1842,9 +1834,8 @@ Lemma sub_element_state_neq s i Hi
   : i <> j -> sub_element_state s (dexist i Hi) = ` (vs0 (IM i)).
 Proof.
   intros Hij.
-  unfold sub_element_state.
-  simpl.
-  case_decide; [contradiction|reflexivity].
+  unfold sub_element_state; cbn.
+  case_decide; congruence.
 Qed.
 
 Lemma preloaded_sub_element_full_projection
@@ -1856,30 +1847,23 @@ Lemma preloaded_sub_element_full_projection
 Proof.
   apply basic_VLSM_full_projection_preloaded_with; [assumption|..].
   - intros l s om Hv.
-    split; [|exact I].
-    cbn.
+    split; [cbn |exact I].
     rewrite sub_element_state_eq with (H_j := Hj).
     assumption.
-  - intros l s om s' om'.
-    cbn.
+  - intros l s om s' om'; cbn.
     rewrite sub_element_state_eq with (H_j := Hj).
-    intro Ht.
-    replace (vtransition _ _ _) with (s', om').
-    f_equal.
+    intro Ht; replace (vtransition _ _ _) with (s', om'); f_equal.
     extensionality sub_i.
-    destruct_dec_sig sub_i i Hi Heqsub_i.
-    subst.
-    destruct (decide (i = j)).
-    + subst.
+    destruct_dec_sig sub_i i Hi Heqsub_i; subst.
+    destruct (decide (i = j)); subst.
       rewrite sub_IM_state_update_eq, sub_element_state_eq.
       reflexivity.
     + rewrite sub_IM_state_update_neq, !sub_element_state_neq by congruence.
       reflexivity.
   - intros sj Hsj sub_i.
-    destruct_dec_sig sub_i i Hi Heqsub_i.
-    subst.
-    destruct (decide (i = j)).
-    + subst. rewrite sub_element_state_eq. assumption.
+    destruct_dec_sig sub_i i Hi Heqsub_i; subst.
+    destruct (decide (i = j)); subst.
+    + rewrite sub_element_state_eq. assumption.
     + rewrite sub_element_state_neq by congruence.
       destruct (vs0 (IM i)).
       assumption.
@@ -1933,14 +1917,11 @@ Lemma sub_transition_element_project_None
     sub_state_element_project s' = sub_state_element_project s.
 Proof.
   intros (sub_i,li) HlX s om s' om' HtX.
-  destruct_dec_sig sub_i i Hi Heqsub_i.
-  subst.
-  unfold sub_label_element_project in HlX.
-  cbn in HlX, HtX.
+  destruct_dec_sig sub_i i Hi Heqsub_i; subst.
+  unfold sub_label_element_project in HlX; cbn in HlX, HtX.
   case_decide as Hij; [congruence|].
-  clear HlX.
   destruct (vtransition _ _ _) as (si', _om').
-  inversion HtX. subst. clear HtX.
+  inversion_clear HtX.
   unfold sub_state_element_project.
   apply sub_IM_state_update_neq.
   congruence.
@@ -1950,49 +1931,37 @@ Lemma sub_element_label_project
   : forall lY, sub_label_element_project (sub_element_label lY) = Some lY.
 Proof.
   intros lY.
-  unfold sub_element_label, sub_label_element_project.
-  simpl.
-  case_decide as Heqj; [|contradiction].
-  replace Heqj with (eq_refl (A := index) (x := j)); [reflexivity|].
-  apply Eqdep_dec.UIP_dec.
-  assumption.
+  unfold sub_element_label, sub_label_element_project; cbn.
+  rewrite decide_left with (HP := eq_refl); cbn.
+  reflexivity.
 Qed.
 
 Lemma sub_element_state_project
   : forall sY, sub_state_element_project (sub_element_state sY) = sY.
 Proof.
   intros sY.
-  unfold sub_element_state, sub_state_element_project.
-  simpl.
-  case_decide as Heqj; [|contradiction].
-  replace Heqj with (eq_refl (A := index) (x := j)); [reflexivity|].
-  apply Eqdep_dec.UIP_dec.
-  assumption.
+  unfold sub_element_state, sub_state_element_project; cbn.
+  rewrite decide_left with (HP := eq_refl); cbn.
+  reflexivity.
 Qed.
 
-Lemma sub_transition_element_project_Some
-  : forall lX1 lX2 lY, sub_label_element_project lX1 = Some lY -> sub_label_element_project lX2 = Some lY ->
-    forall sX1 sX2, sub_state_element_project sX1 = sub_state_element_project sX2 ->
-    forall iom sX1' oom1, composite_transition (sub_IM IM indices) lX1 (sX1, iom) = (sX1', oom1) ->
-    forall sX2' oom2, composite_transition (sub_IM IM indices) lX2 (sX2, iom) = (sX2', oom2) ->
-    sub_state_element_project sX1' = sub_state_element_project sX2' /\ oom1 = oom2.
+Lemma sub_transition_element_project_Some :
+  forall lX1 lX2 lY,
+    sub_label_element_project lX1 = Some lY ->
+    sub_label_element_project lX2 = Some lY ->
+  forall sX1 sX2,
+    sub_state_element_project sX1 = sub_state_element_project sX2 ->
+  forall iom sX1' oom1,
+    composite_transition (sub_IM IM indices) lX1 (sX1, iom) = (sX1', oom1) ->
+  forall sX2' oom2,
+    composite_transition (sub_IM IM indices) lX2 (sX2, iom) = (sX2', oom2) ->
+      sub_state_element_project sX1' = sub_state_element_project sX2' /\ oom1 = oom2.
 Proof.
   intros (sub_j1, lj1) (sub_j2, lj2) lj.
-  destruct_dec_sig sub_j1 j1 Hj1 Heqsub_j1.
-  destruct_dec_sig sub_j2 j2 Hj2 Heqsub_j2.
-  subst.
-  unfold sub_label_element_project.
-  cbn.
-  case_decide as Heqj; intro HlX; inversion HlX as [Heqlj].
-  clear HlX.
-  subst j1.
-  cbv in Heqlj.
-  subst lj1.
-  case_decide as Heqj; intro HlX; inversion HlX as [Heqlj].
-  clear HlX.
-  subst j2.
-  cbv in Heqlj.
-  subst lj2.
+  destruct_dec_sig sub_j1 j1 Hj1 Heqsub_j1;
+  destruct_dec_sig sub_j2 j2 Hj2 Heqsub_j2; subst.
+  unfold sub_label_element_project; cbn.
+  do 2 (case_decide; inversion 1); subst; cbn in *; subst.
   unfold sub_state_element_project.
   intros sX1 sX2 Hsjeq iom.
   replace (sX1 (dec_exist (sub_index_prop indices) j Hj1)) with (sX1 (dexist j Hj))
@@ -2000,13 +1969,9 @@ Proof.
   replace (sX2 (dec_exist (sub_index_prop indices) j Hj2)) with (sX2 (dexist j Hj))
     by apply sub_IM_state_pi.
   rewrite <- Hsjeq.
-  unfold sub_IM.
-  cbn.
+  unfold sub_IM; cbn.
   destruct (vtransition _ _ _) as (si', om').
-  intros sX' oom HtX.
-  inversion HtX. subst oom sX'. clear HtX.
-  intros sX' oom HtX.
-  inversion HtX. subst oom sX'. clear HtX.
+  do 2 inversion_clear 1.
   split; [|reflexivity].
   setoid_rewrite sub_IM_state_update_eq.
   reflexivity.
@@ -2031,10 +1996,9 @@ Proof.
       with (constraint0 := constraint).
     assumption.
   - apply basic_weak_projection_transition_consistency_Some.
-    + intro. apply sub_element_label_project.
-    + intro. apply sub_element_state_project.
-    + intro.
-      setoid_rewrite induced_sub_projection_transition_is_composite.
+    + intro; apply sub_element_label_project.
+    + intro; apply sub_element_state_project.
+    + intro; setoid_rewrite induced_sub_projection_transition_is_composite.
       apply sub_transition_element_project_Some.
 Qed.
 

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -357,10 +357,9 @@ Proof.
   destruct l as (sub_i, li).
   destruct_dec_sig sub_i i Hi Heqsub_i; subst.
   cbn; unfold sub_IM, lift_sub_state;
-  rewrite lift_sub_state_to_eq with (Hi := Hi); cbn.
+  rewrite lift_sub_state_to_eq with (Hi := Hi); cbn;
   destruct (vtransition _ _ _) as (si', om').
-  f_equal.
-  extensionality sub_k.
+  f_equal; extensionality sub_k.
   destruct_dec_sig sub_k k Hk Heqsub_k; subst.
   unfold composite_state_sub_projection; cbn.
   destruct (decide (i = k)); subst.
@@ -1062,45 +1061,36 @@ Lemma induced_sub_projection_lift
 Proof.
   apply basic_VLSM_full_projection.
   - intros l s om (_ & _ & (i, li) & sX & Heql & Heqs & HsX & Hom & Hv & Hc) _ _.
-    unfold composite_label_sub_projection_option in Heql.
-    simpl in Heql.
-    case_decide as Hi; [|congruence].
+    unfold composite_label_sub_projection_option in Heql; cbn in Heql.
+    case_decide as Hi; [| congruence].
     apply Some_inj in Heql; subst l; cbn.
-    unfold constrained_composite_valid, lift_sub_state. cbn.
-    rewrite lift_sub_state_to_eq with (Hi0 := Hi).
-    subst.
+    unfold constrained_composite_valid, lift_sub_state; cbn;
+    rewrite lift_sub_state_to_eq with (Hi0 := Hi); subst.
     split; [assumption|].
     eapply Hconstraint_consistency; [|eassumption].
-    symmetry.
-    apply composite_state_sub_projection_lift_to.
+    symmetry; apply composite_state_sub_projection_lift_to.
   - intros l s om s' om' [_ Ht].
-    revert Ht; cbn.
-    destruct (vtransition _ _ _) as (si', _om').
+    revert Ht; cbn;
+    destruct (vtransition _ _ _) as (si', _om');
     inversion_clear 1.
-    f_equal.
-    extensionality i.
-    destruct l as (sub_j, lj).
-    destruct_dec_sig sub_j j Hj Heqsub_j.
-    subst.
-    simpl.
-    destruct (decide (i = j)).
-    + subst. rewrite state_update_eq.
-      unfold lift_sub_state.
-      rewrite lift_sub_state_to_eq with (Hi := Hj).
-      unfold composite_state_sub_projection.
-      simpl.
-      rewrite state_update_eq.
-      reflexivity.
+    f_equal; extensionality i.
+    destruct l as (sub_j, lj);
+    destruct_dec_sig sub_j j Hj Heqsub_j; subst; cbn;
+    destruct (decide (i = j)); subst.
+    + unfold lift_sub_state.
+      rewrite state_update_eq, lift_sub_state_to_eq with (Hi := Hj).
+      unfold composite_state_sub_projection; cbn.
+      rewrite state_update_eq; reflexivity.
     + rewrite state_update_neq by congruence.
       destruct (decide (i ∈ equivocators)).
       * unfold lift_sub_state.
         rewrite !lift_sub_state_to_eq with (Hi := e).
-        unfold composite_state_sub_projection. simpl.
+        unfold composite_state_sub_projection; cbn.
         rewrite state_update_neq by congruence.
         rewrite lift_sub_state_to_eq with (Hi := e).
         reflexivity.
       * unfold lift_sub_state, lift_sub_state_to.
-        destruct (decide _); [contradiction|reflexivity].
+        case_decide; [contradiction | reflexivity].
   - intros s Hs.
     apply (lift_sub_state_initial IM).
     destruct Hs as [sX [<- HsX]].
@@ -1121,13 +1111,12 @@ Lemma induced_sub_projection_friendliness
     (lift_sub_state IM equivocators))
   : projection_friendly_prop (induced_sub_projection_is_projection IM equivocators constraint).
 Proof.
-  eapply basic_projection_induces_friendliness.
-  assumption.
+  eapply basic_projection_induces_friendliness; assumption.
   Unshelve.
-    - apply induced_sub_projection_transition_consistency_None.
-    - apply composite_label_sub_projection_option_lift.
-    - apply composite_state_sub_projection_lift.
-    - apply induced_sub_projection_transition_consistency_Some.
+  - apply induced_sub_projection_transition_consistency_None.
+  - apply composite_label_sub_projection_option_lift.
+  - apply composite_state_sub_projection_lift.
+  - apply induced_sub_projection_transition_consistency_Some.
 Qed.
 
 End lift_sub_state_to_preloaded.
@@ -1758,17 +1747,16 @@ Proof.
     extensionality sub_i.
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
     destruct (decide (i = j)); subst.
-      rewrite sub_IM_state_update_eq, sub_element_state_eq.
+    + rewrite sub_IM_state_update_eq, sub_element_state_eq.
       reflexivity.
     + rewrite sub_IM_state_update_neq, !sub_element_state_neq by congruence.
       reflexivity.
   - intros sj Hsj sub_i.
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
     destruct (decide (i = j)); subst.
-    + rewrite sub_element_state_eq. assumption.
+    + rewrite sub_element_state_eq; assumption.
     + rewrite sub_element_state_neq by congruence.
-      destruct (vs0 (IM i)).
-      assumption.
+      destruct (vs0 (IM i)); assumption.
   - intros m Hm.
     exists (dexist j Hj), (exist _ m Hm).
     reflexivity.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -509,8 +509,8 @@ Global Instance stdpp_finite_sub_index
 Proof.
   exists (remove_dups sub_index_list_annotate).
   - apply NoDup_remove_dups.
-  - intro sub_x. apply elem_of_remove_dups.
-    apply elem_of_list_annotate.
+  - intro sub_x.
+    apply elem_of_remove_dups, elem_of_list_annotate.
     destruct_dec_sig sub_x x Hx Heqsub_x.
     subst.
     assumption.
@@ -1873,8 +1873,7 @@ Proof.
     + subst.
       rewrite sub_IM_state_update_eq, sub_element_state_eq.
       reflexivity.
-    + rewrite sub_IM_state_update_neq by congruence.
-      rewrite !sub_element_state_neq by congruence.
+    + rewrite sub_IM_state_update_neq, !sub_element_state_neq by congruence.
       reflexivity.
   - intros sj Hsj sub_i.
     destruct_dec_sig sub_i i Hi Heqsub_i.
@@ -1897,13 +1896,11 @@ Lemma valid_preloaded_lifts_can_be_emitted
 Proof.
   intros m Hm.
   eapply VLSM_incl_can_emit.
-  {
-    apply pre_loaded_vlsm_incl_relaxed with (P0 := fun m => Q m \/ P m).
+  - apply pre_loaded_vlsm_incl_relaxed with (P0 := fun m => Q m \/ P m).
     intuition.
-  }
-  eapply VLSM_full_projection_can_emit; [|eassumption].
-  apply preloaded_sub_element_full_projection.
-  intuition.
+  - eapply VLSM_full_projection_can_emit; [|eassumption].
+    apply preloaded_sub_element_full_projection.
+    intuition.
 Qed.
 
 (** *** A subcomposition can be projected to one component

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1801,7 +1801,10 @@ Qed.
 End sub_composition_all.
 
 Section sub_composition_element.
-(** ** A component can be lifted to a free subcomposition *)
+
+(** ** Relating a sub-composition with one of its components
+
+*** A component can be lifted to a free subcomposition *)
 
 Context
   {message : Type}
@@ -1902,6 +1905,18 @@ Proof.
   apply preloaded_sub_element_full_projection.
   intuition.
 Qed.
+
+(** *** A subcomposition can be projected to one component
+
+In the following we define the [projection_induced_vlsm] to a single component
+of the [induced_sub_projection] of a constrained composition so a subset of its
+components.
+
+Note that, in general, this is not trace-equivalent with the direclty obtained
+[projection_induced_vlsm] of the constrained composition to the corresponding
+component, as the intermediate induced projection might generate more
+[input_valid_transitions] to be considered as a basis for the next proejction.
+*)
 
 Definition sub_label_element_project
   (l : composite_label (sub_IM IM indices))

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -671,10 +671,9 @@ given inputs and that they have a [valid_state] and a [valid_message].
       (l : label)
       (som : state * option message)
       (Hv : input_valid l som)
-      : exists (som' : state * option message),
+      : forall som', transition l som = som' ->
         input_valid_transition l som som'.
     Proof.
-      exists (transition l som).
       repeat split; assumption.
     Qed.
 
@@ -686,7 +685,8 @@ given inputs and that they have a [valid_state] and a [valid_message].
             input_valid_transition l som som'.
     Proof.
       split.
-      - apply input_valid_can_transition.
+      - eexists.
+        apply input_valid_can_transition; [assumption|reflexivity].
       - intros [som' Hivt].
         apply input_valid_transition_valid with som'.
         assumption.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -1375,16 +1375,10 @@ traces.
         option_can_produce (destination item) (output item).
     Proof.
       intros item Hitem.
-      cut (exists l1 l2, tr = l1 ++ item :: l2).
-      {
-        intros [l1 [l2 Heq]].
-        eexists _,_.
-        eapply input_valid_transition_to with (tr := tr); [eassumption|].
-        simpl.
-        eassumption.
-      }
-      apply elem_of_list_split.
-      assumption.
+      apply elem_of_list_split in Hitem as (l1 & l2 & Heq).
+      eexists _,_.
+      eapply input_valid_transition_to; [eassumption|].
+      simpl. eassumption.
     Qed.
 
     Lemma can_emit_from_valid_trace
@@ -2198,17 +2192,14 @@ This relation is often used in stating safety and liveness properties.*)
       (Htr : finite_valid_trace_from_to is s tr)
       : forall item, item ∈ tr -> in_futures (destination item) s.
     Proof.
-      intros item.
-      rewrite elem_of_list_In.
-      intros Hitem.
-      apply in_split in Hitem as [pre [suf Heqtr]].
+      intros item Hitem.
+      apply elem_of_list_split in Hitem as (pre & suf & Heqtr).
       exists suf.
-      replace (destination item) with (finite_trace_last is (pre ++ [item]))
-        by apply finite_trace_last_is_last.
+      replace (destination item)
+         with (finite_trace_last is (pre ++ [item]))
+           by apply finite_trace_last_is_last.
       eapply finite_valid_trace_from_to_app_split.
-      rewrite <- app_assoc.
-      simpl.
-      rewrite <- Heqtr.
+      rewrite <- app_assoc. simpl. rewrite <- Heqtr.
       assumption.
     Qed.
 
@@ -2216,17 +2207,14 @@ This relation is often used in stating safety and liveness properties.*)
       (Htr : finite_valid_trace_from_to is s tr)
       : forall item, item ∈ tr -> in_futures is (destination item).
     Proof.
-      intros item.
-      rewrite elem_of_list_In.
-      intros Hitem.
-      apply in_split in Hitem as [pre [suf Heqtr]].
+      intros item Hitem.
+      apply elem_of_list_split in Hitem as (pre & suf & Heqtr).
       exists (pre ++ [item]).
-      replace (destination item) with (finite_trace_last is (pre ++ [item]))
-        by apply finite_trace_last_is_last.
+      replace (destination item)
+         with (finite_trace_last is (pre ++ [item]))
+           by apply finite_trace_last_is_last.
       eapply finite_valid_trace_from_to_app_split.
-      rewrite <- app_assoc.
-      simpl.
-      rewrite <- Heqtr.
+      rewrite <- app_assoc. simpl. rewrite <- Heqtr.
       eassumption.
     Qed.
 

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -1389,13 +1389,11 @@ traces.
       can_emit m.
     Proof.
       apply can_emit_iff.
-      revert Hm.
-      setoid_rewrite Exists_exists.
-      intros (item & Hitem & Houtput).
+      setoid_rewrite Exists_exists in Hm.
+      destruct Hm as (item & Hitem & Houtput).
       exists (destination item).
-      unfold can_produce.
-      rewrite <- Houtput.
-      eapply can_produce_from_valid_trace; [apply Htr|assumption].
+      unfold can_produce; rewrite <- Houtput.
+      eapply can_produce_from_valid_trace; [apply Htr | assumption].
     Qed.
 
     (* End Hide *)
@@ -2813,30 +2811,33 @@ Byzantine fault tolerance analysis.
   Proof.
     revert s Htr Hobs.
     induction tr using rev_ind; intros; split
-    ; [|apply Htr| | apply Htr]
+    ; [|apply Htr | | apply Htr]
     ; destruct Htr as [Htr Hinit].
-    - inversion Htr. subst.
+    - inversion Htr; subst.
       apply (finite_valid_trace_from_to_empty X).
-      apply initial_state_is_valid. assumption.
+      apply initial_state_is_valid.
+      assumption.
     - apply finite_valid_trace_from_to_last in Htr as Hlst.
       apply finite_valid_trace_from_to_app_split in Htr.
       destruct Htr as [Htr Hx].
       specialize (IHtr _ (conj Htr Hinit)).
       spec IHtr.
-      { intros. apply Hobs.
+      {
+        intros. apply Hobs.
         apply trace_has_message_prefix. assumption.
       }
-      apply proj1, finite_valid_trace_from_to_forget_last in IHtr.
-      apply finite_valid_trace_from_add_last; [|assumption].
-      inversion Hx. subst f tl s'.
-      apply (extend_right_finite_trace_from X); [assumption|].
+      destruct IHtr as [IHtr _];
+      apply finite_valid_trace_from_to_forget_last in IHtr.
+      apply finite_valid_trace_from_add_last; [| assumption].
+      inversion Hx; subst f tl s'.
+      apply (extend_right_finite_trace_from X); [assumption |].
       destruct Ht as [[_ [_ Hv]] Ht].
       apply finite_valid_trace_last_pstate in IHtr as Hplst.
       repeat split. 1, 3-4: assumption.
-      destruct iom as [m|]; [|apply option_valid_message_None].
+      destruct iom as [m |]; [| apply option_valid_message_None].
       apply option_valid_message_Some, Hobs.
-      red. rewrite Exists_app, Exists_cons.
-      subst; cbn; firstorder.
+      red; rewrite Exists_app, Exists_cons.
+      subst; cbn; intuition.
   Qed.
 
 End pre_loaded_with_all_messages_vlsm.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -641,6 +641,9 @@ given inputs and that they have a [valid_state] and a [valid_message].
       input_valid l som
       /\  transition l som = som'.
 
+    Definition input_valid_transition_item (s : state) (item : transition_item) :=
+      input_valid_transition (l item) (s, input item) (destination item, output item).
+
     Definition input_valid_transition_preserving
       (R : state -> state -> Prop)
       : Prop

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -641,7 +641,10 @@ given inputs and that they have a [valid_state] and a [valid_message].
       input_valid l som
       /\  transition l som = som'.
 
-    Definition input_valid_transition_item (s : state) (item : transition_item) :=
+    Definition input_valid_transition_item
+      (s : state)
+      (item : transition_item)
+      :=
       input_valid_transition (l item) (s, input item) (destination item, output item).
 
     Definition input_valid_transition_preserving

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -1369,6 +1369,24 @@ traces.
 
     (* begin hide *)
 
+    Lemma can_produce_from_valid_trace si tr
+      (Htr: finite_valid_trace_from si tr)
+      : forall item, item ∈ tr ->
+        option_can_produce (destination item) (output item).
+    Proof.
+      intros item Hitem.
+      cut (exists l1 l2, tr = l1 ++ item :: l2).
+      {
+        intros [l1 [l2 Heq]].
+        eexists _,_.
+        eapply input_valid_transition_to with (tr := tr); [eassumption|].
+        simpl.
+        eassumption.
+      }
+      apply elem_of_list_split.
+      assumption.
+    Qed.
+
     Lemma can_emit_from_valid_trace
       (si : state)
       (m : message)
@@ -1377,17 +1395,14 @@ traces.
       (Hm : trace_has_message (field_selector output) m tr) :
       can_emit m.
     Proof.
-      apply Exists_exists in Hm.
-      destruct Hm as [x [Hin Houtput]].
-      apply elem_of_list_split in Hin.
-      destruct Hin as [l1 [l2 Hconcat]].
-      unfold can_emit.
-      destruct Htr as [Htr _].
-      specialize (input_valid_transition_to _ _ _ _ _ Htr Hconcat).
-      intros Ht.
-      simpl in Houtput, Ht.
-      rewrite Houtput in Ht.
-      do 3 eexists;exact Ht.
+      apply can_emit_iff.
+      revert Hm.
+      setoid_rewrite Exists_exists.
+      intros [item [Hitem Houtput]].
+      exists (destination item).
+      unfold can_produce.
+      replace (Some m) with (output item) by assumption.
+      eapply can_produce_from_valid_trace; [apply Htr|assumption].
     Qed.
 
     (* End Hide *)
@@ -2179,6 +2194,42 @@ This relation is often used in stating safety and liveness properties.*)
       eexists. exact Ht.
     Qed.
 
+    Lemma elem_of_trace_in_futures_left is s tr
+      (Htr : finite_valid_trace_from_to is s tr)
+      : forall item, item ∈ tr -> in_futures (destination item) s.
+    Proof.
+      intros item.
+      rewrite elem_of_list_In.
+      intros Hitem.
+      apply in_split in Hitem as [pre [suf Heqtr]].
+      exists suf.
+      replace (destination item) with (finite_trace_last is (pre ++ [item]))
+        by apply finite_trace_last_is_last.
+      eapply finite_valid_trace_from_to_app_split.
+      rewrite <- app_assoc.
+      simpl.
+      rewrite <- Heqtr.
+      assumption.
+    Qed.
+
+    Lemma elem_of_trace_in_futures_right is s tr
+      (Htr : finite_valid_trace_from_to is s tr)
+      : forall item, item ∈ tr -> in_futures is (destination item).
+    Proof.
+      intros item.
+      rewrite elem_of_list_In.
+      intros Hitem.
+      apply in_split in Hitem as [pre [suf Heqtr]].
+      exists (pre ++ [item]).
+      replace (destination item) with (finite_trace_last is (pre ++ [item]))
+        by apply finite_trace_last_is_last.
+      eapply finite_valid_trace_from_to_app_split.
+      rewrite <- app_assoc.
+      simpl.
+      rewrite <- Heqtr.
+      eassumption.
+    Qed.
+
     Lemma in_futures_witness
       (first second : state)
       (Hfutures : in_futures first second)
@@ -2767,6 +2818,45 @@ Byzantine fault tolerance analysis.
       split; [assumption|].
       apply (finite_valid_trace_singleton pre_loaded_with_all_messages_vlsm).
       revert Hx. apply preloaded_weaken_input_valid_transition.
+  Qed.
+
+  Lemma pre_traces_with_valid_inputs_are_valid is s tr
+    (Htr : finite_valid_trace_init_to pre_loaded_with_all_messages_vlsm is s tr)
+    (Hobs : forall m,
+      trace_has_message (field_selector input) m tr ->
+      valid_message_prop X m
+    )
+    : finite_valid_trace_init_to X is s tr.
+  Proof.
+    revert s Htr Hobs.
+    induction tr using rev_ind; intros; split
+    ; [|apply Htr| | apply Htr]
+    ; destruct Htr as [Htr Hinit].
+    - inversion Htr. subst.
+      apply (finite_valid_trace_from_to_empty X).
+      apply initial_state_is_valid. assumption.
+    - apply finite_valid_trace_from_to_last in Htr as Hlst.
+      apply finite_valid_trace_from_to_app_split in Htr.
+      destruct Htr as [Htr Hx].
+      specialize (IHtr _ (conj Htr Hinit)).
+      spec IHtr.
+      { intros. apply Hobs.
+        apply trace_has_message_prefix. assumption.
+      }
+      apply proj1, finite_valid_trace_from_to_forget_last in IHtr.
+      apply finite_valid_trace_from_add_last; [|assumption].
+      inversion Hx. subst f tl s'.
+      apply (extend_right_finite_trace_from X)
+      ; [assumption|].
+      destruct Ht as [[_ [_ Hv]] Ht].
+      apply finite_valid_trace_last_pstate in IHtr as Hplst.
+      repeat split; try assumption.
+      destruct iom as [m|]; [|apply option_valid_message_None].
+      apply option_valid_message_Some.
+      apply Hobs.
+      apply Exists_app. right.
+      apply Exists_cons. left.
+      subst. reflexivity.
   Qed.
 
 End pre_loaded_with_all_messages_vlsm.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -1377,8 +1377,7 @@ traces.
       intros item Hitem.
       apply elem_of_list_split in Hitem as (l1 & l2 & Heq).
       eexists _,_.
-      eapply input_valid_transition_to; [eassumption|].
-      simpl. eassumption.
+      eapply input_valid_transition_to; cbn; eassumption.
     Qed.
 
     Lemma can_emit_from_valid_trace
@@ -1392,10 +1391,10 @@ traces.
       apply can_emit_iff.
       revert Hm.
       setoid_rewrite Exists_exists.
-      intros [item [Hitem Houtput]].
+      intros (item & Hitem & Houtput).
       exists (destination item).
       unfold can_produce.
-      replace (Some m) with (output item) by assumption.
+      rewrite <- Houtput.
       eapply can_produce_from_valid_trace; [apply Htr|assumption].
     Qed.
 
@@ -2195,12 +2194,10 @@ This relation is often used in stating safety and liveness properties.*)
       intros item Hitem.
       apply elem_of_list_split in Hitem as (pre & suf & Heqtr).
       exists suf.
-      replace (destination item)
-         with (finite_trace_last is (pre ++ [item]))
-           by apply finite_trace_last_is_last.
+      erewrite <- finite_trace_last_is_last.
       eapply finite_valid_trace_from_to_app_split.
-      rewrite <- app_assoc. simpl. rewrite <- Heqtr.
-      assumption.
+      rewrite <- app_assoc; cbn; rewrite <- Heqtr.
+      eassumption.
     Qed.
 
     Lemma elem_of_trace_in_futures_right is s tr
@@ -2210,11 +2207,9 @@ This relation is often used in stating safety and liveness properties.*)
       intros item Hitem.
       apply elem_of_list_split in Hitem as (pre & suf & Heqtr).
       exists (pre ++ [item]).
-      replace (destination item)
-         with (finite_trace_last is (pre ++ [item]))
-           by apply finite_trace_last_is_last.
+      erewrite <- finite_trace_last_is_last.
       eapply finite_valid_trace_from_to_app_split.
-      rewrite <- app_assoc. simpl. rewrite <- Heqtr.
+      rewrite <- app_assoc; cbn; rewrite <- Heqtr.
       eassumption.
     Qed.
 
@@ -2834,17 +2829,14 @@ Byzantine fault tolerance analysis.
       apply proj1, finite_valid_trace_from_to_forget_last in IHtr.
       apply finite_valid_trace_from_add_last; [|assumption].
       inversion Hx. subst f tl s'.
-      apply (extend_right_finite_trace_from X)
-      ; [assumption|].
+      apply (extend_right_finite_trace_from X); [assumption|].
       destruct Ht as [[_ [_ Hv]] Ht].
       apply finite_valid_trace_last_pstate in IHtr as Hplst.
-      repeat split; try assumption.
+      repeat split. 1, 3-4: assumption.
       destruct iom as [m|]; [|apply option_valid_message_None].
-      apply option_valid_message_Some.
-      apply Hobs.
-      apply Exists_app. right.
-      apply Exists_cons. left.
-      subst. reflexivity.
+      apply option_valid_message_Some, Hobs.
+      red. rewrite Exists_app, Exists_cons.
+      subst; cbn; firstorder.
   Qed.
 
 End pre_loaded_with_all_messages_vlsm.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -1031,14 +1031,15 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma pre_VLSM_full_projection_finite_trace_last_output
-  : forall trX,
-    finite_trace_last_output trX = finite_trace_last_output (pre_VLSM_full_projection_finite_trace_project trX).
+Lemma pre_VLSM_full_projection_finite_trace_last_output :
+  forall trX,
+    finite_trace_last_output trX
+      =
+    finite_trace_last_output (pre_VLSM_full_projection_finite_trace_project trX).
 Proof.
-  intros.
-  destruct_list_last trX trX' lst HtrX
-  ; [reflexivity|].
-  setoid_rewrite map_app. simpl. rewrite !finite_trace_last_output_is_last.
+  intros trX.
+  destruct_list_last trX trX' lst HtrX; [reflexivity|].
+  setoid_rewrite map_app; simpl; rewrite !finite_trace_last_output_is_last.
   reflexivity.
 Qed.
 

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -2709,13 +2709,11 @@ Lemma pre_loaded_vlsm_incl_relaxed
   : VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_vlsm X Q).
 Proof.
   apply basic_VLSM_incl.
-  - cbv; intuition.
-  - intros _ _ m _ _ [Him | Hp].
-    + apply initial_message_is_valid. left. assumption.
-    + apply PimpliesQorValid in Hp as [Hq | Hvalid]; [|assumption].
-      apply initial_message_is_valid. right. assumption.
-  - cbv; intuition.
-  - cbv; intuition.
+  1, 3-4: cbv; intuition.
+  intros _ _ m _ _ [Him | Hp].
+  - apply initial_message_is_valid. left. assumption.
+  - apply PimpliesQorValid in Hp as [Hq | Hvalid]; [|assumption].
+    apply initial_message_is_valid. right. assumption.
 Qed.
 
 Lemma pre_loaded_vlsm_incl

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -136,9 +136,7 @@ Lemma VLSM_weak_partial_projection_input_valid
     input_valid Y (l itemY) (sY, input itemY).
 Proof.
   intros sX itemX HitemX sY itemY Hpr.
-  eapply VLSM_weak_partial_projection_input_valid_transition
-  ; [eassumption|].
-  assumption.
+  eapply VLSM_weak_partial_projection_input_valid_transition; eassumption.
 Qed.
 
 End weak_partial_projection_properties.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -2722,7 +2722,7 @@ Lemma pre_loaded_vlsm_incl
   (PimpliesQ : forall m : message, P m -> Q m)
   : VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_vlsm X Q).
 Proof.
-  apply pre_loaded_vlsm_incl_relaxed. intuition.
+  apply pre_loaded_vlsm_incl_relaxed; intuition.
 Qed.
 
 Lemma pre_loaded_vlsm_with_valid_eq
@@ -2731,8 +2731,8 @@ Lemma pre_loaded_vlsm_with_valid_eq
   : VLSM_eq (pre_loaded_vlsm X (fun m => P m \/ Q m)) (pre_loaded_vlsm X P).
 Proof.
   apply VLSM_eq_incl_iff; split.
-  - apply pre_loaded_vlsm_incl_relaxed. intuition.
-  - cbv; apply pre_loaded_vlsm_incl. intuition.
+  - apply pre_loaded_vlsm_incl_relaxed; intuition.
+  - cbv; apply pre_loaded_vlsm_incl; intuition.
 Qed.
 
 Lemma pre_loaded_vlsm_idem_l

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -683,8 +683,8 @@ Lemma VLSM_weak_projection_input_valid
 Proof.
   intros lX lY Hpr sX im HvX.
   destruct (vtransition X lX (sX, im)) eqn:HtX.
-  eapply proj1, VLSM_weak_projection_input_valid_transition, input_valid_can_transition
-  ; [eassumption|assumption|exact HtX].
+  eapply VLSM_weak_projection_input_valid_transition, input_valid_can_transition
+  ; eassumption.
 Qed.
 
 Lemma VLSM_weak_projection_finite_valid_trace_from_to
@@ -1320,7 +1320,7 @@ Lemma VLSM_weak_full_projection_input_valid l s im
 Proof.
   intros.
   eapply (VLSM_weak_projection_input_valid VLSM_weak_full_projection_is_projection)
-  ; [reflexivity|assumption].
+  ; trivial.
 Qed.
 
 Lemma VLSM_weak_full_projection_infinite_valid_trace_from
@@ -3023,13 +3023,12 @@ Lemma induced_projection_valid_is_input_valid
   : vvalid projection_induced_vlsm l (s, om) -> input_valid projection_induced_vlsm l (s,om).
 Proof.
   intro Hv.
-  destruct (id Hv) as [lX [sX [HlX [<- [Hps [Hopm _]]]]]].
-  repeat split.
-  - apply (VLSM_projection_valid_state Hproj). assumption.
+  destruct (id Hv) as (lX & sX & HlX & <- & Hps & Hopm & _).
+  repeat split; [| | assumption].
+  - eapply VLSM_projection_valid_state; eassumption.
   - destruct om as [m|]; [|apply option_valid_message_None].
     apply option_initial_message_is_valid.
     assumption.
-  - assumption.
 Qed.
 
 Section projection_induced_friendliness.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -2795,6 +2795,16 @@ Proof.
   split; apply basic_VLSM_strong_incl; cbv; intuition.
 Qed.
 
+Lemma vlsm_incl_pre_loaded
+  (P : message -> Prop)
+  : VLSM_incl X (pre_loaded_vlsm X P).
+Proof.
+  eapply VLSM_incl_trans.
+  - eapply VLSM_eq_proj1, vlsm_is_pre_loaded_with_False.
+  - apply pre_loaded_vlsm_incl.
+    intuition.
+Qed.
+
 Lemma vlsm_is_pre_loaded_with_False_initial_message
   : strong_full_projection_initial_message_preservation X (pre_loaded_vlsm X (fun m => False)).
 Proof.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -131,17 +131,14 @@ Proof.
 Qed.
 
 Lemma VLSM_weak_partial_projection_input_valid
-  : forall lX sX inX, input_valid X lX (sX, inX) ->
-    forall sX' outX, vtransition X lX (sX, inX) = (sX', outX) ->
-    forall sY itemY,
-    trace_project (sX, [{| l := lX;  input := inX; destination := sX'; output := outX |}])
-      = Some (sY, [itemY]) ->
+  : forall sX itemX, input_valid_transition_item X sX itemX ->
+    forall sY itemY, trace_project (sX, [itemX]) = Some (sY, [itemY]) ->
     input_valid Y (l itemY) (sY, input itemY).
 Proof.
-  intros lX sX inX HvX sX' outX HtX sY itemY Hpr.
-  eapply proj1, VLSM_weak_partial_projection_input_valid_transition
+  intros sX itemX HitemX sY itemY Hpr.
+  eapply VLSM_weak_partial_projection_input_valid_transition
   ; [eassumption|].
-  split; assumption.
+  assumption.
 Qed.
 
 End weak_partial_projection_properties.
@@ -210,12 +207,6 @@ Definition VLSM_partial_projection_input_valid_transition
   := VLSM_weak_partial_projection_input_valid_transition VLSM_partial_projection_weaken.
 
 Definition VLSM_partial_projection_input_valid
-  : forall lX sX inX, input_valid X lX (sX, inX) ->
-    forall sX' outX, vtransition X lX (sX, inX) = (sX', outX) ->
-    forall sY itemY,
-    trace_project (sX, [{| l := lX;  input := inX; destination := sX'; output := outX |}])
-      = Some (sY, [itemY]) ->
-    input_valid Y (l itemY) (sY, input itemY)
   := VLSM_weak_partial_projection_input_valid VLSM_partial_projection_weaken.
 
 End partial_projection_properties.
@@ -832,9 +823,6 @@ Definition VLSM_projection_input_valid_transition
   := VLSM_weak_projection_input_valid_transition VLSM_projection_weaken.
 
 Definition VLSM_projection_input_valid
-  : forall lX lY, label_project lX = Some lY ->
-    forall s im,
-    input_valid X lX (s, im) -> input_valid Y lY (state_project s, im)
   := VLSM_weak_projection_input_valid VLSM_projection_weaken.
 
 Definition VLSM_projection_finite_valid_trace_from_to

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -667,8 +667,7 @@ Qed.
 
 Lemma VLSM_weak_projection_input_valid
   : forall lX lY, label_project lX = Some lY ->
-    forall sX im,
-    input_valid X lX (sX, im) -> input_valid Y lY (state_project sX, im).
+    forall s im, input_valid X lX (s, im) -> input_valid Y lY (state_project s, im).
 Proof.
   intros lX lY Hpr sX im HvX.
   destruct (vtransition X lX (sX, im)) eqn:HtX.
@@ -1029,6 +1028,17 @@ Proof.
   destruct_list_last trX trX' lst HtrX
   ; [reflexivity|].
   setoid_rewrite map_app. simpl. rewrite !finite_trace_last_is_last.
+  reflexivity.
+Qed.
+
+Lemma pre_VLSM_full_projection_finite_trace_last_output
+  : forall trX,
+    finite_trace_last_output trX = finite_trace_last_output (pre_VLSM_full_projection_finite_trace_project trX).
+Proof.
+  intros.
+  destruct_list_last trX trX' lst HtrX
+  ; [reflexivity|].
+  setoid_rewrite map_app. simpl. rewrite !finite_trace_last_output_is_last.
   reflexivity.
 Qed.
 
@@ -2693,12 +2703,37 @@ Context
   (X : VLSM message)
   .
 
+Lemma pre_loaded_vlsm_incl_relaxed
+  (P Q : message -> Prop)
+  (PimpliesQorValid : forall m : message, P m -> Q m \/ valid_message_prop (pre_loaded_vlsm X Q) m)
+  : VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_vlsm X Q).
+Proof.
+  apply basic_VLSM_incl.
+  - cbv; intuition.
+  - intros _ _ m _ _ [Him | Hp].
+    + apply initial_message_is_valid. left. assumption.
+    + apply PimpliesQorValid in Hp as [Hq | Hvalid]; [|assumption].
+      apply initial_message_is_valid. right. assumption.
+  - cbv; intuition.
+  - cbv; intuition.
+Qed.
+
 Lemma pre_loaded_vlsm_incl
   (P Q : message -> Prop)
   (PimpliesQ : forall m : message, P m -> Q m)
   : VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_vlsm X Q).
 Proof.
-  apply basic_VLSM_incl_preloaded_with; cbv; intuition.
+  apply pre_loaded_vlsm_incl_relaxed. intuition.
+Qed.
+
+Lemma pre_loaded_vlsm_with_valid_eq
+  (P Q : message -> Prop)
+  (QimpliesValid : forall m, Q m -> valid_message_prop (pre_loaded_vlsm X P) m)
+  : VLSM_eq (pre_loaded_vlsm X (fun m => P m \/ Q m)) (pre_loaded_vlsm X P).
+Proof.
+  apply VLSM_eq_incl_iff; split.
+  - apply pre_loaded_vlsm_incl_relaxed. intuition.
+  - cbv; apply pre_loaded_vlsm_incl. intuition.
 Qed.
 
 Lemma pre_loaded_vlsm_idem_l

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -2712,9 +2712,9 @@ Proof.
   apply basic_VLSM_incl.
   1, 3-4: cbv; intuition.
   intros _ _ m _ _ [Him | Hp].
-  - apply initial_message_is_valid. left. assumption.
+  - apply initial_message_is_valid; left; assumption.
   - apply PimpliesQorValid in Hp as [Hq | Hvalid]; [|assumption].
-    apply initial_message_is_valid. right. assumption.
+    apply initial_message_is_valid; right; assumption.
 Qed.
 
 Lemma pre_loaded_vlsm_incl
@@ -2801,8 +2801,7 @@ Lemma vlsm_incl_pre_loaded
 Proof.
   eapply VLSM_incl_trans.
   - eapply VLSM_eq_proj1, vlsm_is_pre_loaded_with_False.
-  - apply pre_loaded_vlsm_incl.
-    intuition.
+  - apply pre_loaded_vlsm_incl; contradiction.
 Qed.
 
 Lemma vlsm_is_pre_loaded_with_False_initial_message

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -686,7 +686,7 @@ Proof.
   eapply proj1, VLSM_weak_projection_input_valid_transition, input_valid_can_transition
   ; [eassumption|assumption|exact HtX].
 Qed.
- 
+
 Lemma VLSM_weak_projection_finite_valid_trace_from_to
   : forall sX s'X trX,
     finite_valid_trace_from_to X sX s'X trX -> finite_valid_trace_from_to Y (state_project sX) (state_project s'X) (VLSM_weak_projection_trace_project Hsimul trX).

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -1,147 +1,73 @@
 From stdpp Require Import prelude.
 From Coq Require Import FinFun.
-From VLSM Require Import Lib.Preamble Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces.
+From VLSM.Lib Require Import Preamble ListExtras.
+From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.
 
 (** * VLSM Projection Validators
 
-In the sequel we fix a composite VLSM <<X>> obtained from an indexed family
-of VLSMs <<IM>> and a <<constraint>>, and an index <<i>>, corresponding to
-component <<IM i>>.
+In the sequel we fix a VLSMs <<X>> and <<Y>> and a [VLSM_projection]
+of <<X>> into <<PreY>>, the [pre_loaded_with_all_messages_vlsm] of <<Y>>.
 *)
 
 Section projection_validator.
 
 Context
-    {message : Type}
-    {index : Type}
-    {IndEqDec : EqDecision index}
-    (IM : index -> VLSM message)
-    (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-    (X := composite_vlsm IM constraint)
-    (i : index)
-    (Xi := composite_vlsm_constrained_projection IM constraint i)
-    .
+  {message : Type}
+  {X Y : VLSM message}
+  {label_project : vlabel X -> option (vlabel Y)}
+  {state_project : vstate X -> vstate Y}
+  (PreY := pre_loaded_with_all_messages_vlsm Y)
+  (Hproj : VLSM_projection X PreY label_project state_project)
+  .
 
 (**
-We say that the component <<i>> of X is a validator for received messages if
-non-[projection_valid]itiy implied non-component-[valid]ity (or non-reachability).
+We say that <<Y>> is a validator for received messages if
+non-[projection_induced_valid]itiy implied non-component-[valid]ity
+(or non-reachability).
 *)
 
-Definition projection_validator_received_messages_prop
-    :=
-    forall (li : vlabel (IM i)) (si : vstate (IM i)) (mi : message),
-        ~ vvalid Xi li (si, Some mi)
-        -> ~ input_valid (pre_loaded_with_all_messages_vlsm (IM i)) li (si, Some mi).
+Definition projection_validator_received_messages_prop :=
+  forall (li : vlabel Y) (si : vstate Y) (mi : message),
+    ~ projection_induced_valid X (type Y) label_project state_project li (si, Some mi)
+    -> ~ input_valid PreY li (si, Some mi).
 
 (**
 We can slightly generalize the definition above to also include empty messages
 and state it in a positive manner as the [projection_validator_prop]erty below,
 requiring that [valid]ity in the component (for reachable states) implies
-[projection_valid]ity.
+[projection_induced_valid]ity.
 *)
 
 Definition projection_validator_prop :=
-    forall (li : vlabel (IM i)) (siomi : vstate (IM i) * option message),
-        input_valid (pre_loaded_with_all_messages_vlsm (IM i)) li siomi ->
-        vvalid Xi li siomi.
-
-(** An alternative formulation of the above property with a seemingly
-stronger hypothesis, states that component (IM i) is a validator for the composition constraint
-if for any <<si>> a valid state in the projection <<Xi>>, <<li valid (IM i) (si, om)>>
-implies  that there exists a state <<s>> whose ith  component is <<si>>,
-and <<s>> and <<om>> are valid in <<X>>, and <<(i,li) valid (s,om)>> in <<X>>, that is,
-we have that <<li valid (si, om)>> in the projection <<Xi>>.
-*)
-Definition projection_validator_prop_alt :=
-    forall (li : vlabel (IM i)) (siom : vstate (IM i) * option message),
-        let (si, om) := siom in
-        vvalid (IM i) li siom ->
-        valid_state_prop Xi si ->
-        vvalid Xi li siom.
-
-(** Under validator assumptions, all reachable states for component <<IM i>> are
-valid states in the projection <<Xi>>.
-*)
-Lemma validator_alt_free_states_are_projection_states
-    : projection_validator_prop_alt ->
-    forall s,
-        valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) s ->
-        valid_state_prop Xi s.
-Proof.
-    intros Hvalidator s Hs.
-    induction Hs using valid_state_prop_ind;
-    [apply initial_state_is_valid;assumption|].
-    change s' with (fst (s',om')).
-    destruct Ht as [[_ [_ Hvalid]] Htrans].
-    apply (projection_valid_implies_destination_projection_valid_state IM constraint i) with l s om om'
-    ; [|assumption].
-    apply (Hvalidator l (s,om));assumption.
-Qed.
-
-(** Below we show that the two definitions above are actually equivalent.
-*)
-Lemma projection_validator_prop_alt_iff
-    : projection_validator_prop_alt <-> projection_validator_prop.
-Proof.
-    split.
-    - intros Hvalidator l (si, om) Hvalid.
-      destruct Hvalid as [Hsi [_ Hvalid]].
-      apply validator_alt_free_states_are_projection_states in Hsi
-      ; [|assumption].
-      exact (Hvalidator l (si,om) Hvalid Hsi).
-    - intros Hvalidator l (si, om) Hvalid HXisi.
-      specialize (Hvalidator l (si, om)).
-      apply Hvalidator.
-      repeat split; [| apply any_message_is_valid_in_preloaded | assumption].
-      revert HXisi.
-      apply VLSM_incl_valid_state.
-      apply proj_pre_loaded_with_all_messages_incl.
-Qed.
-
-Lemma validator_free_states_are_projection_states
-    : projection_validator_prop ->
-    forall s,
-        valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) s ->
-        valid_state_prop Xi s.
-Proof.
-    rewrite <- projection_validator_prop_alt_iff.
-    apply validator_alt_free_states_are_projection_states.
-Qed.
+  forall li si omi,
+    input_valid PreY li (si,omi) ->
+    projection_induced_valid X (type Y) label_project state_project li (si,omi).
 
 (**
 It is easy to see that the [projection_validator_prop]erty includes the
 [projection_validator_received_messages_prop]erty.
 *)
 Lemma projection_validator_messages_received
-    : projection_validator_prop -> projection_validator_received_messages_prop.
+  : projection_validator_prop -> projection_validator_received_messages_prop.
 Proof.
-    unfold projection_validator_prop. unfold projection_validator_received_messages_prop. intros.
-    intro Hvalid. elim H0. clear H0.
-    specialize (H li (si, Some mi) Hvalid). assumption.
+  unfold projection_validator_prop, projection_validator_received_messages_prop.
+  intuition.
 Qed.
 
 (**
-We say that component <<i>> is a [transition_validator] if any [valid]
-transition (from a reachable state) in component <<i>> can be "lifted" to
+We say that <<Y>> is a [transition_validator] if any [valid]
+transition (from a reachable state) in <<Y>> can be "lifted" to
 an [input_valid_transition] in <<X>>.
 
 *)
 
 Definition transition_validator :=
-    forall
-        (si : vstate (IM i))
-        (omi : option message)
-        (li : vlabel (IM i))
-        ,
-        input_valid (pre_loaded_with_all_messages_vlsm (IM i)) li (si, omi)
-        ->
-        (exists
-            (s s' : vstate X)
-            (om' : option message),
-            si = s i
-            /\
-            input_valid_transition X (existT i li) (s, omi) (s', om')
-        ).
+  forall lY sY omi, input_valid PreY lY (sY, omi) ->
+  exists lX sX sX' om',
+   input_valid_transition X lX (sX, omi) (sX', om') /\
+   label_project lX = Some lY /\
+   state_project sX = sY.
+   
 
 (**
 Next two results show that the (simpler) [projection_validator_prop]erty
@@ -149,91 +75,320 @@ is equivalent with the [transition_validator] property.
 *)
 
 Lemma projection_validator_messages_transitions
-    : projection_validator_prop -> transition_validator.
+  : projection_validator_prop -> transition_validator.
 Proof.
-    intros Hvalidator si omi li Hpvi.
-    specialize (Hvalidator li (si, omi) Hpvi). clear Hpvi.
-    destruct Hvalidator as [s [Hsi [Hps [Hopm [Hvalid Hctr]]]]].
-    destruct (vtransition X (existT i li) (s, omi)) as (s', om') eqn:Heqt.
-    exists s. exists s'. exists om'.
-    subst si.
-    repeat split; assumption.
+  intros Hvalidator li si omi Hpvi.
+  specialize (Hvalidator _ _ _ Hpvi)
+    as [l [s [Hli [Hsi [Hps [Hopm Hvalid]]]]]].
+  exists l, s.
+  unfold input_valid_transition.
+  destruct (transition _ _ ) as (s', om').
+  exists s', om'.
+  repeat split; assumption.
 Qed.
 
 Lemma transition_validator_messages
-    : transition_validator -> projection_validator_prop.
+  : transition_validator -> projection_validator_prop.
 Proof.
-    intros Hvalidator li (si,omi) Hpvi.
-    specialize (Hvalidator si omi li Hpvi). clear Hpvi.
-    destruct Hvalidator as [s [s' [om' [Hsi [Hvalid Htransition]]]]].
-    symmetry in Hsi.
-    exists s. split; assumption.
+  intros Hvalidator li si omi Hpvi.
+  specialize (Hvalidator _ _ _ Hpvi)
+    as [l [s [s' [om' [[Hvalid Htransition] [Hli Hsi]]]]]].
+  exists l, s.
+  intuition.
 Qed.
 
 (** ** Projection validators and Byzantine behavior
 
-In the sequel we assume that <<X>> has the [projection_validator_prop]erty for
-component <<i>>.  Let <<Xi>> be the projection of <<X>> to component <<i>>
-and <<Preloaded>> be the [pre_loaded_with_all_messages_vlsm] associated to component <<i>>.
+In the sequel we assume that the [projection_induced_vlsm_is_projection] and
+that initial states of <<Y>> can be lifted to <<X>>.
 *)
+
+Section induced_projection_validators.
+
+Context
+  (Htransition_None : weak_projection_transition_consistency_None _ _ label_project state_project)
+  (label_lift : vlabel Y -> vlabel X)
+  (state_lift : vstate Y -> vstate X)
+  (Xi := projection_induced_vlsm X (type Y)
+    label_project state_project label_lift state_lift)
+  (Hlabel_lift : induced_projection_label_lift_prop _ _ label_project label_lift)
+  (Hstate_lift : induced_projection_state_lift_prop _ _ state_project state_lift)
+  (Hinitial_lift : strong_full_projection_initial_state_preservation Y X state_lift)
+  (Htransition_consistency : induced_projection_transition_consistency_Some _ _ label_project state_project)
+  (Htransition_Some  : weak_projection_transition_consistency_Some _ _ label_project state_project label_lift state_lift
+    := basic_weak_projection_transition_consistency_Some _ _ _ _ _ _ Hlabel_lift Hstate_lift Htransition_consistency)
+  (Hproji := projection_induced_vlsm_is_projection _ _ _ _ _ _ Htransition_None Htransition_Some)
+  .
+
+(** If there is a [VLSM_projection] from <<X>> to <<PreY>> and the
+[projection_induced_vlsm_is_projection], then a [transition] [valid] for the
+[projection_induced_vlsm] has the same output as the transition on <<Y>>.
+*)
+Lemma projection_induced_valid_transition_eq
+  : forall l s om, vvalid Xi l (s, om) ->
+    vtransition Xi l (s, om) = vtransition Y l (s, om).
+Proof.
+  intros l s im [lX [sX [Hlx [<- Hv]]]].
+  replace (vtransition Y _ _) with
+    (state_project (vtransition X lX (sX, im)).1, (vtransition X lX (sX, im)).2).
+  - eapply proj2, (VLSM_projection_input_valid_transition Hproji) with (lY := l)
+    ; [eassumption|].
+    split; [assumption|].
+    apply injective_projections; reflexivity.
+  - symmetry.
+    eapply proj2, (VLSM_projection_input_valid_transition Hproj) with (lY := l)
+    ; [eassumption|].
+    split; [assumption|].
+    apply injective_projections; reflexivity.
+Qed.
+
+Lemma induced_projection_incl_preloaded_with_all_messages
+  : VLSM_incl Xi PreY.
+Proof.
+  apply basic_VLSM_incl.
+  - intros is [s [<- Hs]].
+    apply (VLSM_projection_initial_state Hproj).
+    assumption.
+  - intro; intros. apply any_message_is_valid_in_preloaded.
+  - intros l s om [_ [_ [lX [sX [Hlx [<- Hv]]]]]] _ _.
+    simpl.
+    eapply proj2, proj2, (VLSM_projection_input_valid Hproj); eassumption.
+  - intros l s im s' om [[_ [_ HvXi]] HtXi].
+    setoid_rewrite <- HtXi.
+    symmetry.
+    apply projection_induced_valid_transition_eq.
+    assumption.
+Qed.
+
+(** An alternative formulation of the [projection_validator_prop]erty with a
+seemingly stronger hypothesis, states that <<Y>> is a validator for <<X>>
+if for any <<sY>> a valid state in the projection <<Xi>>, <<li valid Y (sY, om)>>
+implies that <<li valid (si, om)>> in the projection <<Xi>> (i.e.,
+[projection_induced_valid]ity).
+*)
+Definition projection_validator_prop_alt :=
+  forall li si iom,
+    vvalid Y li (si, iom) ->
+    valid_state_prop Xi si ->
+    vvalid Xi li (si, iom).
+
+(** Under validator assumptions, all reachable states for component <<Y>> are
+valid states in the induced projection <<Xi>>.
+*)
+Lemma validator_alt_free_states_are_projection_states
+  : projection_validator_prop_alt ->
+  forall s,
+    valid_state_prop (pre_loaded_with_all_messages_vlsm Y) s ->
+    valid_state_prop Xi s.
+Proof.
+  intros Hvalidator sY Hs.
+  induction Hs using valid_state_prop_ind.
+  - apply initial_state_is_valid.
+    exists (state_lift s).
+    split; [apply Hstate_lift|].
+    apply Hinitial_lift.
+    assumption.
+  - destruct Ht as [[_ [_ Hvalid]] Htrans].
+    specialize (Hvalidator _ _ _ Hvalid IHHs)
+      as [lX [sX [HlX [HsX HvX]]]].
+    replace s' with (state_project (vtransition X lX (sX, om)).1).
+    + eapply input_valid_transition_destination,
+        (VLSM_projection_input_valid_transition Hproji);
+      [exact HlX|].
+      split; [exact HvX|].
+      apply injective_projections; reflexivity.
+    + assert (HivtX : input_valid_transition X lX (sX, om) (vtransition X lX (sX, om)))
+        by (split; [assumption|reflexivity]).
+      destruct (vtransition _ _ _) as (sX', _om').
+      apply (VLSM_projection_input_valid_transition Hproj) with (lY := l)
+        in HivtX as [_ Hs']
+      ; [|assumption].
+      rewrite HsX in Hs'.
+      destruct Y as (TY, (SY, MY)).
+      cbv in Htrans, Hs'.
+      rewrite Htrans in Hs'.
+      inversion Hs'.
+      reflexivity.
+Qed.
+
+(** Below we show that the two definitions above are actually equivalent.
+*)
+Lemma projection_validator_prop_alt_iff
+  : projection_validator_prop_alt <-> projection_validator_prop.
+Proof.
+  split.
+  - intros Hvalidator l si om Hvalid.
+    apply Hvalidator; [apply Hvalid|].
+    apply validator_alt_free_states_are_projection_states; [assumption..|].
+    apply Hvalid.
+  - intros Hvalidator l si om Hvalid HXisi.
+    apply Hvalidator.
+    repeat split; [| apply any_message_is_valid_in_preloaded | assumption].
+    revert HXisi.
+    apply VLSM_incl_valid_state.
+    apply induced_projection_incl_preloaded_with_all_messages.
+Qed.
+
+Lemma validator_free_states_are_projection_states
+  : projection_validator_prop ->
+  forall s,
+    valid_state_prop (pre_loaded_with_all_messages_vlsm Y) s ->
+    valid_state_prop Xi s.
+Proof.
+  rewrite <- projection_validator_prop_alt_iff by assumption.
+  apply validator_alt_free_states_are_projection_states.
+Qed.
 
 Section pre_loaded_with_all_messages_validator_proj.
-    Context
-        (Hvalidator : projection_validator_prop)
-        (PreLoaded := pre_loaded_with_all_messages_vlsm (IM i))
-        .
+  Context
+    (Hvalidator : projection_validator_prop)
+    .
 
 (**
-We can show that <<Preloaded>> is included in <<Xi>> by applying the meta-lemma
+We can show that <<PreY>> is included in <<Xi>> by applying the meta-lemma
 [VLSM_incl_finite_traces_characterization], and by induction on the length
 of a trace. The [projection_validator_prop]erty is used to translate
-[input_valid]ity for the preloaded machine into the [projection_valid]ity.
+[input_valid]ity for the PreY machine into the [projection_valid]ity.
 *)
-
-    Lemma pre_loaded_with_all_messages_validator_proj_incl
-        : VLSM_incl PreLoaded Xi.
-    Proof.
-        (* reduce inclusion to inclusion of finite traces. *)
-        apply VLSM_incl_finite_traces_characterization.
-        intros.
-        split; [|apply H].
-        induction H using finite_valid_trace_rev_ind.
-        - apply (finite_valid_trace_from_empty Xi). apply initial_state_is_valid. assumption.
-        - apply (extend_right_finite_trace_from Xi);[assumption|].
-          destruct Hx as [Hvx Htx].
-          split; [|assumption].
-          apply projection_valid_input_valid.
-          apply Hvalidator.
-          assumption.
-    Qed.
+Lemma pre_loaded_with_all_messages_validator_proj_incl
+  : VLSM_incl PreY Xi.
+Proof.
+  (* reduce inclusion to inclusion of finite traces. *)
+  apply VLSM_incl_finite_traces_characterization.
+  intros sY trY HtrY.
+  split; cycle 1.
+  - exists (state_lift sY).
+    split; [apply Hstate_lift|].
+    apply Hinitial_lift.
+    apply HtrY.
+  - induction HtrY using finite_valid_trace_rev_ind.
+    + apply (finite_valid_trace_from_empty Xi).
+      apply initial_state_is_valid.
+      exists (state_lift si).
+      split; [apply Hstate_lift|].
+      apply Hinitial_lift.
+      assumption.
+    + apply (extend_right_finite_trace_from Xi);[assumption|].
+      split.
+      * apply induced_projection_valid_is_input_valid; [assumption|].
+        apply Hvalidator.
+        apply Hx.
+      * replace (sf, _) with (vtransition Y l (finite_trace_last si tr, iom))
+          by apply Hx.
+        apply projection_induced_valid_transition_eq.
+        apply Hvalidator.
+        apply Hx.
+Qed.
 
 (**
 Given that any projection is included in the [pre_loaded_with_all_messages_vlsm]
 of its component (Lemma [proj_pre_loaded_with_all_messages_incl]), we conclude
-that <<Preloaded>> and <<Xi>> are trace-equal.  This means that all the
+that <<PreY>> and <<Xi>> are trace-equal.  This means that all the
 byzantine behavior of a component which is a validator
 is exhibited by its corresponding projection.
 *)
-    Lemma pre_loaded_with_all_messages_validator_proj_eq
-        : VLSM_eq PreLoaded Xi.
-    Proof.
-        split.
-        - apply pre_loaded_with_all_messages_validator_proj_incl.
-        - apply proj_pre_loaded_with_all_messages_incl.
-    Qed.
+Lemma pre_loaded_with_all_messages_validator_proj_eq
+  : VLSM_eq PreY Xi.
+Proof.
+  apply VLSM_eq_incl_iff.
+  split.
+  - apply pre_loaded_with_all_messages_validator_proj_incl.
+  - apply induced_projection_incl_preloaded_with_all_messages.
+Qed.
 
 End pre_loaded_with_all_messages_validator_proj.
 
+End induced_projection_validators.
+
 End projection_validator.
+
+(** ** Validator properties for the [component_projection].
+
+In this section we specialize the validator-related results to the
+components of a composition.
+*)
+
+Section component_projection_validator.
+
+Context
+  {message : Type}
+  {index : Type}
+  {IndEqDec : EqDecision index}
+  (IM : index -> VLSM message)
+  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
+  (X := composite_vlsm IM constraint)
+  (i : index)
+  (Xi := composite_vlsm_constrained_projection IM constraint i)
+  (PreXi := pre_loaded_with_all_messages_vlsm (IM i))
+  .
+
+(**
+We say that the component <<i>> of X is a validator for received messages if
+if [valid]ity in the component (for reachable states) implies [projection_valid]ity.
+*)
+Definition component_projection_validator_prop :=
+  forall (li : vlabel (IM i)) (siomi : vstate (IM i) * option message),
+    input_valid (pre_loaded_with_all_messages_vlsm (IM i)) li siomi ->
+    vvalid Xi li siomi.
+
+Lemma component_projection_to_preloaded
+  : VLSM_projection X PreXi (composite_project_label IM i) (fun s => s i).
+Proof.
+  constructor.
+  - apply component_projection.
+  - intros sX trX HtrX.
+    apply (VLSM_projection_finite_valid_trace (preloaded_component_projection IM i)).
+    revert HtrX.
+    apply VLSM_incl_finite_valid_trace.
+    apply constraint_preloaded_free_incl with (constraint0 := constraint).
+Qed.
+
+(** Assuming the [component_projection_validator_prop]erty, the component
+[pre_loaded_with_all_messages_vlsm] is [VLSM_eq]ual (trace-equivalent) with
+its corresponding [projection_induced_vlsm].
+*)
+Lemma pre_loaded_with_all_messages_validator_component_proj_eq
+  (Hvalidator : component_projection_validator_prop)
+  : VLSM_eq PreXi Xi.
+Proof.
+  apply VLSM_eq_trans with
+    (machine (projection_induced_vlsm X (type (IM i))
+      (composite_project_label IM i) (fun s => s i)
+      (lift_to_composite_label IM i) (lift_to_composite_state IM i)))
+  ; [|apply VLSM_eq_sym; apply composite_vlsm_constrained_projection_is_induced].
+  apply pre_loaded_with_all_messages_validator_proj_eq.
+  - apply component_projection_to_preloaded.
+  - apply component_transition_projection_None.
+  - apply component_label_projection_lift.
+  - apply component_state_projection_lift.
+  - intro s. apply (lift_to_composite_state_initial IM).
+  - apply component_transition_projection_Some.
+  - intros li si omi Hiv.
+    apply Hvalidator in Hiv as [sX [<- HivX]].
+    exists (existT i li), sX.
+    intuition.
+    unfold composite_project_label.
+    simpl.
+    case_decide as Hi; [|contradiction].
+    replace Hi with (@eq_refl index i) by (apply Eqdep_dec.UIP_dec; assumption).
+    reflexivity.
+Qed.
+
+Definition pre_loaded_with_all_messages_validator_component_proj_incl
+  (Hvalidator : component_projection_validator_prop)
+  : VLSM_incl PreXi Xi :=
+  VLSM_eq_proj1 (pre_loaded_with_all_messages_validator_component_proj_eq Hvalidator).
+
+End component_projection_validator.
 
 (** ** VLSM self-validation *)
 
 Section self_validator_vlsm.
 
 Context
-    {message : Type}
-    (X : VLSM message)
-    .
+  {message : Type}
+  (X : VLSM message)
+  .
 
 (**
 Let us fix a (regular) VLSM <<X>>. <<X>> is a self-validator if for any
@@ -242,11 +397,10 @@ arguments satisfying [valid] where the state is reachable in the
 a [valid_state] and [valid_message] for the original VLSM.
 *)
 
-Definition self_validator_vlsm_prop
-    :=
-    forall (l : label) (s : state) (om : option message),
-        input_valid (pre_loaded_with_all_messages_vlsm X) l (s, om) ->
-        input_valid X l (s, om).
+Definition self_validator_vlsm_prop :=
+  forall (l : label) (s : state) (om : option message),
+    input_valid (pre_loaded_with_all_messages_vlsm X) l (s, om) ->
+    input_valid X l (s, om).
 
 (**
 In the sequel we will show that a VLSM with the [self_validator_vlsm_prop]erty
@@ -258,58 +412,58 @@ byzantine behavior.
 *)
 
 Context
-    (Hvalidator : self_validator_vlsm_prop)
-    (PreLoaded := pre_loaded_with_all_messages_vlsm X)
-    .
+  (Hvalidator : self_validator_vlsm_prop)
+  (PreX := pre_loaded_with_all_messages_vlsm X)
+  .
 
 (**
-Let <<PreLoaded>> be the [pre_loaded_with_all_messages_vlsm] associated to X.
+Let <<PreX>> be the [pre_loaded_with_all_messages_vlsm] associated to X.
 From Lemma [vlsm_incl_pre_loaded_with_all_messages_vlsm] we know that <<X>> is
-included in <<PreLoaded>>.
+included in <<PreX>>.
 
 To prove the converse we use the [self_validator_vlsm_prop]erty to
 verify the conditions of meta-lemma [VLSM_incl_finite_traces_characterization].
 *)
 
-    Lemma pre_loaded_with_all_messages_self_validator_vlsm_incl
-        : VLSM_incl PreLoaded X.
-    Proof.
-        unfold self_validator_vlsm_prop  in Hvalidator.
-        destruct X as [T [S M]]. simpl in *.
-        (* redcuction to inclusion of finite traces. *)
-        apply VLSM_incl_finite_traces_characterization.
-        intros.
-        split; [|apply H].
-        destruct H as [Htr Hs].
-        (* reverse induction on the length of a trace. *)
-        induction tr using rev_ind.
-        - constructor. apply initial_state_is_valid. assumption.
-        - apply finite_valid_trace_from_app_iff in Htr.
-          destruct Htr as [Htr Hx].
-          specialize (IHtr Htr).
-          apply (finite_valid_trace_from_app_iff (mk_vlsm M)).
-          split; [assumption|].
-          apply (first_transition_valid (mk_vlsm M)).
-          apply first_transition_valid in Hx.
-          destruct Hx as [Hvx Htx].
-          split; [|assumption].
-          (* using the [self_validator_vlsm_prop]erty. *)
-          revert Hvx.
-          apply Hvalidator.
-    Qed.
+Lemma pre_loaded_with_all_messages_self_validator_vlsm_incl
+  : VLSM_incl PreX X.
+Proof.
+  unfold self_validator_vlsm_prop  in Hvalidator.
+  destruct X as [T [S M]]. simpl in *.
+  (* redcuction to inclusion of finite traces. *)
+  apply VLSM_incl_finite_traces_characterization.
+  intros.
+  split; [|apply H].
+  destruct H as [Htr Hs].
+  (* reverse induction on the length of a trace. *)
+  induction tr using rev_ind.
+  - constructor. apply initial_state_is_valid. assumption.
+  - apply finite_valid_trace_from_app_iff in Htr.
+    destruct Htr as [Htr Hx].
+    specialize (IHtr Htr).
+    apply (finite_valid_trace_from_app_iff (mk_vlsm M)).
+    split; [assumption|].
+    apply (first_transition_valid (mk_vlsm M)).
+    apply first_transition_valid in Hx.
+    destruct Hx as [Hvx Htx].
+    split; [|assumption].
+    (* using the [self_validator_vlsm_prop]erty. *)
+    revert Hvx.
+    apply Hvalidator.
+Qed.
 
 (**
-We conclude that <<X>> and <<Preloaded>> are trace-equal.
+We conclude that <<X>> and <<PreX>> are trace-equal.
 *)
 
-    Lemma pre_loaded_with_all_messages_self_validator_vlsm_eq
-        : VLSM_eq PreLoaded X.
-    Proof.
-        split.
-        - apply pre_loaded_with_all_messages_self_validator_vlsm_incl.
-        - pose (vlsm_incl_pre_loaded_with_all_messages_vlsm X) as Hincl.
-          destruct X as (T, (S, M)).
-          apply Hincl.
-    Qed.
+Lemma pre_loaded_with_all_messages_self_validator_vlsm_eq
+  : VLSM_eq PreX X.
+Proof.
+  split.
+  - apply pre_loaded_with_all_messages_self_validator_vlsm_incl.
+  - pose (vlsm_incl_pre_loaded_with_all_messages_vlsm X) as Hincl.
+    destruct X as (T, (S, M)).
+    apply Hincl.
+Qed.
 
 End self_validator_vlsm.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -127,12 +127,12 @@ Proof.
   intros l s im (lX & sX & Hlx & <- & Hv).
   replace (vtransition Y _ _) with
     (state_project (vtransition X lX (sX, im)).1, (vtransition X lX (sX, im)).2).
-  - eapply (VLSM_projection_input_valid_transition Hproji) with (lY := l)
+  - eapply (VLSM_projection_input_valid_transition Hproji)
     ; [eassumption|].
     split; [assumption|].
     apply injective_projections; reflexivity.
   - symmetry.
-    eapply (VLSM_projection_input_valid_transition Hproj) with (lY := l)
+    eapply (VLSM_projection_input_valid_transition Hproj)
     ; [eassumption|].
     split; [assumption|].
     apply injective_projections; reflexivity.
@@ -145,7 +145,7 @@ Proof.
   - intros is (s & <- & Hs).
     apply (VLSM_projection_initial_state Hproj).
     assumption.
-  - intro; intros. apply any_message_is_valid_in_preloaded.
+  - intros l s m Hv HsY HmX. apply any_message_is_valid_in_preloaded.
   - intros l s om (_ & _ & lX & sX & Hlx & <- & Hv) _ _.
     simpl.
     eapply (VLSM_projection_input_valid Hproj); eassumption.
@@ -195,11 +195,10 @@ Proof.
     + assert (HivtX : input_valid_transition X lX (sX, om) (vtransition X lX (sX, om)))
         by firstorder.
       destruct (vtransition _ _ _) as (sX', _om').
-      apply (VLSM_projection_input_valid_transition Hproj) with (lY := l)
-        in HivtX as [_ Hs']
-      ; [|assumption].
+      eapply (VLSM_projection_input_valid_transition Hproj) in HivtX as [_ Hs']
+      ; [|eassumption].
       rewrite HsX in Hs'.
-      destruct Y as (TY, (SY, MY)).
+      destruct Y as (TY & SY & MY).
       cbv in Htrans, Hs'.
       rewrite Htrans in Hs'.
       inversion Hs'.
@@ -251,15 +250,11 @@ Proof.
   split; cycle 1.
   - exists (state_lift sY).
     split; [apply Hstate_lift|].
-    apply Hinitial_lift.
-    apply HtrY.
+    apply Hinitial_lift, HtrY.
   - induction HtrY using finite_valid_trace_rev_ind.
-    + apply (finite_valid_trace_from_empty Xi).
-      apply initial_state_is_valid.
+    + apply (finite_valid_trace_from_empty Xi), initial_state_is_valid.
       exists (state_lift si).
-      split; [apply Hstate_lift|].
-      apply Hinitial_lift.
-      assumption.
+      auto.
     + apply (extend_right_finite_trace_from Xi);[assumption|].
       split.
       * apply induced_projection_valid_is_input_valid; [assumption|].
@@ -353,7 +348,7 @@ Proof.
   - intro s. apply (lift_to_composite_state_initial IM).
   - apply component_transition_projection_Some.
   - intros li si omi Hiv.
-    apply Hvalidator in Hiv as [sX [<- HivX]].
+    apply Hvalidator in Hiv as (sX & <- & HivX).
     exists (existT i li), sX.
     intuition.
     unfold composite_project_label.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -5,7 +5,7 @@ From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.
 
 (** * VLSM Projection Validators
 
-In the sequel we fix a VLSMs <<X>> and <<Y>> and a [VLSM_projection]
+In the sequel we fix VLSMs <<X>> and <<Y>> and a [VLSM_projection]
 of <<X>> into <<PreY>>, the [pre_loaded_with_all_messages_vlsm] of <<Y>>.
 *)
 
@@ -22,19 +22,7 @@ Context
 
 (**
 We say that <<Y>> is a validator for received messages if
-non-[projection_induced_valid]itiy implied non-component-[valid]ity
-(or non-reachability).
-*)
-
-Definition projection_validator_received_messages_prop :=
-  forall (li : vlabel Y) (si : vstate Y) (mi : message),
-    ~ projection_induced_valid X (type Y) label_project state_project li (si, Some mi)
-    -> ~ input_valid PreY li (si, Some mi).
-
-(**
-We can slightly generalize the definition above to also include empty messages
-and state it in a positive manner as the [projection_validator_prop]erty below,
-requiring that [valid]ity in the component (for reachable states) implies
+[valid]ity in the component (for reachable states) implies
 [projection_induced_valid]ity.
 *)
 
@@ -42,17 +30,6 @@ Definition projection_validator_prop :=
   forall li si omi,
     input_valid PreY li (si,omi) ->
     projection_induced_valid X (type Y) label_project state_project li (si,omi).
-
-(**
-It is easy to see that the [projection_validator_prop]erty includes the
-[projection_validator_received_messages_prop]erty.
-*)
-Lemma projection_validator_messages_received
-  : projection_validator_prop -> projection_validator_received_messages_prop.
-Proof.
-  unfold projection_validator_prop, projection_validator_received_messages_prop.
-  intuition.
-Qed.
 
 (**
 We say that <<Y>> is a [transition_validator] if any [valid]

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -58,16 +58,13 @@ Qed.
 We say that <<Y>> is a [transition_validator] if any [valid]
 transition (from a reachable state) in <<Y>> can be "lifted" to
 an [input_valid_transition] in <<X>>.
-
 *)
-
 Definition transition_validator :=
   forall lY sY omi, input_valid PreY lY (sY, omi) ->
   exists lX sX sX' om',
    input_valid_transition X lX (sX, omi) (sX', om') /\
    label_project lX = Some lY /\
    state_project sX = sY.
-   
 
 (**
 Next two results show that the (simpler) [projection_validator_prop]erty
@@ -109,8 +106,7 @@ Context
   (Htransition_None : weak_projection_transition_consistency_None _ _ label_project state_project)
   (label_lift : vlabel Y -> vlabel X)
   (state_lift : vstate Y -> vstate X)
-  (Xi := projection_induced_vlsm X (type Y)
-    label_project state_project label_lift state_lift)
+  (Xi := projection_induced_vlsm X (type Y) label_project state_project label_lift state_lift)
   (Hlabel_lift : induced_projection_label_lift_prop _ _ label_project label_lift)
   (Hstate_lift : induced_projection_state_lift_prop _ _ state_project state_lift)
   (Hinitial_lift : strong_full_projection_initial_state_preservation Y X state_lift)
@@ -161,10 +157,11 @@ Proof.
 Qed.
 
 (** An alternative formulation of the [projection_validator_prop]erty with a
-seemingly stronger hypothesis, states that <<Y>> is a validator for <<X>>
-if for any <<sY>> a valid state in the projection <<Xi>>, <<li valid Y (sY, om)>>
-implies that <<li valid (si, om)>> in the projection <<Xi>> (i.e.,
-[projection_induced_valid]ity).
+seemingly stronger hypothesis, states that <<Y>> is a validator for <<X>> if
+for any <<li>>, <<si>>, <<iom>> such that <<li valid (si, iom)>> in <<Y>>
+and <<si>> is a valid state in the induced projection <<Xi>>,
+implies that <<li valid (si, om)>> in the induced projection <<Xi>>
+(i.e., [projection_induced_valid]ity).
 *)
 Definition projection_validator_prop_alt :=
   forall li si iom,
@@ -177,9 +174,7 @@ valid states in the induced projection <<Xi>>.
 *)
 Lemma validator_alt_free_states_are_projection_states
   : projection_validator_prop_alt ->
-  forall s,
-    valid_state_prop (pre_loaded_with_all_messages_vlsm Y) s ->
-    valid_state_prop Xi s.
+    forall s, valid_state_prop PreY s -> valid_state_prop Xi s.
 Proof.
   intros Hvalidator sY Hs.
   induction Hs using valid_state_prop_ind.
@@ -211,8 +206,7 @@ Proof.
       reflexivity.
 Qed.
 
-(** Below we show that the two definitions above are actually equivalent.
-*)
+(** Below we show that the two definitions above are actually equivalent. *)
 Lemma projection_validator_prop_alt_iff
   : projection_validator_prop_alt <-> projection_validator_prop.
 Proof.
@@ -231,9 +225,7 @@ Qed.
 
 Lemma validator_free_states_are_projection_states
   : projection_validator_prop ->
-  forall s,
-    valid_state_prop (pre_loaded_with_all_messages_vlsm Y) s ->
-    valid_state_prop Xi s.
+    forall s, valid_state_prop PreY s -> valid_state_prop Xi s.
 Proof.
   rewrite <- projection_validator_prop_alt_iff by assumption.
   apply validator_alt_free_states_are_projection_states.

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -783,6 +783,33 @@ Proof.
     + right. specialize (IHl (Forall_tl Hs)). apply IHl. assumption.
 Qed.
 
+Lemma elem_of_list_annotate
+  `{EqDecision A}
+  (P : A -> Prop)
+  {Pdec : forall a, Decision (P a)}
+  (l : list A)
+  (Hs : Forall P l)
+  (xP : dsig P)
+  : xP ∈ (list_annotate P l Hs) <-> (` xP) ∈ l.
+Proof.
+  split; [apply elem_of_list_annotate_forget|].
+  destruct_dec_sig xP x HPx HeqxP.
+  subst.
+  simpl.
+  intros Hx.
+  induction l; [inversion Hx|].
+  rewrite list_annotate_unroll.
+  destruct (decide (x = a)) as [Heq | Hneq].
+  - subst.
+    replace (@dexist A P _ a (Forall_hd Hs)) with (dec_exist P a HPx); [left|].
+    apply dsig_eq.
+    reflexivity.
+  - right.
+    apply IHl.
+    inversion Hx; [congruence|].
+    assumption.
+Qed.
+
 Lemma nth_error_list_annotate
   {A : Type}
   (P : A -> Prop)

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -116,6 +116,14 @@ Proof.
     inversion Ha.
 Qed.
 
+Lemma set_union_nodup_left `{EqDecision A} (l l' : set A)
+  : NoDup l -> NoDup (set_union l l').
+Proof.
+  intro Hl.
+  induction l' as [|x' l' IH]; [trivial|].
+  now apply set_add_nodup.
+Qed.
+
 Lemma set_union_subseteq_left `{EqDecision A}  : forall (s1 s2 : list A),
   s1 ⊆ (set_union s1 s2).
 Proof.
@@ -128,6 +136,15 @@ Lemma set_union_subseteq_right `{EqDecision A}  : forall (s1 s2 : list A),
 Proof.
   intros; intros x H; apply set_union_intro.
   right; assumption.
+Qed.
+
+Lemma set_union_subseteq_iff `{EqDecision A}  : forall (s1 s2 s : list A),
+  set_union s1 s2 ⊆ s <-> s1 ⊆ s /\ s2 ⊆ s.
+Proof.
+  intros.
+  unfold subseteq, list_subseteq.
+  setoid_rewrite set_union_iff.
+  intuition.
 Qed.
 
 Lemma set_union_iterated_nodup `{EqDecision A}


### PR DESCRIPTION
This PR makes the following changes:
- expands the results about message dependencies, defining a dependency relation, its transitive closure (the happens-before relation), and several properties about them
- Defines the FullMessageDependencies class corresponding to VLSMs which can compute the set encompassing all happens-before dependencies of a given message
- Studies the relation between a sub-composition (the projection of a composition to a subset of nodes) and one of its components
- Makes various improvements to existing results concerning equivocation.