### PR TITLE
update CI to Coq 8.15.2, mark as incompatible with 8.16 for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN    opam init --auto-setup --yes --jobs=${NJOBS} --compiler=${COMPILER} --dis
 
 # From: https://github.com/coq-community/docker-coq/blob/master/Dockerfile
 
-ENV COQ_VERSION="8.15.1"
+ENV COQ_VERSION="8.15.2"
 ENV STDPP_VERSION="1.7.0"
 ENV COQ_OPAM="coq coq-stdpp coq-itauto"
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To install the project dependencies via [opam](https://opam.ocaml.org/doc/Instal
 
 ```shell
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq.8.15.1 coq-stdpp.1.7.0 coq-itauto
+opam install coq.8.15.2 coq-stdpp.1.7.0 coq-itauto
 ```
 
 To build the project when you have all dependencies installed, do:

--- a/coq-vlsm.opam
+++ b/coq-vlsm.opam
@@ -16,7 +16,7 @@ contains a formalization of VLSMs and their theory in the Coq proof assistant.""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {>= "8.15"}
+  "coq" {>= "8.15" & <= "8.16~"}
   "coq-stdpp" {>= "1.7.0"}
   "coq-itauto" 
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -44,7 +44,7 @@ license:
 
 supported_coq_versions:
   text: 8.15
-  opam: '{>= "8.15"}'
+  opam: '{>= "8.15" & <= "8.16~"}'
 
 dependencies:
 - opam:
@@ -80,7 +80,7 @@ build: |-
 
   ```shell
   opam repo add coq-released https://coq.inria.fr/opam/released
-  opam install coq.8.15.1 coq-stdpp.1.7.0 coq-itauto
+  opam install coq.8.15.2 coq-stdpp.1.7.0 coq-itauto
   ```
 
   To build the project when you have all dependencies installed, do:


### PR DESCRIPTION
Hopefully we can be compatible with both 8.15 and 8.16 for a while, but this will require fiddling with some proof scripts to work with 8.16.0.