### PR TITLE
minimal changes for compatibility with Coq 8.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ contains a formalization of VLSMs and their theory in the Coq proof assistant.
 - License: [BSD 3-Clause "New" or "Revised" License](LICENSE.md)
 - Compatible Coq versions: 8.13
 - Additional dependencies:
-  - [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.6.0 or later
+  - [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.6.0
 - Coq namespace: `VLSM`
 
 ## Working with the project online
 
 The simplest way of working with this project without needing to install anything is by doing so online:
+
 [![Open in Papillon](https://papillon.unbounded.network/github-badge.svg)](https://papillon.unbounded.network/projects/github/runtimeverification/vlsm/master)
 
 ## Building instructions

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,5 @@
 -Q theories/VLSM VLSM
+-arg -w -arg -deprecated-instance-without-locality
 
 theories/VLSM/Lib/Preamble.v
 theories/VLSM/Lib/SsrExport.v

--- a/coq-vlsm.opam
+++ b/coq-vlsm.opam
@@ -16,7 +16,7 @@ contains a formalization of VLSMs and their theory in the Coq proof assistant.""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {>= "8.13" & < "8.14~"}
+  "coq" {>= "8.13"}
   "coq-stdpp" {>= "1.6.0"}
 ]
 

--- a/meta.yml
+++ b/meta.yml
@@ -39,14 +39,14 @@ license:
 
 supported_coq_versions:
   text: 8.13
-  opam: '{>= "8.13" & < "8.14~"}'
+  opam: '{>= "8.13"}'
 
 dependencies:
 - opam:
     name: coq-stdpp
     version: '{>= "1.6.0"}'
   description: |-
-    [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.6.0 or later
+    [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.6.0
 
 namespace: VLSM
 
@@ -61,6 +61,7 @@ build: |-
   ## Working with the project online
 
   The simplest way of working with this project without needing to install anything is by doing so online:
+
   [![Open in Papillon](https://papillon.unbounded.network/github-badge.svg)](https://papillon.unbounded.network/projects/github/runtimeverification/vlsm/master)
 
   ## Building instructions

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -389,7 +389,7 @@ Proof.
     case_decide as HAv; [| trivial].
     cbn in Hc; destruct Hc as [Hsent | Hseeded].
     + unfold lift_sub_state.
-      rewrite lift_sub_state_to_eq with (Hi0 := HAv).
+      rewrite (lift_sub_state_to_eq _ _ _ _ _ HAv).
       apply (sub_IM_has_been_sent_iff_by_sender fixed_byzantine_IM non_byzantine
               A sender fixed_byzantine_IM_sender_safety)
       ; [| assumption | assumption].
@@ -662,7 +662,7 @@ Proof.
       subst.
       exists i.
       unfold lift_sub_state.
-      rewrite lift_sub_state_to_eq with (Hi0 := Hi); assumption.
+      rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi); assumption.
     + right.
       apply emitted_messages_are_valid_iff in HomY.
       destruct HomY as [[_v [[_im Him] Heqim]] | Hiom]
@@ -692,7 +692,7 @@ Proof.
       specialize (Hfull j _ _ _ Hv _ Hdm).
       exists j.
       unfold lift_sub_state.
-      rewrite lift_sub_state_to_eq with (Hi0 := Hj); assumption.
+      rewrite (lift_sub_state_to_eq _ _ _ _ _ Hj); assumption.
 Qed.
 
 Lemma preloaded_non_byzantine_vlsm_lift

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -129,7 +129,7 @@ Proof.
                       (lift_sub_state IM non_byzantine (finite_trace_last is pre)) m0).
     { exists i.
       unfold lift_sub_state.
-      rewrite lift_sub_state_to_eq with (Hi0 := Hi).
+      rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi).
       assumption.
     }
     apply (composite_proper_sent IM) in Hsent; [|assumption].
@@ -308,7 +308,7 @@ Proof.
     eapply Hvalidator,
       pre_loaded_sub_composite_input_valid_projection, Ht_sub.
   - unfold lift_sub_state in Hann_s_pr.
-    rewrite Hann_s_pr, lift_sub_state_to_eq with (Hi0 := Hi).
+    rewrite Hann_s_pr, (lift_sub_state_to_eq _ _ _ _ _ Hi).
     apply Ht_sub.
   - apply Rle_trans with (sum_weights (remove_dups byzantine))
     ; [| assumption].
@@ -326,20 +326,20 @@ Proof.
     destruct Ht_sub as [_ Ht_sub]; revert Ht_sub
     ; unfold annotated_transition; cbn
     ; rewrite Hann_s_pr; unfold lift_sub_state at 1
-    ; rewrite lift_sub_state_to_eq with (Hi0 := Hi)
+    ; rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi)
     ; unfold sub_IM at 2; cbn
     ; destruct (vtransition _ _ _) as (si', om')
     ; inversion_clear 1.
     do 2 f_equal; extensionality j.
     destruct (decide (i = j)) as [| Hij]; subst.
-    + unfold lift_sub_state; rewrite lift_sub_state_to_eq with (Hi0 := Hi).
+    + unfold lift_sub_state.
+      rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi).
       rewrite !state_update_eq; reflexivity.
     + rewrite state_update_neq by congruence.
       unfold lift_sub_state.
       destruct (decide (j ∈ set_diff (enum index) byzantine)) as [Hj |].
-      * rewrite !lift_sub_state_to_eq with (Hi0 := Hj),
-                sub_IM_state_update_neq by congruence
-        ; reflexivity.
+      * rewrite !(lift_sub_state_to_eq _ _ _ _ _ Hj).
+        rewrite sub_IM_state_update_neq by congruence; reflexivity.
       * rewrite !lift_sub_state_to_neq by assumption; reflexivity.
 Qed.
 
@@ -410,8 +410,7 @@ Proof.
     apply set_union_subseteq_iff; split; [assumption |].
     unfold coeqv_message_equivocators
     ; case_decide as Hnobs; [apply list_subseteq_nil |].
-    erewrite full_node_msg_dep_coequivocating_senders with (i0 := i) (li0 := li).
-    2-4: eassumption.
+    rewrite (full_node_msg_dep_coequivocating_senders _ _ _ _ Hfull _ _ i li).
     2: cbn; rewrite Hlsti
     ; eapply @pre_loaded_sub_composite_input_valid_projection, Hx.
     rewrite app_nil_r; cbn.
@@ -424,8 +423,8 @@ Proof.
       ; destruct_dec_sig sub_i_im _i_im H_i_im Heqsub_i_im; subst sub_i_im.
       apply composite_has_been_observed_sent_received_iff; left.
       exists _i_im.
-      rewrite Hlsti; cbn; unfold lift_sub_state
-      ; rewrite lift_sub_state_to_eq with (Hi0 := H_i_im).
+      rewrite Hlsti; cbn; unfold lift_sub_state.
+      rewrite (lift_sub_state_to_eq _ _ _ _ _ H_i_im).
       assumption.
     + clear -Hsender Hsigned.
       destruct Hsigned as (_i_im & H_i_im & Hauth).
@@ -462,8 +461,9 @@ Proof.
       as [Hbtr Heqv_byzantine]
     ; [| assumption].
     eexists _,_, byzantine; do 3 (split; [eassumption |]); split.
-    + extensionality sub_i; destruct_dec_sig sub_i i Hi Heqsub_i; subst; cbn
-      ; unfold lift_sub_state; rewrite lift_sub_state_to_eq with (Hi0 := Hi).
+    + extensionality sub_i; destruct_dec_sig sub_i i Hi Heqsub_i; subst; cbn.
+      unfold lift_sub_state.
+      rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi).
       reflexivity.
     + subst Limited.
       rewrite msg_dep_annotate_trace_with_equivocators_project.

--- a/theories/VLSM/Core/Equivocation/LimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedEquivocation.v
@@ -147,8 +147,7 @@ Proof.
     apply (composite_proper_sent IM) in Hsent; [|assumption].
     specialize (Hsent _ _ (conj Hpre_pre Hinit)).
     contradiction.
-  +  apply (SubProjectionTraces.sub_can_emit_sender IM equivocators (fun i => i) sender Hsender_safety)
-        with (v0 := v) in Hemit
+  +  apply (SubProjectionTraces.sub_can_emit_sender IM equivocators (fun i => i) sender Hsender_safety _ _ v) in Hemit
       ; assumption.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -210,7 +210,7 @@ Proof.
       apply no_initial_messages_in_IM.
     }
     destruct Hemit as ((sX, iom) & (sub_i, li) & sX' & HtX).
-    eapply preloaded_composite_observed_valid with (s0 := sX').
+    eapply (preloaded_composite_observed_valid _ _ _ sX').
     + eapply input_valid_transition_destination; eassumption.
     + exists sub_i. destruct_dec_sig sub_i i Hi Heqsub_i; subst.
       eapply message_dependencies_are_necessary; [typeclasses eauto| |eassumption].

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -255,7 +255,7 @@ Lemma is_equivocating_statewise_implies_is_equivocating_tracewise s v
 Proof.
   intros [j [m [Hm [Hnbs_m Hbr_m]]]] is tr Htr.
   exists m. split; [assumption|].
-  apply preloaded_finite_valid_trace_init_to_projection with (j0 := j) in Htr as Htrj.
+  apply (preloaded_finite_valid_trace_init_to_projection _ j) in Htr as Htrj.
   apply proj1 in Htrj as Hlstj.
   apply finite_valid_trace_from_to_last_pstate in Hlstj.
   apply proper_received in Hbr_m; [|assumption].

--- a/theories/VLSM/Core/Equivocators/Composition/Projections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/Projections.v
@@ -1839,11 +1839,9 @@ Proof.
   { revert Htr_to. apply VLSM_incl_finite_valid_trace_init_to.
     apply seeded_no_equivocation_incl_preloaded.
   }
-  apply pre_equivocators_valid_trace_project
-    with (final_descriptors0 := final_descriptors)
-    in Hpre_tr_to
-  ; [|typeclasses eauto|assumption].
-  destruct Hpre_tr_to as [initial_descriptors [Hproper_initial [trX [Hpr_trX Hpre_trX]]]].
+  pose proof (pre_equivocators_valid_trace_project _ _ _ _
+    Hpre_tr_to final_descriptors Hproper) as Hex.
+  destruct Hex as [initial_descriptors [Hproper_initial [trX [Hpr_trX Hpre_trX]]]].
   exists trX, initial_descriptors.
   split; [assumption|]. split; [assumption|].
   apply finite_valid_trace_init_to_last in Hpre_trX as Hfinal_stateX.
@@ -1915,10 +1913,8 @@ Proof.
     { revert Htr_to. apply VLSM_incl_finite_valid_trace_init_to.
       apply seeded_no_equivocation_incl_preloaded.
     }
-    apply pre_equivocators_valid_trace_project
-      with (final_descriptors0 := final_descriptors')
-      in Hpre_tr_to as Hpr_tr'
-    ; [|typeclasses eauto|assumption].
+    pose proof (pre_equivocators_valid_trace_project sub_IM _ _ _
+     Hpre_tr_to final_descriptors' Hproper') as Hpr_tr'.
     destruct Hpr_tr' as [_initial_descriptors [_ [_trX' [_Hpr_trX' Heq_final_stateX']]]].
     replace (equivocators_trace_project _ _ _) with (Some (trX', initial_descriptors))
       in _Hpr_trX'.
@@ -1951,12 +1947,8 @@ Proof.
     assert (Hfinal_descriptors_m_proper : proper_equivocator_descriptors sub_IM final_descriptors_m (finite_trace_last is tr'))
       by (apply not_equivocating_equivocator_descriptors_proper; assumption).
     specialize (H final_descriptors_m Hfinal_descriptors_m_proper).
-
-    apply pre_equivocators_valid_trace_project
-      with (final_descriptors0 := final_descriptors_m)
-      in Hpre_tr_to as Hpr_tr'
-    ; [|typeclasses eauto|assumption].
-
+    pose proof (pre_equivocators_valid_trace_project _ _ _ _
+     Hpre_tr_to final_descriptors_m Hfinal_descriptors_m_proper) as Hpr_tr'.
     destruct Hpr_tr' as [initial_descriptors_m' [Hproper_initial_m [trXm' [Hproject_trXm' HtrXm]]]].
     specialize (H _ _ Hproject_trXm').
     simpl in *. rewrite Hproject_trXm in Hproject_trXm'.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -122,7 +122,7 @@ Proof.
     apply Hreflects with m; [assumption |].
     destruct Hinit as [Hinit | Hp]; [| assumption].
     contradict Hinit; apply no_initial_messages_in_X.
-  - apply (observed_valid (pre_loaded_vlsm X P)) with (s0 := s).
+  - apply (observed_valid (pre_loaded_vlsm X P) s).
     + exists (Some m). apply can_produce_valid; assumption.
     + cut (has_been_observed X s dm).
       {

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1063,7 +1063,7 @@ Proof.
     case_decide as Hi; [| congruence].
     apply Some_inj in Heql; subst l; cbn.
     unfold constrained_composite_valid, lift_sub_state; cbn;
-    rewrite lift_sub_state_to_eq with (Hi0 := Hi); subst.
+    rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi); subst.
     split; [assumption|].
     eapply Hconstraint_consistency; [|eassumption].
     symmetry; apply composite_state_sub_projection_lift_to.
@@ -1457,7 +1457,7 @@ Proof.
   destruct_dec_sig sub_i i Hi Heqsub_i.
   subst.
   cbn. unfold sub_IM at 6. simpl.
-  unfold lift_sub_state at 1. rewrite lift_sub_state_to_eq with (Hi0 := Hi).
+  unfold lift_sub_state at 1. rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi).
   destruct (vtransition _ _ _) as (si', _om').
   split; inversion 1; subst; clear H; f_equal; extensionality sub_j
   ; destruct_dec_sig sub_j j Hj Heqsub_j
@@ -1470,7 +1470,7 @@ Proof.
   ; rewrite (state_update_neq _ (lift_sub_state _ _ _)) by congruence
   ; rewrite state_update_neq by (setoid_rewrite dsig_eq; simpl; congruence)
   ; unfold lift_sub_state
-  ; rewrite lift_sub_state_to_eq with (Hi0 := Hj)
+  ; rewrite (lift_sub_state_to_eq _ _ _ _ _ Hj)
   ; intuition.
 Qed.
 
@@ -1708,7 +1708,7 @@ Lemma valid_preloaded_lifts_can_be_emitted
 Proof.
   intros m Hm.
   eapply VLSM_incl_can_emit.
-  - apply pre_loaded_vlsm_incl_relaxed with (P0 := fun m => Q m \/ P m).
+  - apply (pre_loaded_vlsm_incl_relaxed _ (fun m => Q m \/ P m)).
     intuition.
   - eapply VLSM_full_projection_can_emit; [|eassumption].
     apply preloaded_sub_element_full_projection.
@@ -1815,8 +1815,7 @@ Proof.
   apply projection_induced_vlsm_is_projection.
   - intros lX HlX s om s' om' [_ Ht].
     apply sub_transition_element_project_None with lX om om'; [assumption|].
-    setoid_rewrite <- induced_sub_projection_transition_is_composite
-      with (constraint0 := constraint).
+    setoid_rewrite <- (induced_sub_projection_transition_is_composite _ _ constraint).
     assumption.
   - apply basic_weak_projection_transition_consistency_Some.
     + intro; apply sub_element_label_project.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -1863,9 +1863,9 @@ definitions, mostly reducing them to properties about their finite segments.
       intros s tl1 tl2 Heq Htl1.
       apply infinite_valid_trace_from_prefix_rev.
       intro n.
-      apply stream_prefix_EqSt with (n0 := n) in Heq.
-      apply infinite_valid_trace_from_prefix with (n := n) in Htl1.
-      rewrite <- Heq. assumption.
+      rewrite <- (stream_prefix_EqSt _ _ Heq n).
+      apply infinite_valid_trace_from_prefix.
+      assumption.
     Qed.
 
     Lemma infinite_valid_trace_from_segment

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -615,8 +615,7 @@ Proof.
   unfold VLSM_weak_projection_infinite_trace_project, pre_VLSM_projection_infinite_trace_project.
   replace (stream_prefix _ _) with (VLSM_weak_projection_trace_project Hsimul (stream_prefix trX m)).
   apply VLSM_weak_projection_finite_valid_trace_from.
-
-  apply infinite_valid_trace_from_prefix with (n0 := m) in HtrX.
+  apply infinite_valid_trace_from_prefix.
   assumption.
 Qed.
 
@@ -1645,8 +1644,8 @@ Proof.
       split; [|assumption].
       apply infinite_valid_trace_from_prefix_rev.
       intros.
-      apply infinite_valid_trace_from_prefix with (n0 := n) in HtrX.
-      apply (Hincl _ _ (conj HtrX HisX)).
+      pose proof (infinite_valid_trace_from_prefix _ _ _ HtrX n) as HfinX.
+      apply (Hincl _ _ (conj HfinX HisX)).
 Qed.
 
 (** A [VLSM_incl]usion is equivalent to a [VLSM_full_projection] in which both the

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -307,7 +307,7 @@ Proof.
     apply (VLSM_projection_finite_valid_trace (preloaded_component_projection IM i)).
     revert HtrX.
     apply VLSM_incl_finite_valid_trace.
-    apply constraint_preloaded_free_incl with (constraint0 := constraint).
+    apply (constraint_preloaded_free_incl _ constraint).
 Qed.
 
 Lemma component_projection_validator_prop_is_induced

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -60,7 +60,7 @@ Section general.
     (X Y : C) :
     size (X ∩ Y) <= size X.
   Proof.
-    apply subseteq_size with (X0 := X ∩ Y) (Y0 := X).
+    apply (subseteq_size (X ∩ Y) X).
     set_solver.
   Qed.
 
@@ -68,7 +68,7 @@ Section general.
     (X Y : C) :
     size (X ∩ Y) <= size Y.
   Proof.
-    apply subseteq_size with (X0 := X ∩ Y) (Y0 := Y).
+    apply (subseteq_size (X ∩ Y) Y).
     set_solver.
   Qed.
 

--- a/theories/VLSM/Lib/SortedLists.v
+++ b/theories/VLSM/Lib/SortedLists.v
@@ -358,7 +358,7 @@ Lemma lsorted_pairwise_ordered
   (Hconcat : l = alfa ++ [x] ++ beta ++ [y] ++ gamma) :
   R x y.
 Proof.
-  apply lsorted_app with (R0 := R) (alfa0 := alfa) in Hconcat.
+  apply (lsorted_app _ _ Hsorted _ alfa) in Hconcat.
   destruct Hconcat as [_ Hneed].
   simpl in Hneed.
   rewrite <- Sorted_LocallySorted_iff in Hneed.
@@ -368,8 +368,6 @@ Proof.
   spec Hneed.
   apply elem_of_app.
   right; left.
-  assumption.
-  assumption.
   assumption.
   assumption.
 Qed.

--- a/theories/VLSM/dune
+++ b/theories/VLSM/dune
@@ -1,6 +1,7 @@
 (coq.theory
  (name VLSM)
  (package coq-vlsm)
- (synopsis "Core definitions in Coq for VLSMs"))
+ (synopsis "Core definitions in Coq for VLSMs")
+ (flags :standard -w -deprecated-instance-without-locality))
 
 (include_subdirs qualified)


### PR DESCRIPTION
Coq 8.15 did some fixes to the argument naming mechanism. Here, I add some minimal changes **inside proofs** to be compatible with all of Coq 8.13, 8.14, and 8.15. Hopefully, this pays off some technical debt beforehand.