### PR TITLE
fix nat lemma deprecations using the Nat.result form

### DIFF
--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -1,8 +1,9 @@
 From stdpp Require Import prelude.
 From Coq Require Import FinFun Rdefinitions FunctionalExtensionality.
-From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet Lib.ListSetExtras Lib.Measurable.
-From VLSM Require Import Core.VLSM VLSMProjections Core.Composition Core.ProjectionTraces Core.SubProjectionTraces Core.MessageDependencies.
-From VLSM Require Import Core.Equivocation Core.Equivocation.NoEquivocation Core.Equivocation.FixedSetEquivocation Core.Equivocation.TraceWiseEquivocation.
+From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras Measurable.
+From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.
+From VLSM.Core Require Import SubProjectionTraces MessageDependencies Equivocation.
+From VLSM.Core Require Import NoEquivocation FixedSetEquivocation TraceWiseEquivocation.
 
 (** * Witnessed equivocation
 
@@ -541,7 +542,7 @@ Proof.
       end.
       specialize (NoDup_subseteq_length (equivocating_validators_nodup s) (proj1 Heq))
         as Hlen2.
-      spec IHn ; [subst s m; apply le_antisym; assumption|].
+      spec IHn ; [subst s m; apply Nat.le_antisymm; assumption|].
       specialize (IHn eq_refl).
       destruct Htr'_item as [Htr'_item Hinit].
       apply finite_valid_trace_from_to_app_split in Htr'_item.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -2210,8 +2210,7 @@ This relation is often used in stating safety and liveness properties.*)
         rewrite finite_trace_nth_last.
         congruence.
       - rewrite finite_trace_nth_app2;[|lia].
-        rewrite Minus.minus_plus.
-        rewrite finite_trace_nth_last.
+        rewrite Nat.add_comm, Nat.add_sub, finite_trace_nth_last.
         congruence.
     Qed.
 

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -1681,7 +1681,7 @@ Proof.
   - simpl in nz. lia.
   - simpl in *.
     destruct (a <=? (list_max l)) eqn : eq_leb.
-    + assert (Init.Nat.max a (list_max l) = list_max l). {
+    + assert (Nat.max a (list_max l) = list_max l). {
          apply max_r.
          apply Nat.leb_le.
          assumption.
@@ -1690,7 +1690,7 @@ Proof.
       right.
       apply IHl.
       assumption.
-    + assert (Init.Nat.max a (list_max l) = a). {
+    + assert (Nat.max a (list_max l) = a). {
         apply leb_iff_conv in eq_leb.
         apply max_l.
         lia.
@@ -1709,7 +1709,7 @@ Proof.
   - destruct l;[intuition congruence|].
     specialize (list_max_le (n :: l) 0) as Hle.
     destruct Hle as [Hle _].
-    rewrite eq_max in Hle. spec Hle. apply le_refl.
+    rewrite eq_max in Hle. spec Hle. apply Nat.le_refl.
     rewrite Forall_forall in Hle.
     specialize (Hle n). spec Hle; [left |].
     simpl. lia.
@@ -1750,7 +1750,7 @@ Proof.
   - destruct l;[intuition congruence|].
     specialize (list_max_le (n :: l) 0) as Hle.
     destruct Hle as [Hle _].
-    rewrite eq_max in Hle. spec Hle. apply le_refl.
+    rewrite eq_max in Hle. spec Hle. apply Nat.le_refl.
     rewrite Forall_forall in Hle.
     specialize (Hle n). spec Hle. left.
     assert (Hn0: n = 0) by lia.

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -1,5 +1,5 @@
 From stdpp Require Import prelude.
-From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppExtras Lib.StdppListSet.
+From VLSM.Lib Require Import Preamble ListExtras StdppExtras StdppListSet.
 
 (** * List set utility definitions and lemmas *)
 
@@ -754,7 +754,7 @@ Proof.
     rewrite 2 filter_cons.
     destruct (decide (~ a0 ∈ a)); destruct (decide (~ a0 ∈ b)).
     + simpl.
-      apply lt_n_S.
+      rewrite <- Nat.succ_lt_mono.
       apply IHl.
     + contradict n.
       apply H_subseteq.
@@ -762,7 +762,7 @@ Proof.
       contradict n0.
       assumption.
     + simpl.
-      apply lt_S.
+      apply Nat.lt_lt_succ_r.
       apply IHl.
     + apply IHl.
 Qed.

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -559,7 +559,7 @@ Proof.
     rewrite Hs in Heq.
     rewrite Heq.
     rewrite stream_prefix_nth.
-    + rewrite Plus.plus_comm; reflexivity.
+    + rewrite Nat.add_comm; reflexivity.
     + lia.
     + lia.
 Qed.

--- a/theories/VLSM/Lib/StreamFilters.v
+++ b/theories/VLSM/Lib/StreamFilters.v
@@ -162,8 +162,8 @@ Proof.
   specialize (filtering_subsequence_witness _ _ _ Hfs m) as Hm.
   rewrite decide_True in Hfilter by assumption.
   rewrite decide_True by assumption.
-  rewrite app_length, Plus.plus_comm in Hfilter. simpl in Hfilter.
-  rewrite app_length, Plus.plus_comm. simpl.
+  rewrite app_length, Nat.add_comm in Hfilter. simpl in Hfilter.
+  rewrite app_length, Nat.add_comm. simpl.
   rewrite Hfilter.
   f_equal.
   clear -Hfs.
@@ -188,12 +188,11 @@ Lemma filtering_subsequence_prefix_is_filter_last
 Proof.
   specialize (filtering_subsequence_witness_rev _ _ _ Hfs _ Hn) as [k Heqn].
   replace (length _) with k; [subst; reflexivity|].
-
   specialize (filtering_subsequence_prefix_length _ _ _ Hfs k) as Hlength.
   rewrite! stream_prefix_S, filter_app in Hlength.
   unfold filter at 2 in Hlength. simpl in Hlength.
   rewrite decide_True in Hlength by (subst; assumption).
-  rewrite app_length, Plus.plus_comm in Hlength. simpl in Hlength.
+  rewrite app_length, Nat.add_comm in Hlength. simpl in Hlength.
   inversion Hlength. subst. reflexivity.
 Qed.
 
@@ -236,7 +235,7 @@ Proof.
   rewrite filter_annotate_unroll in Heqlst. simpl in Heqlst.
   case_decide; subst lst; simpl.
   2: {
-    rewrite Plus.plus_comm, app_nil_r. simpl. assumption.
+    rewrite Nat.add_comm, app_nil_r. simpl. assumption.
   }
   replace (length (list_filter_map P f (stream_prefix s n)) + 1)
     with (S (length (list_filter_map P f (stream_prefix s n))))
@@ -249,7 +248,6 @@ Proof.
   f_equal. apply dsig_eq.
   simpl. rewrite nat_sequence_nth.
   f_equal.
-
   unfold list_filter_map.
   rewrite map_length. rewrite filter_annotate_length.
   apply filtering_subsequence_prefix_is_filter_last; assumption.
@@ -407,7 +405,7 @@ Proof.
     as [k [Heq [Hp Hnp]]].
   subst sn fpair.
   rewrite Heq.
-  clear -Hp Hnp. rewrite Str_nth_plus, Plus.plus_comm in Hp.
+  clear -Hp Hnp. rewrite Str_nth_plus, Nat.add_comm in Hp.
   split; [assumption|].
   intros i [Hlt_i Hilt].
   apply le_plus_dec in Hlt_i as [i' Hi].


### PR DESCRIPTION
The Coq standard library maintainers have decided that going forward, nearly everything related to `nat`s should be accessed via the `Nat.result` shape. Here, I proactively apply this to the project.

@traiansf @wkolowski @bmmoore maybe useful to see as an illustration of best practices when `lia` doesn't work by itself.