### PR TITLE
Make VLSM a record, combine non-VLSMType fields into VLSMMachine

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -100,13 +100,6 @@ Definition all_messages_s0 := exist (fun s: @state _ all_messages_type => True) 
 Instance all_messages_state_inh : Inhabited (sig  (fun s: @state _ all_messages_type => True)) :=
   {| inhabitant := all_messages_s0 |}.
 
-Definition all_messages_sig
-    : VLSMSign all_messages_type
-    :=
-    {| initial_state_prop := fun s => True
-     ; initial_message_prop := fun m => False
-    |}.
-
 (**
 
 The [transition] function of the [emit_any_message_vlsm] generates the
@@ -132,9 +125,11 @@ Definition all_messages_valid
     := True.
 
 Definition emit_any_message_vlsm_machine
-    : VLSMClass all_messages_sig
+    : VLSMMachine all_messages_type
     :=
-    {| transition := all_messages_transition
+    {| initial_state_prop := fun s => True
+     ; initial_message_prop := fun m => False
+     ; transition := all_messages_transition
      ; valid := all_messages_valid
     |}.
 
@@ -378,7 +373,7 @@ Proof.
         (VLSM_incl_valid_trace
             (pre_loaded_with_all_messages_validator_component_proj_incl _ _ _ Hvalidator)).
     revert Htr.
-    apply byzantine_pre_loaded_with_all_messages.
+    simpl. apply byzantine_pre_loaded_with_all_messages.
 Qed.
 
 
@@ -463,7 +458,7 @@ resist any kind of external influence:
     Proof.
         apply validator_pre_loaded_with_all_messages_incl.
         apply alt_pre_loaded_with_all_messages_incl.
-        apply byzantine_alt_byzantine_iff.
+        apply byzantine_alt_byzantine_iff in Hbyz.
         assumption.
     Qed.
 End composite_validator_byzantine_traces.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -179,7 +179,7 @@ Lemma limited_PreNonByzantine_vlsm_lift
 Proof.
   apply basic_VLSM_full_projection; intros ? *.
   - intros; apply limited_PreNonByzantine_lift_valid; assumption.
-  - intros * []; apply lift_sub_transition; assumption.
+  - intros * []; rapply lift_sub_transition; assumption.
   - intros; apply (lift_sub_state_initial IM); assumption.
   - intros Hv HsY [[sub_i [[im Him] Heqm]] | Hseeded].
     + cbn in Heqm; subst.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -150,12 +150,12 @@ The next few results describe several properties of the [state_update] operation
     Qed.
   End composite_type.
 
-  Section composite_sig.
-(** ** The signature of a composite VLSM
+  Section sec_composite_vlsm.
+(** ** Constrained VLSM composition
 
 Assume an non-empty <<index>> type and let <<IT>> be
-an <<index>>ed family of [VLSMType]s, and for each index <<i>>, let <<IS i>> be
-a [VLSMSign]ature of type <<IT i>>.
+an <<index>>ed family of [VLSMType]s, and for each index <<i>>, let <<IM i>> be
+a [VLSMMachine] of type <<IT i>>.
 *)
 
 (**
@@ -181,8 +181,8 @@ states have the [initial_state_prop]erty in the corresponding component signatur
       {| inhabitant := composite_s0 |}.
 
 (**
-A message has the [initial_message_prop]erty in the [composite_sig]nature
-iff it has the [initial_message_prop]erty in any of the component signatures.
+A message has the [initial_message_prop]erty in the composite
+iff it has the [initial_message_prop]erty in any of the components.
 *)
     Definition composite_initial_message_prop (m : message) : Prop
       :=
@@ -190,13 +190,6 @@ iff it has the [initial_message_prop]erty in any of the component signatures.
 
     Definition option_composite_initial_message_prop : option message -> Prop
       := from_option composite_initial_message_prop True.
-
-    Definition composite_sig
-      : VLSMSign composite_type
-      :=
-        {|   initial_state_prop := composite_initial_state_prop
-           ; initial_message_prop := composite_initial_message_prop
-        |}.
 
 (**
 We can always "lift" state <<sj>> from component <<j>> to a composite state by
@@ -267,20 +260,10 @@ updating an initial composite state, say [s0], to <<sj>> on component <<j>>.
       - exact input_a.
     Defined.
 
-  End composite_sig.
-
-  Section sec_composite_vlsm.
-(** ** Constrained VLSM composition
-
-Assume an non-empty <<index>> type, let
-<<IT>> be an <<index>>ed family of [VLSMType]s, and for each index <<i>>, let
-<<IS i>> be a [VLSMSign]ature of type <<IT i>> and <<IM i>> be a VLSM of
-signature <<IS i>>.
-*)
-
 (**
-The [transition] function for the [composite_vlsm] is defined as follows
-takes a transition in the VLSM corresponding to the given [composite_label]
+The [transition] function for the [composite_vlsm] takes a transition in
+the component selected by the index in the given [composite_label]
+with the contained label,
 and returnes the produced message together with the state updated on that
 component:
 *)
@@ -326,9 +309,11 @@ the [composite_valid]ity.
 
     Definition composite_vlsm_machine
       (constraint : composite_label -> composite_state * option message -> Prop)
-      : VLSMClass composite_sig
+      : VLSMMachine composite_type
       :=
-      {|  transition := composite_transition
+      {|  initial_state_prop := composite_initial_state_prop
+       ;  initial_message_prop := composite_initial_message_prop
+       ;  transition := composite_transition
        ;  valid := constrained_composite_valid constraint
       |}.
 
@@ -879,7 +864,7 @@ Proof.
       apply valid_state_project_preloaded_to_preloaded.
     + apply any_message_is_valid_in_preloaded.
     + destruct l. apply Hcvalid.
-  - apply composite_transition_project_active in Htrans;assumption.
+  - revert Htrans; rapply composite_transition_project_active.
 Qed.
 
 Lemma input_valid_transition_project_active
@@ -1015,12 +1000,13 @@ Context
   {index : Type}
   {IndEqDec : EqDecision index}
   (IM : index -> VLSM message)
+  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   {index_listing : list index}
   (finite_index : Listing index_listing).
 
 Lemma composite_decidable_initial_message
   (Hdec_init : forall i, vdecidable_initial_messages_prop (IM i))
-  : decidable_initial_messages_prop (composite_sig IM).
+  : decidable_initial_messages_prop (composite_vlsm_machine IM constraint).
 Proof.
   intro m. simpl. unfold composite_initial_message_prop.
   apply

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1,5 +1,5 @@
 From stdpp Require Import prelude finite.
-From Coq Require Import Streams FinFun Rdefinitions Program.Tactics.
+From Coq Require Import Streams FinFun Rdefinitions.
 From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet.
 From VLSM Require Import Lib.ListSetExtras Lib.Measurable Lib.FinFunExtras.
 From VLSM Require Import Core.Decisions Core.VLSM Core.VLSMProjections.
@@ -546,7 +546,7 @@ Section Simple.
       split; [|assumption].
       revert Htr.
       unfold pre_vlsm;clear.
-      destruct vlsm as (T,(S,M)).
+      destruct vlsm as (T,M).
       apply VLSM_incl_finite_valid_trace_init_to.
       apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
     Qed.
@@ -571,7 +571,7 @@ Section Simple.
       spec Hsm;[|assumption].
       revert Htr.
       unfold pre_vlsm;clear.
-      destruct vlsm as (T,(S,M)).
+      destruct vlsm as (T,M).
       apply VLSM_incl_finite_valid_trace_init_to.
       apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
     Qed.
@@ -947,7 +947,7 @@ Record oracle_stepwise_props
        (message_selector: message -> transition_item -> Prop)
        (oracle: state_message_oracle vlsm) : Prop :=
   {oracle_no_inits: forall (s: vstate vlsm),
-      initial_state_prop (VLSMSign:=sign vlsm) s ->
+      initial_state_prop (VLSMMachine:=vmachine vlsm) s ->
       forall m, ~oracle s m;
    oracle_step_update:
        forall l s im s' om,
@@ -1149,7 +1149,7 @@ Section StepwiseFromTrace.
          no_traces_have_message_prop vlsm selector (fun m s => ~oracle m s) s m).
 
   Lemma oracle_no_inits_from_trace:
-    forall (s: vstate vlsm), initial_state_prop (VLSMSign:=sign vlsm) s ->
+    forall (s: vstate vlsm), initial_state_prop (VLSMMachine:=vmachine vlsm) s ->
                              forall m, ~oracle s m.
   Proof.
     intros s Hinit m Horacle.
@@ -2150,7 +2150,7 @@ Section Composite.
       is_equivocating_dec := Hdec
     |}.
   Next Obligation.
-   apply (Listing_NoDup finite_validator).
+   intros; apply (Listing_NoDup finite_validator).
   Defined.
 
   Definition equivocation_fault_constraint

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -1,9 +1,7 @@
 From stdpp Require Import prelude.
-From Coq Require Import FunctionalExtensionality FinFun Program.Tactics.
+From Coq Require Import FunctionalExtensionality FinFun.
 From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StreamExtras.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.Equivocation.
-
-Require Import Coq.Program.Tactics.
 
 (** * VLSM No Equivocation Composition Constraints *)
 

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -295,9 +295,7 @@ Section incl_oracle.
 Context
   {message : Type}
   {T : VLSMType message}
-  {SX SY : VLSMSign T}
-  {MX : VLSMClass SX}
-  {MY : VLSMClass SY}
+  {MX MY : VLSMMachine T}
   (X := mk_vlsm MX)
   (Y := mk_vlsm MY)
   (Hincl : VLSM_incl (pre_loaded_with_all_messages_vlsm X) (pre_loaded_with_all_messages_vlsm Y))

--- a/theories/VLSM/Core/Equivocators/Common.v
+++ b/theories/VLSM/Core/Equivocators/Common.v
@@ -573,13 +573,6 @@ Defined.
 Instance equivocator_initial_state_inh : Inhabited equivocator_initial_state :=
   {| inhabitant := equivocator_s0 |}.
 
-Definition equivocator_sig
-  : VLSMSign equivocator_type
-  :=
-    {|   initial_state_prop := equivocator_initial_state_prop
-       ; initial_message_prop := vinitial_message_prop X
-    |}.
-
 Definition equivocator_transition
   (bl : equivocator_label)
   (bsom : equivocator_state * option message)
@@ -620,9 +613,11 @@ Definition equivocator_valid
   end.
 
 Definition equivocator_vlsm_machine
-  : VLSMClass equivocator_sig
+  : VLSMMachine equivocator_type
   :=
-  {|  transition := equivocator_transition
+  {|  initial_state_prop := equivocator_initial_state_prop
+   ;  initial_message_prop := vinitial_message_prop X
+   ;  transition := equivocator_transition
    ;  valid := equivocator_valid
   |}.
 
@@ -894,7 +889,7 @@ Lemma equivocator_transition_reflects_singleton_state
   (iom oom: option message)
   (l: vlabel equivocator_vlsm)
   (s s': vstate equivocator_vlsm)
-  (Ht: vtransition equivocator_vlsm l (s, iom) = (s', oom))
+  (Ht: equivocator_transition X l (s, iom) = (s', oom))
   : is_singleton_state X s' -> is_singleton_state X s.
 Proof.
   unfold is_singleton_state.
@@ -912,7 +907,7 @@ Lemma equivocator_transition_cannot_decrease_state_size
   (iom oom: option message)
   (l: vlabel equivocator_vlsm)
   (s s': vstate equivocator_vlsm)
-  (Ht: vtransition equivocator_vlsm l (s, iom) = (s', oom))
+  (Ht: equivocator_transition X l (s, iom) = (s', oom))
   : equivocator_state_n s <= equivocator_state_n s'.
 Proof.
   specialize (equivocator_state_extend_size X s) as Hex_size.
@@ -931,7 +926,7 @@ Lemma equivocator_transition_preserves_equivocating_state
   (iom oom: option message)
   (l: vlabel equivocator_vlsm)
   (s s': vstate equivocator_vlsm)
-  (Ht: vtransition equivocator_vlsm l (s, iom) = (s', oom))
+  (Ht: equivocator_transition X l (s, iom) = (s', oom))
   : is_equivocating_state X s -> is_equivocating_state X s'.
 Proof.
   intros Hs Hs'. elim Hs. clear Hs. revert Ht Hs' .
@@ -942,7 +937,7 @@ Lemma zero_descriptor_transition_reflects_equivocating_state
   (iom oom: option message)
   (l: vlabel equivocator_vlsm)
   (s s': vstate equivocator_vlsm)
-  (Ht: vtransition equivocator_vlsm l (s, iom) = (s', oom))
+  (Ht: equivocator_transition X l (s, iom) = (s', oom))
   li
   (Hzero : l = ContinueWith 0 li)
   : is_equivocating_state X s' -> is_equivocating_state X s.
@@ -1051,7 +1046,7 @@ Proof.
   apply (VLSM_eq_valid_state (vlsm_is_pre_loaded_with_False equivocator_vlsm)) in Hbs.
   specialize (preloaded_with_equivocator_state_project_valid_state _ _ Hbs _ _ Hpr) as Hsi.
   apply (VLSM_eq_valid_state (vlsm_is_pre_loaded_with_False X)) in Hsi.
-  destruct X as (T, (S, M)).
+  destruct X as (T, M).
   assumption.
 Qed.
 
@@ -1068,7 +1063,7 @@ Proof.
   apply preloaded_with_equivocator_state_project_valid_message in Hom.
   specialize (vlsm_is_pre_loaded_with_False_initial_message_rev X) as Hinit_rev.
   apply (VLSM_incl_valid_message (VLSM_eq_proj2 (vlsm_is_pre_loaded_with_False X))) in Hom
-  ; destruct X as (T, (S, M))
+  ; destruct X as (T, M)
   ; assumption.
 Qed.
 
@@ -1087,7 +1082,7 @@ Proof.
   apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True equivocator_vlsm)) in Hbs.
   specialize (preloaded_with_equivocator_state_project_valid_state _ _ Hbs _ _ Hpr) as Hsi.
   apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True X)) in Hsi.
-  destruct X as (T, (S, M)).
+  destruct X as (T, M).
   assumption.
 Qed.
 

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -101,7 +101,7 @@ Proof.
   apply transitivity.
   destruct Ht as [_ Ht].
   revert Ht.
-  apply equivocators_transition_preserves_equivocating_indices.
+  rapply @equivocators_transition_preserves_equivocating_indices.
 Qed.
 
 (** Composition of equivocators with no message equivocation and a

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -55,7 +55,7 @@ Proof.
   apply basic_VLSM_full_projection; intros ? *.
   - split; [|exact I].
     apply lift_sub_valid. apply Hv.
-  - intros [_ Ht]. apply lift_sub_transition. assumption.
+  - intros [_ Ht]. revert Ht. apply lift_sub_transition.
   - intros; apply (lift_sub_state_initial equivocator_IM). assumption.
   - intros; destruct HmX as [Hinit|Hseeded]; [|apply Hseed; assumption].
     apply initial_message_is_valid.

--- a/theories/VLSM/Core/Equivocators/Projections.v
+++ b/theories/VLSM/Core/Equivocators/Projections.v
@@ -940,13 +940,13 @@ Proof.
     split; [assumption|].
     apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj2 (vlsm_is_pre_loaded_with_False X))) in Htr.
     clear -Htr.
-    destruct X as (T, (S, M)).
+    destruct X as (T, M).
     assumption.
   - destruct Hdi as [s [Hpr_bs_i Htr]].
     eexists; split; [exact Hpr_bs_i|].
     apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj2 (vlsm_is_pre_loaded_with_False X))) in Htr.
     clear -Htr.
-    destruct X as (T, (S, M)).
+    destruct X as (T, M).
     assumption.
 Qed.
 
@@ -984,13 +984,13 @@ Proof.
     split; [assumption|].
     apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj2 (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True X))) in Htr.
     clear -Htr.
-    destruct X as (T, (S, M)).
+    destruct X as (T, M).
     assumption.
   - destruct Hdi as [s [Hpr_bs_i Htr]].
     eexists; split; [exact Hpr_bs_i|].
     apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj2 (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True X))) in Htr.
     clear -Htr.
-    destruct X as (T, (S, M)).
+    destruct X as (T, M).
     assumption.
 Qed.
 

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -128,15 +128,14 @@ Proof.
     apply (@message_dependencies_are_necessary _ m s) in Hdm
     ; [|revert Hproduce; apply VLSM_incl_can_produce; apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages].
     clear H1 no_initial_messages_in_X Hreflects.
-    revert H H0 s Hdm Hproduce; destruct X as (T & S & M); cbn; intros.
+    revert H H0 s Hdm Hproduce; destruct X as [T M]; clear X; cbn; intros.
     eapply VLSM_incl_has_been_observed
     ; [apply basic_VLSM_incl_preloaded; cbv;intuition | | eassumption].
-
     exists (Some m).
     apply can_produce_valid.
     revert Hproduce.
     eapply VLSM_incl_can_produce.
-    apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
+    exact (pre_loaded_vlsm_incl_pre_loaded_with_all_messages (mk_vlsm M) P).
 Qed.
 
 (** Under [MessageDependencies] assumptions, if a message [has_been_sent]

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -48,14 +48,6 @@ with the exception that the [initial_message]s for the projection are defined
 to be all [valid_message]s of <<X>>:
 
 *)
-  Definition composite_vlsm_constrained_projection_sig
-    (i : index)
-    : VLSMSign (type (IM i))
-    :=
-    {|   initial_state_prop := vinitial_state_prop (IM i)
-     ;   initial_message_prop := fun pmi => exists xm : valid_message X, proj1_sig xm = pmi
-     ;   s0 := @s0 _ _ (sign (IM i))
-    |}.
 
 (**
 [projection_valid]ity is defined as the projection of [input_valid]ity of <<X>>:
@@ -215,8 +207,12 @@ having the same transition function as <<IM i>>, the <<i>>th component of <<IM>>
 *)
   Definition composite_vlsm_constrained_projection_machine
     (i : index)
-    : VLSMClass (composite_vlsm_constrained_projection_sig i) :=
-    {|  transition :=  vtransition (IM i)
+    : VLSMMachine (type (IM i))
+    :=
+    {|   initial_state_prop := vinitial_state_prop (IM i)
+     ;   initial_message_prop := fun pmi => exists xm : valid_message X, proj1_sig xm = pmi
+     ;   s0 := @s0 _ _ (machine (IM i))
+     ;  transition :=  vtransition (IM i)
      ;  valid := projection_valid i
     |}.
 
@@ -860,7 +856,7 @@ Proof.
   - apply (valid_initial_state_message PreLoaded).
     assumption. destruct om;exact I.
   - apply (valid_generated_state_message PreLoaded) with s _om _s om l; try assumption.
-    eapply (projection_valid_implies_valid IM). exact Hv.
+    simpl. eapply (projection_valid_implies_valid IM). exact Hv.
 Qed.
 
 (**
@@ -873,7 +869,8 @@ Proof.
   apply (basic_VLSM_incl (machine Xj) (machine PreLoaded)); intro; intros.
   - assumption.
   - apply initial_message_is_valid; exact I.
-  - eapply (projection_valid_implies_valid IM).
+  - unfold vvalid;simpl.
+    eapply (projection_valid_implies_valid IM).
     apply Hv.
   - apply H.
 Qed.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -20,8 +20,7 @@ Local Program Instance sub_index_prop_dec
   (i : index)
   : Decision (sub_index_prop i).
 Next Obligation.
-  unfold sub_index_prop.
-  apply decide_rel; typeclasses eauto.
+  intros; apply decide_rel; typeclasses eauto.
 Qed.
 
 Definition sub_index : Type
@@ -341,10 +340,9 @@ Proof.
   simpl_existT. subst.
   exists i.
   split; [assumption|].
-  apply proj1 in Hv.
   cbn in Hv.
   exists li, (sX i).
-  repeat split; [|apply any_message_is_valid_in_preloaded|assumption].
+  repeat split; [|apply any_message_is_valid_in_preloaded|apply Hv].
   apply (VLSM_projection_valid_state (preloaded_component_projection IM i)).
   apply (VLSM_incl_valid_state (vlsm_incl_pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM))).
   apply (VLSM_incl_valid_state (constraint_free_incl IM constraint)).
@@ -839,6 +837,14 @@ Qed.
 
 End sub_composition.
 
+(* make initial arguments of lift_sub_transition not maximally inserted,
+   so tactics like rapply lift_sub_transition
+   do not try to guess those arguments before looking at the goal,
+   and we don't have to always write rapply @lift_sub_transition.
+ *)
+Arguments lift_sub_transition [message index]%type_scope {EqDecision0} IM%function_scope
+  sub_index_list%list_scope l s om s' om' Ht.
+
 (** ** Lifting a trace from a sub-composition to the full composition
 
 In this section we first show that given a valid state for a composition of
@@ -892,11 +898,10 @@ Proof.
   simpl in Hl.
   destruct (decide _); [congruence|].
   inversion Hl. subst lY. clear Hl.
-  apply proj1 in Hv.
   split; [|exact I].
   cbn in Hv |- *.
   unfold remove_equivocating_state_project.
-  rewrite lift_sub_state_to_neq; assumption.
+  rewrite lift_sub_state_to_neq;[apply Hv|assumption].
 Qed.
 
 Lemma remove_equivocating_strong_projection_transition_preservation_Some eqv_is
@@ -1653,12 +1658,11 @@ Proof.
   apply basic_VLSM_strong_full_projection; intro; intros.
   - destruct l as (sub_i, li). split; [|apply H].
     destruct_dec_sig sub_i i Hi Heqi. subst sub_i.
-    apply proj1 in H.
     simpl in *.
     unfold sub_IM, SubProjectionTraces.sub_IM in H. simpl in H.
     unfold free_sub_free_state.
     replace (s (free_sub_free_index i)) with (s (@dec_exist _ _ (sub_index_prop_dec (enum index)) i Hi))
-    ; [assumption|].
+    ; [apply H|].
     apply sub_IM_state_pi.
   - destruct l as (sub_i, li). simpl in *.
     destruct_dec_sig sub_i i Hi Heqi. subst sub_i.
@@ -1916,7 +1920,7 @@ Proof.
   apply (basic_VLSM_full_projection_preloaded_with SubFree Free seed seed); intro; intros.
   - assumption.
   - split; [|exact I]. apply lift_sub_valid. apply H.
-  - apply lift_sub_transition; assumption.
+  - rapply lift_sub_transition; assumption.
   - apply (lift_sub_state_initial IM); assumption.
   - apply (lift_sub_message_initial IM indices); assumption.
 Qed.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -1545,8 +1545,7 @@ Section VLSM_equality.
     .
 
 Definition VLSM_eq_part
-  {SigX SigY: VLSMSign vtype}
-  (MX : VLSMClass SigX) (MY : VLSMClass SigY)
+  (MX MY : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   :=
   forall t : Trace,
@@ -1554,8 +1553,7 @@ Definition VLSM_eq_part
 Local Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
 
 Definition VLSM_incl_part
-  {SigX SigY: VLSMSign vtype}
-  (MX : VLSMClass SigX) (MY : VLSMClass SigY)
+  (MX MY : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   :=
   forall t : Trace,
@@ -1563,8 +1561,7 @@ Definition VLSM_incl_part
 Local Notation VLSM_incl X Y := (VLSM_incl_part (machine X) (machine Y)).
 
 Lemma VLSM_incl_refl
-  {SigX : VLSMSign vtype}
-  (MX : VLSMClass SigX)
+  (MX : VLSMMachine vtype)
   (X := mk_vlsm MX)
   : VLSM_incl X X.
 Proof.
@@ -1572,8 +1569,7 @@ Proof.
 Qed.
 
 Lemma VLSM_incl_trans
-  {SigX SigY SigZ: VLSMSign vtype}
-  (MX : VLSMClass SigX) (MY : VLSMClass SigY) (MZ : VLSMClass SigZ)
+  (MX MY MZ : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY) (Z := mk_vlsm MZ)
   : VLSM_incl X Y -> VLSM_incl Y Z -> VLSM_incl X Z.
 Proof.
@@ -1583,8 +1579,7 @@ Qed.
 (* begin hide *)
 
 Lemma VLSM_eq_incl_l
-  {SigX SigY: VLSMSign vtype}
-  (MX : VLSMClass SigX) (MY : VLSMClass SigY)
+  (MX MY : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_eq X Y -> VLSM_incl X Y.
 Proof.
@@ -1595,8 +1590,7 @@ Proof.
 Qed.
 
 Lemma VLSM_eq_incl_r
-  {SigX SigY: VLSMSign vtype}
-  (MX : VLSMClass SigX) (MY : VLSMClass SigY)
+  (MX MY : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_eq X Y -> VLSM_incl Y X.
 Proof.
@@ -1607,8 +1601,7 @@ Proof.
 Qed.
 
 Lemma VLSM_eq_incl_iff
-  {SigX SigY: VLSMSign vtype}
-  (MX : VLSMClass SigX) (MY : VLSMClass SigY)
+  (MX MY : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_eq X Y <-> VLSM_incl X Y /\ VLSM_incl Y X.
 Proof.
@@ -1625,8 +1618,7 @@ Proof.
 Qed.
 
 Lemma VLSM_incl_finite_traces_characterization
-  {SigX SigY: VLSMSign vtype}
-  (MX : VLSMClass SigX) (MY : VLSMClass SigY)
+  (MX MY : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_incl X Y <->
     forall (s : vstate X)
@@ -1656,8 +1648,7 @@ Qed.
 label and state projection functions are identities.
 *)
 Lemma VLSM_incl_full_projection_iff
-  {SigX SigY: VLSMSign vtype}
-  (MX : VLSMClass SigX) (MY : VLSMClass SigY)
+  (MX MY : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_incl X Y <-> VLSM_full_projection X Y id id.
 Proof.
@@ -1675,16 +1666,14 @@ Proof.
 Qed.
 
 Definition VLSM_incl_is_full_projection
-  {SigX SigY: VLSMSign vtype}
-  {MX : VLSMClass SigX} {MY : VLSMClass SigY}
+  {MX MY : VLSMMachine vtype}
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   (Hincl : VLSM_incl X Y)
   : VLSM_full_projection X Y id id
   := proj1 (VLSM_incl_full_projection_iff MX MY) Hincl.
 
 Lemma VLSM_incl_is_full_projection_finite_trace_project
-  {SigX SigY: VLSMSign vtype}
-  {MX : VLSMClass SigX} {MY : VLSMClass SigY}
+  {MX MY : VLSMMachine vtype}
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   (Hincl : VLSM_incl X Y)
   : forall tr,
@@ -1703,8 +1692,7 @@ Notation VLSM_incl X Y := (VLSM_incl_part (machine X) (machine Y)).
 Lemma VLSM_eq_refl
   {message : Type}
   {vtype : VLSMType message}
-  {SigX : VLSMSign vtype}
-  (MX : VLSMClass SigX)
+  (MX : VLSMMachine vtype)
   (X := mk_vlsm MX)
   : VLSM_eq X X.
 Proof.
@@ -1714,8 +1702,7 @@ Qed.
 Lemma VLSM_eq_sym
   {message : Type}
   {vtype : VLSMType message}
-  {SigX SigY: VLSMSign vtype}
-  (MX : VLSMClass SigX) (MY : VLSMClass SigY)
+  (MX MY : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_eq X Y -> VLSM_eq Y X.
 Proof.
@@ -1725,8 +1712,7 @@ Qed.
 Lemma VLSM_eq_trans
   {message : Type}
   {vtype : VLSMType message}
-  {SigX SigY SigZ: VLSMSign vtype}
-  (MX : VLSMClass SigX) (MY : VLSMClass SigY) (MZ : VLSMClass SigZ)
+  (MX MY MZ : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY) (Z := mk_vlsm MZ)
   : VLSM_eq X Y -> VLSM_eq Y Z -> VLSM_eq X Z.
 Proof.
@@ -1738,9 +1724,7 @@ Section VLSM_incl_preservation.
 Context
   {message : Type}
   {T : VLSMType message}
-  {SX SY : VLSMSign T}
-  (MX : VLSMClass SX)
-  (MY : VLSMClass SY)
+  (MX MY : VLSMMachine T)
   (X := mk_vlsm MX)
   (Y := mk_vlsm MY)
   .
@@ -1771,8 +1755,8 @@ End VLSM_incl_preservation.
 Section VLSM_incl_properties.
 
 Context
-  {message : Type} [vtype : VLSMType message] [SigX SigY : VLSMSign vtype]
-  [MX : VLSMClass SigX] [MY : VLSMClass SigY]
+  {message : Type} [vtype : VLSMType message]
+  [MX MY : VLSMMachine vtype]
   (Hincl : VLSM_incl_part MX MY)
   (X := mk_vlsm MX)
   (Y := mk_vlsm MY)
@@ -1950,14 +1934,14 @@ Lemma vlsm_incl_pre_loaded_with_all_messages_vlsm
 Proof.
   apply VLSM_incl_finite_traces_characterization.
   intros. split; [|apply H].
-  apply preloaded_weaken_valid_trace_from. destruct X as (T, (S, M)). apply H.
+  apply preloaded_weaken_valid_trace_from. destruct X. apply H.
 Qed.
 
 Section VLSM_eq_properties.
 
 Context
-  {message : Type} [vtype : VLSMType message] [SigX SigY : VLSMSign vtype]
-  [MX : VLSMClass SigX] [MY : VLSMClass SigY]
+  {message : Type} [vtype : VLSMType message]
+  [MX MY : VLSMMachine vtype]
   (Hincl : VLSM_eq_part MX MY)
   (X := mk_vlsm MX)
   (Y := mk_vlsm MY)
@@ -2643,9 +2627,7 @@ Section basic_VLSM_incl.
 Context
   {message : Type}
   {T : VLSMType message}
-  {SX SY : VLSMSign T}
-  (MX : VLSMClass SX)
-  (MY : VLSMClass SY)
+  (MX MY : VLSMMachine T)
   (X := mk_vlsm MX)
   (Y := mk_vlsm MY)
   .
@@ -2790,7 +2772,7 @@ Qed.
 Lemma vlsm_is_pre_loaded_with_False
   : VLSM_eq X (pre_loaded_vlsm X (fun m => False)).
 Proof.
-  destruct X as (T, (S, M)). intro Hpp.
+  destruct X as (T, M). intro Hpp.
   apply VLSM_eq_incl_iff. simpl.
   split; apply basic_VLSM_strong_incl; cbv; intuition.
 Qed.
@@ -2842,7 +2824,7 @@ Lemma vlsm_is_pre_loaded_with_False_valid_state_message s om
 Proof.
   pose proof vlsm_is_pre_loaded_with_False as Heq.
   apply VLSM_eq_incl_iff in Heq.
-  destruct X as (T, (S, M)); simpl in *.
+  destruct X as (T, M); simpl in *.
   split; (apply VLSM_incl_valid_state_message; [|cbv;tauto]); apply Heq.
 Qed.
 
@@ -2862,7 +2844,7 @@ Lemma preloaded_weaken_finite_valid_trace_from
   finite_valid_trace_from X from tr ->
   finite_valid_trace_from (pre_loaded_with_all_messages_vlsm X) from tr.
 Proof.
-  destruct X as (T, (S, M)).
+  destruct X as (T, M).
   apply VLSM_incl_finite_valid_trace_from.
   apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
@@ -2872,7 +2854,7 @@ Lemma preloaded_weaken_finite_valid_trace_from_to
   finite_valid_trace_from_to X from to tr ->
   finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm X) from to tr.
 Proof.
-  destruct X as (T, (S, M)).
+  destruct X as (T, M).
   apply VLSM_incl_finite_valid_trace_from_to.
   apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
@@ -2905,21 +2887,11 @@ Context
 Definition projection_induced_initial_state_prop (sY : @state _ TY) : Prop :=
   exists sX, state_project sX = sY /\ vinitial_state_prop X sX.
 
-Program Instance projection_induced_initial_state_inh : Inhabited (sig projection_induced_initial_state_prop)
-  := populate (exist _ (state_project (proj1_sig (@inhabitant _ (@s0 _ _ (sign X))))) _).
-Next Obligation.
-  eexists. split.
-  - reflexivity.
-  - destruct (@inhabitant _ (@s0 _ _ (sign X))). assumption.
-Qed.
+Instance projection_induced_initial_state_inh : Inhabited (sig projection_induced_initial_state_prop)
+  := populate (exist _ (state_project (` (vs0 X))) (ex_intro _ _ (conj (eq_refl _) (proj2_sig _)))).
 
 Definition projection_induced_initial_message_prop : message -> Prop :=
   valid_message_prop X.
-
-Definition projection_induced_vlsm_sig : VLSMSign TY :=
-  {| initial_message_prop := projection_induced_initial_message_prop
-   ; initial_state_prop := projection_induced_initial_state_prop
-  |}.
 
 Definition projection_induced_transition
   (lY : @label _ TY)
@@ -2937,13 +2909,15 @@ Definition projection_induced_valid
   exists lX sX, label_project lX = Some lY /\ state_project sX = sY /\
   input_valid X lX (sX, om).
 
-Definition projection_induced_vlsm_class : VLSMClass projection_induced_vlsm_sig :=
-  {| transition := projection_induced_transition
+Definition projection_induced_vlsm_machine : VLSMMachine TY :=
+  {| initial_message_prop := projection_induced_initial_message_prop
+   ; initial_state_prop := projection_induced_initial_state_prop
+   ; transition := projection_induced_transition
    ;  valid := projection_induced_valid
   |}.
 
 Definition projection_induced_vlsm : VLSM message :=
-  mk_vlsm projection_induced_vlsm_class.
+  mk_vlsm projection_induced_vlsm_machine.
 
 (** <<label_project>> is a left-inverse of <<label_lift>> *)
 Definition induced_projection_label_lift_prop : Prop :=
@@ -3128,8 +3102,7 @@ their projections induced by the same maps.
 Lemma projection_induced_vlsm_incl
   {message : Type}
   {TX : VLSMType message}
-  {SigX1 SigX2: VLSMSign TX}
-  (MX1 : VLSMClass SigX1) (MX2 : VLSMClass SigX2)
+  (MX1 MX2 : VLSMMachine TX)
   (X1 := mk_vlsm MX1) (X2 := mk_vlsm MX2)
   (TY : VLSMType message)
   (label_project : @label _ TX -> option (@label _ TY))
@@ -3189,8 +3162,7 @@ their projections induced by the same maps.
 Lemma projection_induced_vlsm_eq
   {message : Type}
   {TX : VLSMType message}
-  {SigX1 SigX2: VLSMSign TX}
-  (MX1 : VLSMClass SigX1) (MX2 : VLSMClass SigX2)
+  (MX1 MX2: VLSMMachine TX)
   (X1 := mk_vlsm MX1) (X2 := mk_vlsm MX2)
   (TY : VLSMType message)
   (label_project : @label _ TX -> option (@label _ TY))

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -175,7 +175,7 @@ Proof.
       eapply (VLSM_projection_input_valid_transition Hproj) in HivtX as [_ Hs']
       ; [|eassumption].
       rewrite HsX in Hs'.
-      destruct Y as (TY & SY & MY).
+      destruct Y as (TY & MY).
       cbv in Htrans, Hs'.
       rewrite Htrans in Hs'.
       inversion Hs'.
@@ -316,7 +316,7 @@ Proof.
     (machine (projection_induced_vlsm X (type (IM i))
       (composite_project_label IM i) (fun s => s i)
       (lift_to_composite_label IM i) (lift_to_composite_state IM i)))
-  ; [|apply VLSM_eq_sym, composite_vlsm_constrained_projection_is_induced].
+  ; simpl; [|apply VLSM_eq_sym, composite_vlsm_constrained_projection_is_induced].
   apply pre_loaded_with_all_messages_validator_proj_eq.
   - apply component_projection_to_preloaded.
   - apply component_transition_projection_None.
@@ -390,7 +390,7 @@ Lemma pre_loaded_with_all_messages_self_validator_vlsm_incl
   : VLSM_incl PreX X.
 Proof.
   unfold self_validator_vlsm_prop  in Hvalidator.
-  destruct X as (T & S & M). simpl in *.
+  destruct X as (T & M). simpl in *.
   (* redcuction to inclusion of finite traces. *)
   apply VLSM_incl_finite_traces_characterization.
   intros s tr [Htr Hs].
@@ -422,7 +422,7 @@ Proof.
   split.
   - apply pre_loaded_with_all_messages_self_validator_vlsm_incl.
   - pose (vlsm_incl_pre_loaded_with_all_messages_vlsm X) as Hincl.
-    destruct X as (T, (S, M)).
+    destruct X as (T, M).
     apply Hincl.
 Qed.
 

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -1,3 +1,5 @@
+From Coq Require Export Program.Tactics.
+Obligation Tactic := idtac.
 From stdpp Require Import prelude.
 From Coq Require Import Eqdep_dec.
 


### PR DESCRIPTION
This changes the definition of VLSM from a nested sigT into
a record, and collapses the two records VLSMSign and VLSMClass
into a single VLSMMachine record because that division was never
useful.
(Separating VLSMType from the rest lets us write definitions like
VLSM_incl that can only be applied to two VLSMs with the same
VLSMType, and it was never helpful to talk about two VLSMs with
the same initial messages and states but different transitions.
The other possible use would be if definitions like
pre_loaded_with_all_messages_vlsm could reuse some of the records,
but VLSMClass dependend on VLSMSign and we never wanted to
change just the transition or valid functions while leaving the
initial states or messages alone).

Unfortunately this somehow changed things so that the extremely
limited form of unification used in the `apply` tactic can no longer
directly apply some lemmas to some goals. For example, lemmas with
conclusions about composite_transition no longer work with the
plain `apply` if the goal was (vtransition (free_composite_vlsm IM)),
even though that expression can reduce to composite_transition.

This can usually be fixed by using `rapply`, which is like
`apply` but based on `refine` and uses a less limited unification
algorithm. I now export it from our Preamble (it's from
Coq.Program.Tactics).
If that fails you can also explicitly supply more arguments.

There is not an `rapply lem in H` form, but the special case of
`apply lem in H;assumption.` can become `revert H;rapply lem`.