### PR TITLE
A tactic which automates reasoning about the state_update function

### DIFF
--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -246,8 +246,7 @@ Proof.
     ; unfold annotated_transition; cbn
     ; destruct (vtransition _ _ _) as (si', om').
     intros [_ Ht]; inversion Ht.
-    f_equal; symmetry.
-    apply state_update_eq.
+    by state_update_simpl.
   - intros [j lj].
     unfold annotated_composite_label_project, composite_project_label; cbn.
     case_decide as Hij; [congruence |].
@@ -256,7 +255,7 @@ Proof.
     ; unfold annotated_transition; cbn
     ; destruct (vtransition _ _ _) as (si', om').
     intros [_ Ht]; inversion Ht.
-    apply state_update_neq; congruence.
+    by state_update_simpl.
   - intros [s ann] [Hs _]; cbn; apply Hs.
   - intro; intros; apply any_message_is_valid_in_preloaded.
 Qed.
@@ -276,7 +275,7 @@ Proof.
   unfold annotated_transition; cbn
   ; destruct (vtransition _ _ _) as (si', om')
   ; inversion 1; clear Ht; subst om' s'X; cbn.
-  by rewrite state_update_neq.
+  by state_update_simpl.
 Qed.
 
 Lemma annotated_composite_induced_validator_label_lift
@@ -311,7 +310,7 @@ Proof.
   ; intros <- iom sX1' oom1
   ;destruct (vtransition _ _ _) as (si', om').
   inversion_clear 1; intros sX2' oom2; inversion_clear 1.
-  by cbn; rewrite !state_update_eq.
+  by cbn; state_update_simpl.
 Qed.
 
 Definition annotated_composite_induced_validator_is_projection :=

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -232,7 +232,7 @@ Proof.
   assert (valid_state_message_prop Alt s None) as Hs
       by (apply valid_initial_state, proj2_sig).
   by eapply (valid_generated_state_message Alt) with s None s None (existT second _)
-  ; cbn; [..| rewrite !state_update_id].
+  ; cbn; state_update_simpl.
 Qed.
 
 (**

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -278,8 +278,7 @@ Proof.
       by split; [cbn; apply Ht|].
     * simpl.
       replace (lifted_alt_state s first) with s
-        by (unfold lifted_alt_state,lift_to_composite_state'
-           ; rewrite state_update_eq; done).
+        by (unfold lifted_alt_state,lift_to_composite_state'; state_update_simpl; done).
       apply proj2 in Ht.
       change (vtransition M l (s: vstate M,om0) = (s',om')) in Ht.
       rewrite Ht.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -330,7 +330,7 @@ Proof.
     destruct (decide (i = j)) as [| Hij]; subst.
     + unfold lift_sub_state.
       by rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi), !state_update_eq.
-    + rewrite state_update_neq by congruence.
+    + state_update_simpl.
       unfold lift_sub_state.
       destruct (decide (j ∈ set_diff (enum index) byzantine)) as [Hj |].
       * by rewrite !(lift_sub_state_to_eq _ _ _ _ _ Hj), sub_IM_state_update_neq.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -327,14 +327,11 @@ Proof.
     ; destruct (vtransition _ _ _) as (si', om')
     ; inversion_clear 1.
     do 2 f_equal; extensionality j.
-    destruct (decide (i = j)) as [| Hij]; subst.
-    + unfold lift_sub_state.
-      by rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi), !state_update_eq.
-    + state_update_simpl.
-      unfold lift_sub_state.
-      destruct (decide (j ∈ set_diff (enum index) byzantine)) as [Hj |].
+    state_update i j; unfold lift_sub_state.
+    + by rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi), !state_update_eq.
+    + destruct (decide (j ∈ set_diff (enum index) byzantine)) as [Hj |].
       * by rewrite !(lift_sub_state_to_eq _ _ _ _ _ Hj), sub_IM_state_update_neq.
-      * by rewrite !lift_sub_state_to_neq.
+      * by state_update_simpl.
 Qed.
 
 (** Considering a trace with the [fixed_byzantine_trace_alt_prop]erty for a

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -327,7 +327,8 @@ Proof.
     ; destruct (vtransition _ _ _) as (si', om')
     ; inversion_clear 1.
     do 2 f_equal; extensionality j.
-    state_update i j; unfold lift_sub_state.
+    unfold lift_sub_state.
+    destruct (decide (i = j)); subst; state_update_simpl.
     + by rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi), !state_update_eq.
     + destruct (decide (j ∈ set_diff (enum index) byzantine)) as [Hj |].
       * by rewrite !(lift_sub_state_to_eq _ _ _ _ _ Hj), sub_IM_state_update_neq.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -843,7 +843,7 @@ End sec_composite_vlsm.
 End VLSM_composition.
 
 (**
-  A nice little tactic for dealing with [state_update].
+  Hint database and tactic for dealing with updates and lifting via [state_update].
 *)
 
 Create HintDb state_update.
@@ -857,9 +857,6 @@ Create HintDb state_update.
 
 Ltac state_update_simpl :=
   autounfold with state_update in *; autorewrite with state_update in *.
-
-Ltac state_update i j :=
-  destruct (decide (i = j)); subst; state_update_simpl.
 
 (**
    These basic projection lemmas relate

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1675,7 +1675,7 @@ Proof.
   rewrite Heq_s in Heqs at 1; clear Heq_s.
   specialize (unique_transition_to_state Ht1 Ht2) as Heq;
     destruct_and! Heq; subst; repeat split.
-  extensionality j; destruct (decide (i = j)); [by subst |].
+  extensionality j; state_update i j; [done |].
   apply f_equal with (f := fun s => s j) in Heqs.
   by state_update_simpl.
 Qed.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -845,20 +845,18 @@ End VLSM_composition.
 (**
   A nice little tactic for dealing with [state_update].
 *)
+
+Create HintDb state_update.
+
+#[export] Hint Rewrite @state_update_neq using done : state_update.
+#[export] Hint Rewrite @state_update_id using done : state_update.
+#[export] Hint Rewrite @state_update_eq : state_update.
+
+#[export] Hint Unfold lift_to_composite_state : state_update.
+#[export] Hint Unfold lift_to_composite_state' : state_update.
+
 Ltac state_update_simpl :=
-repeat match goal with
-| |- context [state_update _ _ ?i _ ?i] => rewrite (state_update_eq _ _ i)
-| Heq : ?i <> ?j |- context [state_update _ _ ?i _ ?j] =>
-  rewrite (state_update_neq _ _ i _ j) by done
-| Heq : ?j <> ?i |- context [state_update _ _ ?i _ ?j] =>
-  rewrite (state_update_neq _ _ i _ j) by done
-| H : context [state_update _ _ ?i _ ?i] |- _ => rewrite (state_update_eq _ _ i) in H
-| Heq : ?i <> ?j, H : context [state_update _ _ ?i _ ?j] |- _ =>
-  rewrite (state_update_neq _ _ i _ j) in H by done
-| Heq : ?j <> ?i, H : context [state_update _ _ ?i _ ?j] |- _ =>
-  rewrite (state_update_neq _ _ i _ j) in H by done
-(*   | |- context [state_update _ _ ?i _ ?j] => destruct (decide (i = j)); subst *)
-end.
+  autounfold with state_update in *; autorewrite with state_update in *.
 
 Ltac state_update i j :=
   destruct (decide (i = j)); subst; state_update_simpl.
@@ -1716,12 +1714,11 @@ Proof.
       assert (Hss1 : input_valid_transition RFree (existT i li)
                   (state_update IM s j (s1 j), om) (s1, om')).
       {
-        repeat split; [apply IHHs2 | apply any_message_is_valid_in_preloaded |..].
-        - by cbn; state_update_simpl.
-        - cbn; state_update_simpl.
-          replace (vtransition _ _ _) with (s' i, om').
-          f_equal; extensionality k; apply f_equal with (f := fun s => s k) in Heqs'.
-          by rewrite Heq_s'; state_update i k; state_update j k.
+        repeat split; [apply IHHs2 | apply any_message_is_valid_in_preloaded |..]
+        ; cbn; state_update_simpl; [done |].
+        replace (vtransition _ _ _) with (s' i, om').
+        f_equal; extensionality k; apply f_equal with (f := fun s => s k) in Heqs'.
+        by rewrite Heq_s'; state_update i k; state_update j k.
       }
       repeat split; cbn.
       * by eapply input_valid_transition_destination.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -901,7 +901,7 @@ Proof.
     simpl in Ht. unfold vtransition in Ht. simpl in Ht.
     destruct (vtransition (IM j) _ _) as (si', _om') eqn:Hti.
     inversion_clear Ht.
-    state_update i j; [| done].
+    destruct (decide (i = j)); subst; state_update_simpl; [| done].
     by apply preloaded_protocol_generated with lj (s j) om _om'; [| apply Hv |].
 Qed.
 
@@ -1513,7 +1513,7 @@ Proof.
     inversion 1; subst; clear H.
     f_equal. extensionality j.
     unfold same_IM_state_rew at 2.
-    by state_update i j.
+    by destruct (decide (i = j)); subst; state_update_simpl.
   - intros i. apply same_VLSM_initial_state_preservation, H.
   - apply initial_message_is_valid.
     destruct HmX as [[i [[im Him] Hi]] | Hseed]; [| by right].
@@ -1670,7 +1670,8 @@ Proof.
   rewrite Heq_s in Heqs at 1; clear Heq_s.
   specialize (unique_transition_to_state Ht1 Ht2) as Heq;
     destruct_and! Heq; subst; repeat split.
-  extensionality j; state_update i j; [done |].
+  extensionality j.
+  destruct (decide (i = j)); subst; [done |].
   apply f_equal with (f := fun s => s j) in Heqs.
   by state_update_simpl.
 Qed.
@@ -1715,7 +1716,8 @@ Proof.
         ; cbn; state_update_simpl; [done |].
         replace (vtransition _ _ _) with (s' i, om').
         f_equal; extensionality k; apply f_equal with (f := fun s => s k) in Heqs'.
-        by rewrite Heq_s'; state_update i k; state_update j k.
+        rewrite Heq_s'.
+        by destruct (decide (i = k)), (decide (j = k)); subst; state_update_simpl.
       }
       repeat split; cbn.
       * by eapply input_valid_transition_destination.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -431,10 +431,8 @@ Proof.
     clear.
     apply functional_extensionality_dep. intro sub_j.
     destruct_dec_sig sub_j j Hj Heqsub_j. subst.
-    unfold composite_state_sub_projection at 2. simpl.
-    state_update i j.
-    + by rewrite sub_IM_state_update_eq.
-    + by rewrite !state_update_neq; [done .. | inversion 1].
+    unfold composite_state_sub_projection at 2.
+    by state_update i j.
 Qed.
 
 (** See Lemma [fixed_output_has_strong_fixed_equivocation] below. *)
@@ -533,7 +531,7 @@ Proof.
         inversion_clear Ht; clear -Hl.
         extensionality sub_j; destruct_dec_sig sub_j j Hj Heqsub_j;
         subst; unfold composite_state_sub_projection.
-        by rewrite state_update_neq; [|contradict Hl; subst].
+        by state_update i j.
 Qed.
 
 (**
@@ -827,9 +825,7 @@ Proof.
     destruct (vtransition _ _ _) as (si', _om');
     inversion_clear 1.
     f_equal; extensionality j.
-    state_update i j.
-    + by rewrite lift_sub_state_to_neq, !state_update_eq.
-    + by unfold lift_sub_state_to; rewrite state_update_neq.
+    by state_update i j.
   - intros [i liX].
     unfold remove_equivocating_state_project;
     unfold remove_equivocating_label_project; cbn.
@@ -930,13 +926,12 @@ Proof.
     destruct (vtransition _ _ _) as (si', _om');
     intros [_ Ht]; inversion_clear Ht.
     f_equal. extensionality i.
-    destruct (decide (i = j)); subst.
+    state_update i j.
     + by rewrite lift_sub_state_to_eq with (Hi := Hj), !state_update_eq.
-    + rewrite state_update_neq by congruence.
-      destruct (decide (i ∈ equivocators)).
+    + destruct (decide (i ∈ equivocators)).
       * rewrite !lift_sub_state_to_eq with (Hi := e), state_update_neq; [done |].
         by intros Hcontra%dsig_eq.
-      * by rewrite !lift_sub_state_to_neq.
+      * by state_update_simpl.
   - by intros s H2; apply fixed_equivocator_lifting_initial_state.
   - intros l s m Hv HsY [[(i, Hi) [[im Him] Heqm]] | Hm].
     + apply initial_message_is_valid.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -432,10 +432,9 @@ Proof.
     apply functional_extensionality_dep. intro sub_j.
     destruct_dec_sig sub_j j Hj Heqsub_j. subst.
     unfold composite_state_sub_projection at 2. simpl.
-    destruct (decide (j = i)).
-    + by subst; rewrite sub_IM_state_update_eq, state_update_eq.
-    + rewrite !state_update_neq; [done ..|].
-      by inversion 1.
+    state_update i j.
+    + by rewrite sub_IM_state_update_eq.
+    + by rewrite !state_update_neq; [done .. | inversion 1].
 Qed.
 
 (** See Lemma [fixed_output_has_strong_fixed_equivocation] below. *)
@@ -828,10 +827,9 @@ Proof.
     destruct (vtransition _ _ _) as (si', _om');
     inversion_clear 1.
     f_equal; extensionality j.
-    destruct (decide (i = j)); subst.
+    state_update i j.
     + by rewrite lift_sub_state_to_neq, !state_update_eq.
-    + unfold lift_sub_state_to.
-      by rewrite state_update_neq, state_update_neq.
+    + by unfold lift_sub_state_to; rewrite state_update_neq.
   - intros [i liX].
     unfold remove_equivocating_state_project;
     unfold remove_equivocating_label_project; cbn.
@@ -841,9 +839,7 @@ Proof.
     inversion_clear 1.
     extensionality j.
     unfold lift_sub_state_to.
-    case_decide as Hj; [done |].
-    destruct (decide (i = j)); [by contradict Hj; subst |].
-    apply state_update_neq. congruence.
+    by case_decide; [| state_update i j].
   - intros s Hs i.
     unfold remove_equivocating_state_project, lift_sub_state_to.
     case_decide as Hi.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -432,7 +432,7 @@ Proof.
     apply functional_extensionality_dep. intro sub_j.
     destruct_dec_sig sub_j j Hj Heqsub_j. subst.
     unfold composite_state_sub_projection at 2.
-    by state_update i j.
+    by destruct (decide (i = j)); subst; state_update_simpl.
 Qed.
 
 (** See Lemma [fixed_output_has_strong_fixed_equivocation] below. *)
@@ -531,7 +531,7 @@ Proof.
         inversion_clear Ht; clear -Hl.
         extensionality sub_j; destruct_dec_sig sub_j j Hj Heqsub_j;
         subst; unfold composite_state_sub_projection.
-        by state_update i j.
+        by destruct (decide (i = j)); subst; state_update_simpl.
 Qed.
 
 (**
@@ -825,7 +825,7 @@ Proof.
     destruct (vtransition _ _ _) as (si', _om');
     inversion_clear 1.
     f_equal; extensionality j.
-    by state_update i j.
+    by destruct (decide (i = j)); subst; state_update_simpl.
   - intros [i liX].
     unfold remove_equivocating_state_project;
     unfold remove_equivocating_label_project; cbn.
@@ -835,7 +835,8 @@ Proof.
     inversion_clear 1.
     extensionality j.
     unfold lift_sub_state_to.
-    by case_decide; [| state_update i j].
+    case_decide; [done |].
+    by destruct (decide (i = j)); subst; state_update_simpl.
   - intros s Hs i.
     unfold remove_equivocating_state_project, lift_sub_state_to.
     case_decide as Hi.
@@ -925,8 +926,8 @@ Proof.
     rewrite lift_sub_state_to_eq with (Hi := Hj);
     destruct (vtransition _ _ _) as (si', _om');
     intros [_ Ht]; inversion_clear Ht.
-    f_equal. extensionality i.
-    state_update i j.
+    f_equal; extensionality i.
+    destruct (decide (i = j)); subst; state_update_simpl.
     + by rewrite lift_sub_state_to_eq with (Hi := Hj), !state_update_eq.
     + destruct (decide (i ∈ equivocators)).
       * rewrite !lift_sub_state_to_eq with (Hi := e), state_update_neq; [done |].

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -130,7 +130,7 @@ Proof.
     cbn; unfold sub_IM, sub_state_element_project; cbn.
     rewrite (sub_IM_state_pi sX Hj Hi).
     destruct (vtransition _ _ _) as (sj', _om'); inversion_clear 1.
-    f_equal; symmetry; apply sub_IM_state_update_eq.
+    f_equal; symmetry. apply sub_IM_state_update_eq.
   - intros [sub_i li] HlX_pr sX om sX' om' [_ HtX].
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
     unfold sub_label_element_project in HlX_pr; cbn in HlX_pr.
@@ -138,7 +138,7 @@ Proof.
     cbn in HtX; destruct (vtransition _ _ _) as (si', _om').
     inversion_clear HtX.
     unfold sub_state_element_project.
-    rewrite sub_IM_state_update_neq; congruence.
+    by state_update_simpl.
   - by intros sX HsX; apply (HsX (dexist j Hj)).
   - intro; intros; apply any_message_is_valid_in_preloaded.
 Qed.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -144,7 +144,7 @@ Proof.
   destruct l as (j, lj).
   destruct (vtransition (equivocator_IM j) lj (s0 j, iom)) as (sj', om') eqn:Htj.
   inversion Ht. subst. clear Ht.
-  state_update i j; [| done].
+  destruct (decide (i = j)); subst; state_update_simpl; [| done].
   by revert Hsi; apply equivocator_transition_reflects_singleton_state with iom oom lj.
 Qed.
 
@@ -153,11 +153,12 @@ Lemma equivocators_transition_cannot_decrease_state_size
   (Ht: composite_transition equivocator_IM l (s, iom) = (s', oom))
   : forall eqv, equivocator_state_n (s eqv) <= equivocator_state_n (s' eqv).
 Proof.
-  destruct l as (j, lj). cbn in Ht.
-  destruct (equivocator_transition _ _ _) as (sj', om') eqn:Htj.
+  intro eqv.
+  destruct l as [j lj]; cbn in Ht.
+  destruct (equivocator_transition _ _ _) as [sj' om'] eqn: Htj.
   apply equivocator_transition_cannot_decrease_state_size in Htj.
-  inversion Ht. subst. clear Ht.
-  by intro eqv; state_update j eqv.
+  inversion Ht; subst; clear Ht.
+  by destruct (decide (j = eqv)); subst; state_update_simpl.
 Qed.
 
 Lemma equivocators_plan_cannot_decrease_state_size
@@ -340,7 +341,7 @@ Lemma proper_equivocator_descriptors_state_update_eqv
 Proof.
   intro eqv'.
   specialize (Hproper eqv').
-  by state_update eqv eqv'.
+  by destruct (decide (eqv = eqv')); subst; state_update_simpl.
 Qed.
 
 Definition equivocators_state_project

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -340,9 +340,7 @@ Lemma proper_equivocator_descriptors_state_update_eqv
 Proof.
   intro eqv'.
   specialize (Hproper eqv').
-  destruct (decide (eqv' = eqv)); subst.
-  - by rewrite state_update_eq in Hproper.
-  - by rewrite state_update_neq in Hproper.
+  by state_update eqv eqv'.
 Qed.
 
 Definition equivocators_state_project
@@ -477,10 +475,8 @@ Lemma equivocators_state_project_state_update_eqv
   equivocators_state_project eqv_descriptors (state_update equivocator_IM s eqv seqv)
   = state_update IM (equivocators_state_project eqv_descriptors s) eqv si.
 Proof.
-  apply functional_extensionality_dep.
-  intro ieqv.
-  unfold equivocators_state_project.
-  unfold state_update.
+  cbn; extensionality ieqv.
+  unfold equivocators_state_project, state_update.
   by case_decide; subst.
 Qed.
 
@@ -512,6 +508,11 @@ Proof.
 Qed.
 
 End fully_equivocating_composition.
+
+#[export] Hint Rewrite @equivocator_descriptors_update_eq : state_update.
+#[export] Hint Rewrite @equivocator_descriptors_update_id using done : state_update.
+#[export] Hint Rewrite @equivocator_descriptors_update_neq using done : state_update.
+#[export] Hint Rewrite @equivocators_state_project_state_update_eqv using done : state_update.
 
 Section equivocators_sub_projections.
 

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -144,8 +144,7 @@ Proof.
   destruct l as (j, lj).
   destruct (vtransition (equivocator_IM j) lj (s0 j, iom)) as (sj', om') eqn:Htj.
   inversion Ht. subst. clear Ht.
-  destruct (decide (i = j)); [| by rewrite state_update_neq in Hsi].
-  subst. rewrite state_update_eq in Hsi.
+  state_update i j; [| done].
   by revert Hsi; apply equivocator_transition_reflects_singleton_state with iom oom lj.
 Qed.
 
@@ -158,10 +157,7 @@ Proof.
   destruct (equivocator_transition _ _ _) as (sj', om') eqn:Htj.
   apply equivocator_transition_cannot_decrease_state_size in Htj.
   inversion Ht. subst. clear Ht.
-  intro eqv.
-  destruct (decide (j = eqv)); subst.
-  - by rewrite state_update_eq.
-  - by rewrite state_update_neq.
+  by intro eqv; state_update j eqv.
 Qed.
 
 Lemma equivocators_plan_cannot_decrease_state_size
@@ -408,7 +404,7 @@ Lemma equivocator_descriptors_update_neq
   (Hneq : j <> i)
   : equivocator_descriptors_update s i si j = s j.
 Proof.
-  unfold equivocator_descriptors_update. destruct (decide (j = i)); congruence.
+  unfold equivocator_descriptors_update. by case_decide.
 Qed.
 
 (**
@@ -424,9 +420,8 @@ Lemma equivocator_descriptors_update_eq_rew
   : equivocator_descriptors_update s i si j = eq_rect_r (fun i => MachineDescriptor (IM i)) si Heq.
 Proof.
   unfold equivocator_descriptors_update.
-  destruct (decide (j = i)); [|congruence]. subst.
-  f_equal.
-  by apply Eqdep_dec.UIP_dec.
+  case_decide; [| done].
+  by f_equal; apply Eqdep_dec.UIP_dec.
 Qed.
 
 Lemma equivocator_descriptors_update_eq

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -354,24 +354,24 @@ Proof.
   - repeat split.
     + by state_update_simpl.
     + by state_update_simpl.
-    + by extensionality j; state_update i j.
+    + by extensionality j; destruct (decide (i = j)); subst; state_update_simpl.
     + by state_update_simpl.
     + subst. specialize (Hchar _ eq_refl) as [Hvx Htx].
       unfold equivocators_state_project, EquivocatorsComposition.equivocators_state_project.
-      state_update_simpl.
-      by rewrite Hli in Hvx.
+      rewrite Hli in Hvx.
+      by state_update_simpl.
     + subst. specialize (Hchar _ eq_refl) as [Hvx Htx].
       unfold equivocators_state_project, EquivocatorsComposition.equivocators_state_project.
       state_update_simpl.
       simpl in *. rewrite Hli in Htx. rewrite Htx. f_equal.
-      by extensionality eqv; state_update i eqv.
+      by extensionality eqv; destruct (decide (i = eqv)); subst; state_update_simpl.
   - repeat split.
     + by state_update_simpl.
     + by state_update_simpl.
-    + by extensionality j; state_update i j.
+    + by extensionality j; destruct (decide (i = j)); subst; state_update_simpl.
     + by state_update_simpl.
     + unfold equivocators_state_project, EquivocatorsComposition.equivocators_state_project.
-      by extensionality eqv; state_update i eqv.
+      by extensionality eqv; destruct (decide (i = eqv)); subst; state_update_simpl.
 Qed.
 
 Lemma equivocators_transition_item_project_proper_characterization
@@ -416,8 +416,8 @@ Proof.
   clear Hv Ht Hoitem.
   split; [| by repeat split]; clear Hchar.
   intro eqv.
-  state_update eqv (projT1 (l item)); [done |].
-  by rewrite Heqv', Hs; state_update_simpl.
+  rewrite Heqv', Hs.
+  by destruct (decide (eqv = projT1 (l item))); subst; state_update_simpl.
 Qed.
 
 Lemma equivocators_transition_item_project_inv_characterization
@@ -1069,7 +1069,8 @@ Proof.
     ; inversion Hproject_x; subst; clear Hproject_x
     ; inversion Heqproject_x; subst; clear Heqproject_x
     ; intro eqv; specialize (IHtr eqv)
-    ; (state_update i eqv; cbn in *; [rewrite ?Hfinali; eexists |]; done).
+    ; (destruct (decide (i = eqv)); subst; state_update_simpl
+       ; cbn in *; [rewrite ?Hfinali; eexists |]; done).
 Qed.
 
 (**
@@ -1130,7 +1131,7 @@ Proof.
   remember (equivocator_descriptors_update (zero_descriptor IM) i eqv_final) as final_descriptors.
   assert (Hfinal_descriptors : not_equivocating_equivocator_descriptors IM final_descriptors final).
   { intro eqv. subst final_descriptors.
-    state_update i eqv; [done |].
+    destruct (decide (i = eqv)); subst; state_update_simpl; [done |].
     apply zero_descriptor_proper.
   }
   exists final_descriptors.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -28,7 +28,7 @@ Context {message : Type}
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
-Hint Unfold equivocator_descriptors_update : state_update.
+#[local] Hint Unfold equivocator_descriptors_update : state_update.
 
 (** Given a [transition_item] <<item>> in the compositions of equivocators
 of components [IM] and an [equivocator_descriptors], if the descriptors
@@ -1897,7 +1897,7 @@ Context {message : Type}
   (sub_IM := sub_IM IM (finite.enum index))
   .
 
-Hint Unfold equivocator_descriptors_update : state_update.
+#[local] Hint Unfold equivocator_descriptors_update : state_update.
 
 Definition free_sub_free_equivocator_descriptors
   (descriptors : equivocator_descriptors IM)

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -28,6 +28,8 @@ Context {message : Type}
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
+Hint Unfold equivocator_descriptors_update : state_update.
+
 (** Given a [transition_item] <<item>> in the compositions of equivocators
 of components [IM] and an [equivocator_descriptors], if the descriptors
 are all valid in the destination of the transition this returns a
@@ -94,9 +96,8 @@ Proof.
     unfold equivocating_indices in *.
     unfold newmachine_descriptors_list in *.
     rewrite! elem_of_list_filter in *.
-    rewrite state_update_eq.
     specialize (Hdescriptors eqv).
-    rewrite state_update_eq in Hitem_pr, Hdescriptors.
+    state_update_simpl.
     cut (is_equivocating_state (IM eqv) si' \/  is_newmachine_descriptor (IM eqv) (descriptors eqv)).
       by itauto.
     apply
@@ -105,24 +106,15 @@ Proof.
       input := input;
       destination := si';
       output := output |} _ Hdescriptors _ _ Hitem_pr _ Hv Htei).
-    clear -Heqv.
-    unfold equivocator_descriptors_update in Heqv.
-    rewrite equivocator_descriptors_update_eq in Heqv.
     itauto.
-  - destruct Heqv as [Heqv | Heqv].
+  - destruct Heqv as [Heqv | Heqv]
+    ; apply elem_of_list_filter in Heqv as [Heqv Hin].
     + left.
-      apply elem_of_list_filter in Heqv.
-      destruct Heqv as [Heqv Hin].
       apply elem_of_list_filter.
-      split; [| done].
-      by rewrite state_update_neq by apply n.
+      by state_update_simpl.
     + right.
-      apply elem_of_list_filter in Heqv.
-      destruct Heqv as [Heqv Hin].
       apply elem_of_list_filter.
-      split; [| done].
-      unfold equivocator_descriptors_update in Heqv.
-      by rewrite equivocator_descriptors_update_neq in Heqv.
+      by state_update_simpl.
 Qed.
 
 (**
@@ -159,7 +151,7 @@ Proof.
       | (let (_, _) := ?t in _) = _ => destruct t as (si', om') eqn:Hti
       end.
       inversion Ht; subst; cbn.
-      by rewrite state_update_eq.
+      by state_update_simpl.
     }
     spec Hpr_item.
     {
@@ -169,16 +161,13 @@ Proof.
     }
     destruct Hpr_item as [oitem' Hpr_item].
     rewrite Hpr_item in Hpr.
-    by destruct oitem'; inversion Hpr
-    ; unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
-  -
-  destruct
+    by destruct oitem'; inversion Hpr; state_update_simpl.
+  - destruct
     (equivocator_vlsm_transition_item_project (IM (projT1 (l item)))
       (composite_transition_item_projection equivocator_IM item)
       (descriptors (projT1 (l item))))
     eqn: Hpr'; [|congruence].
-  by destruct p, o; inversion Hpr
-  ; unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_neq.
+  by destruct p, o; inversion Hpr; state_update_simpl.
 Qed.
 
 Lemma equivocators_transition_item_project_proper_descriptor
@@ -240,14 +229,15 @@ Proof.
   spec Heqv_pr.
   { simpl. unfold eq_rect_r. simpl.
     destruct (vtransition (equivocator_IM x) v (s x, input)) eqn:Hti.
-    clear -Ht Hti; inversion Ht; subst. by rewrite state_update_eq.
+    clear -Ht Hti; inversion Ht; subst.
+    by state_update_simpl.
   }
   destruct Heqv_pr as [Hex Heqv_pr].
   exists Hex.
   unfold equivocators_transition_item_project.
   unfold l. unfold projT1.
   rewrite Hzero, Heqv_pr; cbn; repeat f_equal.
-  by apply equivocator_descriptors_update_id.
+  by state_update_simpl.
 Qed.
 
 Lemma exists_equivocators_transition_item_project
@@ -283,22 +273,23 @@ Proof.
   destruct Hproject as [Heqv' [eqv [Heqv Hproject]]].
   exists (equivocator_descriptors_update (zero_descriptor IM) (projT1 (l item)) eqv).
   split.
-  { intro i. unfold equivocator_descriptors_update. destruct (decide (i = projT1 (l item))).
-    - by subst; rewrite equivocator_descriptors_update_eq.
+  {
+    intro i. unfold equivocator_descriptors_update. destruct (decide (i = projT1 (l item))).
+    - by subst; state_update_simpl.
     - rewrite equivocator_descriptors_update_neq by done; cbn.
       by rewrite equivocator_state_project_zero.
   }
   exists (equivocator_descriptors_update (zero_descriptor IM) (projT1 (l item)) (equivocator_label_descriptor (l (composite_transition_item_projection equivocator_IM item)))).
   split.
   { intro i. unfold equivocator_descriptors_update. destruct (decide (i = projT1 (l item))).
-    - by subst; rewrite equivocator_descriptors_update_eq.
+    - by subst; state_update_simpl.
     - rewrite equivocator_descriptors_update_neq by done.
       simpl. by rewrite equivocator_state_project_zero.
   }
   unfold equivocators_transition_item_project.
-  unfold equivocator_descriptors_update.
-  rewrite equivocator_descriptors_update_eq, Hproject.
-  f_equal. f_equal. apply equivocator_descriptors_update_twice.
+  state_update_simpl.
+  rewrite Hproject.
+  do 2 f_equal. apply equivocator_descriptors_update_twice.
 Qed.
 
 Lemma equivocators_transition_item_project_proper_descriptor_characterization
@@ -361,37 +352,26 @@ Proof.
   ; destruct Hchar as (Hproper' & Hex_new & Hchar)
   .
   - repeat split.
-    + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
-    + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
+    + by state_update_simpl.
+    + by state_update_simpl.
     + by extensionality j; state_update i j.
-    + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
+    + by state_update_simpl.
     + subst. specialize (Hchar _ eq_refl) as [Hvx Htx].
-      unfold equivocators_state_project. unfold EquivocatorsComposition.equivocators_state_project.
-      unfold equivocator_descriptors_update.
-      rewrite equivocator_descriptors_update_eq.
+      unfold equivocators_state_project, EquivocatorsComposition.equivocators_state_project.
+      state_update_simpl.
       by rewrite Hli in Hvx.
     + subst. specialize (Hchar _ eq_refl) as [Hvx Htx].
-      unfold equivocators_state_project. unfold EquivocatorsComposition.equivocators_state_project.
-      unfold equivocator_descriptors_update.
-      rewrite equivocator_descriptors_update_eq.
+      unfold equivocators_state_project, EquivocatorsComposition.equivocators_state_project.
+      state_update_simpl.
       simpl in *. rewrite Hli in Htx. rewrite Htx. f_equal.
-      extensionality eqv.
-      destruct (decide (eqv = i)).
-      * subst. repeat rewrite state_update_eq.
-        by rewrite state_update_eq in Hdestinationi.
-      * repeat (rewrite state_update_neq; [| done]).
-        by rewrite equivocator_descriptors_update_neq.
+      by extensionality eqv; state_update i eqv.
   - repeat split.
-    + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
-    + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
+    + by state_update_simpl.
+    + by state_update_simpl.
     + by extensionality j; state_update i j.
-    + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
-    + extensionality eqv.
-      unfold equivocators_state_project. unfold EquivocatorsComposition.equivocators_state_project.
-      unfold equivocator_descriptors_update.
-      destruct (decide (eqv = i)); subst.
-      * by rewrite state_update_eq, equivocator_descriptors_update_eq.
-      * by rewrite state_update_neq, ?equivocator_descriptors_update_neq.
+    + by state_update_simpl.
+    + unfold equivocators_state_project, EquivocatorsComposition.equivocators_state_project.
+      by extensionality eqv; state_update i eqv.
 Qed.
 
 Lemma equivocators_transition_item_project_proper_characterization
@@ -436,11 +416,8 @@ Proof.
   clear Hv Ht Hoitem.
   split; [| by repeat split]; clear Hchar.
   intro eqv.
-  destruct (decide (eqv = (projT1 (l item)))); [subst; done |].
-  rewrite Heqv', Hs, state_update_neq; [| done].
-  unfold proper_descriptor, equivocator_descriptors_update.
-  rewrite equivocator_descriptors_update_neq; [| done].
-  apply Hproper.
+  state_update eqv (projT1 (l item)); [done |].
+  by rewrite Heqv', Hs; state_update_simpl.
 Qed.
 
 Lemma equivocators_transition_item_project_inv_characterization
@@ -784,8 +761,7 @@ Proof.
         -- simpl in Hex_new, Hex_new'. rewrite Hex_new'. simpl.  lia.
         -- destruct (idescriptors eqv); simpl in *; lia.
     + rewrite Heq_final_descriptors' in Hex_new'.
-      unfold equivocator_descriptors_update in Hex_new'.
-      by rewrite equivocator_descriptors_update_neq in Hex_new'.
+      by state_update_simpl.
 Qed.
 
 Lemma equivocators_trace_project_preserves_equivocating_indices_final
@@ -875,12 +851,12 @@ Proof.
         ; inversion Hproject_xi; subst descriptor' project_xi; clear Hproject_xi
         ; inversion Hpr_item_x; subst; clear Hpr_item_x
         ; inversion Hproject_x; subst; clear Hproject_x
-        ; unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq
+        ; state_update_simpl
         ; [| by split].
         split; [done |].
         simpl. destruct x. simpl in *. destruct l as (i, li). simpl in *.
         unfold pre_VLSM_projection_transition_item_project, composite_project_label. simpl.
-        destruct (decide (i = i)); [| done].
+        destruct (decide (i = i)); [|congruence].
         f_equal.
         replace e with (@eq_refl _ i) by (apply Eqdep_dec.UIP_dec; done). clear e.
         destruct item'.
@@ -899,11 +875,9 @@ Proof.
         destruct oitem' as [item'|]
         ; inversion Hpr_item_x; subst; clear Hpr_item_x
         ; inversion Hproject_x; subst; clear Hproject_x
-        ; unfold equivocator_descriptors_update; (rewrite equivocator_descriptors_update_neq ; [| done])
+        ; state_update_simpl
         ; [| by split].
-        split; [done |].
-        simpl.
-        by rewrite (composite_transition_item_projection_neq IM i).
+        by simpl; rewrite (composite_transition_item_projection_neq IM i).
     }
     destruct Hfinal'i as [Hfinal'i Hpr_xi].
     rewrite <- Hfinal'i in HtrXi'.
@@ -1070,10 +1044,9 @@ Proof.
     intro e. specialize (IHtr e).
     destruct (decide (e = projT1 l)).
     + subst.
-      unfold equivocator_descriptors_update in IHtr. rewrite equivocator_descriptors_update_eq in IHtr.
+      unfold equivocator_descriptors_update in IHtr; rewrite equivocator_descriptors_update_eq in IHtr.
       by rewrite Hfinali.
-    + unfold equivocator_descriptors_update in IHtr.
-      rewrite equivocator_descriptors_update_neq in IHtr; [| done].
+    + state_update_simpl.
       destruct Ht as [Hv Ht].
       simpl in Ht. unfold vtransition in Ht. simpl in Ht.
       destruct l as (i, li).
@@ -1081,15 +1054,14 @@ Proof.
       | (let (_,_) := ?t in _) = _ => destruct t as (si', om')
       end.
       inversion Ht. subst. simpl in n.
-      by rewrite state_update_neq.
+      by state_update_simpl.
   - destruct l as (i, li).
-    unfold projT2 in Heqprojecti.
-    unfold projT1 in Heqprojecti.
+    unfold projT1, projT2 in Heqprojecti.
     destruct Ht as [Hv Ht].
     cbn in Ht.
     destruct (equivocator_transition _ _ _) as (si', om') eqn:Ht'.
     inversion Ht. subst om'. clear Ht.
-    replace (s i) with si' in * by (subst; rewrite state_update_eq; done).
+    replace (s i) with si' in * by (subst; state_update_simpl; done).
     destruct (equivocator_state_project si' j) as [si'j|] eqn:Hj; [| done].
     destruct li as [ndi | idi li | idi li]
     ; destruct (decide _)
@@ -1097,19 +1069,7 @@ Proof.
     ; inversion Hproject_x; subst; clear Hproject_x
     ; inversion Heqproject_x; subst; clear Heqproject_x
     ; intro eqv; specialize (IHtr eqv)
-    ; (destruct (decide (eqv = i))
-      ; [subst eqv
-        ; unfold equivocator_descriptors_update in IHtr; rewrite equivocator_descriptors_update_eq in IHtr
-        ; simpl in *; rewrite Hfinali; rewrite state_update_eq
-        ; eexists; done
-        |
-        unfold equivocator_descriptors_update in IHtr
-        ; rewrite equivocator_descriptors_update_neq in IHtr
-        ; [| done]
-        ; rewrite state_update_neq; [| done]
-        ; done
-        ]
-      ).
+    ; (state_update i eqv; cbn in *; [rewrite ?Hfinali; eexists |]; done).
 Qed.
 
 (**
@@ -1170,12 +1130,8 @@ Proof.
   remember (equivocator_descriptors_update (zero_descriptor IM) i eqv_final) as final_descriptors.
   assert (Hfinal_descriptors : not_equivocating_equivocator_descriptors IM final_descriptors final).
   { intro eqv. subst final_descriptors.
-    destruct (decide (eqv = i)).
-    - subst i.
-      by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
-    - unfold equivocator_descriptors_update.
-      rewrite equivocator_descriptors_update_neq; [| done].
-      apply zero_descriptor_proper.
+    state_update i eqv; [done |].
+    apply zero_descriptor_proper.
   }
   exists final_descriptors.
   subst final.
@@ -1189,7 +1145,7 @@ Proof.
       eqv_init tr trX trXi Hproject_tr)
     as Hcommute.
   assert (Hfinali : final_descriptors i = eqv_final).
-  { subst. apply equivocator_descriptors_update_eq. }
+  { by subst; state_update_simpl. }
   rewrite Hfinali in Hcommute.
   spec Hcommute Hprojecti.
   destruct Hcommute as [Hiniti Hcommute].
@@ -1477,17 +1433,17 @@ Proof.
   ; rewrite !equivocator_state_project_zero.
   - inversion_clear Ht.
     rewrite decide_False; [done |].
-    rewrite state_update_eq. rewrite equivocator_state_extend_lst. cbv; lia.
+    by state_update_simpl; cbn.
   - destruct (equivocator_state_project _ _) as [s_i|]; [| done].
     destruct (vtransition _ _ _) as (si', _om').
-    inversion_clear Ht. rewrite!state_update_eq.
+    inversion_clear Ht. state_update_simpl.
     destruct ji as [|ji].
     + by rewrite decide_True.
     + by rewrite decide_False.
   - destruct (equivocator_state_project _ _) as [s_i|]; [| done].
     destruct (vtransition _ _ _) as (si', _om').
     inversion_clear Ht.
-    by rewrite !state_update_eq, !equivocator_state_extend_lst, decide_False.
+    by state_update_simpl; cbn; rewrite decide_False.
 Qed.
 
 Lemma equivocators_total_trace_project_final_state
@@ -1653,7 +1609,7 @@ Proof.
       by destruct oitem' as [item' |]
       ; inversion Hpr_item_x; subst; clear Hpr_item_x
       ; inversion Hpr_item; subst; clear Hpr_item
-      ; rewrite equivocator_descriptors_update_neq.
+      ; state_update_simpl.
     + destruct oitem' as [item'|]
       ; inversion Hpr_item_x; subst; clear Hpr_item_x
       ; inversion Hpr_item; subst; clear Hpr_item
@@ -1940,6 +1896,8 @@ Context {message : Type}
   (sub_IM := sub_IM IM (finite.enum index))
   .
 
+Hint Unfold equivocator_descriptors_update : state_update.
+
 Definition free_sub_free_equivocator_descriptors
   (descriptors : equivocator_descriptors IM)
   : equivocator_descriptors sub_IM
@@ -2126,19 +2084,16 @@ Proof.
   intros l Hl s om s' om' [[_ [_ [Hv _]]] Ht].
   destruct l as [i [sn| ji li| ji li]]; cbn in Hv, Ht.
   - inversion_clear Ht. unfold equivocators_total_state_project.
-    rewrite (equivocators_state_project_state_update_eqv IM).
-    by apply state_update_id.
+    by state_update_simpl.
   - simpl in Hl. destruct ji as [|ji]; [inversion Hl|]. clear Hl.
     destruct (equivocator_state_project _ _) as [si|]; [| done].
     destruct (vtransition _ _ _) as (si', _om').
     inversion_clear Ht.  unfold equivocators_total_state_project.
-    rewrite (equivocators_state_project_state_update_eqv IM).
-    by apply state_update_id.
+    by state_update_simpl.
   - destruct (equivocator_state_project _ _) as [si|]; [| done].
     destruct (vtransition _ _ _) as (si', _om').
     inversion_clear Ht.  unfold equivocators_total_state_project.
-    rewrite (equivocators_state_project_state_update_eqv IM).
-    by apply state_update_id.
+    by state_update_simpl.
 Qed.
 
 Lemma equivocators_no_equivocations_vlsm_X_vlsm_projection

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -363,10 +363,7 @@ Proof.
   - repeat split.
     + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
     + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
-    + extensionality j.
-      destruct (decide (j = i)).
-      * by subst; rewrite state_update_eq.
-      * by rewrite !state_update_neq.
+    + by extensionality j; state_update i j.
     + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
     + subst. specialize (Hchar _ eq_refl) as [Hvx Htx].
       unfold equivocators_state_project. unfold EquivocatorsComposition.equivocators_state_project.
@@ -387,10 +384,7 @@ Proof.
   - repeat split.
     + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
     + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
-    + extensionality j.
-      destruct (decide (j = i)).
-      * by subst; rewrite state_update_eq.
-      * by rewrite !state_update_neq.
+    + by extensionality j; state_update i j.
     + by unfold equivocator_descriptors_update; rewrite equivocator_descriptors_update_eq.
     + extensionality eqv.
       unfold equivocators_state_project. unfold EquivocatorsComposition.equivocators_state_project.
@@ -886,7 +880,7 @@ Proof.
         split; [done |].
         simpl. destruct x. simpl in *. destruct l as (i, li). simpl in *.
         unfold pre_VLSM_projection_transition_item_project, composite_project_label. simpl.
-        destruct (decide (i = i)); [|congruence].
+        destruct (decide (i = i)); [| done].
         f_equal.
         replace e with (@eq_refl _ i) by (apply Eqdep_dec.UIP_dec; done). clear e.
         destruct item'.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -73,12 +73,8 @@ Proof.
   destruct l as (eqv, leqv).
   destruct (equivocator_transition _ _ _) as (si', _om') eqn:Hti.
   inversion Ht. subst. clear Ht.
-  destruct (decide (i = eqv)).
-  - subst. rewrite state_update_eq in Hi.
-    apply
-      (zero_descriptor_transition_reflects_equivocating_state
-        (IM eqv) _ _ _ _ _ Hti _ Hzero Hi).
-  - by rewrite state_update_neq in Hi.
+  state_update i eqv; [| done].
+  apply (zero_descriptor_transition_reflects_equivocating_state (IM eqv) _ _ _ _ _ Hti _ Hzero Hi).
 Qed.
 
 (**

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -73,7 +73,7 @@ Proof.
   destruct l as (eqv, leqv).
   destruct (equivocator_transition _ _ _) as (si', _om') eqn:Hti.
   inversion Ht. subst. clear Ht.
-  state_update i eqv; [| done].
+  destruct (decide (i = eqv)); subst; state_update_simpl; [| done].
   apply (zero_descriptor_transition_reflects_equivocating_state (IM eqv) _ _ _ _ _ Hti _ Hzero Hi).
 Qed.
 

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -51,7 +51,7 @@ Proof.
   destruct (equivocator_transition _ _ _).
   inversion Ht; subst.
   apply elem_of_list_filter, proj1 in Hi.
-  rewrite state_update_neq in Hi by done.
+  state_update_simpl.
   by apply Hs, elem_of_list_filter; split; [| apply elem_of_enum].
 Qed.
 
@@ -683,7 +683,8 @@ Proof.
   match type of Ht with
   | (let (_, _) := ?t in _) = _ => destruct t as (si', om') eqn:Hti
   end.
-  inversion Ht. subst. rewrite state_update_eq in Hsingleton_d_item. clear Ht.
+  inversion Ht; subst; clear Ht.
+  state_update_simpl.
   specialize (equivocator_transition_no_equivocation_zero_descriptor (IM x) _ _ _ _ _ Hv Hti Hsingleton_d_item)
     as [li Hsndv].
   unfold equivocators_transition_item_project in Hpr.
@@ -695,7 +696,7 @@ Proof.
   unfold eq_rect_r in Hpr. simpl in Hpr.
   rewrite Heqv_descriptors'' in Hpr.
   unfold equivocator_vlsm_transition_item_project in Hpr.
-  rewrite state_update_eq in Hpr.
+  state_update_simpl.
   rewrite equivocator_state_project_zero in Hpr.
   rewrite decide_True in Hpr by done.
   inversion Hpr. subst. clear Hpr.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -47,7 +47,7 @@ Context {message : Type}
   (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM)
 .
 
-Hint Unfold equivocator_descriptors_update : state_update.
+#[local] Hint Unfold equivocator_descriptors_update : state_update.
 
 Lemma SeededXE_Free_full_projection
   (Hseed : forall m, seed m -> valid_message_prop FreeE m)

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -186,8 +186,8 @@ Proof.
     ; destruct (composite_apply_plan _ _ _) as (aitems, afinal); simpl in *.
     spec IHl i; destruct_dec_sig x ix Hix Heqx; subst x; simpl in *.
     case_decide as _Hix; cycle 1.
-    + by state_update i ix.
-    + state_update ix i.
+    + by destruct (decide (i = ix)); subst; state_update_simpl.
+    + destruct (decide (ix = i)); subst; state_update_simpl.
       * rewrite decide_False in IHl.
         2: {
           intro Heqv.
@@ -248,7 +248,7 @@ Proof.
     destruct_equivocator_state_project (lfinal (` x)) n lfinal_x_n Hltn'; [|lia].
     by state_update_simpl.
   - intro i. apply proj2 in IHl. specialize (IHl i).
-    by state_update (` x) i; [lia |].
+    by destruct (decide (i = `x)); subst; state_update_simpl; [lia |].
 Qed.
 
 Lemma equivocator_state_project_replayed_initial_state_from_left full_replay_state is
@@ -272,7 +272,7 @@ Proof.
   simpl in *.
   rewrite finite_trace_last_is_last. simpl.
   intros i j Hj.
-  state_update (` x) i; [| auto].
+  destruct (decide (`x = i)); subst; state_update_simpl; [| auto].
   specialize (IHl (` x) j Hj).
   destruct_equivocator_state_project (full_replay_state (` x)) j s_x_j Hltj; [|lia].
   rewrite equivocator_state_extend_project_1; [done |].
@@ -460,9 +460,8 @@ Proof.
   rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi).
   replace (equivocator_transition _ _ _) with
     (equivocator_state_append (full_replay_state i) _si', _om').
-  f_equal.
-  extensionality j.
-  state_update i j.
+  f_equal; extensionality j.
+  destruct (decide (i = j)); subst; state_update_simpl.
   - by rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi), state_update_eq.
   - unfold lift_equivocators_sub_state_to.
     destruct (decide _); [| done].

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -186,8 +186,8 @@ Proof.
     ; destruct (composite_apply_plan _ _ _) as (aitems, afinal); simpl in *.
     spec IHl i; destruct_dec_sig x ix Hix Heqx; subst x; simpl in *.
     case_decide as _Hix; cycle 1.
-    + by destruct (decide (i = ix)); subst; state_update_simpl.
-    + destruct (decide (ix = i)); subst; state_update_simpl.
+    + by destruct (decide (i = ix)); subst; equivocator_state_update_simpl.
+    + destruct (decide (ix = i)); subst; equivocator_state_update_simpl.
       * rewrite decide_False in IHl.
         2: {
           intro Heqv.
@@ -243,12 +243,12 @@ Proof.
     specialize (IHl (` x)).
     cbn. unfold equivocators_transition_item_project; simpl.
     unfold equivocator_vlsm_transition_item_project. rewrite Heqv_x.
-    simpl; state_update_simpl.
+    simpl; equivocator_state_update_simpl.
     rewrite decide_False by lia.
     destruct_equivocator_state_project (lfinal (` x)) n lfinal_x_n Hltn'; [|lia].
-    by state_update_simpl.
+    by equivocator_state_update_simpl.
   - intro i. apply proj2 in IHl. specialize (IHl i).
-    by destruct (decide (i = `x)); subst; state_update_simpl; [lia |].
+    by destruct (decide (i = `x)); subst; equivocator_state_update_simpl; [lia |].
 Qed.
 
 Lemma equivocator_state_project_replayed_initial_state_from_left full_replay_state is
@@ -272,7 +272,7 @@ Proof.
   simpl in *.
   rewrite finite_trace_last_is_last. simpl.
   intros i j Hj.
-  destruct (decide (`x = i)); subst; state_update_simpl; [| auto].
+  destruct (decide (`x = i)); subst; equivocator_state_update_simpl; [| auto].
   specialize (IHl (` x) j Hj).
   destruct_equivocator_state_project (full_replay_state (` x)) j s_x_j Hltj; [|lia].
   rewrite equivocator_state_extend_project_1; [done |].
@@ -404,7 +404,7 @@ Proof.
   rewrite equivocator_state_append_lst.
   by destruct li as [sn_d| id li| id li]; simpl
   ; rewrite !decide_False by lia
-  ; state_update_simpl.
+  ; equivocator_state_update_simpl.
 Qed.
 
 Lemma equivocators_total_trace_project_replayed_trace_from full_replay_state is tr
@@ -454,14 +454,14 @@ Proof.
   cbn in Ht.
   destruct (equivocator_transition _ _ _) as (_si', _om').
   inversion Ht; subst s' om'; clear Ht.
-  state_update_simpl.
+  equivocator_state_update_simpl.
   specialize (Hlift eq_refl).
   cbn.
   rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi).
   replace (equivocator_transition _ _ _) with
     (equivocator_state_append (full_replay_state i) _si', _om').
   f_equal; extensionality j.
-  destruct (decide (i = j)); subst; state_update_simpl.
+  destruct (decide (i = j)); subst; equivocator_state_update_simpl.
   - by rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi), state_update_eq.
   - unfold lift_equivocators_sub_state_to.
     destruct (decide _); [| done].

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -465,12 +465,10 @@ Proof.
   replace (equivocator_transition _ _ _) with
     (equivocator_state_append (full_replay_state i) _si', _om').
   f_equal.
-  apply functional_extensionality_dep. intro j.
-  destruct (decide (i = j)).
-  - subst. rewrite state_update_eq.
-    by rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi), state_update_eq.
-  - rewrite state_update_neq by congruence.
-    unfold lift_equivocators_sub_state_to.
+  extensionality j.
+  state_update i j.
+  - by rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi), state_update_eq.
+  - unfold lift_equivocators_sub_state_to.
     destruct (decide _); [| done].
     rewrite state_update_neq; [done |].
     intro Hcontra. apply dsig_eq in Hcontra. simpl in Hcontra. congruence.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -47,6 +47,8 @@ Context {message : Type}
   (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM)
 .
 
+Hint Unfold equivocator_descriptors_update : state_update.
+
 Lemma SeededXE_Free_full_projection
   (Hseed : forall m, seed m -> valid_message_prop FreeE m)
   : VLSM_full_projection SeededXE
@@ -184,10 +186,9 @@ Proof.
     ; destruct (composite_apply_plan _ _ _) as (aitems, afinal); simpl in *.
     spec IHl i; destruct_dec_sig x ix Hix Heqx; subst x; simpl in *.
     case_decide as _Hix; cycle 1.
-    + rewrite state_update_neq; congruence.
-    + destruct (decide (ix = i)).
-      * subst ix; rewrite state_update_eq.
-        rewrite decide_False in IHl.
+    + by state_update i ix.
+    + state_update ix i.
+      * rewrite decide_False in IHl.
         2: {
           intro Heqv.
           apply NoDup_app in Hnodup as (_ & Hnodup & _).
@@ -200,8 +201,7 @@ Proof.
            apply equivocator_state_append_singleton_is_extend, (His (dexist i Hix)).
         -- rewrite elem_of_app, elem_of_list_singleton; right.
            by apply dec_sig_eq_iff; cbn.
-      * rewrite state_update_neq by congruence.
-        case_decide.
+      * case_decide.
         -- rewrite decide_True; rewrite ?elem_of_app; itauto.
         -- rewrite decide_False; [done |].
            intros [Hin | Hx]%elem_of_app; [ done |].
@@ -243,15 +243,12 @@ Proof.
     specialize (IHl (` x)).
     cbn. unfold equivocators_transition_item_project; simpl.
     unfold equivocator_vlsm_transition_item_project. rewrite Heqv_x.
-    simpl. rewrite state_update_eq.
-    rewrite equivocator_state_extend_project_1 by lia.
+    simpl; state_update_simpl.
+    rewrite decide_False by lia.
     destruct_equivocator_state_project (lfinal (` x)) n lfinal_x_n Hltn'; [|lia].
-    rewrite equivocator_state_extend_lst, decide_False by lia.
-    by rewrite equivocator_descriptors_update_id.
+    by state_update_simpl.
   - intro i. apply proj2 in IHl. specialize (IHl i).
-    destruct (decide (` x = i)).
-    + subst. rewrite state_update_eq, equivocator_state_extend_size. lia.
-    + by rewrite state_update_neq.
+    by state_update (` x) i; [lia |].
 Qed.
 
 Lemma equivocator_state_project_replayed_initial_state_from_left full_replay_state is
@@ -275,13 +272,11 @@ Proof.
   simpl in *.
   rewrite finite_trace_last_is_last. simpl.
   intros i j Hj.
-  destruct (decide (` x = i)); subst.
-  - rewrite state_update_eq.
-    specialize (IHl (` x) j Hj).
-    destruct_equivocator_state_project (full_replay_state (` x)) j s_x_j Hltj; [|lia].
-    rewrite equivocator_state_extend_project_1; [done |].
-    by apply equivocator_state_project_Some_rev in IHl as Hltj'.
-  - rewrite state_update_neq; auto.
+  state_update (` x) i; [| auto].
+  specialize (IHl (` x) j Hj).
+  destruct_equivocator_state_project (full_replay_state (` x)) j s_x_j Hltj; [|lia].
+  rewrite equivocator_state_extend_project_1; [done |].
+  by apply equivocator_state_project_Some_rev in IHl as Hltj'.
 Qed.
 
 Lemma equivocator_state_descriptor_project_replayed_initial_state_from_left full_replay_state is
@@ -409,7 +404,7 @@ Proof.
   rewrite equivocator_state_append_lst.
   by destruct li as [sn_d| id li| id li]; simpl
   ; rewrite !decide_False by lia
-  ; rewrite equivocator_descriptors_update_id.
+  ; state_update_simpl.
 Qed.
 
 Lemma equivocators_total_trace_project_replayed_trace_from full_replay_state is tr
@@ -458,7 +453,8 @@ Proof.
     ) as Hlift.
   cbn in Ht.
   destruct (equivocator_transition _ _ _) as (_si', _om').
-  inversion Ht. subst s' om'. clear Ht. rewrite state_update_eq in Hlift.
+  inversion Ht; subst s' om'; clear Ht.
+  state_update_simpl.
   specialize (Hlift eq_refl).
   cbn.
   rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi).
@@ -470,8 +466,7 @@ Proof.
   - by rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi), state_update_eq.
   - unfold lift_equivocators_sub_state_to.
     destruct (decide _); [| done].
-    rewrite state_update_neq; [done |].
-    intro Hcontra. apply dsig_eq in Hcontra. simpl in Hcontra. congruence.
+    by rewrite state_update_neq; [| inversion 1].
 Qed.
 
 Section pre_loaded_constrained_projection.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -179,10 +179,7 @@ Proof.
         intro i.
         unfold equivocators_total_state_project at 1.
         unfold equivocators_state_project.
-        destruct (decide (i = eqv)).
-        * by subst; rewrite !state_update_eq.
-        * rewrite !state_update_neq by congruence.
-          simpl. apply Hes_pr_i.
+        by state_update i eqv; [| apply Hes_pr_i].
       }
       split; [done |].
       eexists; split; [| split; [split; [done |] |]].

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -179,7 +179,7 @@ Proof.
         intro i.
         unfold equivocators_total_state_project at 1.
         unfold equivocators_state_project.
-        by state_update i eqv; [| apply Hes_pr_i].
+        by destruct (decide (i = eqv)); subst; state_update_simpl; [| apply Hes_pr_i].
       }
       split; [done |].
       eexists; split; [| split; [split; [done |] |]].

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -446,22 +446,26 @@ Proof.
   lia.
 Qed.
 
-#[local] Hint Rewrite @equivocator_state_update_size : state_update.
-#[local] Hint Rewrite @equivocator_state_update_lst : state_update.
-#[local] Hint Rewrite @equivocator_state_update_project_eq using first [done | lia] : state_update.
-#[local] Hint Rewrite @equivocator_state_update_project_neq using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_update_size : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_update_lst : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_update_project_eq using first [done | lia] : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_update_project_neq using first [done | lia] : equivocator_state_update.
 
-#[local] Hint Rewrite @equivocator_state_extend_size using done : state_update.
-#[local] Hint Rewrite @equivocator_state_extend_lst using done : state_update.
-#[local] Hint Rewrite @equivocator_state_extend_project_1 using first [done | lia] : state_update.
-#[local] Hint Rewrite @equivocator_state_extend_project_2 using first [done | lia] : state_update.
-#[local] Hint Rewrite @equivocator_state_extend_project_3 using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_extend_size using done : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_extend_lst using done : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_extend_project_1 using first [done | lia] : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_extend_project_2 using first [done | lia] : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_extend_project_3 using first [done | lia] : equivocator_state_update.
 
-#[local] Hint Rewrite @equivocator_state_append_size using done : state_update.
-#[local] Hint Rewrite @equivocator_state_append_lst using done : state_update.
-#[local] Hint Rewrite @equivocator_state_append_project_1 using first [done | lia] : state_update.
-#[local] Hint Rewrite @equivocator_state_append_project_2 using first [done | lia] : state_update.
-#[local] Hint Rewrite @equivocator_state_append_project_3 using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_append_size using done : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_append_lst using done : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_append_project_1 using first [done | lia] : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_append_project_2 using first [done | lia] : equivocator_state_update.
+#[local] Hint Rewrite @equivocator_state_append_project_3 using first [done | lia] : equivocator_state_update.
+
+#[local] Ltac equivocator_state_update_simpl :=
+  autounfold with state_update in *;
+  autorewrite with equivocator_state_update state_update in *.
 
 #[local] Ltac destruct_equivocator_state_append_project' es es' i Hi k Hk Hpr :=
   let Hi' := fresh "Hi" in
@@ -509,18 +513,18 @@ Proof.
   intro i.
   destruct_equivocator_state_append_project es1 (equivocator_state_extend es2 s) i Hi k Hk.
   - apply equivocator_state_extend_project_3.
-    by state_update_simpl; lia.
-  - subst. state_update_simpl.
+    by equivocator_state_update_simpl; lia.
+  - subst. equivocator_state_update_simpl.
     destruct (decide (k = equivocator_state_n es2)).
     + subst.
       rewrite !equivocator_state_extend_project_2
       ; [done | done |].
-      by state_update_simpl; lia.
+      by equivocator_state_update_simpl; lia.
     + rewrite !equivocator_state_extend_project_1
       ; [rewrite equivocator_state_append_project_2 with (k := k)|lia|]
       ; [done | done |].
-      by state_update_simpl; lia.
-  - by rewrite equivocator_state_extend_project_1; state_update_simpl; [| lia].
+      by equivocator_state_update_simpl; lia.
+  - by rewrite equivocator_state_extend_project_1; equivocator_state_update_simpl; [| lia].
 Qed.
 
 Lemma equivocator_state_append_update_commute es1 es2 s n
@@ -531,15 +535,15 @@ Proof.
   intro i.
   destruct_equivocator_state_append_project es1 (equivocator_state_update es2 n s) i Hi k Hk.
   - rewrite equivocator_state_project_None; [done |].
-    by state_update_simpl.
+    by equivocator_state_update_simpl.
   - destruct (decide (n = k)).
-    + subst. state_update_simpl.
+    + subst. equivocator_state_update_simpl.
       rewrite equivocator_state_update_project_eq;
       [| rewrite equivocator_state_append_size; lia | done].
-      by state_update_simpl.
-    + state_update_simpl.
+      by equivocator_state_update_simpl.
+    + equivocator_state_update_simpl.
       by apply equivocator_state_append_project_2 with (k := k).
-  - by state_update_simpl.
+  - by equivocator_state_update_simpl.
 Qed.
 
 (* An [equivocator_state] has the [initial_state_prop]erty if it only
@@ -643,22 +647,26 @@ Proof. done. Qed.
 
 End sec_equivocator_vlsm.
 
-#[export] Hint Rewrite @equivocator_state_update_size : state_update.
-#[export] Hint Rewrite @equivocator_state_update_lst : state_update.
-#[export] Hint Rewrite @equivocator_state_update_project_eq using first [done | lia] : state_update.
-#[export] Hint Rewrite @equivocator_state_update_project_neq using first [done | lia] : state_update.
+#[export] Hint Rewrite @equivocator_state_update_size : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_update_lst : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_update_project_eq using first [done | lia] : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_update_project_neq using first [done | lia] : equivocator_state_update.
 
-#[export] Hint Rewrite @equivocator_state_extend_size using done : state_update.
-#[export] Hint Rewrite @equivocator_state_extend_lst using done : state_update.
-#[export] Hint Rewrite @equivocator_state_extend_project_1 using first [done | lia] : state_update.
-#[export] Hint Rewrite @equivocator_state_extend_project_2 using first [done | lia] : state_update.
-#[export] Hint Rewrite @equivocator_state_extend_project_3 using first [done | lia] : state_update.
+#[export] Hint Rewrite @equivocator_state_extend_size using done : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_extend_lst using done : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_extend_project_1 using first [done | lia] : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_extend_project_2 using first [done | lia] : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_extend_project_3 using first [done | lia] : equivocator_state_update.
 
-#[export] Hint Rewrite @equivocator_state_append_size using done : state_update.
-#[export] Hint Rewrite @equivocator_state_append_lst using done : state_update.
-#[export] Hint Rewrite @equivocator_state_append_project_1 using first [done | lia] : state_update.
-#[export] Hint Rewrite @equivocator_state_append_project_2 using first [done | lia] : state_update.
-#[export] Hint Rewrite @equivocator_state_append_project_3 using first [done | lia] : state_update.
+#[export] Hint Rewrite @equivocator_state_append_size using done : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_append_lst using done : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_append_project_1 using first [done | lia] : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_append_project_2 using first [done | lia] : equivocator_state_update.
+#[export] Hint Rewrite @equivocator_state_append_project_3 using first [done | lia] : equivocator_state_update.
+
+Ltac equivocator_state_update_simpl :=
+  autounfold with state_update in *;
+  autorewrite with equivocator_state_update state_update in *.
 
 Arguments Spawn {_ _} _: assert.
 Arguments ContinueWith {_ _} _ _: assert.
@@ -871,7 +879,7 @@ Proof.
   ; [ inversion Ht; subst; rewrite equivocator_state_extend_size in Hs'; cbv in Hs'; lia|..]
   ; cbn in Hv, Ht;  destruct_equivocator_state_project s ei sei Hei; [| done | | done]
   ; destruct (vtransition _ _ _) as (si', om')
-  ; inversion Ht; subst; state_update_simpl.
+  ; inversion Ht; subst; equivocator_state_update_simpl.
   - exists l. f_equal. lia.
   - lia.
 Qed.
@@ -892,7 +900,7 @@ Proof.
   ; destruct (equivocator_state_project _ _)
   ; [| by inversion Ht | | by inversion Ht]
   ; destruct (vtransition _ _ _) as (si', om')
-  ; inversion Ht; subst; clear Ht; state_update_simpl.
+  ; inversion Ht; subst; clear Ht; equivocator_state_update_simpl.
 Qed.
 
 Lemma equivocator_transition_cannot_decrease_state_size
@@ -910,7 +918,7 @@ Proof.
   ; [|inversion Ht; lia| |inversion Ht; lia]
   ; destruct (vtransition _ _ _) as (si', om')
   ; inversion Ht; subst; clear Ht.
-  - by state_update_simpl.
+  - by equivocator_state_update_simpl.
   - by rewrite Hex_size; lia.
 Qed.
 
@@ -940,7 +948,7 @@ Proof.
   destruct (vtransition _ _ _).
   inversion Ht. subst.
   unfold is_equivocating_state, is_singleton_state.
-  by state_update_simpl.
+  by equivocator_state_update_simpl.
 Qed.
 
 (**
@@ -1118,7 +1126,7 @@ Proof.
   rewrite Hv in Ht.
   destruct (vtransition _ _ _).
   inversion Ht. subst.
-  by state_update_simpl.
+  by equivocator_state_update_simpl.
 Qed.
 
 Lemma new_machine_label_equivocator_state_project_last

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -446,27 +446,6 @@ Proof.
   lia.
 Qed.
 
-#[local] Hint Rewrite @equivocator_state_update_size : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_update_lst : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_update_project_eq using first [done | lia] : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_update_project_neq using first [done | lia] : equivocator_state_update.
-
-#[local] Hint Rewrite @equivocator_state_extend_size using done : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_extend_lst using done : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_extend_project_1 using first [done | lia] : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_extend_project_2 using first [done | lia] : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_extend_project_3 using first [done | lia] : equivocator_state_update.
-
-#[local] Hint Rewrite @equivocator_state_append_size using done : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_append_lst using done : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_append_project_1 using first [done | lia] : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_append_project_2 using first [done | lia] : equivocator_state_update.
-#[local] Hint Rewrite @equivocator_state_append_project_3 using first [done | lia] : equivocator_state_update.
-
-#[local] Ltac equivocator_state_update_simpl :=
-  autounfold with state_update in *;
-  autorewrite with equivocator_state_update state_update in *.
-
 #[local] Ltac destruct_equivocator_state_append_project' es es' i Hi k Hk Hpr :=
   let Hi' := fresh "Hi" in
   destruct (decide (i < equivocator_state_n es)) as [Hi| Hi']; swap 1 2;
@@ -512,19 +491,22 @@ Proof.
   apply equivocator_state_project_ext.
   intro i.
   destruct_equivocator_state_append_project es1 (equivocator_state_extend es2 s) i Hi k Hk.
-  - apply equivocator_state_extend_project_3.
-    by equivocator_state_update_simpl; lia.
-  - subst. equivocator_state_update_simpl.
+  - rewrite equivocator_state_extend_size in Hi.
+    apply equivocator_state_extend_project_3.
+    by rewrite equivocator_state_append_size; lia.
+  - subst; rewrite equivocator_state_extend_size in Hi.
     destruct (decide (k = equivocator_state_n es2)).
     + subst.
       rewrite !equivocator_state_extend_project_2
       ; [done | done |].
-      by equivocator_state_update_simpl; lia.
+      by rewrite equivocator_state_append_size; lia.
     + rewrite !equivocator_state_extend_project_1
       ; [rewrite equivocator_state_append_project_2 with (k := k)|lia|]
       ; [done | done |].
-      by equivocator_state_update_simpl; lia.
-  - by rewrite equivocator_state_extend_project_1; equivocator_state_update_simpl; [| lia].
+      by rewrite equivocator_state_append_size; lia.
+  - rewrite equivocator_state_extend_project_1.
+    + by rewrite equivocator_state_append_project_1.
+    + by rewrite equivocator_state_append_size; lia.
 Qed.
 
 Lemma equivocator_state_append_update_commute es1 es2 s n
@@ -534,16 +516,17 @@ Proof.
   apply equivocator_state_project_ext.
   intro i.
   destruct_equivocator_state_append_project es1 (equivocator_state_update es2 n s) i Hi k Hk.
-  - rewrite equivocator_state_project_None; [done |].
-    by equivocator_state_update_simpl.
+  - apply equivocator_state_project_None.
+    by rewrite equivocator_state_update_size, equivocator_state_append_size in *; lia.
   - destruct (decide (n = k)).
-    + subst. equivocator_state_update_simpl.
+    + subst; rewrite equivocator_state_update_size in Hi.
       rewrite equivocator_state_update_project_eq;
       [| rewrite equivocator_state_append_size; lia | done].
-      by equivocator_state_update_simpl.
-    + equivocator_state_update_simpl.
+      by rewrite equivocator_state_update_project_eq; [| lia |].
+    + rewrite !equivocator_state_update_project_neq by lia.
       by apply equivocator_state_append_project_2 with (k := k).
-  - by equivocator_state_update_simpl.
+  - by rewrite equivocator_state_update_project_neq,
+      equivocator_state_append_project_1 by lia.
 Qed.
 
 (* An [equivocator_state] has the [initial_state_prop]erty if it only

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -2,7 +2,7 @@ From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto aut
 From stdpp Require Import prelude.
 From Coq Require Import Eqdep Fin FunctionalExtensionality.
 From VLSM.Lib Require Import Preamble.
-From VLSM.Core Require Import VLSM VLSMProjections.
+From VLSM.Core Require Import VLSM VLSMProjections Composition.
 
 (** * VLSM Equivocation
 
@@ -446,6 +446,23 @@ Proof.
   lia.
 Qed.
 
+Hint Rewrite @equivocator_state_update_size : state_update.
+Hint Rewrite @equivocator_state_update_lst : state_update.
+Hint Rewrite @equivocator_state_update_project_eq using first [done | lia] : state_update.
+Hint Rewrite @equivocator_state_update_project_neq using first [done | lia] : state_update.
+
+Hint Rewrite @equivocator_state_extend_size using done : state_update.
+Hint Rewrite @equivocator_state_extend_lst using done : state_update.
+Hint Rewrite @equivocator_state_extend_project_1 using first [done | lia] : state_update.
+Hint Rewrite @equivocator_state_extend_project_2 using first [done | lia] : state_update.
+Hint Rewrite @equivocator_state_extend_project_3 using first [done | lia] : state_update.
+
+Hint Rewrite @equivocator_state_append_size using done : state_update.
+Hint Rewrite @equivocator_state_append_lst using done : state_update.
+Hint Rewrite @equivocator_state_append_project_1 using first [done | lia] : state_update.
+Hint Rewrite @equivocator_state_append_project_2 using first [done | lia] : state_update.
+Hint Rewrite @equivocator_state_append_project_3 using first [done | lia] : state_update.
+
 #[local] Ltac destruct_equivocator_state_append_project' es es' i Hi k Hk Hpr :=
   let Hi' := fresh "Hi" in
   destruct (decide (i < equivocator_state_n es)) as [Hi| Hi']; swap 1 2;
@@ -492,25 +509,18 @@ Proof.
   intro i.
   destruct_equivocator_state_append_project es1 (equivocator_state_extend es2 s) i Hi k Hk.
   - apply equivocator_state_extend_project_3.
-    rewrite equivocator_state_append_size.
-    rewrite equivocator_state_extend_size in Hi.
-    lia.
-  - subst.
-    rewrite equivocator_state_extend_size in Hi.
+    by state_update_simpl; lia.
+  - subst. state_update_simpl.
     destruct (decide (k = equivocator_state_n es2)).
     + subst.
       rewrite !equivocator_state_extend_project_2
       ; [done | done |].
-      rewrite equivocator_state_append_size.
-      lia.
+      by state_update_simpl; lia.
     + rewrite !equivocator_state_extend_project_1
       ; [rewrite equivocator_state_append_project_2 with (k := k)|lia|]
       ; [done | done |].
-      rewrite equivocator_state_append_size.
-      lia.
-  - rewrite equivocator_state_extend_project_1.
-    + by apply equivocator_state_append_project_1.
-    + rewrite equivocator_state_append_size. lia.
+      by state_update_simpl; lia.
+  - by rewrite equivocator_state_extend_project_1; state_update_simpl; [| lia].
 Qed.
 
 Lemma equivocator_state_append_update_commute es1 es2 s n
@@ -520,20 +530,16 @@ Proof.
   apply equivocator_state_project_ext.
   intro i.
   destruct_equivocator_state_append_project es1 (equivocator_state_update es2 n s) i Hi k Hk.
-  - apply equivocator_state_project_None.
-    rewrite equivocator_state_update_size in *.
-    rewrite equivocator_state_append_size.
-    lia.
+  - rewrite equivocator_state_project_None; [done |].
+    by state_update_simpl.
   - destruct (decide (n = k)).
-    + subst. rewrite equivocator_state_update_size in Hi.
+    + subst. state_update_simpl.
       rewrite equivocator_state_update_project_eq;
       [| rewrite equivocator_state_append_size; lia | done].
-      symmetry.
-      apply equivocator_state_update_project_eq; lia.
-    + rewrite !equivocator_state_update_project_neq by lia.
+      by state_update_simpl.
+    + state_update_simpl.
       by apply equivocator_state_append_project_2 with (k := k).
-  - by rewrite equivocator_state_update_project_neq,
-       equivocator_state_append_project_1 by lia.
+  - by state_update_simpl.
 Qed.
 
 (* An [equivocator_state] has the [initial_state_prop]erty if it only
@@ -636,6 +642,23 @@ Lemma mk_singleton_initial_state
 Proof. done. Qed.
 
 End sec_equivocator_vlsm.
+
+#[export] Hint Rewrite @equivocator_state_update_size : state_update.
+#[export] Hint Rewrite @equivocator_state_update_lst : state_update.
+#[export] Hint Rewrite @equivocator_state_update_project_eq using first [done | lia] : state_update.
+#[export] Hint Rewrite @equivocator_state_update_project_neq using first [done | lia] : state_update.
+
+#[export] Hint Rewrite @equivocator_state_extend_size using done : state_update.
+#[export] Hint Rewrite @equivocator_state_extend_lst using done : state_update.
+#[export] Hint Rewrite @equivocator_state_extend_project_1 using first [done | lia] : state_update.
+#[export] Hint Rewrite @equivocator_state_extend_project_2 using first [done | lia] : state_update.
+#[export] Hint Rewrite @equivocator_state_extend_project_3 using first [done | lia] : state_update.
+
+#[export] Hint Rewrite @equivocator_state_append_size using done : state_update.
+#[export] Hint Rewrite @equivocator_state_append_lst using done : state_update.
+#[export] Hint Rewrite @equivocator_state_append_project_1 using first [done | lia] : state_update.
+#[export] Hint Rewrite @equivocator_state_append_project_2 using first [done | lia] : state_update.
+#[export] Hint Rewrite @equivocator_state_append_project_3 using first [done | lia] : state_update.
 
 Arguments Spawn {_ _} _: assert.
 Arguments ContinueWith {_ _} _ _: assert.
@@ -848,9 +871,9 @@ Proof.
   ; [ inversion Ht; subst; rewrite equivocator_state_extend_size in Hs'; cbv in Hs'; lia|..]
   ; cbn in Hv, Ht;  destruct_equivocator_state_project s ei sei Hei; [| done | | done]
   ; destruct (vtransition _ _ _) as (si', om')
-  ; inversion Ht; subst.
-  - rewrite equivocator_state_update_size in Hs'. exists l. f_equal. lia.
-  - rewrite equivocator_state_extend_size in Hs'. lia.
+  ; inversion Ht; subst; state_update_simpl.
+  - exists l. f_equal. lia.
+  - lia.
 Qed.
 
 (** If the state obtained after one transition has no equivocation, then
@@ -864,14 +887,12 @@ Lemma equivocator_transition_reflects_singleton_state
   : is_singleton_state X s' -> is_singleton_state X s.
 Proof.
   unfold is_singleton_state.
-  destruct l as [sn| ei l| ei l]; cbn in Ht
+  by destruct l as [sn| ei l| ei l]; cbn in Ht
   ; [inversion Ht; rewrite equivocator_state_extend_size; cbv; lia| ..]
   ; destruct (equivocator_state_project _ _)
   ; [| by inversion Ht | | by inversion Ht]
   ; destruct (vtransition _ _ _) as (si', om')
-  ; inversion Ht; subst; clear Ht.
-  - by rewrite equivocator_state_update_size.
-  - by rewrite equivocator_state_extend_size; cbv; lia.
+  ; inversion Ht; subst; clear Ht; state_update_simpl.
 Qed.
 
 Lemma equivocator_transition_cannot_decrease_state_size
@@ -889,8 +910,8 @@ Proof.
   ; [|inversion Ht; lia| |inversion Ht; lia]
   ; destruct (vtransition _ _ _) as (si', om')
   ; inversion Ht; subst; clear Ht.
-  - rewrite equivocator_state_update_size. lia.
-  - rewrite Hex_size. lia.
+  - by state_update_simpl.
+  - by rewrite Hex_size; lia.
 Qed.
 
 Lemma equivocator_transition_preserves_equivocating_state
@@ -919,7 +940,7 @@ Proof.
   destruct (vtransition _ _ _).
   inversion Ht. subst.
   unfold is_equivocating_state, is_singleton_state.
-  by rewrite equivocator_state_update_size.
+  by state_update_simpl.
 Qed.
 
 (**
@@ -1097,7 +1118,7 @@ Proof.
   rewrite Hv in Ht.
   destruct (vtransition _ _ _).
   inversion Ht. subst.
-  apply equivocator_state_update_size.
+  by state_update_simpl.
 Qed.
 
 Lemma new_machine_label_equivocator_state_project_last

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -446,22 +446,22 @@ Proof.
   lia.
 Qed.
 
-Hint Rewrite @equivocator_state_update_size : state_update.
-Hint Rewrite @equivocator_state_update_lst : state_update.
-Hint Rewrite @equivocator_state_update_project_eq using first [done | lia] : state_update.
-Hint Rewrite @equivocator_state_update_project_neq using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_update_size : state_update.
+#[local] Hint Rewrite @equivocator_state_update_lst : state_update.
+#[local] Hint Rewrite @equivocator_state_update_project_eq using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_update_project_neq using first [done | lia] : state_update.
 
-Hint Rewrite @equivocator_state_extend_size using done : state_update.
-Hint Rewrite @equivocator_state_extend_lst using done : state_update.
-Hint Rewrite @equivocator_state_extend_project_1 using first [done | lia] : state_update.
-Hint Rewrite @equivocator_state_extend_project_2 using first [done | lia] : state_update.
-Hint Rewrite @equivocator_state_extend_project_3 using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_extend_size using done : state_update.
+#[local] Hint Rewrite @equivocator_state_extend_lst using done : state_update.
+#[local] Hint Rewrite @equivocator_state_extend_project_1 using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_extend_project_2 using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_extend_project_3 using first [done | lia] : state_update.
 
-Hint Rewrite @equivocator_state_append_size using done : state_update.
-Hint Rewrite @equivocator_state_append_lst using done : state_update.
-Hint Rewrite @equivocator_state_append_project_1 using first [done | lia] : state_update.
-Hint Rewrite @equivocator_state_append_project_2 using first [done | lia] : state_update.
-Hint Rewrite @equivocator_state_append_project_3 using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_append_size using done : state_update.
+#[local] Hint Rewrite @equivocator_state_append_lst using done : state_update.
+#[local] Hint Rewrite @equivocator_state_append_project_1 using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_append_project_2 using first [done | lia] : state_update.
+#[local] Hint Rewrite @equivocator_state_append_project_3 using first [done | lia] : state_update.
 
 #[local] Ltac destruct_equivocator_state_append_project' es es' i Hi k Hk Hpr :=
   let Hi' := fresh "Hi" in

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -688,7 +688,7 @@ Proof.
   intros * []; constructor; [| done |].
   - by eapply VLSM_full_projection_input_valid_transition in dobst_transition0;
       [| apply lift_to_composite_preloaded_vlsm_full_projection].
-  - by destruct item; cbn in *; unfold lift_to_composite_state'; rewrite state_update_eq.
+  - by destruct item; cbn in *; state_update_simpl.
 Qed.
 
 Lemma composite_observed_before_send_lift :

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -39,12 +39,12 @@ Proof.
     unfold composite_project_label in HlX; cbn in HlX;
       case_decide; inversion HlX; subst; clear HlX; cbn in *.
     unfold vtransition in Ht; destruct (transition _ _) as (si', _om').
-    by inversion Ht; rewrite state_update_eq.
+    by inversion Ht; state_update_simpl.
   - intros [i li] HlX s om s' om' [_ Ht].
       unfold composite_project_label in HlX; cbn in HlX;
       case_decide; inversion HlX; cbn in *.
     destruct (vtransition _ _ _); inversion Ht.
-    by rewrite state_update_neq.
+    by state_update_simpl.
   - by intros sX HsX; specialize (HsX j).
   - intros [i li] lY HlX s m (_ & Hm & _ & _) _.
     by apply initial_message_is_valid; right.
@@ -95,10 +95,10 @@ Proof.
   - apply H0.
   - destruct (vtransition _ _ _) as [si' _om']
     ; inversion H0; subst; clear H0.
-    by rewrite state_update_eq.
+    by state_update_simpl.
   - destruct (vtransition _ _ _) as [si' _om']
     ; inversion H0; subst; clear H0.
-    by rewrite state_update_neq.
+    by state_update_simpl.
 Qed.
 
 Definition composite_transition_item_projection_from_eq
@@ -226,7 +226,7 @@ Proof.
   destruct (vtransition _ _ _) as (si', om') eqn:Htj.
   inversion Ht. subst; clear Ht.
   simpl in Hi.
-  by rewrite state_update_neq.
+  by state_update_simpl.
 Qed.
 
 End PreLoadedProjectionTraces.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -224,8 +224,7 @@ Proof.
   simpl in Hv. simpl in Ht. cbn in Ht.
   destruct l as [il l].
   destruct (vtransition _ _ _) as (si', om') eqn:Htj.
-  inversion Ht. subst; clear Ht.
-  simpl in Hi.
+  inversion Ht; subst; clear Ht.
   by state_update_simpl.
 Qed.
 
@@ -559,7 +558,7 @@ Proof.
   - by apply initial_state_is_valid, (composite_initial_state_prop_lift IM j).
   - destruct Ht as [Hvj Ht].
     specialize (Hfr _ _ _ Hvj _ IHHp).
-    spec Hfr; [apply state_update_eq|].
+    spec Hfr; [apply state_update_eq |].
     exists om'.
     destruct Hvj as [_ [_ Hvj]].
     apply (projection_valid_implies_composition_valid_message IM) in Hvj as Hom.
@@ -569,7 +568,7 @@ Proof.
     apply Hgen.
     simpl.
     unfold lift_to_composite_state' at 1.
-    rewrite state_update_eq.
+    state_update_simpl.
     replace (vtransition (IM j) _ _) with (s', om').
     f_equal.
     apply state_update_twice.
@@ -586,11 +585,12 @@ Lemma projection_friendliness_lift_to_composite_vlsm_full_projection
   : VLSM_full_projection Xj X (lift_to_composite_label IM j) (lift_to_composite_state' IM j).
 Proof.
   apply basic_VLSM_full_projection; intro; intros.
-  - apply (Hfr _ _ _ Hv); [|apply state_update_eq].
+  - apply (Hfr _ _ _ Hv); [| apply state_update_eq].
     apply (projection_friendliness_sufficient_condition_valid_state Hfr).
     apply Hv.
   - unfold lift_to_composite_label, vtransition. simpl.
-    unfold lift_to_composite_state' at 1. rewrite state_update_eq.
+    unfold lift_to_composite_state' at 1.
+    state_update_simpl.
     replace (vtransition (IM j) _ _) with (s', om')
       by (symmetry; apply H).
     f_equal. unfold lift_to_composite_state'. apply state_update_twice.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -164,7 +164,7 @@ Proof.
   symmetry.
   extensionality j.
   unfold lift_sub_state_to.
-  by state_update i j; case_decide.
+  by destruct (decide (i = j)); subst; state_update_simpl; case_decide.
 Qed.
 
 Hint Rewrite @sub_IM_state_update_eq using done : state_update.
@@ -275,7 +275,7 @@ Proof.
   subst.
   unfold composite_state_sub_projection in HsXeq_pr |- *.
   simpl in HsXeq_pr |- *.
-  by state_update i j.
+  by destruct (decide (i = j)); subst; state_update_simpl.
 Qed.
 
 (** The [pre_induced_sub_projection] is actually a [VLSM_projection] of the
@@ -328,7 +328,7 @@ Proof.
   f_equal; extensionality sub_k.
   destruct_dec_sig sub_k k Hk Heqsub_k; subst.
   unfold composite_state_sub_projection; cbn.
-  state_update i k; [done |].
+  destruct (decide (i = k)); subst; state_update_simpl; [done |].
   apply lift_sub_state_to_eq.
 Qed.
 
@@ -443,8 +443,8 @@ Proof.
   f_equal.
   extensionality sub_j.
   destruct_dec_sig sub_j j Hj Heqj.
-  subst sub_j. unfold composite_state_sub_projection at 2.
-  by cbn; state_update i j.
+  unfold composite_state_sub_projection at 2.
+  by destruct (decide (i = j)); subst; state_update_simpl.
 Qed.
 
 Lemma valid_sub_projection
@@ -751,9 +751,9 @@ Proof.
   case_decide as _Hi; [| done].
   rewrite (sub_IM_state_pi s _Hi Hi).
   clear _Hi; destruct (transition _ _) as (si', _om'); inversion_clear 1.
-  f_equal.
-  by extensionality j; state_update i j; unfold lift_sub_state, lift_sub_state_to
-  ; case_decide; state_update_simpl.
+  f_equal; extensionality j.
+  unfold lift_sub_state, lift_sub_state_to.
+  by destruct (decide (i = j)); subst; state_update_simpl; case_decide; state_update_simpl.
 Qed.
 
 End sub_composition.
@@ -847,7 +847,7 @@ Proof.
   destruct (vtransition _ _ _) as (si', _om').
   inversion_clear Ht.
   f_equal; extensionality j.
-  by state_update i j.
+  by destruct (decide (i = j)); subst; state_update_simpl.
 Qed.
 
 Lemma remove_equivocating_strong_projection_transition_consistency_None eqv_is
@@ -864,7 +864,7 @@ Proof.
   extensionality j.
   unfold remove_equivocating_state_project, lift_sub_state_to.
   case_decide; [done |].
-  by state_update i j.
+  by destruct (decide (i = j)); subst; state_update_simpl.
 Qed.
 
 Lemma remove_equivocating_strong_full_projection_initial_state_preservation eqv_is
@@ -928,7 +928,7 @@ Proof.
   destruct (transition _ _) as (si', _om').
   inversion_clear 1.
   f_equal; extensionality i.
-  state_update i j.
+  destruct (decide (i = j)); subst; state_update_simpl.
   - by rewrite lift_sub_state_to_eq with (Hi := Hj); state_update_simpl.
   - destruct (decide (i ∈ equivocators)).
     + by rewrite !lift_sub_state_to_eq with (Hi := e); state_update_simpl.
@@ -1107,7 +1107,8 @@ Proof.
   rewrite (sub_IM_state_pi s H_i Hi).
   destruct (transition _ _) as (si', _om'); inversion_clear 1; f_equal.
   extensionality sub2_j; destruct_dec_sig sub2_j j Hj Heqsub2_j; subst.
-  by state_update i j; unfold lift_sub_incl_state; cbn; case_decide; state_update_simpl.
+  unfold lift_sub_incl_state.
+  by destruct (decide (i = j)); subst; state_update_simpl; cbn; case_decide; state_update_simpl.
 Qed.
 
 Lemma lift_sub_incl_full_projection
@@ -1338,7 +1339,7 @@ Proof.
   ; unfold composite_state_sub_projection
   ; simpl
   ; unfold sub_IM
-  ; (state_update i j; [done |])
+  ; (destruct (decide (i = j)); subst; state_update_simpl; [done |])
   ; unfold lift_sub_state
   ; rewrite (lift_sub_state_to_eq _ _ _ _ _ Hj)
   ; itauto.
@@ -1429,7 +1430,8 @@ Proof.
     ; inversion_clear 1; f_equal.
     extensionality sub_j; destruct_dec_sig sub_j j Hj Heqj; subst sub_j
     ; unfold composite_state_sub_projection at 2; cbn.
-    by state_update i j; unfold free_sub_free_index; state_update_simpl.
+    unfold free_sub_free_index.
+    by destruct (decide (i = j)); subst; state_update_simpl.
   - by intros s Hs; rapply (composite_initial_state_sub_projection IM).
   - intros m [[i Hi] | Hseed]; [left | by right].
     by exists (free_sub_free_index i).
@@ -1447,7 +1449,8 @@ Proof.
     ; cbn; destruct (transition _ _) as (si', _om'); inversion_clear 1.
     f_equal; extensionality sub_j; destruct_dec_sig sub_j j Hj Heqj; subst sub_j
     ; unfold composite_state_sub_projection at 2; cbn.
-    by state_update i j; by unfold free_sub_free_index; state_update_simpl.
+    unfold free_sub_free_index.
+    by destruct (decide (i = j)); subst; state_update_simpl.
   - by intros s Hs; rapply (composite_initial_state_sub_projection IM).
   - by intros m [i Hi]; exists (free_sub_free_index i).
 Qed.
@@ -1468,7 +1471,8 @@ Proof.
     ; rewrite (sub_IM_state_pi s (free_sub_free_index_obligation_1 i) Hi)
     ; destruct (vtransition _ _ _) as (si', _om'); inversion_clear 1.
     f_equal; extensionality j; unfold free_sub_free_state at 2.
-    by state_update i j; unfold free_sub_free_index, sub_IM; state_update_simpl.
+    unfold free_sub_free_index, sub_IM.
+    by destruct (decide (i = j)); subst; state_update_simpl.
   - intros s Hi i; rapply Hi.
   - by intros m [[i Hi] Him]; exists i.
 Qed.
@@ -1536,7 +1540,7 @@ Proof.
     intro Ht; replace (vtransition _ _ _) with (s', om'); f_equal.
     extensionality sub_i.
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
-    by state_update i j.
+    by destruct (decide (i = j)); subst; state_update_simpl.
   - intros sj Hsj sub_i.
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
     destruct (decide (i = j)); subst.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -53,7 +53,7 @@ Proof.
   cut (forall be1 be2, be1 = be2 ->
       state_update sub_IM s (exist _ i be1) si (exist _ i be2) = si).
   { intro Heq. apply Heq. apply proof_irrel. }
-  intros. subst. apply state_update_eq.
+  by intros; subst; state_update_simpl.
 Qed.
 
 Lemma sub_IM_state_update_neq
@@ -68,10 +68,7 @@ Lemma sub_IM_state_update_neq
         =
       s (dexist j ej).
 Proof.
-  intro Hneq.
-  apply state_update_neq.
-  setoid_rewrite dsig_eq.
-  simpl. congruence.
+  by intro Hneq; apply state_update_neq; inversion 1.
 Qed.
 
 Definition free_sub_vlsm_composition : VLSM message
@@ -165,10 +162,16 @@ Lemma lift_sub_state_to_neq_state_update
     lift_sub_state_to (state_update IM s0 i si') s.
 Proof.
   symmetry.
-  apply functional_extensionality_dep. intro j.
+  extensionality j.
   unfold lift_sub_state_to.
   by state_update i j; case_decide.
 Qed.
+
+Hint Rewrite @sub_IM_state_update_eq using done : state_update.
+Hint Rewrite @sub_IM_state_update_neq using done : state_update.
+Hint Rewrite @lift_sub_state_to_eq using done : state_update.
+Hint Rewrite @lift_sub_state_to_neq using done : state_update.
+Hint Rewrite @lift_sub_state_to_neq_state_update using done : state_update.
 
 Section sec_induced_sub_projection.
 
@@ -207,10 +210,8 @@ Proof.
   apply proj2 in HtX. cbn in HtX.
   destruct (vtransition _ _ _) as (si', _om').
   inversion_clear HtX.
-  rewrite state_update_neq; [done |].
-  intros ->.
-  unfold composite_label_sub_projection_option in HlX.
-  simpl in HlX.
+  rewrite state_update_neq; [done | intros ->].
+  unfold composite_label_sub_projection_option in HlX; simpl in HlX.
   by case_decide.
 Qed.
 
@@ -327,9 +328,8 @@ Proof.
   f_equal; extensionality sub_k.
   destruct_dec_sig sub_k k Hk Heqsub_k; subst.
   unfold composite_state_sub_projection; cbn.
-  state_update i k.
-  + by rewrite sub_IM_state_update_eq.
-  + by erewrite sub_IM_state_update_neq, lift_sub_state_to_eq.
+  state_update i k; [done |].
+  apply lift_sub_state_to_eq.
 Qed.
 
 End sec_induced_sub_projection.
@@ -444,9 +444,7 @@ Proof.
   extensionality sub_j.
   destruct_dec_sig sub_j j Hj Heqj.
   subst sub_j. unfold composite_state_sub_projection at 2.
-  cbn; state_update i j.
-  - apply sub_IM_state_update_eq.
-  - by rewrite! state_update_neq; cbn; [| inversion 1].
+  by cbn; state_update i j.
 Qed.
 
 Lemma valid_sub_projection
@@ -754,16 +752,17 @@ Proof.
   rewrite (sub_IM_state_pi s _Hi Hi).
   clear _Hi; destruct (transition _ _) as (si', _om'); inversion_clear 1.
   f_equal.
-  extensionality j.
-  state_update i j.
-  - unfold lift_sub_state, lift_sub_state_to.
-    by case_decide; rewrite ?sub_IM_state_update_eq.
-  - unfold lift_sub_state, lift_sub_state_to.
-    case_decide; [| done].
-    by rewrite state_update_neq; [| inversion 1].
+  by extensionality j; state_update i j; unfold lift_sub_state, lift_sub_state_to
+  ; case_decide; state_update_simpl.
 Qed.
 
 End sub_composition.
+
+#[export] Hint Rewrite @sub_IM_state_update_eq using done : state_update.
+#[export] Hint Rewrite @sub_IM_state_update_neq using done : state_update.
+#[export] Hint Rewrite @lift_sub_state_to_eq using done : state_update.
+#[export] Hint Rewrite @lift_sub_state_to_neq using done : state_update.
+#[export] Hint Rewrite @lift_sub_state_to_neq_state_update using done : state_update.
 
 Arguments sub_IM_state_pi {_ _ _ _ _ _} _ _ _.
 (* make initial arguments of lift_sub_transition not maximally inserted,
@@ -847,12 +846,8 @@ Proof.
   rewrite lift_sub_state_to_neq by done.
   destruct (vtransition _ _ _) as (si', _om').
   inversion_clear Ht.
-  f_equal.
-  apply functional_extensionality_dep.
-  intro j.
-  state_update i j.
-  - by rewrite lift_sub_state_to_neq, state_update_eq.
-  - by unfold lift_sub_state_to; rewrite !state_update_neq.
+  f_equal; extensionality j.
+  by state_update i j.
 Qed.
 
 Lemma remove_equivocating_strong_projection_transition_consistency_None eqv_is
@@ -866,13 +861,10 @@ Proof.
   cbn in Ht.
   destruct (vtransition _ _ _) as (si', _om').
   inversion_clear Ht.
-  apply functional_extensionality_dep.
-  intro j.
-  unfold remove_equivocating_state_project.
-  unfold lift_sub_state_to.
+  extensionality j.
+  unfold remove_equivocating_state_project, lift_sub_state_to.
   case_decide; [done |].
-  apply state_update_neq.
-  by intro; subst.
+  by state_update i j.
 Qed.
 
 Lemma remove_equivocating_strong_full_projection_initial_state_preservation eqv_is
@@ -935,14 +927,12 @@ Proof.
   rewrite lift_sub_state_to_eq with (Hi := Hj).
   destruct (transition _ _) as (si', _om').
   inversion_clear 1.
-  f_equal.
-  apply functional_extensionality_dep. intro i.
+  f_equal; extensionality i.
   state_update i j.
-  - by subst; rewrite lift_sub_state_to_eq with (Hi := Hj), !state_update_eq.
+  - by rewrite lift_sub_state_to_eq with (Hi := Hj); state_update_simpl.
   - destruct (decide (i ∈ equivocators)).
-    + rewrite !lift_sub_state_to_eq with (Hi := e).
-      by rewrite state_update_neq; [| inversion 1].
-    + by rewrite !lift_sub_state_to_neq.
+    + by rewrite !lift_sub_state_to_eq with (Hi := e); state_update_simpl.
+    + by state_update_simpl.
 Qed.
 
 (**
@@ -1000,10 +990,9 @@ Proof.
       by rewrite state_update_eq, lift_sub_state_to_eq with (Hi := Hj), state_update_eq.
     + state_update_simpl.
       destruct (decide (i ∈ equivocators)).
-      * unfold lift_sub_state.
-        rewrite !lift_sub_state_to_eq with (Hi := e).
-        unfold composite_state_sub_projection; cbn.
-        by rewrite state_update_neq, lift_sub_state_to_eq with (Hi := e).
+      * unfold lift_sub_state, composite_state_sub_projection; cbn.
+        by rewrite !lift_sub_state_to_eq with (Hi := e), state_update_neq,
+          lift_sub_state_to_eq with (Hi := e).
       * by unfold lift_sub_state, lift_sub_state_to; case_decide.
   - intros s Hs.
     apply (lift_sub_state_initial IM).
@@ -1118,15 +1107,7 @@ Proof.
   rewrite (sub_IM_state_pi s H_i Hi).
   destruct (transition _ _) as (si', _om'); inversion_clear 1; f_equal.
   extensionality sub2_j; destruct_dec_sig sub2_j j Hj Heqsub2_j; subst.
-  destruct (decide (i = j)) as [| Hij]; subst.
-  - rewrite sub_IM_state_update_eq.
-    unfold lift_sub_incl_state; cbn.
-    case_decide; [| done].
-    by rewrite sub_IM_state_update_eq.
-  - rewrite sub_IM_state_update_neq by done.
-    unfold lift_sub_incl_state; cbn.
-    case_decide; [| done].
-    by rewrite sub_IM_state_update_neq.
+  by state_update i j; unfold lift_sub_incl_state; cbn; case_decide; state_update_simpl.
 Qed.
 
 Lemma lift_sub_incl_full_projection
@@ -1357,10 +1338,7 @@ Proof.
   ; unfold composite_state_sub_projection
   ; simpl
   ; unfold sub_IM
-  ; (destruct (decide (i = j))
-    ; [by subst; rewrite state_update_eq, sub_IM_state_update_eq|])
-  ; rewrite (state_update_neq _ (lift_sub_state _ _ _)) by congruence
-  ; rewrite state_update_neq by (setoid_rewrite dsig_eq; simpl; congruence)
+  ; (state_update i j; [done |])
   ; unfold lift_sub_state
   ; rewrite (lift_sub_state_to_eq _ _ _ _ _ Hj)
   ; itauto.
@@ -1451,11 +1429,7 @@ Proof.
     ; inversion_clear 1; f_equal.
     extensionality sub_j; destruct_dec_sig sub_j j Hj Heqj; subst sub_j
     ; unfold composite_state_sub_projection at 2; cbn.
-    destruct (decide (i = j)) as [| Hij]; subst.
-    + unfold free_sub_free_index.
-      by rewrite state_update_eq, sub_IM_state_update_eq.
-    + rewrite !state_update_neq; [done | done |].
-      contradict Hij; apply dsig_eq in Hij; cbn in Hij; congruence.
+    by state_update i j; unfold free_sub_free_index; state_update_simpl.
   - by intros s Hs; rapply (composite_initial_state_sub_projection IM).
   - intros m [[i Hi] | Hseed]; [left | by right].
     by exists (free_sub_free_index i).
@@ -1473,11 +1447,7 @@ Proof.
     ; cbn; destruct (transition _ _) as (si', _om'); inversion_clear 1.
     f_equal; extensionality sub_j; destruct_dec_sig sub_j j Hj Heqj; subst sub_j
     ; unfold composite_state_sub_projection at 2; cbn.
-    destruct (decide (i = j)) as [| Hij]; subst.
-    + unfold free_sub_free_index.
-      by rewrite state_update_eq, sub_IM_state_update_eq.
-    + rewrite !state_update_neq; [done | done |].
-      contradict Hij; apply dsig_eq in Hij; simpl in Hij; congruence.
+    by state_update i j; by unfold free_sub_free_index; state_update_simpl.
   - by intros s Hs; rapply (composite_initial_state_sub_projection IM).
   - by intros m [i Hi]; exists (free_sub_free_index i).
 Qed.
@@ -1498,11 +1468,7 @@ Proof.
     ; rewrite (sub_IM_state_pi s (free_sub_free_index_obligation_1 i) Hi)
     ; destruct (vtransition _ _ _) as (si', _om'); inversion_clear 1.
     f_equal; extensionality j; unfold free_sub_free_state at 2.
-    destruct (decide (i = j)) as [| Hij]; subst.
-    + unfold free_sub_free_index, sub_IM.
-      by rewrite state_update_eq, sub_IM_state_update_eq.
-    + rewrite !state_update_neq; [done | | congruence].
-      contradict Hij; apply dsig_eq in Hij; simpl in Hij; congruence.
+    by state_update i j; unfold free_sub_free_index, sub_IM; state_update_simpl.
   - intros s Hi i; rapply Hi.
   - by intros m [[i Hi] Him]; exists i.
 Qed.
@@ -1551,6 +1517,9 @@ Proof.
   case_decide; congruence.
 Qed.
 
+Hint Rewrite @sub_element_state_eq : state_update.
+Hint Rewrite @sub_element_state_neq using done : state_update.
+
 Lemma preloaded_sub_element_full_projection
   (P Q : message -> Prop)
   (PimpliesQ : forall m, P m -> Q m)
@@ -1567,9 +1536,7 @@ Proof.
     intro Ht; replace (vtransition _ _ _) with (s', om'); f_equal.
     extensionality sub_i.
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
-    destruct (decide (i = j)); subst.
-    + by rewrite sub_IM_state_update_eq, sub_element_state_eq.
-    + by rewrite sub_IM_state_update_neq, !sub_element_state_neq.
+    by state_update i j.
   - intros sj Hsj sub_i.
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
     destruct (decide (i = j)); subst.
@@ -1630,8 +1597,7 @@ Proof.
   destruct (vtransition _ _ _) as (si', _om').
   inversion_clear HtX.
   unfold sub_state_element_project.
-  apply sub_IM_state_update_neq.
-  congruence.
+  by state_update_simpl.
 Qed.
 
 Lemma sub_element_label_project
@@ -1673,8 +1639,7 @@ Proof.
   ; unfold sub_IM at 3 13; cbn
   ; destruct (vtransition _ _ _) as (si', om').
   do 2 inversion_clear 1.
-  rewrite !sub_IM_state_update_eq.
-  itauto.
+  by state_update_simpl.
 Qed.
 
 Definition induced_sub_element_projection constraint : VLSM message :=

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -166,11 +166,8 @@ Lemma lift_sub_state_to_neq_state_update
 Proof.
   symmetry.
   apply functional_extensionality_dep. intro j.
-  destruct (decide (j = i)).
-  - subst. rewrite state_update_eq.
-    unfold lift_sub_state_to. case_decide; [done |].
-    apply state_update_eq.
-  - by unfold lift_sub_state_to; rewrite !state_update_neq.
+  unfold lift_sub_state_to.
+  by state_update i j; case_decide.
 Qed.
 
 Section sec_induced_sub_projection.
@@ -277,9 +274,7 @@ Proof.
   subst.
   unfold composite_state_sub_projection in HsXeq_pr |- *.
   simpl in HsXeq_pr |- *.
-  destruct (decide (i = j)).
-  - by subst; rewrite !state_update_eq.
-  - by rewrite !state_update_neq.
+  by state_update i j.
 Qed.
 
 (** The [pre_induced_sub_projection] is actually a [VLSM_projection] of the
@@ -332,10 +327,9 @@ Proof.
   f_equal; extensionality sub_k.
   destruct_dec_sig sub_k k Hk Heqsub_k; subst.
   unfold composite_state_sub_projection; cbn.
-  destruct (decide (i = k)); subst.
-  + by rewrite state_update_eq, sub_IM_state_update_eq.
-  + rewrite sub_IM_state_update_neq, state_update_neq by congruence.
-    apply lift_sub_state_to_eq.
+  state_update i k.
+  + by rewrite sub_IM_state_update_eq.
+  + by erewrite sub_IM_state_update_neq, lift_sub_state_to_eq.
 Qed.
 
 End sec_induced_sub_projection.
@@ -450,11 +444,9 @@ Proof.
   extensionality sub_j.
   destruct_dec_sig sub_j j Hj Heqj.
   subst sub_j. unfold composite_state_sub_projection at 2.
-  destruct (decide (j = i)).
-  - subst.
-    simpl. rewrite state_update_eq.
-    apply sub_IM_state_update_eq.
-  - rewrite! state_update_neq; cbn; [done | done | by inversion 1].
+  cbn; state_update i j.
+  - apply sub_IM_state_update_eq.
+  - by rewrite! state_update_neq; cbn; [| inversion 1].
 Qed.
 
 Lemma valid_sub_projection
@@ -763,16 +755,12 @@ Proof.
   clear _Hi; destruct (transition _ _) as (si', _om'); inversion_clear 1.
   f_equal.
   extensionality j.
-  destruct (decide (i = j)).
-  - subst.
-    rewrite state_update_eq.
-    unfold lift_sub_state, lift_sub_state_to. simpl.
+  state_update i j.
+  - unfold lift_sub_state, lift_sub_state_to.
     by case_decide; rewrite ?sub_IM_state_update_eq.
-  - rewrite state_update_neq by congruence.
-    unfold lift_sub_state, lift_sub_state_to. simpl.
+  - unfold lift_sub_state, lift_sub_state_to.
     case_decide; [| done].
-    rewrite state_update_neq; [done |].
-    by inversion 1.
+    by rewrite state_update_neq; [| inversion 1].
 Qed.
 
 End sub_composition.
@@ -862,9 +850,8 @@ Proof.
   f_equal.
   apply functional_extensionality_dep.
   intro j.
-  destruct (decide (i = j)).
-  - subst. rewrite state_update_eq.
-    by rewrite lift_sub_state_to_neq, state_update_eq.
+  state_update i j.
+  - by rewrite lift_sub_state_to_neq, state_update_eq.
   - by unfold lift_sub_state_to; rewrite !state_update_neq.
 Qed.
 
@@ -950,13 +937,11 @@ Proof.
   inversion_clear 1.
   f_equal.
   apply functional_extensionality_dep. intro i.
-  destruct (decide (i = j)).
+  state_update i j.
   - by subst; rewrite lift_sub_state_to_eq with (Hi := Hj), !state_update_eq.
-  - rewrite state_update_neq by congruence.
-    destruct (decide (i ∈ equivocators)).
+  - destruct (decide (i ∈ equivocators)).
     + rewrite !lift_sub_state_to_eq with (Hi := e).
-      rewrite state_update_neq; [done |].
-      by inversion 1.
+      by rewrite state_update_neq; [| inversion 1].
     + by rewrite !lift_sub_state_to_neq.
 Qed.
 
@@ -1013,7 +998,7 @@ Proof.
     ; destruct (decide (i = j)); subst.
     + unfold lift_sub_state, composite_state_sub_projection; cbn.
       by rewrite state_update_eq, lift_sub_state_to_eq with (Hi := Hj), state_update_eq.
-    + rewrite state_update_neq by congruence.
+    + state_update_simpl.
       destruct (decide (i ∈ equivocators)).
       * unfold lift_sub_state.
         rewrite !lift_sub_state_to_eq with (Hi := e).

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -167,11 +167,11 @@ Proof.
   by destruct (decide (i = j)); subst; state_update_simpl; case_decide.
 Qed.
 
-Hint Rewrite @sub_IM_state_update_eq using done : state_update.
-Hint Rewrite @sub_IM_state_update_neq using done : state_update.
-Hint Rewrite @lift_sub_state_to_eq using done : state_update.
-Hint Rewrite @lift_sub_state_to_neq using done : state_update.
-Hint Rewrite @lift_sub_state_to_neq_state_update using done : state_update.
+#[local] Hint Rewrite @sub_IM_state_update_eq using done : state_update.
+#[local] Hint Rewrite @sub_IM_state_update_neq using done : state_update.
+#[local] Hint Rewrite @lift_sub_state_to_eq using done : state_update.
+#[local] Hint Rewrite @lift_sub_state_to_neq using done : state_update.
+#[local] Hint Rewrite @lift_sub_state_to_neq_state_update using done : state_update.
 
 Section sec_induced_sub_projection.
 
@@ -1521,8 +1521,8 @@ Proof.
   case_decide; congruence.
 Qed.
 
-Hint Rewrite @sub_element_state_eq : state_update.
-Hint Rewrite @sub_element_state_neq using done : state_update.
+#[local] Hint Rewrite @sub_element_state_eq : state_update.
+#[local] Hint Rewrite @sub_element_state_neq using done : state_update.
 
 Lemma preloaded_sub_element_full_projection
   (P Q : message -> Prop)
@@ -1673,6 +1673,9 @@ Proof.
 Qed.
 
 End sub_composition_element.
+
+#[export] Hint Rewrite @sub_element_state_eq : state_update.
+#[export] Hint Rewrite @sub_element_state_neq using done : state_update.
 
 Section sub_composition_preloaded_lift.
 

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -713,7 +713,7 @@ Lemma component_transition_projection_None
 Proof.
   intros [j lj] HlX sX iom s'X oom [_ Ht]; cbn in Ht.
   destruct (vtransition _ _ _) as (si', om'); inversion Ht; subst.
-  state_update i j; [| done].
+  destruct (decide (i = j)); subst; state_update_simpl; [| done].
   unfold composite_project_label in HlX; cbn in HlX.
   by case_decide.
 Qed.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -713,7 +713,7 @@ Lemma component_transition_projection_None
 Proof.
   intros [j lj] HlX sX iom s'X oom [_ Ht]; cbn in Ht.
   destruct (vtransition _ _ _) as (si', om'); inversion Ht; subst.
-  apply state_update_neq.
+  state_update i j; [| done].
   unfold composite_project_label in HlX; cbn in HlX.
   by case_decide.
 Qed.
@@ -828,14 +828,15 @@ Proof.
   apply VLSM_eq_incl_iff; split; cbn; apply basic_VLSM_strong_incl.
   - intros s Hs; cbn in *; red.
     exists (lift_to_composite_state' IM i s).
-    split; [apply state_update_eq |].
+    split; [by state_update_simpl |].
     by apply (composite_initial_state_prop_lift IM).
   - by intros m [Him | Hpm]; right; [apply Hinits |].
   - intros l s iom [sX [<- Hv]].
     exists (existT i l), sX.
     by split; [apply composite_project_label_eq |..].
   - intros l s iom s' oom.
-    cbn; unfold lift_to_composite_state' at 1; rewrite state_update_eq.
+    cbn; unfold lift_to_composite_state' at 1.
+    state_update_simpl.
     intros Ht; setoid_rewrite Ht.
     by state_update_simpl.
   - by intros s [sX [<- HsX]]; cbn.
@@ -847,7 +848,7 @@ Proof.
     by inversion HlX; subst.
   - intros l s iom s' oom Ht; cbn in *.
     unfold lift_to_composite_state' in Ht;
-      rewrite state_update_eq in Ht;
+      state_update_simpl;
       destruct (vtransition _ _ _) as (si', om').
     by state_update_simpl.
 Qed.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -731,7 +731,7 @@ Proof.
   destruct (vtransition _ _ _) as [si' om'].
   intros sX1' oom1 Ht1; inversion Ht1; subst; clear Ht1.
   intros sX2' oom2 Ht2; inversion Ht2; subst; clear Ht2.
-  by rewrite !state_update_eq.
+  by state_update_simpl.
 Qed.
 
 (** The [projection_induced_validator] by the [composite_project_label] and the
@@ -837,7 +837,7 @@ Proof.
   - intros l s iom s' oom.
     cbn; unfold lift_to_composite_state' at 1; rewrite state_update_eq.
     intros Ht; setoid_rewrite Ht.
-    by rewrite state_update_eq.
+    by state_update_simpl.
   - by intros s [sX [<- HsX]]; cbn.
   - by intros m [| Hm]; [| right].
   - intros l s iom ([j li] & sX & [HlX [=] Hv]).
@@ -849,7 +849,7 @@ Proof.
     unfold lift_to_composite_state' in Ht;
       rewrite state_update_eq in Ht;
       destruct (vtransition _ _ _) as (si', om').
-    by rewrite state_update_eq in Ht.
+    by state_update_simpl.
 Qed.
 
 Lemma pre_composite_vlsm_induced_projection_validator_iff

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -294,7 +294,7 @@ Proof.
   induction l as [|hd tl IHl]; intros x H_false; cbn.
   - by rewrite decide_False.
   - destruct (decide (x = hd)); cbn; [done |].
-    by destruct (decide (P hd)); rewrite <- (IHl).
+    by destruct (decide (P hd)); rewrite <- IHl.
 Qed.
 
 Lemma set_add_ignore `{StrictlyComparable X} :
@@ -304,7 +304,7 @@ Lemma set_add_ignore `{StrictlyComparable X} :
 Proof.
   induction l as [|hd tl IHl]; inversion 1; subst; cbn.
   - by rewrite decide_True.
-  - rewrite IHl; [| done]. by destruct (decide (x = hd)).
+  - by case_decide; [| rewrite IHl].
 Qed.
 
 Lemma set_add_new `{EqDecision A}:

--- a/theories/VLSM/Lib/Measurable.v
+++ b/theories/VLSM/Lib/Measurable.v
@@ -35,10 +35,10 @@ Lemma sum_weights_in
 Proof.
   induction vs; intros; inversion H0; subst; clear H0.
   - inversion H; subst; clear H. simpl. apply Rplus_eq_compat_l.
-    destruct (decide (a = a)); congruence.
+    by rewrite decide_True.
   - inversion H; subst; clear H. simpl.
     pose proof (in_not_in _ _ _ _ H3 H2).
-    destruct (decide (v = a)); [done |]. simpl.
+    rewrite decide_False; [| done]. simpl.
     rewrite <- Rplus_assoc. rewrite (Rplus_comm (proj1_sig (weight v)) (proj1_sig (weight a))). rewrite Rplus_assoc.
     by apply Rplus_eq_compat_l, IHvs.
 Qed.


### PR DESCRIPTION
I noticed that there are some clear patterns when reasoning about the `state_update` function from `Composition.v`. Namely, if the indices are equal, we `rewrite state_update_eq`, when they are not we `rewrite state_update_neq` and when we don't know, we do `destruct (decide (i = j)); subst` and then we `rewrite` accordingly.

This often causes the nesting level of the proof to increase by 1, which makes proofs less readable. So maybe it's a good idea to have a tactic for this?