### PR TITLE
More coqdoc structure, fix a brittle proof

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,7 @@
 -Q theories/VLSM VLSM
+
 -arg -w -arg -deprecated-instance-without-locality
+-arg -w -arg -future-coercion-class-field
 
 theories/VLSM/Lib/Preamble.v
 theories/VLSM/Lib/SsrExport.v

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -375,10 +375,8 @@ Proof.
     destruct l as [sub_i li]; destruct_dec_sig sub_i i Hi Heqsub_i; subst sub_i
     ; destruct IHHbyzantine as [[Htr0_ann Hsi_ann] Htr0_eqv_byzantine]
     ; cbn in Htr0_eqv_byzantine |- *.
-    unfold msg_dep_annotate_trace_with_equivocators,
-     coeqv_annotate_trace_with_equivocators, annotate_trace in Htr0_eqv_byzantine.
     remember (@finite_trace_last _ (annotated_type (free_composite_vlsm IM) (set index)) _ _)
-          as lst.
+     as lst in Htr0_eqv_byzantine at 1 |- * at 1 2 3 4 5 6.
     assert (Hlsti : original_state lst = lift_sub_state IM (set_diff (enum index) byzantine)
                                           (finite_trace_last si tr0)).
     {

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -7,7 +7,7 @@ From VLSM.Core Require Import Validator Equivocation Equivocation.FixedSetEquivo
 From VLSM.Core Require Import Equivocation.LimitedEquivocation Equivocation.LimitedEquivocation.
 From VLSM.Core Require Import Equivocation.MsgDepLimitedEquivocation Equivocation.TraceWiseEquivocation.
 
-(** * VLSM Compositions with byzantine nodes of limited weight
+(** * VLSM Compositions with Byzantine nodes of limited weight
 
 In this module we define and study protocol executions allowing a
 (weight-)limited amount of byzantine faults.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -6,7 +6,11 @@ From VLSM.Core Require Import VLSM.
 From VLSM.Core.VLSMProjections Require Export VLSMPartialProjection VLSMTotalProjection.
 From VLSM.Core.VLSMProjections Require Export VLSMEmbedding VLSMInclusion VLSMEquality.
 
+(** * VLSM Projection Properties *)
+
 Section same_VLSM_full_projection.
+
+(** ** Same VLSM full projection *)
 
 Context
   {message : Type}
@@ -27,6 +31,8 @@ Qed.
 End same_VLSM_full_projection.
 
 Section transitivity_props.
+
+(** ** Transitivity properties *)
 
 Lemma pre_VLSM_projection_finite_trace_project_trans
   {message : Type}

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -6,16 +6,16 @@ From VLSM.Core Require Import VLSM VLSMProjections.VLSMTotalProjection.
 
 Section VLSM_full_projection.
 
-(** * VLSM Projections : VLSM Full Projection (Embedding)
+(** * VLSM Full Projection (Embedding)
 
 A VLSM projection guaranteeing the existence of projection for all labels and
 states, and the full correspondence between [transition_item]s.
-We say that VLSM X fully projects (embeds) into VLSM Y (sharing the same messages)
-if there exist maps <<label_project>> taking X-labels to Y-labels
-and <<state_project>> taking X-states to Y-states, such that the
+We say that VLSM <<X>> fully projects (embeds) into VLSM <<Y>> (sharing the same messages)
+if there exist maps <<label_project>> taking <<X>>-labels to <<Y>>-labels
+and <<state_project>> taking <<X>>-states to <<Y>>-states, such that the
 [finite_valid_trace_prop]erty is preserved by the trace
 transformation induced by the label and state projection functions,
-in which each X-[transition_item] is projected to an Y-[transition_item]
+in which each <<X>>-[transition_item] is projected to an <<Y>>-[transition_item]
 preserving the messages and transforming labels and states accordingly.
 
 Besides [VLSM_incl]usions, which are a prototypical example of VLSM embeddings,
@@ -276,6 +276,8 @@ Qed.
 
 Section weak_projection_properties.
 
+(** ** Weak projection properties *)
+
 Context
   {message : Type}
   {X Y : VLSM message}
@@ -386,6 +388,8 @@ Qed.
 End weak_projection_properties.
 
 Section full_projection_properties.
+
+(** ** Full projection properties *)
 
 Context
   {message : Type}
@@ -562,6 +566,8 @@ like <<X>>'s [transition].
 
 Section basic_VLSM_full_projection.
 
+(** ** Basic full VLSM projection *)
+
 Context
   {message : Type}
   (X Y : VLSM message)
@@ -575,6 +581,8 @@ Context
   .
 
 Section weak_full_projection.
+
+(** ** Weak full VLSM projection *)
 
 Context
   (Hstate : weak_projection_initial_state_preservation X Y state_project)

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -2,12 +2,12 @@ From Cdcl Require Import Itauto. Local Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMInclusion VLSMProjections.VLSMEmbedding.
 
-(** * VLSM Projections : VLSM Equality
+(** * VLSM Trace Equality
 
 We can also define VLSM _equality_ in terms of traces.
 When both VLSMs have the same state and label types they also share the
 same [Trace] type, and sets of traces can be compared without conversion.
-Then VLSM X and VLSM Y are _equal_ if their [valid_trace]s are exactly the same.
+Then VLSM <<X>> and VLSM <<Y>> are _equal_ if their [valid_trace]s are exactly the same.
 *)
 
 Section VLSM_equality.
@@ -81,6 +81,8 @@ Proof.
 Qed.
 
 Section VLSM_eq_properties.
+
+(** ** VLSM equality properties *)
 
 Context
   {message : Type} [vtype : VLSMType message]
@@ -241,6 +243,8 @@ Qed.
 End VLSM_eq_properties.
 
 Section VLSM_incl_preloaded_properties.
+
+(** ** Inclusion properties for pre-loaded VLSMs *)
 
 Context
   {message : Type}

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -2,12 +2,12 @@ From Cdcl Require Import Itauto. Local Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMEmbedding VLSMProjections.VLSMTotalProjection.
 
-(** * VLSM Projections : VLSM Inclusion
+(** * VLSM Inclusion
 
 When both VLSMs have the same state and label types they also share the
 same [Trace] type, and sets of traces can be compared without conversion.
-Then VLSM X is _included_ in VLSM Y if every [valid_trace] available to X
-is also available to Y.
+Then VLSM <<X>> is _included_ in VLSM <<Y>> if every [valid_trace] available to <<X>>
+is also available to <<Y>>.
 *)
 Section VLSM_inclusion.
   Context
@@ -112,6 +112,8 @@ Notation VLSM_incl X Y := (VLSM_incl_part (machine X) (machine Y)).
 
 Section VLSM_incl_preservation.
 
+(** ** VLSM inclusion preservation *)
+
 Context
   {message : Type}
   {T : VLSMType message}
@@ -144,6 +146,8 @@ Definition strong_incl_initial_message_preservation : Prop :=
 End VLSM_incl_preservation.
 
 Section VLSM_incl_properties.
+
+(** ** VLSM inclusion properties *)
 
 Context
   {message : Type} [vtype : VLSMType message]

--- a/theories/VLSM/Core/VLSMProjections/VLSMPartialProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMPartialProjection.v
@@ -5,21 +5,21 @@ From VLSM.Core Require Import VLSM.
 
 Section VLSM_partial_projection.
 
-(** * VLSM Projections : VLSM Partial Projection
+(** * VLSM Partial Projections
 
-A generic notion of VLSM projection. We say that VLSM X partially projects to
-VLSM Y (sharing the same messages) if there exists a partial map <<partial_trace_project>>
-from traces over X (pairs of state and list of transitions from that state)
-to traces over Y such that:
+A generic notion of VLSM projection. We say that VLSM <<X>> partially projects to
+VLSM <<Y>> (sharing the same messages) if there exists a partial map <<partial_trace_project>>
+from traces over <<X>> (pairs of state and list of transitions from that state)
+to traces over <<Y>> such that:
 
 - [partial_trace_project_preserves_valid_trace]s, if the projection is defined.
 
 - The projection operation is stable to adding valid prefixes (property
 [partial_trace_project_extends_left]). More precisely, if the projection of a
-trace (sX, tX) yields (sY, tY), then for any trace (s'X, preX) ending in sX
-such that (s'X, preX ++ tX) is a valid trace, then there exists a
-trace (s'Y, preY) ending in sY such that (s'X, preX ++ tX) projects
-to (s'Y, preY ++ tY).
+trace <<(sX, tX)>> yields <<(sY, tY)>>, then for any trace <<(s'X, preX)>> ending in <<sX>>
+such that <<(s'X, preX ++ tX)>> is a valid trace, then there exists a
+trace <<(s'Y, preY)>> ending in <<sY>> such that <<(s'X, preX ++ tX)>> projects
+to <<(s'Y, preY ++ tY)>>.
 
 Proper examples of partial projections (which are not [VLSM_projection]s) are
 the projections from the compositions of equivocators to the composition
@@ -75,6 +75,8 @@ Record VLSM_partial_projection
   }.
 
 Section weak_partial_projection_properties.
+
+(** ** Weak partial projection properties *)
 
 Context
   {message : Type}
@@ -136,6 +138,8 @@ Qed.
 End weak_partial_projection_properties.
 
 Section partial_projection_properties.
+
+(** ** Partial projection properties *)
 
 Context
   {message : Type}

--- a/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
@@ -3,15 +3,14 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras StreamExtras StreamFilters.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMPartialProjection.
 
-
 Section VLSM_projection.
 
-(** * VLSM Projections : VLSM (Total) Projection
+(** * VLSM Total Projections
 
 A VLSM projection guaranteeing the existence of projection for all states and
-traces. We say that VLSM X projects to VLSM Y (sharing the same messages) if
-there exists maps <<state_project>> taking X-states to Y-states,
-and <<trace_project>>, taking list of transitions from X to Y, such that:
+traces. We say that VLSM <<X>> projects to VLSM <<Y>> (sharing the same messages) if
+there exists maps <<state_project>> taking <<X>>-states to <<Y>>-states,
+and <<trace_project>>, taking list of transitions from <<X>> to <<Y>>, such that:
 
 - state and [trace_project_preserves_valid_trace]s.
 
@@ -154,6 +153,8 @@ Record VLSM_projection_type
         finite_valid_trace_from X sX trX ->
         state_project (finite_trace_last sX trX) = finite_trace_last (state_project sX) (trace_project trX)
   }.
+
+(** ** Projection definitions and properties *)
 
 Section projection_type_properties.
 
@@ -698,7 +699,7 @@ Proof.
   - by apply VLSM_projection_initial_state.
 Qed.
 
-(** ** Projection Friendliness
+(** ** Projection friendliness
 
 A projection is friendly if all the valid traces of the projection are
 projections of the valid traces of the source VLSM.


### PR DESCRIPTION
Here I add more coqdoc structure to projections-related files, to make the whole package/project more surveyable.

A proof in `LimitedByzantineTraces` was brittle and broke again on 8.16. I included a permanent fix that makes the proof stable.

