### PR TITLE
Validating for free composition from message dependencies

### DIFF
--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -688,7 +688,7 @@ Lemma [basic_VLSM_incl]
     Qed.
 
     (**
-    If all messages desribed by a predicate <<P>> are valid for the free
+    If all messages described by a predicate <<P>> are valid for the free
     composition pre-loaded with messages described by a predicate <<Q>>, then
     any message which can be emitted by a component pre-loaded with <<P>> can
     also be emitted by the free composition pre-loaded with <<Q>>.
@@ -710,7 +710,7 @@ Lemma [basic_VLSM_incl]
 
     (**
     As a specialization of [valid_preloaded_lifts_can_be_emitted], if all
-    messages desribed by a predicate <<P>> are valid for the free composition,
+    messages described by a predicate <<P>> are valid for the free composition,
     then any message which can be emitted by a component pre-loaded with <<P>>
     can also be emitted by the free composition.
     *)

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -687,6 +687,48 @@ Lemma [basic_VLSM_incl]
       - intro; intros. apply lift_to_composite_state_initial. assumption.
     Qed.
 
+    (** If all messages desribed by a predicate <<P>> are valid for the free
+    composition pre-loaded with messages described by a predicate <<Q>>, then
+    any message which can be emitted by a component pre-loaded with <<P>> can
+    also be emitted by the free composition pre-loaded with <<Q>>.
+    *)
+    Lemma valid_preloaded_lifts_can_be_emitted
+      (P Q : message -> Prop)
+      (HPvalid : forall dm, P dm -> valid_message_prop (pre_loaded_vlsm free_composite_vlsm Q) dm)
+      : forall j m, can_emit (pre_loaded_vlsm (IM j) P) m ->
+        can_emit (pre_loaded_vlsm free_composite_vlsm Q) m.
+    Proof.
+      intros j m Hm.
+      eapply VLSM_incl_can_emit.
+      - apply (pre_loaded_vlsm_incl_relaxed _ (fun m => Q m \/ P m)).
+        intuition.
+      - eapply VLSM_full_projection_can_emit; [|eassumption].
+        apply lift_to_composite_generalized_preloaded_vlsm_full_projection.
+        intuition.
+    Qed.
+
+    (** As a specialization of [valid_preloaded_lifts_can_be_emitted], if all
+    messages desribed by a predicate <<P>> are valid for the free composition,
+    then any message which can be emitted by a component pre-loaded with <<P>>
+    can also be emitted by the free composition.
+    *)
+    Lemma free_valid_preloaded_lifts_can_be_emitted
+      (P : message -> Prop)
+      (Hdeps : forall dm, P dm -> valid_message_prop free_composite_vlsm dm)
+      : forall i m, can_emit (pre_loaded_vlsm (IM i) P) m ->
+        can_emit free_composite_vlsm m.
+    Proof.
+      intros.
+      eapply VLSM_incl_can_emit.
+      - eapply VLSM_eq_proj2, (vlsm_is_pre_loaded_with_False free_composite_vlsm).
+      - eapply valid_preloaded_lifts_can_be_emitted; [|eassumption].
+        intros dm Hdm.
+        eapply VLSM_incl_valid_message.
+        + apply VLSM_eq_proj1, (vlsm_is_pre_loaded_with_False free_composite_vlsm).
+        + cbv; intuition.
+        + apply Hdeps; assumption.
+    Qed.
+
     Lemma valid_state_preloaded_composite_free_lift
       (j : index)
       (sj : vstate (IM j))

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -702,7 +702,7 @@ Lemma [basic_VLSM_incl]
       eapply VLSM_incl_can_emit.
       - apply (pre_loaded_vlsm_incl_relaxed _ (fun m => Q m \/ P m)).
         intuition.
-      - eapply VLSM_full_projection_can_emit; [|eassumption].
+      - eapply VLSM_full_projection_can_emit; [| eassumption].
         apply lift_to_composite_generalized_preloaded_vlsm_full_projection.
         intuition.
     Qed.
@@ -721,7 +721,7 @@ Lemma [basic_VLSM_incl]
       intros.
       eapply VLSM_incl_can_emit.
       - eapply VLSM_eq_proj2, (vlsm_is_pre_loaded_with_False free_composite_vlsm).
-      - eapply valid_preloaded_lifts_can_be_emitted; [|eassumption].
+      - eapply valid_preloaded_lifts_can_be_emitted; [| eassumption].
         intros dm Hdm.
         eapply VLSM_incl_valid_message.
         + apply VLSM_eq_proj1, (vlsm_is_pre_loaded_with_False free_composite_vlsm).

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -687,7 +687,8 @@ Lemma [basic_VLSM_incl]
       - intro; intros. apply lift_to_composite_state_initial. assumption.
     Qed.
 
-    (** If all messages desribed by a predicate <<P>> are valid for the free
+    (**
+    If all messages desribed by a predicate <<P>> are valid for the free
     composition pre-loaded with messages described by a predicate <<Q>>, then
     any message which can be emitted by a component pre-loaded with <<P>> can
     also be emitted by the free composition pre-loaded with <<Q>>.
@@ -707,7 +708,8 @@ Lemma [basic_VLSM_incl]
         intuition.
     Qed.
 
-    (** As a specialization of [valid_preloaded_lifts_can_be_emitted], if all
+    (**
+    As a specialization of [valid_preloaded_lifts_can_be_emitted], if all
     messages desribed by a predicate <<P>> are valid for the free composition,
     then any message which can be emitted by a component pre-loaded with <<P>>
     can also be emitted by the free composition.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -46,7 +46,7 @@ Lemma messages_with_valid_dependences_can_be_emitted s dm
   (Hemitted: can_emit (pre_loaded_with_all_messages_vlsm (IM dm_i)) dm)
   : can_emit (equivocators_composition_for_sent IM equivocators s) dm.
 Proof.
-  eapply valid_preloaded_lifts_can_be_emitted, message_dependencies_are_sufficient
+  eapply sub_valid_preloaded_lifts_can_be_emitted, message_dependencies_are_sufficient
   ; intuition eauto.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -408,7 +408,7 @@ Proof.
                       IM full_message_dependencies sender (original_state s) im)).
   - specialize (equivocating_messages_are_equivocator_emitted _ _ HLemit Hnobserved)
             as (j & Heqv_j & Hemitj).
-    eapply valid_preloaded_lifts_can_be_emitted
+    eapply sub_valid_preloaded_lifts_can_be_emitted
     ; [eassumption | | eassumption]; cbn; intros dm H_dm.
     assert (Hdm : msg_dep_happens_before message_dependencies dm im)
         by (apply msg_dep_happens_before_iff_one; left; assumption).
@@ -421,7 +421,7 @@ Proof.
                   _ _ HLemit Hnobserved _ Hdm)
             as [Hobs_dm | (dm_i & Hdm_i & Hemit_dm)]
     ; [left; right; assumption | right].
-    eapply valid_preloaded_lifts_can_be_emitted
+    eapply sub_valid_preloaded_lifts_can_be_emitted
     ; [eassumption | |]; cycle 1.
     + eapply message_dependencies_are_sufficient; [typeclasses eauto | assumption].
     + intros dm' Hdm'; apply Hind.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1700,7 +1700,7 @@ Proof.
     reflexivity.
 Qed.
 
-Lemma valid_preloaded_lifts_can_be_emitted
+Lemma sub_valid_preloaded_lifts_can_be_emitted
   (P Q : message -> Prop)
   (HPvalid : forall dm, P dm -> valid_message_prop (pre_loaded_vlsm (free_composite_vlsm (sub_IM IM indices)) Q) dm)
   : forall m, can_emit (pre_loaded_vlsm (IM j) P) m ->

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -176,15 +176,6 @@ In Coq, we can define these objects (which we name [transition_item]s) as consis
       : Prop
       := forall m, trace_received_not_sent_before_or_after tr m -> P m.
 
-  (** [proto_run] is used for an alternative definition of [valid_state_message_prop], which
-  takes into account transitions. See 'vlsm_run_prop'.
-  *)
-  Record proto_run : Type := mk_proto_run
-    { start : state
-      ; transitions : list transition_item
-      ; final : state * option message
-    }.
-
   Inductive Trace : Type :=
   | Finite : state -> list transition_item -> Trace
   | Infinite : state -> Stream transition_item -> Trace.
@@ -428,7 +419,6 @@ or [VLSMType]. Functions [machine] and [type] below achieve this precise purpose
   Definition vvalid := @valid _ _ machine.
   Definition vtransition_item := @transition_item _ type.
   Definition vTrace := @Trace _ type.
-  Definition vproto_run := @proto_run _ type.
 
 End vlsm_projections.
 

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -365,6 +365,15 @@ Definition pre_loaded_with_all_messages_validator_component_proj_incl
 
 End component_projection_validator.
 
+(** ** Basic validation condition for free composition
+
+In this section we show (Lemma [valid_free_validating_is_message_validating])
+that, under [FullMessageDependencies] assumptions, if the validity predicate
+ensures that message itself and all of its dependencies can be emitted using
+only its dependencies, then the input message is valid for the free composition,
+thus the node itself is a validator for the free composition.
+*)
+
 Section free_composition_validators.
 
 Context
@@ -422,7 +431,7 @@ Definition valid_all_dependencies_emittable_from_dependencies_prop
 (**
 If a message can be emitted by a node preloaded with the message's direct
 dependencies, and if all the dependencies of the message are valid for the
-free composition, the the message itself is valid for the free composition.
+free composition, then the message itself is valid for the free composition.
 *)
 Lemma free_valid_from_valid_dependencies
   m i
@@ -459,7 +468,7 @@ Proof.
 Qed.
 
 (**
-If a node in a composition satisfied the
+If a node in a composition satisfies the
 [valid_all_dependencies_emittable_from_dependencies_prop]erty, then it also has
 the [component_message_validator_prop]erty, that is, it is a validator for the
 free composition.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -383,7 +383,7 @@ Context
 component corresponding to its sender pre-loaded with the dependencies of the
 message.
 *)
-Definition emitable_from_dependencies_prop (m : message) : Prop :=
+Definition emittable_from_dependencies_prop (m : message) : Prop :=
   match sender m with
   | None => False
   | Some v => can_emit (pre_loaded_vlsm (IM (A v)) (fun dm => dm ∈ message_dependencies m)) m
@@ -392,16 +392,16 @@ Definition emitable_from_dependencies_prop (m : message) : Prop :=
 (** The property of a message that both itself and all of its dependencies are
 emitable from their dependencies.
 *)
-Definition all_dependencies_emitable_from_dependencies_prop (m : message) : Prop :=
-  forall dm, dm ∈ m :: full_message_dependencies m  -> emitable_from_dependencies_prop dm.
+Definition all_dependencies_emittable_from_dependencies_prop (m : message) : Prop :=
+  forall dm, dm ∈ m :: full_message_dependencies m -> emittable_from_dependencies_prop dm.
 
 (** The property of requiring that the validity predicate subsumes the
-[all_dependencies_emitable_from_dependencies_prop]erty.
+[all_dependencies_emittable_from_dependencies_prop]erty.
 *)
-Definition valid_all_dependencies_emitable_from_dependencies_prop
-  (i : index)
-  := forall l s m, input_valid (pre_loaded_with_all_messages_vlsm (IM i)) l (s, Some m) ->
-    all_dependencies_emitable_from_dependencies_prop m.
+Definition valid_all_dependencies_emittable_from_dependencies_prop
+  (i : index) : Prop :=
+    forall l s m, input_valid (pre_loaded_with_all_messages_vlsm (IM i)) l (s, Some m) ->
+      all_dependencies_emittable_from_dependencies_prop m.
 
 (** If a message can be emitted by a node preloaded with the message's direct
 dependencies, and if all the dependencies of the message are valid for the
@@ -416,35 +416,37 @@ Lemma free_valid_from_valid_dependencies
   : valid_message_prop (free_composite_vlsm IM) m.
 Proof.
   eapply emitted_messages_are_valid, free_valid_preloaded_lifts_can_be_emitted;
-    [|eassumption].
+    [| eassumption].
   intros; apply Hdeps, full_message_dependencies_happens_before, msg_dep_happens_before_iff_one;
     left ; assumption.
 Qed.
 
-(** Any message with the [all_dependencies_emitable_from_dependencies_prop]erty
+(** Any message with the [all_dependencies_emittable_from_dependencies_prop]erty
 is valid for the free composition.
 *)
-Lemma free_valid_from_all_dependencies_emitable_from_dependencies
-  : forall m, all_dependencies_emitable_from_dependencies_prop m -> valid_message_prop (free_composite_vlsm IM) m.
+Lemma free_valid_from_all_dependencies_emitable_from_dependencies :
+  forall m,
+    all_dependencies_emittable_from_dependencies_prop m ->
+      valid_message_prop (free_composite_vlsm IM) m.
 Proof.
   intros m Hm.
-  specialize (Hm m) as Hemit; spec Hemit; [left|].
-  unfold emitable_from_dependencies_prop in Hemit; destruct (sender m); [|contradiction].
-  apply free_valid_from_valid_dependencies with (A v); [assumption|clear v Hemit].
-  eapply FullMessageDependencies_ind; [eassumption|].
+  specialize (Hm m) as Hemit; spec Hemit; [left |].
+  unfold emittable_from_dependencies_prop in Hemit; destruct (sender m); [| contradiction].
+  apply free_valid_from_valid_dependencies with (A v); [assumption | clear v Hemit].
+  eapply FullMessageDependencies_ind; [eassumption |].
   intros dm Hdm Hdeps.
-  specialize (Hm dm); spec Hm; [right; assumption|].
-  unfold emitable_from_dependencies_prop in Hm; destruct (sender dm); [|contradiction].
+  specialize (Hm dm); spec Hm; [right; assumption |].
+  unfold emittable_from_dependencies_prop in Hm; destruct (sender dm); [| contradiction].
   apply free_valid_from_valid_dependencies with (A v); assumption.
 Qed.
 
 (** If a node in a composition satisfied the
-[valid_all_dependencies_emitable_from_dependencies_prop]erty, then it also has
+[valid_all_dependencies_emittable_from_dependencies_prop]erty, then it also has
 the [component_message_validator_prop]erty, that is, it is a validator for the
 free composition.
 *)
 Lemma valid_free_validating_is_message_validating
-  : forall i, valid_all_dependencies_emitable_from_dependencies_prop i ->
+  : forall i, valid_all_dependencies_emittable_from_dependencies_prop i ->
     component_message_validator_prop IM (free_constraint IM) i.
 Proof.
   intros i Hvalidating l s im Hv.


### PR DESCRIPTION
Based on the discussion on Wednesday, I've shown that one can reduce the validator property for the free composition to showing that all of the (direct or indirect) message dependencies of a message can be emitted (using their corresponding dependencies).

@denisadiaconescu and @wkolowski I've marked you as reviewers because (1) this could be added to the VLSM paper; and (2) this could potentially be used to prove validation for the MO components.

Anyone else feel free to review.