### PR TITLE
Move Stdpp list lemmas to StdppExtras.v

### DIFF
--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -126,17 +126,6 @@ Proof.
     apply incl_tl. apply incl_refl.
 Qed.
 
-Lemma filter_in {A} P `{∀ (x:A), Decision (P x)} x s :
-  In x s ->
-  P x ->
-  In x (filter P s).
-Proof.
-  intros.
-  apply elem_of_list_In.
-  apply elem_of_list_In in H0.
-  apply elem_of_list_filter; auto.
-Qed.
-
 Lemma filter_incl {A} P `{∀ (x:A), Decision (P x)} s1 s2 :
   incl s1 s2 ->
   incl (filter P s1) (filter P s2).

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -1,5 +1,5 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
-From stdpp Require Import prelude finite.
+From stdpp Require Import base tactics.
 From Coq Require Import FinFun.
 From VLSM Require Import Lib.Preamble.
 

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -324,3 +324,14 @@ Proof.
   rewrite <- rev_length, <- !skipn_rev, rev_involutive.
   by apply drop_S.
 Qed.
+
+Lemma filter_in {A} P `{∀ (x:A), Decision (P x)} x s :
+  In x s ->
+  P x ->
+  In x (filter P s).
+Proof.
+  intros.
+  apply elem_of_list_In.
+  apply elem_of_list_In in H0.
+  apply elem_of_list_filter; auto.
+Qed.


### PR DESCRIPTION
The file `ListExtras.v` has grown beyond reasonable bounds and now includes a lot of extensions to the Stdpp library. We would like to move the lemmas that are directly dependent on Stdpp to `StdppExtras.v`, and only keep the Coq stdlib extensions. To this end, I limit `ListExtras.v` to only use Stdpp base and tactics. The goal is to have a PR that builds again with relevant lemmas in `StdppExtras.v`.