### PR TITLE
weak full projections from component to free composition

### DIFF
--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -215,7 +215,7 @@ Definition annotated_composite_label_lift : vlabel (IM i) -> vlabel AnnotatedFre
 Definition annotated_composite_state_lift : vstate (IM i) -> vstate AnnotatedFree
   := fun si =>
      @Build_annotated_state _ (free_composite_vlsm IM) _
-      (lift_to_composite_initial_state IM i si) (` inhabitant).
+      (lift_to_composite_state' IM i si) (` inhabitant).
 
 Definition annotated_projection_validator_prop_alt : Prop :=
   @projection_validator_prop_alt _ AnnotatedFree (IM i)
@@ -293,7 +293,7 @@ Lemma annotated_composite_induced_projection_initial_lift
     annotated_composite_state_lift.
 Proof.
   split; cbn.
-  - by apply lift_to_composite_initial_state_preservation.
+  - by apply composite_initial_state_prop_lift.
   - by destruct inhabitant.
 Qed.
 

--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -215,7 +215,7 @@ Definition annotated_composite_label_lift : vlabel (IM i) -> vlabel AnnotatedFre
 Definition annotated_composite_state_lift : vstate (IM i) -> vstate AnnotatedFree
   := fun si =>
      @Build_annotated_state _ (free_composite_vlsm IM) _
-      (lift_to_composite_state IM i si) (` inhabitant).
+      (lift_to_composite_initial_state IM i si) (` inhabitant).
 
 Definition annotated_projection_validator_prop_alt : Prop :=
   @projection_validator_prop_alt _ AnnotatedFree (IM i)
@@ -293,7 +293,7 @@ Lemma annotated_composite_induced_projection_initial_lift
     annotated_composite_state_lift.
 Proof.
   split; cbn.
-  - by apply lift_to_composite_state_initial.
+  - by apply lift_to_composite_initial_state_preservation.
   - by destruct inhabitant.
 Qed.
 

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -255,7 +255,7 @@ by simply setting to <<s>> the  corresponding component of the initial
     Definition lifted_alt_state
         (s : vstate M)
         : vstate Alt
-        := lift_to_composite_state
+        := lift_to_composite_initial_state
              (binary_IM M emit_any_message_vlsm) first s.
 
 (**
@@ -281,7 +281,7 @@ Lifting a [valid_state] of <<PreLoaded>> we obtain a [valid_state] of <<Alt>>.
           by split; [cbn; apply Ht|].
         * simpl.
           replace (lifted_alt_state s first) with s
-            by (unfold lifted_alt_state,lift_to_composite_state
+            by (unfold lifted_alt_state,lift_to_composite_initial_state
                ;rewrite state_update_eq; done).
           apply proj2 in Ht.
           change (vtransition M l (s: vstate M,om0) = (s',om')) in Ht.

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -255,7 +255,7 @@ by simply setting to <<s>> the  corresponding component of the initial
     Definition lifted_alt_state
         (s : vstate M)
         : vstate Alt
-        := lift_to_composite_initial_state
+        := lift_to_composite_state'
              (binary_IM M emit_any_message_vlsm) first s.
 
 (**
@@ -281,8 +281,8 @@ Lifting a [valid_state] of <<PreLoaded>> we obtain a [valid_state] of <<Alt>>.
           by split; [cbn; apply Ht|].
         * simpl.
           replace (lifted_alt_state s first) with s
-            by (unfold lifted_alt_state,lift_to_composite_initial_state
-               ;rewrite state_update_eq; done).
+            by (unfold lifted_alt_state,lift_to_composite_state'
+               ; rewrite state_update_eq; done).
           apply proj2 in Ht.
           change (vtransition M l (s: vstate M,om0) = (s',om')) in Ht.
           rewrite Ht.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -774,10 +774,9 @@ Lemma [basic_VLSM_incl]
     Proof.
       induction Hs using valid_state_prop_ind.
       - by apply initial_state_is_valid, composite_update_initial_state_with_initial.
-      - destruct Ht as [[Hps [Hom Hv]] Ht]; unfold transition in Ht; cbn in Ht.
-        destruct Hv as [Hv _]; cbn in Hv.
-        destruct l as (j, lj).
-        destruct (vtransition _ _ _) as (sj', omj') eqn:Htj.
+      - destruct Ht as [[Hps [Hom [Hv _]]] Ht]; cbn in Ht, Hv.
+        destruct l as [j lj].
+        destruct (vtransition _ _ _) as [sj' omj'] eqn: Htj.
         inversion_clear Ht.
         destruct (decide (i = j)).
         + by subst; rewrite state_update_twice.
@@ -792,9 +791,7 @@ Lemma [basic_VLSM_incl]
       forall l s om, vvalid (IM i) l (s, om) ->
         composite_valid (lift_to_composite_label i l)
           (lift_to_composite_state' cs i s, om).
-    Proof.
-      by intros; unfold lift_to_composite_state'; cbn; rewrite state_update_eq.
-    Qed.
+    Proof. by intros; cbn; rewrite state_update_eq. Qed.
 
     Lemma lift_to_composite_transition_preservation :
       forall (i : index) (cs : composite_state),
@@ -813,7 +810,7 @@ Lemma [basic_VLSM_incl]
       forall (i : index),
           forall m, vinitial_message_prop (IM i) m ->
           composite_initial_message_prop m.
-    Proof.  by intros i m Hm; exists i, (exist _ _ Hm).  Qed.
+    Proof. by intros i m Hm; exists i, (exist _ _ Hm). Qed.
  
     Lemma pre_lift_to_free_weak_full_projection :
       forall (i : index) (cs : composite_state) (P : message -> Prop),
@@ -822,14 +819,14 @@ Lemma [basic_VLSM_incl]
             (pre_loaded_vlsm (IM i) P) (pre_loaded_vlsm free_composite_vlsm P)
             (lift_to_composite_label i) (lift_to_composite_state' cs i).
     Proof.
-      intros.
+      intros i cs P Hvsp.
       apply basic_VLSM_weak_full_projection.
       - intros l s om (_ & _ & Hv) _ _.
         by split; [apply lift_to_composite_valid_preservation |].
-      - by intros * ? * [_ Ht]; apply lift_to_composite_transition_preservation.
+      - by inversion 1; apply lift_to_composite_transition_preservation.
       - by intros s Hs; apply pre_composite_free_update_state_with_initial.
       - intros _ _ m _ _ [Hm | Hp]; apply initial_message_is_valid; [left | by right].
-        + by eapply lift_to_composite_initial_message_preservation.
+        by eapply lift_to_composite_initial_message_preservation.
     Qed.
 
     Lemma lift_to_free_weak_full_projection :
@@ -840,7 +837,7 @@ Lemma [basic_VLSM_incl]
     Proof.
       constructor; intros.
       apply (VLSM_eq_finite_valid_trace_from (vlsm_is_pre_loaded_with_False free_composite_vlsm)),
-        pre_lift_to_free_weak_full_projection.
+            pre_lift_to_free_weak_full_projection.
       - by apply (VLSM_eq_valid_state (vlsm_is_pre_loaded_with_False free_composite_vlsm)).
       - apply (VLSM_eq_finite_valid_trace_from (vlsm_is_pre_loaded_with_False (IM i))).
         by destruct (IM i).
@@ -855,7 +852,7 @@ Lemma [basic_VLSM_incl]
     Proof.
       constructor; intros.
       apply (VLSM_eq_finite_valid_trace_from (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True free_composite_vlsm)),
-        pre_lift_to_free_weak_full_projection.
+            pre_lift_to_free_weak_full_projection.
       - by apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True free_composite_vlsm)).
       - apply (VLSM_eq_finite_valid_trace_from (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True (IM i))).
         by destruct (IM i).

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -2424,7 +2424,7 @@ End Composite.
     : has_been_observed (IM i) (s i) m -> composite_has_been_observed IM s m.
   Proof. by exists i. Qed.
 
-  Lemma lift_to_composite_initial_state_observed
+  Lemma composite_has_been_observed_lift
     {message}
     `{finite.Finite index}
     (IM : index -> VLSM message)
@@ -2434,11 +2434,11 @@ End Composite.
     (s : vstate (IM i))
     (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) s)
     (m : message)
-    : composite_has_been_observed IM (lift_to_composite_initial_state IM i s) m <-> has_been_observed (IM i) s m.
+    : composite_has_been_observed IM (lift_to_composite_state' IM i s) m <-> has_been_observed (IM i) s m.
   Proof.
     pose (free_composite_vlsm IM) as Free.
     assert
-      (Hlift_s : valid_state_prop (pre_loaded_with_all_messages_vlsm Free) (lift_to_composite_initial_state IM i s)).
+      (Hlift_s : valid_state_prop (pre_loaded_with_all_messages_vlsm Free) (lift_to_composite_state' IM i s)).
     { revert Hs.  apply valid_state_preloaded_composite_free_lift. }
     split; intros Hobs.
     - apply (proper_observed (IM i)); [done |].
@@ -2465,7 +2465,7 @@ End Composite.
       apply Exists_exists.
       apply Exists_exists in Hobs.
       destruct Hobs as [item [Hitem Hx]].
-      exists (lift_transition_item_to_composite_initial_state IM i item).
+      exists (lift_to_composite_transition_item' IM i item).
       split; [| by destruct item].
       apply elem_of_list_In.
       apply in_map_iff. exists item.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -2424,7 +2424,7 @@ End Composite.
     : has_been_observed (IM i) (s i) m -> composite_has_been_observed IM s m.
   Proof. by exists i. Qed.
 
-  Lemma lift_to_composite_state_observed
+  Lemma lift_to_composite_initial_state_observed
     {message}
     `{finite.Finite index}
     (IM : index -> VLSM message)
@@ -2434,11 +2434,11 @@ End Composite.
     (s : vstate (IM i))
     (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) s)
     (m : message)
-    : composite_has_been_observed IM (lift_to_composite_state IM i s) m <-> has_been_observed (IM i) s m.
+    : composite_has_been_observed IM (lift_to_composite_initial_state IM i s) m <-> has_been_observed (IM i) s m.
   Proof.
     pose (free_composite_vlsm IM) as Free.
     assert
-      (Hlift_s : valid_state_prop (pre_loaded_with_all_messages_vlsm Free) (lift_to_composite_state IM i s)).
+      (Hlift_s : valid_state_prop (pre_loaded_with_all_messages_vlsm Free) (lift_to_composite_initial_state IM i s)).
     { revert Hs.  apply valid_state_preloaded_composite_free_lift. }
     split; intros Hobs.
     - apply (proper_observed (IM i)); [done |].
@@ -2465,7 +2465,7 @@ End Composite.
       apply Exists_exists.
       apply Exists_exists in Hobs.
       destruct Hobs as [item [Hitem Hx]].
-      exists (lift_to_composite_transition_item IM i item).
+      exists (lift_transition_item_to_composite_initial_state IM i item).
       split; [| by destruct item].
       apply elem_of_list_In.
       apply in_map_iff. exists item.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -256,7 +256,7 @@ Qed.
 Definition composite_vlsm_induced_projection : VLSM message :=
   projection_induced_vlsm X (type (IM j))
     composite_project_label (fun s => s j)
-    (lift_to_composite_label IM j) (lift_to_composite_state IM j).
+    (lift_to_composite_label IM j) (lift_to_composite_initial_state IM j).
 
 (** The [composite_vlsm_constraint_projection] is [VLSM_eq]ual (trace-equivalent)
 to the [projection_induced_vlsm] by the [composite_project_label] and the
@@ -269,15 +269,15 @@ Proof.
   split.
   - apply basic_VLSM_strong_incl.
     + intros s Hs; cbn in *; red.
-      exists (lift_to_composite_state IM j s).
+      exists (lift_to_composite_initial_state IM j s).
       split; [apply state_update_eq|].
-      by apply (lift_to_composite_state_initial IM).
+      by apply (lift_to_composite_initial_state_preservation IM).
     + by intros m [[im Him] <-].
     + intros l s iom [sX [<- Hv]].
       exists (existT j l), sX.
       by split; [apply composite_project_label_eq|split].
     + intros l s iom s' oom.
-      cbn; unfold lift_to_composite_state at 1; rewrite state_update_eq.
+      cbn; unfold lift_to_composite_initial_state at 1; rewrite state_update_eq.
       intros Ht; setoid_rewrite Ht.
       by rewrite state_update_eq.
   - cbn; apply basic_VLSM_strong_incl.
@@ -289,7 +289,7 @@ Proof.
       case_decide; [| congruence].
       by subst i; apply Some_inj in HlX; cbn in HlX; subst li.
     + intros l s iom s' oom; cbn.
-      unfold lift_to_composite_state at 1;
+      unfold lift_to_composite_initial_state at 1;
       rewrite state_update_eq;
       destruct (vtransition _ _ _) as (si', om').
       by rewrite state_update_eq.
@@ -305,7 +305,7 @@ Qed.
 
 Lemma component_state_projection_lift
   : induced_projection_state_lift_prop X (type (IM j)) (fun s => s j)
-    (lift_to_composite_state IM j).
+    (lift_to_composite_initial_state IM j).
 Proof.
   intros sj.
   apply state_update_eq.
@@ -356,7 +356,7 @@ Lemma induced_component_projection
   : VLSM_projection X
     (projection_induced_vlsm X (type (IM j))
       composite_project_label (fun s => s j)
-      (lift_to_composite_label IM j) (lift_to_composite_state IM j))
+      (lift_to_composite_label IM j) (lift_to_composite_initial_state IM j))
     composite_project_label (fun s => s j).
 Proof.
   apply projection_induced_vlsm_is_projection.
@@ -877,10 +877,10 @@ Lemma projection_friendliness_sufficient_condition_valid_state
   (Hfr : projection_friendliness_sufficient_condition)
   (s : state)
   (Hp : valid_state_prop Xj s)
-  : valid_state_prop X (lift_to_composite_state IM j s).
+  : valid_state_prop X (lift_to_composite_initial_state IM j s).
 Proof.
   induction Hp using valid_state_prop_ind.
-  - by apply initial_state_is_valid, (lift_to_composite_state_initial IM j).
+  - by apply initial_state_is_valid, (lift_to_composite_initial_state_preservation IM j).
   - destruct Ht as [Hvj Ht].
     specialize (Hfr _ _ _ Hvj _ IHHp).
     spec Hfr; [apply state_update_eq|].
@@ -892,7 +892,7 @@ Proof.
     specialize (valid_generated_state_message X _ _ HsX _ _ Hom _ Hfr) as Hgen.
     apply Hgen.
     simpl.
-    unfold lift_to_composite_state at 1.
+    unfold lift_to_composite_initial_state at 1.
     rewrite state_update_eq.
     replace (vtransition (IM j) _ _) with (s', om').
     f_equal.
@@ -907,18 +907,18 @@ projection to be lifted direclty to <<X>>
 *)
 Lemma projection_friendliness_lift_to_composite_vlsm_full_projection
   (Hfr : projection_friendliness_sufficient_condition)
-  : VLSM_full_projection Xj X (lift_to_composite_label IM j) (lift_to_composite_state IM j).
+  : VLSM_full_projection Xj X (lift_to_composite_label IM j) (lift_to_composite_initial_state IM j).
 Proof.
   apply basic_VLSM_full_projection; intro; intros.
   - apply (Hfr _ _ _ Hv); [|apply state_update_eq].
     apply (projection_friendliness_sufficient_condition_valid_state Hfr).
     apply Hv.
   - unfold lift_to_composite_label, vtransition. simpl.
-    unfold lift_to_composite_state at 1. rewrite state_update_eq.
+    unfold lift_to_composite_initial_state at 1. rewrite state_update_eq.
     replace (vtransition (IM j) _ _) with (s', om')
       by (symmetry; apply H).
-    f_equal. unfold lift_to_composite_state. apply state_update_twice.
-  - by apply (lift_to_composite_state_initial IM j).
+    f_equal. unfold lift_to_composite_initial_state. apply state_update_twice.
+  - by apply (lift_to_composite_initial_state_preservation IM j).
   - by destruct Hv as [Hs [Homj [sX [Heqs [HsX [Hom Hv]]]]]].
 Qed.
 

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -256,7 +256,7 @@ Qed.
 Definition composite_vlsm_induced_projection : VLSM message :=
   projection_induced_vlsm X (type (IM j))
     composite_project_label (fun s => s j)
-    (lift_to_composite_label IM j) (lift_to_composite_initial_state IM j).
+    (lift_to_composite_label IM j) (lift_to_composite_state' IM j).
 
 (** The [composite_vlsm_constraint_projection] is [VLSM_eq]ual (trace-equivalent)
 to the [projection_induced_vlsm] by the [composite_project_label] and the
@@ -269,15 +269,15 @@ Proof.
   split.
   - apply basic_VLSM_strong_incl.
     + intros s Hs; cbn in *; red.
-      exists (lift_to_composite_initial_state IM j s).
+      exists (lift_to_composite_state' IM j s).
       split; [apply state_update_eq|].
-      by apply (lift_to_composite_initial_state_preservation IM).
+      by apply (composite_initial_state_prop_lift IM).
     + by intros m [[im Him] <-].
     + intros l s iom [sX [<- Hv]].
       exists (existT j l), sX.
       by split; [apply composite_project_label_eq|split].
     + intros l s iom s' oom.
-      cbn; unfold lift_to_composite_initial_state at 1; rewrite state_update_eq.
+      cbn; unfold lift_to_composite_state' at 1; rewrite state_update_eq.
       intros Ht; setoid_rewrite Ht.
       by rewrite state_update_eq.
   - cbn; apply basic_VLSM_strong_incl.
@@ -289,7 +289,7 @@ Proof.
       case_decide; [| congruence].
       by subst i; apply Some_inj in HlX; cbn in HlX; subst li.
     + intros l s iom s' oom; cbn.
-      unfold lift_to_composite_initial_state at 1;
+      unfold lift_to_composite_state' at 1;
       rewrite state_update_eq;
       destruct (vtransition _ _ _) as (si', om').
       by rewrite state_update_eq.
@@ -305,7 +305,7 @@ Qed.
 
 Lemma component_state_projection_lift
   : induced_projection_state_lift_prop X (type (IM j)) (fun s => s j)
-    (lift_to_composite_initial_state IM j).
+    (lift_to_composite_state' IM j).
 Proof.
   intros sj.
   apply state_update_eq.
@@ -356,7 +356,7 @@ Lemma induced_component_projection
   : VLSM_projection X
     (projection_induced_vlsm X (type (IM j))
       composite_project_label (fun s => s j)
-      (lift_to_composite_label IM j) (lift_to_composite_initial_state IM j))
+      (lift_to_composite_label IM j) (lift_to_composite_state' IM j))
     composite_project_label (fun s => s j).
 Proof.
   apply projection_induced_vlsm_is_projection.
@@ -877,10 +877,10 @@ Lemma projection_friendliness_sufficient_condition_valid_state
   (Hfr : projection_friendliness_sufficient_condition)
   (s : state)
   (Hp : valid_state_prop Xj s)
-  : valid_state_prop X (lift_to_composite_initial_state IM j s).
+  : valid_state_prop X (lift_to_composite_state' IM j s).
 Proof.
   induction Hp using valid_state_prop_ind.
-  - by apply initial_state_is_valid, (lift_to_composite_initial_state_preservation IM j).
+  - by apply initial_state_is_valid, (composite_initial_state_prop_lift IM j).
   - destruct Ht as [Hvj Ht].
     specialize (Hfr _ _ _ Hvj _ IHHp).
     spec Hfr; [apply state_update_eq|].
@@ -892,7 +892,7 @@ Proof.
     specialize (valid_generated_state_message X _ _ HsX _ _ Hom _ Hfr) as Hgen.
     apply Hgen.
     simpl.
-    unfold lift_to_composite_initial_state at 1.
+    unfold lift_to_composite_state' at 1.
     rewrite state_update_eq.
     replace (vtransition (IM j) _ _) with (s', om').
     f_equal.
@@ -907,18 +907,18 @@ projection to be lifted direclty to <<X>>
 *)
 Lemma projection_friendliness_lift_to_composite_vlsm_full_projection
   (Hfr : projection_friendliness_sufficient_condition)
-  : VLSM_full_projection Xj X (lift_to_composite_label IM j) (lift_to_composite_initial_state IM j).
+  : VLSM_full_projection Xj X (lift_to_composite_label IM j) (lift_to_composite_state' IM j).
 Proof.
   apply basic_VLSM_full_projection; intro; intros.
   - apply (Hfr _ _ _ Hv); [|apply state_update_eq].
     apply (projection_friendliness_sufficient_condition_valid_state Hfr).
     apply Hv.
   - unfold lift_to_composite_label, vtransition. simpl.
-    unfold lift_to_composite_initial_state at 1. rewrite state_update_eq.
+    unfold lift_to_composite_state' at 1. rewrite state_update_eq.
     replace (vtransition (IM j) _ _) with (s', om')
       by (symmetry; apply H).
-    f_equal. unfold lift_to_composite_initial_state. apply state_update_twice.
-  - by apply (lift_to_composite_initial_state_preservation IM j).
+    f_equal. unfold lift_to_composite_state'. apply state_update_twice.
+  - by apply (composite_initial_state_prop_lift IM j).
   - by destruct Hv as [Hs [Homj [sX [Heqs [HsX [Hom Hv]]]]]].
 Qed.
 

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -312,7 +312,7 @@ Proof.
     + apply component_transition_projection_None.
     + apply component_label_projection_lift.
     + apply component_state_projection_lift.
-    + intros isi; apply (lift_to_composite_initial_state_preservation IM).
+    + intros isi; apply (composite_initial_state_prop_lift IM).
     + apply component_transition_projection_Some.
     + done.
 Qed.
@@ -331,14 +331,14 @@ Proof.
   apply VLSM_eq_trans with
     (machine (projection_induced_vlsm X (type (IM i))
       (composite_project_label IM i) (fun s => s i)
-      (lift_to_composite_label IM i) (lift_to_composite_initial_state IM i)))
+      (lift_to_composite_label IM i) (lift_to_composite_state' IM i)))
   ; simpl; [|apply VLSM_eq_sym, composite_vlsm_constrained_projection_is_induced].
   apply pre_loaded_with_all_messages_validator_proj_eq.
   - apply component_projection_to_preloaded.
   - apply component_transition_projection_None.
   - apply component_label_projection_lift.
   - apply component_state_projection_lift.
-  - intro s. apply (lift_to_composite_initial_state_preservation IM).
+  - intro s. apply (composite_initial_state_prop_lift IM).
   - apply component_transition_projection_Some.
   - intros li si omi Hiv.
     apply Hvalidator in Hiv as (sX & <- & HivX).

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -312,7 +312,7 @@ Proof.
     + apply component_transition_projection_None.
     + apply component_label_projection_lift.
     + apply component_state_projection_lift.
-    + intros isi; apply (lift_to_composite_state_initial IM).
+    + intros isi; apply (lift_to_composite_initial_state_preservation IM).
     + apply component_transition_projection_Some.
     + done.
 Qed.
@@ -331,14 +331,14 @@ Proof.
   apply VLSM_eq_trans with
     (machine (projection_induced_vlsm X (type (IM i))
       (composite_project_label IM i) (fun s => s i)
-      (lift_to_composite_label IM i) (lift_to_composite_state IM i)))
+      (lift_to_composite_label IM i) (lift_to_composite_initial_state IM i)))
   ; simpl; [|apply VLSM_eq_sym, composite_vlsm_constrained_projection_is_induced].
   apply pre_loaded_with_all_messages_validator_proj_eq.
   - apply component_projection_to_preloaded.
   - apply component_transition_projection_None.
   - apply component_label_projection_lift.
   - apply component_state_projection_lift.
-  - intro s. apply (lift_to_composite_state_initial IM).
+  - intro s. apply (lift_to_composite_initial_state_preservation IM).
   - apply component_transition_projection_Some.
   - intros li si omi Hiv.
     apply Hvalidator in Hiv as (sX & <- & HivX).


### PR DESCRIPTION
I realized we didn't have these generic results (we only had something similat for lifting from sub-compositions).

Once these are merged, the can be used directly for UMO and RUMO.