### PR TITLE
Top sort refactorings

### DIFF
--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -176,6 +176,16 @@ Proof. itauto. Qed.
 Example get_maximal_elements2 : get_maximal_elements Nat.le [1; 4; 2; 4] = [].
 Proof. itauto. Qed.
 
+(**
+Returns all elements <<x>> of a set <<S>> such that <<x>> does not compare less
+than any other element in <<S>> w.r.t to a given precedes relation.
+*)
+Definition get_set_maximal_elements
+  `{HfinSetMessage : FinSet A SetA}
+   (precedes: relation A) `{!RelDecision precedes} (s : SetA)
+   : SetA :=
+    filter (fun a => set_Forall (fun b => ~ precedes a b) s) s.
+
 Lemma filter_ext_elem_of {A} P Q
  `{∀ (x:A), Decision (P x)} `{∀ (x:A), Decision (Q x)} (l:list A) :
  (forall a, a ∈ l -> (P a <-> Q a)) ->

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -165,22 +165,22 @@ Qed.
 (* Returns all elements X of l such that X does not compare less
    than any other element w.r.t to the precedes relation *)
 
-Definition get_maximal_elements
+Definition maximal_elements_list
   {A} (precedes: relation A) `{!RelDecision precedes} (l : list A)
   : list A :=
   filter (fun a => Forall (fun b => (~ precedes a b)) l) l.
 
-Example get_maximal_elements1: get_maximal_elements Nat.lt [1; 4; 2; 4] = [4;4].
+Example maximal_elements_list1: maximal_elements_list Nat.lt [1; 4; 2; 4] = [4;4].
 Proof. itauto. Qed.
 
-Example get_maximal_elements2 : get_maximal_elements Nat.le [1; 4; 2; 4] = [].
+Example maximal_elements_list2 : maximal_elements_list Nat.le [1; 4; 2; 4] = [].
 Proof. itauto. Qed.
 
 (**
 Returns all elements <<x>> of a set <<S>> such that <<x>> does not compare less
 than any other element in <<S>> w.r.t to a given precedes relation.
 *)
-Definition get_set_maximal_elements
+Definition maximal_elements_set
   `{HfinSetMessage : FinSet A SetA}
    (precedes: relation A) `{!RelDecision precedes} (s : SetA)
    : SetA :=

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -241,19 +241,25 @@ Qed.
 
 End min_predecessors.
 
-Global Instance precedes_P_transitive `{Transitive A preceeds} (P : A -> Prop) : Transitive (precedes_P preceeds P).
+Global Instance precedes_P_transitive
+  `{Transitive A preceeds} (P : A -> Prop)
+  : Transitive (precedes_P preceeds P).
 Proof.
   intros [x Hx] [y Hy] [z Hz]; unfold precedes_P; cbn.
   by etransitivity.
 Qed.
 
-Global Instance precedes_P_irreflexive `{Irreflexive A preceeds} (P : A -> Prop) : Irreflexive (precedes_P preceeds P).
+Global Instance precedes_P_irreflexive
+  `{Irreflexive A preceeds} (P : A -> Prop)
+  : Irreflexive (precedes_P preceeds P).
 Proof.
   intros [x Hx]; unfold precedes_P, complement; cbn.
   by apply irreflexivity.
 Qed.
 
-Global Instance precedes_P_strict `{StrictOrder A preceeds} (P : A -> Prop) : StrictOrder (precedes_P preceeds P).
+Global Instance precedes_P_strict
+  `{StrictOrder A preceeds} (P : A -> Prop)
+  : StrictOrder (precedes_P preceeds P).
 Proof.
   split; typeclasses eauto.
 Qed.

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -245,7 +245,7 @@ Global Instance precedes_P_transitive
   `{Transitive A preceeds} (P : A -> Prop)
   : Transitive (precedes_P preceeds P).
 Proof.
-  intros [x Hx] [y Hy] [z Hz]; unfold precedes_P; cbn.
+  intros [x Hx] [y Hy] [z Hz]; unfold precedes_P.
   by etransitivity.
 Qed.
 


### PR DESCRIPTION
I've added some corollaries to top-sort to allow a simpler usages in places like `Inspector.v`