### PR TITLE
fix incompatilities with coq-stdpp.1.8.0

### DIFF
--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -95,7 +95,7 @@ Lemma is_singleton_state_dec
   (s : equivocator_state)
   : Decision (is_singleton_state s).
 Proof.
-  apply nat_eq_dec.
+  apply Nat.eq_dec.
 Qed.
 
 Definition is_equivocating_state

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -200,13 +200,12 @@ Lemma set_map_size_upper_bound
 Proof.
   unfold set_map.
   remember (f <$> elements X) as fX.
-  specialize (list_to_set_size (A := B) fX) as Hsize.
-  assert (length fX = size X). {
-    unfold size. unfold set_size. simpl.
-    subst fX.
-    apply fmap_length.
-  }
-  lia.
+  set (x := size (list_to_set _)).
+  cut (x <= length fX); [|by apply list_to_set_size].
+  enough (length fX = size X) by lia.
+  unfold size, set_size.
+  simpl; subst fX.
+  by apply fmap_length.
 Qed.
 
 End map.


### PR DESCRIPTION
This fixes two proof incompatibilities with Coq 8.16 and Stdpp 1.8.0 in a backwards-compatible way.