### PR TITLE
Default projection induced vlsm without initial messages

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -158,7 +158,7 @@ Definition fixed_byzantine_trace_prop
 Section fixed_byzantine_traces_as_projections.
 
 Definition fixed_non_byzantine_projection : VLSM message :=
-  induced_sub_projection fixed_byzantine_IM non_byzantine non_byzantine_not_equivocating_constraint.
+  pre_induced_sub_projection fixed_byzantine_IM non_byzantine non_byzantine_not_equivocating_constraint.
 
 Lemma fixed_non_byzantine_projection_initial_state_preservation
   : forall s, vinitial_state_prop fixed_non_byzantine_projection s <->
@@ -215,7 +215,7 @@ Qed.
 
 (** Characterization result for the first definition:
 the [fixed_byzantine_trace_prop]erty is equivalent to the
-[finite_valid_trace_prop]erty of the [induced_sub_projection] of the
+[finite_valid_trace_prop]erty of the [pre_induced_sub_projection] of the
 the composition in which a fixed set of nodes were replaced by byzantine nodes
 and the rest are protocol-following to the set of protocol-following nodes.
 *)
@@ -364,7 +364,7 @@ Proof.
     + split; [| done].
       by apply fixed_non_byzantine_projection_valid_no_equivocations.
   - intros l s om s' om' [_ Ht].
-    by apply induced_sub_projection_transition_preservation in Ht.
+    by setoid_rewrite <- induced_sub_projection_transition_preservation.
 Qed.
 
 Lemma pre_loaded_fixed_non_byzantine_vlsm_lift_valid
@@ -468,11 +468,7 @@ Proof.
   apply basic_VLSM_incl.
   - by intro; intros; apply fixed_non_byzantine_projection_initial_state_preservation.
   - intros l s m Hv _ Him.
-    apply initial_message_is_valid.
-    apply (pre_loaded_fixed_non_byzantine_vlsm_lift_initial_message l s m).
-    1,3: done.
-    apply (VLSM_full_projection_valid_state pre_loaded_fixed_non_byzantine_vlsm_lift).
-    by destruct Hv.
+    by apply initial_message_is_valid.
   - intro; intros.
     exists (lift_sub_label fixed_byzantine_IM non_byzantine l).
     exists (lift_sub_state fixed_byzantine_IM non_byzantine s).
@@ -481,8 +477,7 @@ Proof.
     revert Hv.
     apply (VLSM_full_projection_input_valid pre_loaded_fixed_non_byzantine_vlsm_lift).
   - intros l s om s' om' [_ Ht].
-    revert Ht.
-    apply @induced_sub_projection_transition_preservation.
+    by setoid_rewrite induced_sub_projection_transition_preservation.
 Qed.
 
 Lemma fixed_non_byzantine_pre_loaded_eq
@@ -537,7 +532,7 @@ Context
   (selection_complement := set_diff (enum index) selection)
   (PreNonByzantine : VLSM message := pre_loaded_fixed_non_byzantine_vlsm IM selection A sender)
   (Fixed : VLSM message := fixed_equivocation_vlsm_composition IM selection)
-  (FixedNonEquivocating : VLSM message := induced_sub_projection IM selection_complement (fixed_equivocation_constraint IM selection))
+  (FixedNonEquivocating : VLSM message := pre_induced_sub_projection IM selection_complement (fixed_equivocation_constraint IM selection))
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   (can_emit_signed : channel_authentication_prop IM A sender)
   (Hsender_safety : sender_safety_alt_prop IM A sender :=
@@ -546,7 +541,7 @@ Context
 
 Lemma fixed_non_equivocating_incl_sub_non_equivocating
   : VLSM_incl FixedNonEquivocating
-      (induced_sub_projection IM (set_diff (enum index) selection)
+      (pre_induced_sub_projection IM (set_diff (enum index) selection)
         (sub_IM_not_equivocating_constraint IM
           (set_diff (enum index) selection) A sender)).
 Proof.
@@ -593,8 +588,7 @@ Proof.
     apply (VLSM_incl_input_valid fixed_non_equivocating_incl_sub_non_equivocating)
        in Hv as (_ & _ & Hv).
     split.
-    + revert Hv.
-      apply induced_sub_projection_valid_preservation.
+    + by eapply induced_sub_projection_valid_preservation.
     + split; [| done].
       apply sub_IM_no_equivocation_preservation in Hv as Hnoequiv.
       2-4: done.
@@ -731,12 +725,7 @@ Proof.
     + apply composite_state_sub_projection_lift_to.
     + by apply (lift_sub_state_initial IM).
   - intro; intros.
-    apply initial_message_is_valid.
-    eapply Hfixed_non_byzantine_vlsm_lift_initial_message.
-    1, 3: done.
-    destruct Hv as [Hv _].
-    eapply VLSM_full_projection_valid_state in Hv; [done |].
-    apply fixed_non_byzantine_vlsm_lift_from_initial.
+    by apply initial_message_is_valid.
   - intro; intros.
     exists (lift_sub_label IM (set_diff (enum index) selection) l).
     exists (lift_sub_state IM (set_diff (enum index) selection) s).

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -1035,10 +1035,10 @@ Context
   (non_equivocators := set_diff (finite.enum index) equivocators)
   (Free := free_composite_vlsm IM)
   (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
-  (FixedNonEquivocating:= induced_sub_projection IM non_equivocators
+  (FixedNonEquivocating:= pre_induced_sub_projection IM non_equivocators
                                 (fixed_equivocation_constraint IM equivocators))
   (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
-  (StrongFixedNonEquivocating:= induced_sub_projection IM non_equivocators
+  (StrongFixedNonEquivocating:= pre_induced_sub_projection IM non_equivocators
                                 (strong_fixed_equivocation_constraint IM equivocators))
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
   .

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -258,12 +258,15 @@ Definition composite_vlsm_induced_projection : VLSM message :=
     composite_project_label (fun s => s j)
     (lift_to_composite_label IM j) (lift_to_composite_state' IM j).
 
+Definition pre_composite_vlsm_induced_projection : VLSM message :=
+  pre_loaded_with_all_messages_vlsm composite_vlsm_induced_projection.
+
 (** The [composite_vlsm_constraint_projection] is [VLSM_eq]ual (trace-equivalent)
 to the [projection_induced_vlsm] by the [composite_project_label] and the
 projection of the state to the component.
 *)
 Lemma composite_vlsm_constrained_projection_is_induced
-  : VLSM_eq Xj composite_vlsm_induced_projection.
+  : VLSM_eq Xj pre_composite_vlsm_induced_projection.
 Proof.
   apply VLSM_eq_incl_iff.
   split.
@@ -280,19 +283,20 @@ Proof.
       cbn; unfold lift_to_composite_state' at 1; rewrite state_update_eq.
       intros Ht; setoid_rewrite Ht.
       by rewrite state_update_eq.
-  - cbn; apply basic_VLSM_strong_incl.
+  - cbn; apply basic_VLSM_incl.
     + intros s [sX [<- HsX]]; cbn. apply HsX.
-    + by intros m Him; cbn; exists (exist _ m Him).
-    + intros l s iom ((i, li) & sX & HlX & <- & Hv); cbn.
+    + intros l * (HsXj & HmXj & lX & sX & HlX & <- & HsX & HmX & Hv) Hs _.
+      by apply initial_message_is_valid; exists (exist _ m HmX).
+    + intros l s iom (_ & _ & (i, li) & sX & HlX & <- & Hv) _ _; cbn.
       exists sX; split; [done |].
       unfold composite_project_label in HlX; cbn in *.
       case_decide; [| congruence].
       by subst i; apply Some_inj in HlX; cbn in HlX; subst li.
-    + intros l s iom s' oom; cbn.
-      unfold lift_to_composite_state' at 1;
-      rewrite state_update_eq;
+    + intros l s iom s' oom [_ Ht]; cbn in *.
+      unfold lift_to_composite_state' in Ht;
+      rewrite state_update_eq in Ht;
       destruct (vtransition _ _ _) as (si', om').
-      by rewrite state_update_eq.
+      by rewrite state_update_eq in Ht.
 Qed.
 
 Lemma component_label_projection_lift
@@ -354,7 +358,7 @@ projection of the state to the component is indeed a [VLSM_projection].
 *)
 Lemma induced_component_projection
   : VLSM_projection X
-    (projection_induced_vlsm X (type (IM j))
+    (pre_projection_induced_vlsm X (type (IM j))
       composite_project_label (fun s => s j)
       (lift_to_composite_label IM j) (lift_to_composite_state' IM j))
     composite_project_label (fun s => s j).

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -190,8 +190,8 @@ Definition composite_label_sub_projection_option
 (** By restricting the components of a composition to a subset we obtain a
 [projection_induced_vlsm].
 *)
-Definition induced_sub_projection : VLSM message :=
-  projection_induced_vlsm X (composite_type sub_IM)
+Definition pre_induced_sub_projection : VLSM message :=
+  pre_projection_induced_vlsm X (composite_type sub_IM)
     composite_label_sub_projection_option
     composite_state_sub_projection
     lift_sub_label lift_sub_state.
@@ -301,11 +301,11 @@ Proof.
   - apply induced_sub_projection_transition_consistency_Some.
 Qed.
 
-(** The [induced_sub_projection] is actually a [VLSM_projection] of the
+(** The [pre_induced_sub_projection] is actually a [VLSM_projection] of the
 original composition.
 *)
 Lemma induced_sub_projection_is_projection
-  : VLSM_projection X induced_sub_projection
+  : VLSM_projection X pre_induced_sub_projection
     composite_label_sub_projection_option
     composite_state_sub_projection.
 Proof.
@@ -315,7 +315,7 @@ Proof.
 Qed.
 
 Lemma induced_sub_projection_valid_projection l s om
-  (Hv : vvalid induced_sub_projection l (s, om))
+  (Hv : vvalid pre_induced_sub_projection l (s, om))
   : exists i, i ∈ sub_index_list /\
     exists l s, input_valid (pre_loaded_with_all_messages_vlsm (IM i)) l (s, om).
 Proof.
@@ -341,7 +341,7 @@ Proof.
 Qed.
 
 Lemma induced_sub_projection_transition_is_composite l s om
-  : vtransition induced_sub_projection l (s, om) = composite_transition sub_IM l (s, om).
+  : vtransition pre_induced_sub_projection l (s, om) = composite_transition sub_IM l (s, om).
 Proof.
   destruct l as (sub_i, li).
   destruct_dec_sig sub_i i Hi Heqsub_i; subst.
@@ -368,7 +368,7 @@ Context
 
 Lemma induced_sub_projection_constraint_subsumption_incl
   (Hsubsumption : input_valid_constraint_subsumption IM constraint1 constraint2)
-  : VLSM_incl (induced_sub_projection constraint1) (induced_sub_projection constraint2).
+  : VLSM_incl (pre_induced_sub_projection constraint1) (pre_induced_sub_projection constraint2).
 Proof.
   apply projection_induced_vlsm_incl.
   - apply weak_induced_sub_projection_transition_consistency_Some.
@@ -996,7 +996,7 @@ Proof.
 Qed.
 
 (** If the composition constraint only depends on the projection sub-state,
-then valid traces of the [induced_sub_projection] can be lifted to valid traces
+then valid traces of the [pre_induced_sub_projection] can be lifted to valid traces
 of the constrained composition.
 *)
 Lemma induced_sub_projection_lift
@@ -1004,10 +1004,9 @@ Lemma induced_sub_projection_lift
   (Hconstraint_consistency :
     forall s1 s2,
       composite_state_sub_projection IM equivocators s1 = composite_state_sub_projection IM equivocators s2 ->
-      forall l om, constraint l (s1, om) -> constraint l (s2, om)
-    )
-  : VLSM_full_projection
-    (induced_sub_projection IM equivocators constraint)
+      forall l om, constraint l (s1, om) -> constraint l (s2, om))
+   : VLSM_full_projection
+    (pre_induced_sub_projection IM equivocators constraint)
     (composite_vlsm IM constraint)
     (lift_sub_label IM equivocators)
     (lift_sub_state IM equivocators).
@@ -1047,16 +1046,16 @@ Proof.
     destruct Hs as [sX [<- HsX]].
     intro sub_i; destruct_dec_sig sub_i i Hi Heqsub_i; subst.
     apply HsX.
-  - by intro.
+  - by intros _ _ m (_ & _ & _ & _ & _ & _ & _ & HmX & _) _ _.
 Qed.
 
 (** A specialization of [basic_projection_induces_friendliness] for
-[induced_sub_projection]s.
+[pre_induced_sub_projection]s.
 *)
 Lemma induced_sub_projection_friendliness
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (Hlift_proj : VLSM_full_projection
-    (induced_sub_projection IM equivocators constraint)
+    (pre_induced_sub_projection IM equivocators constraint)
     (composite_vlsm IM constraint)
     (lift_sub_label IM equivocators)
     (lift_sub_state IM equivocators))
@@ -1375,7 +1374,7 @@ Context
   .
 
 Lemma induced_sub_projection_valid_preservation constraint l s om
-  (Hv : vvalid (induced_sub_projection IM indices constraint) l (s, om))
+  (Hv : vvalid (pre_induced_sub_projection IM indices constraint) l (s, om))
   : composite_valid sub_IM l (s, om).
 Proof.
   destruct Hv as [lX [sX [Heql [Heqs [HsX [Hom [Hv Hc]]]]]]].
@@ -1389,7 +1388,7 @@ Qed.
 
 Lemma induced_sub_projection_transition_preservation [constraint]
   : forall l s om s' om',
-  vtransition (induced_sub_projection IM indices constraint) l (s, om) = (s', om') <->
+  vtransition (pre_induced_sub_projection IM indices constraint) l (s, om) = (s', om') <->
   composite_transition sub_IM l (s, om) = (s', om').
 Proof.
   intros.
@@ -1416,7 +1415,7 @@ Qed.
 
 Lemma sub_IM_no_equivocation_preservation
   l s om
-  (Hv : vvalid (induced_sub_projection IM indices sub_IM_not_equivocating_constraint)
+  (Hv : vvalid (pre_induced_sub_projection IM indices sub_IM_not_equivocating_constraint)
     l (s, om))
   : composite_no_equivocations_except_from sub_IM
       non_sub_index_authenticated_message l (s, om).
@@ -1650,7 +1649,7 @@ Qed.
 (** *** A subcomposition can be projected to one component
 
 In the following we define the [projection_induced_vlsm] to a single component
-of the [induced_sub_projection] of a constrained composition so a subset of its
+of the [pre_induced_sub_projection] of a constrained composition so a subset of its
 components.
 
 Note that, in general, this is not trace-equivalent with the direclty obtained
@@ -1732,14 +1731,17 @@ Qed.
 
 Definition induced_sub_element_projection constraint : VLSM message :=
   projection_induced_vlsm
-    (induced_sub_projection IM indices constraint) (type (IM j))
+    (pre_induced_sub_projection IM indices constraint) (type (IM j))
     sub_label_element_project sub_state_element_project
     sub_element_label sub_element_state.
 
+Definition pre_induced_sub_element_projection constraint : VLSM message :=
+  pre_loaded_with_all_messages_vlsm (induced_sub_element_projection constraint).
+
 Lemma induced_sub_element_projection_is_projection constraint
   : VLSM_projection
-    (induced_sub_projection IM indices constraint)
-    (induced_sub_element_projection constraint)
+    (pre_induced_sub_projection IM indices constraint)
+    (pre_induced_sub_element_projection constraint)
     sub_label_element_project sub_state_element_project.
 Proof.
   apply projection_induced_vlsm_is_projection.
@@ -1749,8 +1751,9 @@ Proof.
   - apply basic_weak_projection_transition_consistency_Some.
     + intro; apply sub_element_label_project.
     + intro; apply sub_element_state_project.
-    + intro; setoid_rewrite induced_sub_projection_transition_is_composite.
-      apply sub_transition_element_project_Some.
+    + intros ? **; eapply sub_transition_element_project_Some; cycle 2.
+      2,3: setoid_rewrite <- (induced_sub_projection_transition_is_composite _ _ constraint).
+      all: done.
 Qed.
 
 End sub_composition_element.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -94,7 +94,7 @@ Context
   (Htransition_None : weak_projection_transition_consistency_None _ _ label_project state_project)
   (label_lift : vlabel Y -> vlabel X)
   (state_lift : vstate Y -> vstate X)
-  (Xi := projection_induced_vlsm X (type Y) label_project state_project label_lift state_lift)
+  (Xi := pre_projection_induced_vlsm X (type Y) label_project state_project label_lift state_lift)
   (Hlabel_lift : induced_projection_label_lift_prop _ _ label_project label_lift)
   (Hstate_lift : induced_projection_state_lift_prop _ _ state_project state_lift)
   (Hinitial_lift : strong_full_projection_initial_state_preservation Y X state_lift)
@@ -128,7 +128,7 @@ Proof.
   apply basic_VLSM_incl.
   - intros is (s & <- & Hs).
     by apply (VLSM_projection_initial_state Hproj).
-  - intros l s m Hv HsY HmX. apply any_message_is_valid_in_preloaded.
+  - by intros l s m Hv HsY HmX; apply initial_message_is_valid.
   - intros l s om (_ & _ & lX & sX & Hlx & <- & Hv) _ _.
     simpl.
     by eapply (VLSM_projection_input_valid Hproj).
@@ -328,11 +328,8 @@ Lemma pre_loaded_with_all_messages_validator_component_proj_eq
   (Hvalidator : component_projection_validator_prop)
   : VLSM_eq PreXi Xi.
 Proof.
-  apply VLSM_eq_trans with
-    (machine (projection_induced_vlsm X (type (IM i))
-      (composite_project_label IM i) (fun s => s i)
-      (lift_to_composite_label IM i) (lift_to_composite_state' IM i)))
-  ; simpl; [|apply VLSM_eq_sym, composite_vlsm_constrained_projection_is_induced].
+  eapply VLSM_eq_trans;
+    [| apply VLSM_eq_sym, composite_vlsm_constrained_projection_is_induced].
   apply pre_loaded_with_all_messages_validator_proj_eq.
   - apply component_projection_to_preloaded.
   - apply component_transition_projection_None.


### PR DESCRIPTION
This definition is more general, as it can be preloaded with any set of initial messages, if needed.
Also, if in a composition with no initial messages it would correspond more closely to the original VLSM. 