### PR TITLE
Minimizing requires and fixing the imports to build again

### DIFF
--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import ListExtras.
-From VLSM.Core Require Import VLSM VLSMProjections Validator Composition ProjectionTraces.
+From VLSM.Core Require Import VLSM VLSMProjections Validator Composition.
 
 (** * State-annotated VLSMs
 

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -1,5 +1,4 @@
 From stdpp Require Import prelude.
-From Coq Require Import FinFun.
 From VLSM Require Import Lib.Preamble Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces Core.Validator.
 
 (** * VLSM Byzantine Traces

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -2,7 +2,7 @@ From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto aut
 From stdpp Require Import prelude finite.
 From Coq Require Import FunctionalExtensionality.
 From VLSM.Lib Require Import Preamble StdppListSet FinFunExtras ListExtras.
-From VLSM Require Import Core.VLSM Core.MessageDependencies Core.VLSMProjections Core.Composition Core.ProjectionTraces Core.SubProjectionTraces Core.ByzantineTraces.
+From VLSM Require Import Core.VLSM Core.MessageDependencies Core.ProjectionTraces Core.VLSMProjections Core.Composition Core.SubProjectionTraces Core.ByzantineTraces.
 From VLSM Require Import Core.Validator Core.Equivocation Core.EquivocationProjections Core.Equivocation.NoEquivocation Core.Equivocation.FixedSetEquivocation.
 
 (** * VLSM Compositions with a fixed set of byzantine nodes

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -1,10 +1,10 @@
 From stdpp Require Import prelude finite.
 From Coq Require Import FunctionalExtensionality Reals.
-From VLSM.Lib Require Import Preamble StdppListSet Measurable FinFunExtras StdppExtras ListSetExtras.
+From VLSM.Lib Require Import Preamble StdppListSet Measurable ListSetExtras.
 From VLSM.Core Require Import VLSM MessageDependencies VLSMProjections Composition ProjectionTraces.
-From VLSM.Core Require Import SubProjectionTraces AnnotatedVLSM ByzantineTraces FixedSetByzantineTraces.
+From VLSM.Core Require Import SubProjectionTraces AnnotatedVLSM FixedSetByzantineTraces.
 From VLSM.Core Require Import Validator Equivocation Equivocation.FixedSetEquivocation.
-From VLSM.Core Require Import Equivocation.LimitedMessageEquivocation Equivocation.LimitedMessageEquivocation.
+From VLSM.Core Require Import Equivocation.LimitedMessageEquivocation.
 From VLSM.Core Require Import Equivocation.MsgDepLimitedEquivocation Equivocation.TraceWiseEquivocation.
 
 (** * VLSM Compositions with Byzantine nodes of limited weight

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
-From Coq Require Import Streams FunctionalExtensionality FinFun.
-From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet Lib.StreamExtras.
+From Coq Require Import Streams FunctionalExtensionality.
+From VLSM Require Import Lib.Preamble Lib.ListExtras.
 From VLSM Require Import Core.VLSM Core.Plans Core.VLSMProjections.
 
 (** * VLSM Composition *)

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1,8 +1,8 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
-From Coq Require Import Streams FinFun Rdefinitions.
+From Coq Require Import Streams Rdefinitions.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import Preamble ListExtras StdppListSet StdppExtras.
-From VLSM.Lib Require Import ListSetExtras Measurable FinFunExtras.
+From VLSM.Lib Require Import ListSetExtras Measurable.
 From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces Validator.
 
 (** * VLSM Equivocation Definitions **)

--- a/theories/VLSM/Core/Equivocation/FullNode.v
+++ b/theories/VLSM/Core/Equivocation/FullNode.v
@@ -1,5 +1,4 @@
 From stdpp Require Import prelude.
-From Coq Require Import FinFun.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition.
 From VLSM Require Import Core.Equivocation.
 

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -1,6 +1,6 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
-From Coq Require Import FinFun Rdefinitions RIneq.
+From Coq Require Import FinFun RIneq.
 From VLSM Require Import Lib.Preamble Lib.Measurable Lib.StdppListSet Lib.RealsExtras.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.MessageDependencies Core.Composition Core.Equivocation Core.Equivocation.FixedSetEquivocation Core.Equivocation.TraceWiseEquivocation.
 From VLSM Require Import Core.Equivocation.WitnessedEquivocation.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -1,7 +1,6 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
-From stdpp Require Import prelude finite.
-From Coq Require Import Relations.Relation_Operators.
-From VLSM.Lib Require Import Preamble StdppListSet FinFunExtras.
+From stdpp Require Import prelude.
+From VLSM.Lib Require Import Preamble StdppListSet.
 From VLSM.Core Require Import VLSM MessageDependencies VLSMProjections Composition Equivocation FixedSetEquivocation ProjectionTraces SubProjectionTraces.
 
 Section msg_dep_fixed_set_equivocation.

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -1,11 +1,10 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From Coq Require Import Reals.
-From stdpp Require Import prelude finite.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras FinFunExtras Measurable StdppExtras.
-From VLSM.Core Require Import VLSM AnnotatedVLSM MessageDependencies VLSMProjections Composition.
-From VLSM.Core Require Import Validator ProjectionTraces SubProjectionTraces Equivocation.
-From VLSM.Core.Equivocation Require Import FixedSetEquivocation TraceWiseEquivocation.
-From VLSM.Core.Equivocation Require Import LimitedMessageEquivocation MsgDepFixedSetEquivocation.
+From stdpp Require Import prelude.
+From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras Measurable StdppExtras.
+From VLSM.Core Require Import VLSM AnnotatedVLSM MessageDependencies VLSMProjections Composition SubProjectionTraces.
+From VLSM.Core.Equivocation Require Import FixedSetEquivocation LimitedMessageEquivocation MsgDepFixedSetEquivocation TraceWiseEquivocation.
+From VLSM.Core Require Import Validator ProjectionTraces Equivocation.
 
 (** To allow capturing the two models of limited equivocation described in the
     sections below, we first define a notion of limited equivocation parameterized

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -1,6 +1,5 @@
 From stdpp Require Import prelude.
-From Coq Require Import FunctionalExtensionality FinFun.
-From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StreamExtras.
+From VLSM Require Import Lib.Preamble.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.Equivocation.
 
 (** * VLSM No Equivocation Composition Constraints *)

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -2,9 +2,8 @@ From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto aut
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun Rdefinitions.
 From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet.
-From VLSM Require Import Lib.ListSetExtras Lib.Measurable.
 From VLSM Require Import Core.VLSM Core.Composition Core.ProjectionTraces.
-From VLSM Require Import Core.Equivocation Core.Equivocation.NoEquivocation Core.Equivocation.FixedSetEquivocation.
+From VLSM Require Import Core.Equivocation.
 From VLSM Require Import Lib.Preamble Lib.StdppExtras.
 
 (** * VLSM Trace-wise Equivocation

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -1,7 +1,6 @@
 From stdpp Require Import prelude.
-From Coq Require Import FinFun Rdefinitions FunctionalExtensionality.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras Measurable.
-From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.
+From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras.
+From VLSM.Core Require Import VLSM VLSMProjections Composition.
 From VLSM.Core Require Import SubProjectionTraces MessageDependencies Equivocation.
 From VLSM.Core Require Import NoEquivocation FixedSetEquivocation TraceWiseEquivocation.
 

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -1,5 +1,5 @@
 From stdpp Require Import prelude.
-From VLSM.Lib Require Import Preamble FinFunExtras.
+From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM Equivocation.
 From VLSM.Core Require Import Composition VLSMProjections Validator ProjectionTraces.
 

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -1,10 +1,10 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun FunctionalExtensionality.
-From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet Lib.ListSetExtras Lib.StdppExtras.
-From VLSM Require Import Lib.FinExtras Lib.FinFunExtras Lib.Measurable.
+From VLSM Require Import Lib.Preamble Lib.ListSetExtras Lib.StdppExtras.
+From VLSM Require Import Lib.FinExtras Lib.Measurable.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Plans Core.Composition Core.Equivocation Core.SubProjectionTraces Core.Equivocation.NoEquivocation.
-From VLSM Require Import Core.Equivocators.Equivocators Core.Equivocators.EquivocatorsProjections.
+From VLSM Require Import Core.Equivocators.Equivocators.
 From VLSM Require Import Core.Equivocators.MessageProperties.
 
 (** * VLSM Equivocator Composition

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -1,11 +1,11 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From Coq Require Import FinFun FunctionalExtensionality.
 From stdpp Require Import prelude finite.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet FinExtras.
-From VLSM.Core Require Import VLSM VLSMProjections Composition Validator ProjectionTraces.
+From VLSM.Lib Require Import Preamble ListExtras StdppListSet.
+From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces Validator.
 From VLSM.Core Require Import SubProjectionTraces Equivocation.
 From VLSM.Core.Equivocation Require Import NoEquivocation.
-From VLSM.Core.Equivocators Require Import Equivocators EquivocatorsProjections MessageProperties Composition.EquivocatorsComposition.
+From VLSM.Core.Equivocators Require Import Equivocators EquivocatorsProjections Composition.EquivocatorsComposition MessageProperties.
 
 (** * VLSM Equivocator Composition Projections *)
 

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -1,12 +1,10 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
-From Coq Require Import FinFun.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet FinExtras.
+From VLSM.Lib Require Import Preamble ListExtras StdppListSet.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.Equivocation.
 From VLSM Require Import Core.Equivocation.NoEquivocation Core.Equivocation.FullNode Core.Equivocation.FixedSetEquivocation.
 From VLSM Require Import Core.SubProjectionTraces Core.ProjectionTraces.
 From VLSM Require Import Core.Equivocators.Equivocators Core.Equivocators.EquivocatorsProjections.
-From VLSM Require Import Core.Equivocators.MessageProperties.
 From VLSM Require Import Core.Equivocators.Composition.EquivocatorsComposition.
 From VLSM Require Import Core.Equivocators.Composition.EquivocatorsCompositionProjections.
 

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -1,11 +1,9 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From Coq Require Import FinFun.
 From VLSM Require Import Lib.Preamble Lib.ListExtras.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces Core.SubProjectionTraces.
 From VLSM Require Import Core.Equivocation Core.EquivocationProjections Core.Equivocation.FixedSetEquivocation Core.Equivocation.NoEquivocation.
 From VLSM Require Import Core.Equivocators.Equivocators Core.Equivocators.EquivocatorsProjections.
-From VLSM Require Import Core.Equivocators.MessageProperties.
 From VLSM Require Import Core.Equivocators.Composition.EquivocatorsComposition.
 From VLSM Require Import Core.Equivocators.Composition.EquivocatorsCompositionProjections.
 From VLSM Require Import Core.Equivocators.Composition.SimulatingFree.FullReplayTraces.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
@@ -1,9 +1,9 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
-From stdpp Require Import prelude finite.
+From stdpp Require Import prelude.
 From Coq Require Import FinFun Reals.
-From VLSM Require Import Lib.StdppListSet Lib.FinFunExtras.
-From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces Core.SubProjectionTraces Core.AnnotatedVLSM.
-From VLSM Require Import Core.Equivocation Core.EquivocationProjections Core.Equivocation.FixedSetEquivocation Core.Equivocation.NoEquivocation.
+From VLSM Require Import Lib.StdppListSet.
+From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.AnnotatedVLSM.
+From VLSM Require Import Core.Equivocation Core.Equivocation.FixedSetEquivocation.
 From VLSM Require Import Lib.Measurable Core.Equivocation.TraceWiseEquivocation Core.Equivocation.LimitedMessageEquivocation Core.Equivocation.MsgDepLimitedEquivocation.
 From VLSM Require Import MessageDependencies Core.Equivocation.WitnessedEquivocation.
 From VLSM Require Import Core.Equivocators.Composition.EquivocatorsComposition Core.Equivocators.Composition.EquivocatorsCompositionProjections.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
@@ -1,11 +1,11 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
-From Coq Require Import FinFun Lia Reals Lra.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras FinExtras FinFunExtras Measurable.
-From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces Core.AnnotatedVLSM.
+From Coq Require Import FinFun Reals.
+From VLSM.Lib Require Import Preamble StdppListSet ListSetExtras Measurable.
+From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.AnnotatedVLSM.
 From VLSM Require Import Core.Equivocation Core.Equivocation.TraceWiseEquivocation.
 From VLSM Require Import Core.Equivocation.NoEquivocation Core.Equivocation.LimitedMessageEquivocation Core.Equivocation.MsgDepLimitedEquivocation.
-From VLSM Require Import Core.Equivocators.Equivocators Core.Equivocators.EquivocatorsProjections.
+From VLSM Require Import Core.Equivocators.Equivocators.
 From VLSM Require Import Core.Equivocators.MessageProperties Core.Equivocators.Composition.EquivocatorsComposition.
 From VLSM Require Import Core.Equivocators.Composition.EquivocatorsCompositionProjections Core.MessageDependencies.
 From VLSM Require Import Core.Equivocators.Composition.LimitedEquivocation.FixedEquivocation.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -1,8 +1,8 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
-From Coq Require Import FinFun Lia Program.
-From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.FinExtras Lib.FinFunExtras.
-From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces Core.SubProjectionTraces.
+From Coq Require Import FinFun Program.
+From VLSM Require Import Lib.Preamble Lib.ListExtras.
+From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.SubProjectionTraces.
 From VLSM Require Import Core.Equivocation Core.Equivocation.NoEquivocation.
 From VLSM Require Import Core.Equivocators.Equivocators Core.Equivocators.EquivocatorsProjections Core.Equivocators.EquivocatorReplay.
 From VLSM Require Import Core.Equivocators.MessageProperties Core.Equivocators.Composition.EquivocatorsComposition.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -1,15 +1,12 @@
 From stdpp Require Import prelude finite.
-From Coq Require Import FinFun Lia FunctionalExtensionality.
-From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.FinExtras Lib.FinFunExtras.
-From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.ProjectionTraces Core.SubProjectionTraces.
+From Coq Require Import FinFun FunctionalExtensionality.
+From VLSM Require Import Lib.Preamble Lib.ListExtras.
+From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Composition Core.SubProjectionTraces.
 From VLSM Require Import Core.Equivocation Core.Equivocation.NoEquivocation.
-From VLSM Require Import Core.Equivocators.Equivocators Core.Equivocators.EquivocatorsProjections.
-From VLSM Require Import Core.Equivocators.MessageProperties.
+From VLSM Require Import Core.Equivocators.Equivocators.
 From VLSM Require Import Core.Equivocators.Composition.EquivocatorsComposition.
 From VLSM Require Import Core.Equivocators.Composition.EquivocatorsCompositionProjections.
 From VLSM Require Import Core.Equivocators.Composition.SimulatingFree.FullReplayTraces.
-From VLSM Require Import Core.Equivocators.Composition.LimitedEquivocation.FixedEquivocation.
-From VLSM Require Import Core.Plans.
 
 (** * Equivocators simulating regular nodes
 

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -1,6 +1,6 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From Coq Require Import Eqdep Vectors.Fin Program.Equality Lia FunctionalExtensionality.
+From Coq Require Import Eqdep Vectors.Fin FunctionalExtensionality.
 From VLSM Require Import Lib.Preamble Core.VLSM Core.VLSMProjections.
 
 (** * VLSM Equivocation

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -1,5 +1,4 @@
 From stdpp Require Import prelude.
-From Coq Require Import Eqdep Lia.
 From VLSM Require Import Lib.Preamble Lib.ListExtras.
 From VLSM Require Import Core.VLSM Core.VLSMProjections Core.Equivocators.Equivocators.
 

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -1,7 +1,6 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From Coq Require Import Vectors.Fin FunctionalExtensionality Arith.Compare_dec Lia Program.Equality.
-From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet.
+From VLSM Require Import Lib.Preamble Lib.StdppListSet.
 From VLSM Require Import Lib.ListSetExtras Lib.FinExtras.
 From VLSM Require Import Core.VLSM Core.Equivocation.
 From VLSM Require Import Core.Equivocators.Equivocators Core.Equivocators.EquivocatorsProjections.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -1,8 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
-From Coq Require Import FinFun Relations.Relation_Operators Program.Equality.
-From stdpp Require Import prelude finite.
-From VLSM.Lib Require Import Preamble ListExtras FinFunExtras StdppListSet Measurable.
-From VLSM.Core Require Import VLSM VLSMProjections Composition Validator ProjectionTraces.
+From stdpp Require Import prelude.
+From VLSM.Lib Require Import Preamble ListExtras StdppListSet.
+From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.
 From VLSM.Core Require Import SubProjectionTraces Equivocation EquivocationProjections.
 
 (** * VLSM Message Dependencies

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -1,8 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
-From Coq Require Import Streams FunctionalExtensionality FinFun Eqdep.
 From stdpp Require Import prelude.
-From VLSM.Lib Require Import Preamble StreamExtras ListExtras StdppExtras.
-From VLSM.Core Require Import VLSM Plans Composition VLSMProjections Validator.
+From VLSM.Lib Require Import Preamble StdppExtras.
+From VLSM.Core Require Import VLSM Composition VLSMProjections Validator.
 
 Section projections.
 

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1,5 +1,5 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
-From Coq Require Import FunctionalExtensionality Lia FinFun.
+From Coq Require Import FunctionalExtensionality Lia.
 From stdpp Require Import prelude finite.
 From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet StdppExtras.
 From VLSM.Core Require Import VLSM VLSMProjections ProjectionTraces Composition Validator.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -1,7 +1,6 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
 From Coq Require Import FunctionalExtensionality.
-From VLSM.Lib Require Import Preamble ListExtras StreamExtras StreamFilters.
 From VLSM.Core Require Import VLSM.
 From VLSM.Core.VLSMProjections Require Export VLSMPartialProjection VLSMTotalProjection.
 From VLSM.Core.VLSMProjections Require Export VLSMEmbedding VLSMInclusion VLSMEquality.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -1,6 +1,5 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From Coq Require Import FunctionalExtensionality.
 From VLSM.Lib Require Import Preamble ListExtras StreamExtras StreamFilters.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMTotalProjection.
 

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -1,7 +1,5 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From Coq Require Import FinFun.
-From VLSM.Lib Require Import Preamble ListExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition (* Equivocation MessageDependencies*).
 
 (** * VLSM Projection Validators

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -665,8 +665,6 @@ Proof.
   - done.
 Qed.
 
-Require Import Setoid.
-
 Add Parametric Relation A : (set A) (@set_eq A)
  reflexivity proved by (@set_eq_refl A)
  transitivity proved by (@set_eq_tran A) as set_eq_rel.

--- a/theories/VLSM/Lib/RealsExtras.v
+++ b/theories/VLSM/Lib/RealsExtras.v
@@ -1,4 +1,4 @@
-From Coq Require Import Reals RelationClasses.
+From Coq Require Import Reals.
 From stdpp Require Import prelude.
 
 (** * Real number utility lemmas *)

--- a/theories/VLSM/Lib/SortedLists.v
+++ b/theories/VLSM/Lib/SortedLists.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From Coq Require Import Sorting RelationClasses Relations Orders.
-From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.StdppListSet Lib.ListSetExtras.
+From Coq Require Import Sorting.
+From VLSM Require Import Lib.Preamble Lib.ListExtras Lib.ListSetExtras.
 
 (** * Sorted list utility functions and lemmas **)
 


### PR DESCRIPTION
I've run the minimize-requires script for the entire VLSM project, and after the minimization, some files failed on build. (I still cannot understand why) This is why I manually fixed the imports, such that now it compiles fine again.