### PR TITLE
Fix typo in docs

### DIFF
--- a/theories/VLSM/Core/Equivocators/Common.v
+++ b/theories/VLSM/Core/Equivocators/Common.v
@@ -22,7 +22,7 @@ Section sec_equivocator_vlsm.
 
 (** The state of such a machine will be abstracted using
 
-1. A [nat]ural <<n>>, stating the number of copies of the original machine
+1. A natural <<n>>, stating the number of copies of the original machine
 2. A state of <<X>> for each 1..n+1
 *)
 Local Definition bounded_state_copies := {n : nat & Fin.t (S n) -> vstate X}.


### PR DESCRIPTION
This is a part of fixing typos and bad phrasing in the VLSM paper.