### PR TITLE
Standardize section names

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -59,6 +59,8 @@ Example:
 Section sec_step_relations.
 ```
 
+The role of the "sec_" prefix is to prevent name collisions for crossreferences in coqdoc documentation. It should not appear in names of non-sections.
+
 ### Type classes
 
 - CamelCase name

--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -52,11 +52,11 @@ From Equations Require Import Equations.
 
 ### Sections
 
-- C-style name
+- C-style name prefixed with "sec_"
 
 Example:
 ```coq
-Section step_relations.
+Section sec_step_relations.
 ```
 
 ### Type classes

--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -52,14 +52,18 @@ From Equations Require Import Equations.
 
 ### Sections
 
-- C-style name prefixed with "sec_"
+- C-style name prefixed with "sec_" (the role of the prefix is to prevent name collisions for cross-references in coqdoc documentation; it should not appear in names of non-sections)
+- parts of section names can still be in CamelCase if it refers to an identifier written in CamelCase
 
 Example:
 ```coq
 Section sec_step_relations.
 ```
 
-The role of the "sec_" prefix is to prevent name collisions for crossreferences in coqdoc documentation. It should not appear in names of non-sections.
+Example (`ELMOComponent` is a previously defined identifier):
+```coq
+Section sec_ELMOComponent_lemmas.
+```
 
 ### Type classes
 

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -22,7 +22,7 @@ From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces 
 
 (** ** Definition and basic properties *)
 
-Section ByzantineTraces.
+Section sec_byzantine_traces.
 Context
     {message : Type}
     (M : VLSM message)
@@ -164,7 +164,7 @@ Qed.
   in the definition of the [alternate_byzantine_trace_prop]erty.
 *)
 
-Section pre_loaded_with_all_messages_byzantine_alt.
+Section sec_pre_loaded_with_all_messages_byzantine_alt.
 
 Context
     (PreLoaded := pre_loaded_with_all_messages_vlsm M)
@@ -295,7 +295,7 @@ Proof.
     - apply alt_pre_loaded_with_all_messages_incl.
 Qed.
 
-End pre_loaded_with_all_messages_byzantine_alt.
+End sec_pre_loaded_with_all_messages_byzantine_alt.
 
 (**
   Finally, we can conclude that the two definitions for byzantine traces are
@@ -310,7 +310,7 @@ Proof.
     - by apply pre_loaded_with_all_messages_alt_incl, byzantine_pre_loaded_with_all_messages.
 Qed.
 
-End ByzantineTraces.
+End sec_byzantine_traces.
 
 (** ** Byzantine fault tolerance for a single validator
 
@@ -343,7 +343,7 @@ Qed.
   traces obtained upon placing this composition in any, possibly adversarial,
   context) are [valid_trace]s of <<X>>.
 *)
-Section composite_validator_byzantine_traces.
+Section sec_composite_validator_byzantine_traces.
 
 Context
   {message : Type}
@@ -409,4 +409,4 @@ Proof.
   by apply byzantine_alt_byzantine_iff in Hbyz.
 Qed.
 
-End composite_validator_byzantine_traces.
+End sec_composite_validator_byzantine_traces.

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -23,7 +23,7 @@ From VLSM.Core Require Import Validator Equivocation EquivocationProjections Equ
   protocol it suffices to consider equivocating nodes.
 *)
 
-Section emit_any_signed_message_vlsm.
+Section sec_emit_any_signed_message_vlsm.
 
 (** ** A machine which can emit any valid message for a given node
 
@@ -61,9 +61,9 @@ Definition emit_any_signed_message_vlsm_machine
 Definition emit_any_signed_message_vlsm
     := mk_vlsm emit_any_signed_message_vlsm_machine.
 
-End emit_any_signed_message_vlsm.
+End sec_emit_any_signed_message_vlsm.
 
-Section fixed_byzantine_traces.
+Section sec_fixed_byzantine_traces.
 
 Context
   {message : Type}
@@ -154,7 +154,7 @@ Definition fixed_byzantine_trace_prop
 
 (** ** Byzantine traces characterization as projections *)
 
-Section fixed_byzantine_traces_as_projections.
+Section sec_fixed_byzantine_traces_as_projections.
 
 Definition fixed_non_byzantine_projection : VLSM message :=
   pre_induced_sub_projection fixed_byzantine_IM non_byzantine non_byzantine_not_equivocating_constraint.
@@ -225,7 +225,7 @@ Proof.
   apply fixed_non_byzantine_projection_friendliness.
 Qed.
 
-End fixed_byzantine_traces_as_projections.
+End sec_fixed_byzantine_traces_as_projections.
 
 (** ** Fixed Byzantine traces as traces pre-loaded with signed messages
 
@@ -234,7 +234,7 @@ End fixed_byzantine_traces_as_projections.
   signed by the nodes in the <<byzantine>>.
 *)
 
-Section fixed_byzantine_traces_as_pre_loaded.
+Section sec_fixed_byzantine_traces_as_pre_loaded.
 
 Definition fixed_set_signed_message (m : message) : Prop :=
   non_sub_index_authenticated_message non_byzantine A sender m /\
@@ -486,7 +486,7 @@ Proof.
   - apply pre_loaded_fixed_non_byzantine_incl.
 Qed.
 
-End fixed_byzantine_traces_as_pre_loaded.
+End sec_fixed_byzantine_traces_as_pre_loaded.
 
 (** *** Second fixed byzantine trace definition
 
@@ -505,7 +505,7 @@ Definition fixed_byzantine_trace_alt_prop is tr : Prop :=
     (composite_state_sub_projection IM non_byzantine is)
     (finite_trace_sub_projection IM non_byzantine tr).
 
-End fixed_byzantine_traces.
+End sec_fixed_byzantine_traces.
 
 (** ** Relation between Byzantine nodes and equivocators
 
@@ -515,7 +515,7 @@ End fixed_byzantine_traces.
   allows them to locally verify the authenticity of a received message.
 *)
 
-Section fixed_non_equivocating_vs_byzantine.
+Section sec_fixed_non_equivocating_vs_byzantine.
 
 Context
   {message : Type}
@@ -616,7 +616,7 @@ Proof.
   by apply (VLSM_projection_finite_valid_trace Hproj).
 Qed.
 
-Section validator_fixed_set_byzantine.
+Section sec_validator_fixed_set_byzantine.
 
 Context
   (message_dependencies : message -> set message)
@@ -691,7 +691,7 @@ Proof.
   - by intro; intros; apply (lift_sub_state_initial IM).
 Qed.
 
-Section assuming_initial_messages_lift.
+Section sec_assuming_initial_messages_lift.
 
 Context
   (Hfixed_non_byzantine_vlsm_lift_initial_message
@@ -747,7 +747,7 @@ Proof.
   - apply fixed_non_equivocating_incl_fixed_non_byzantine.
 Qed.
 
-End assuming_initial_messages_lift.
+End sec_assuming_initial_messages_lift.
 
 Context
   (Hvalidator:
@@ -812,6 +812,6 @@ Proof.
     by apply fixed_non_equivocating_traces_char.
 Qed.
 
-End validator_fixed_set_byzantine.
+End sec_validator_fixed_set_byzantine.
 
-End fixed_non_equivocating_vs_byzantine.
+End sec_fixed_non_equivocating_vs_byzantine.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -20,7 +20,7 @@ From VLSM.Core Require Import Equivocation.MsgDepLimitedEquivocation Equivocatio
   composition constraint allowing only a limited amount of equivocation.
 *)
 
-Section limited_byzantine_traces.
+Section sec_limited_byzantine_traces.
 
 Context
   {message : Type}
@@ -75,7 +75,7 @@ Context
   selection.
 *)
 
-Section fixed_limited_selection.
+Section sec_fixed_limited_selection.
 
 Context
   (byzantine: set index)
@@ -198,7 +198,7 @@ Proof.
       by eapply Hvalidator.
 Qed.
 
-End fixed_limited_selection.
+End sec_fixed_limited_selection.
 
 (**
   Given a trace with the [fixed_limited_byzantine_trace_prop]erty for a selection
@@ -248,7 +248,7 @@ Proof.
   exists bs, btr; eauto.
 Qed.
 
-End limited_byzantine_traces.
+End sec_limited_byzantine_traces.
 
 Section sec_msg_dep_limited_byzantine_traces.
 

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -11,7 +11,7 @@ From VLSM.Core Require Import VLSM Plans VLSMProjections.
   to components.
 *)
 
-Section VLSM_composition.
+Section sec_VLSM_composition.
 
 (**
   Let us fix a type for <<message>>s, and an <<index>> type for the VLSM components
@@ -24,7 +24,7 @@ Context
   (IM : index -> VLSM message)
   .
 
-Section composite_type.
+Section sec_composite_type.
 
 (** ** The type of a composite VLSM
 
@@ -149,7 +149,7 @@ Proof.
   by rewrite !state_update_neq.
 Qed.
 
-End composite_type.
+End sec_composite_type.
 
 Section sec_composite_vlsm.
 (** ** Constrained VLSM composition
@@ -841,7 +841,7 @@ Qed.
 
 End sec_composite_vlsm.
 
-End VLSM_composition.
+End sec_VLSM_composition.
 
 (** Hint database and tactic for dealing with updates and lifting via [state_update]. *)
 
@@ -1032,7 +1032,7 @@ Proof.
   revert Ht. apply input_valid_transition_preloaded_project_active.
 Qed.
 
-Section binary_free_composition.
+Section sec_binary_free_composition.
 
 (** ** Free composition of two VLSMs
 
@@ -1068,9 +1068,9 @@ Definition binary_free_composition
   : VLSM message
   := free_composite_vlsm binary_IM.
 
-End binary_free_composition.
+End sec_binary_free_composition.
 
-Section composite_decidable_initial_message.
+Section sec_composite_decidable_initial_message.
 
 (** ** Composite decidable initial message
 
@@ -1102,9 +1102,9 @@ Proof.
   - apply @Exists_dec. intro i. apply Hdec_init.
 Qed.
 
-End composite_decidable_initial_message.
+End sec_composite_decidable_initial_message.
 
-Section composite_plan_properties.
+Section sec_composite_plan_properties.
 
 Context
   {message : Type}
@@ -1386,9 +1386,9 @@ Proof.
         by setoid_rewrite Hdiff0.
 Qed.
 
-End composite_plan_properties.
+End sec_composite_plan_properties.
 
-Section empty_composition_properties.
+Section sec_empty_composition_properties.
 
 Context {message : Type}
   `{finite.Finite index}
@@ -1454,7 +1454,7 @@ Proof.
   intros m [s' [l _]]; elim (empty_composition_no_label l).
 Qed.
 
-End empty_composition_properties.
+End sec_empty_composition_properties.
 
 (** ** Properties of extensionally-equal indexed compositions
 
@@ -1481,7 +1481,7 @@ Definition same_IM_state_rew
   : composite_state IM2 :=
   fun i => same_VLSM_state_rew (Heq i) (s1 i).
 
-Section pre_loaded_constrained.
+Section sec_pre_loaded_constrained.
 
 Context
   (constraint1 : composite_label IM1 -> composite_state IM1 * option message -> Prop)
@@ -1527,7 +1527,7 @@ Proof.
     + by exists (exist _ m Hm).
 Qed.
 
-End pre_loaded_constrained.
+End sec_pre_loaded_constrained.
 
 Lemma same_IM_preloaded_free_full_projection
   : VLSM_full_projection

--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -12,7 +12,7 @@ From VLSM.Core Require Import VLSM MessageDependencies FinSetMessageDependencies
   type with decidable equality.
 *)
 
-Section sec_BaseELMO.
+Section sec_base_ELMO.
 
 Context
   {Address : Type}
@@ -485,7 +485,7 @@ Proof.
   now destruct (decide (isReceive ob)).
 Qed.
 
-End sec_BaseELMO.
+End sec_base_ELMO.
 
 Notation "s <+> ob" := (addObservation ob s) (left associativity, at level 50).
 Notation "s <++> obs" := (addObservations obs s) (left associativity, at level 50).

--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -12,7 +12,7 @@ From VLSM.Core Require Import VLSM MessageDependencies FinSetMessageDependencies
   type with decidable equality.
 *)
 
-Section BaseELMO.
+Section sec_BaseELMO.
 
 Context
   {Address : Type}
@@ -485,7 +485,7 @@ Proof.
   now destruct (decide (isReceive ob)).
 Qed.
 
-End BaseELMO.
+End sec_BaseELMO.
 
 Notation "s <+> ob" := (addObservation ob s) (left associativity, at level 50).
 Notation "s <++> obs" := (addObservations obs s) (left associativity, at level 50).

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -18,7 +18,7 @@ Hint Resolve submseteq_tail_l : ELMO_hints.
   the ELMO protocol.
 *)
 
-Section ELMO.
+Section sec_ELMO.
 
 Context
   {Address : Type}
@@ -400,7 +400,7 @@ Proof.
   by inversion 1.
 Qed.
 
-Section ELMOComponent_Lemmas.
+Section sec_ELMOComponent_lemmas.
 
 (** ** Component lemmas *)
 
@@ -1164,7 +1164,7 @@ Proof.
   - by left; eapply ELMOComponent_sentMessages_of_ram_trace.
 Qed.
 
-End ELMOComponent_Lemmas.
+End sec_ELMOComponent_lemmas.
 
 Section sec_TraceableVLSM_ELMOComponent.
 
@@ -1297,7 +1297,7 @@ Qed.
 
 End sec_MessageDependencies_ELMOComponent.
 
-Section ELMOProtocol.
+Section sec_ELMOProtocol.
 
 Context `{Inhabited index}.
 
@@ -3028,6 +3028,6 @@ Proof.
   - by repeat split; [| apply option_valid_message_None | apply Hvt].
 Qed.
 
-End ELMOProtocol.
+End sec_ELMOProtocol.
 
-End ELMO.
+End sec_ELMO.

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -12,7 +12,7 @@ From VLSM.Core Require Import BaseELMO UMO.
   the MO protocol.
 *)
 
-Section MO.
+Section sec_MO.
 
 Context
   {Address : Type}
@@ -41,7 +41,7 @@ Inductive MO_msg_valid (P : Address -> Prop) : Message -> Prop :=
     forall m mr : Message,
       MO_msg_valid P m -> MO_msg_valid P mr -> MO_msg_valid P (m <*> MkObservation Receive mr).
 
-Section alternative_definition_of_validity.
+Section sec_alternative_definition_of_validity.
 
 (** ** Alternative definition of validity
 
@@ -364,7 +364,7 @@ Proof.
       by constructor 2; apply IH; [unfold sizeMessage; cbn; lia |].
 Qed.
 
-End alternative_definition_of_validity.
+End sec_alternative_definition_of_validity.
 
 Inductive MOComponentValid (P : Address -> Prop) : Label -> State -> option Message -> Prop :=
 | MOCV_Receive :
@@ -395,7 +395,7 @@ Definition MOComponent (P : Address -> Prop) (i : Address) : VLSM Message :=
   vmachine := MOComponentMachine P i;
 |}.
 
-Section MOComponent_Lemmas.
+Section sec_MOComponent_lemmas.
 
 (** ** Component lemmas
 
@@ -790,9 +790,9 @@ Proof.
     ; rewrite ?H12, ?H22 in Hsuf; lia.
 Qed.
 
-End MOComponent_Lemmas.
+End sec_MOComponent_lemmas.
 
-Section MOProtocol.
+Section sec_MOProtocol.
 
 Context
   (index : Type)
@@ -1363,9 +1363,9 @@ Proof.
   by intros l Hrobs; apply rec_obs_size_desc, Nat.lt_irrefl in Hrobs.
 Qed.
 
-End MOProtocol.
+End sec_MOProtocol.
 
-End MO.
+End sec_MO.
 
 Arguments rec_obs_send_inv : clear implicits.
 Arguments rec_obs_recv_inv : clear implicits.

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -11,7 +11,7 @@ From VLSM.Core Require Import BaseELMO.
   the UMO protocol.
 *)
 
-Section UMO.
+Section sec_UMO.
 
 Context
   {Address : Type}
@@ -285,7 +285,7 @@ Qed.
   another (named [Ri]) for dealing with reachable states.
 *)
 
-Section UMOComponent_Lemmas.
+Section sec_UMOComponent_lemmas.
 
 (**
   [Ui] is a notation for an [UMOComponent] of address [i].
@@ -1394,7 +1394,7 @@ Inductive sent_comparable : Message -> Message -> Prop :=
 Definition incomparable (m1 m2 : Message) : Prop :=
   adr (state m1) = adr (state m2) /\ ~ sent_comparable m1 m2.
 
-End UMOComponent_Lemmas.
+End sec_UMOComponent_lemmas.
 
 #[export]
 Instance sent_comparable_sym : Symmetric sent_comparable.
@@ -1419,7 +1419,7 @@ Defined.
 Instance incomparable_sym : Symmetric incomparable.
 Proof. by intros x y []; constructor. Defined.
 
-Section UMOProtocol.
+Section sec_UMOProtocol.
 
 Context
   (index : Type)
@@ -1711,8 +1711,8 @@ Proof.
     (preloaded_valid_state_projection _ _ _ Hvsp).
 Qed.
 
-End UMOProtocol.
+End sec_UMOProtocol.
 
-End UMO.
+End sec_UMO.
 
 Arguments UMO_reachable_ind' [Address]%type_scope (C P Hinit Hextend)%function_scope s Hs.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -122,7 +122,7 @@ Qed.
   constraints act upon states, not traces.
 *)
 
-Section Simple.
+Section sec_simple.
 
 Context
   {message : Type}
@@ -658,7 +658,7 @@ Proof.
   by apply has_been_received_consistency.
 Qed.
 
-End Simple.
+End sec_simple.
 
 #[global] Hint Mode HasBeenSentCapability - ! : typeclass_instances.
 #[global] Hint Mode HasBeenReceivedCapability - ! : typeclass_instances.
@@ -767,7 +767,7 @@ Qed.
   to choose a trace to the state for the directions where
   one is not given.
 *)
-Section TraceFromStepwise.
+Section sec_trace_from_stepwise.
 
 Context
   (message : Type)
@@ -856,7 +856,7 @@ Proof.
   by eapply oracle_partial_trace_update; [| | right].
 Qed.
 
-End TraceFromStepwise.
+End sec_trace_from_stepwise.
 
 (**
   The stepwise properties are proven from the trace properties
@@ -864,7 +864,7 @@ End TraceFromStepwise.
   property, and by considering a trace that ends with the given
   [input_valid_transition] to prove the [oracle_step_update] property.
 *)
-Section StepwiseFromTrace.
+Section sec_stepwise_from_trace.
 
 Context
   (message : Type)
@@ -947,7 +947,7 @@ Proof.
   refine oracle_step_property_from_trace.
 Defined.
 
-End StepwiseFromTrace.
+End sec_stepwise_from_trace.
 
 (** ** Stepwise view of [HasBeenSentCapability]
 
@@ -1240,7 +1240,7 @@ Definition no_additional_equivocations_constraint
   let (s, om) := som in
   from_option (no_additional_equivocations vlsm s) True om.
 
-Section sent_received_observed_capabilities.
+Section sec_sent_received_observed_capabilities.
 
 Context
   {message : Type}
@@ -1367,7 +1367,7 @@ Proof.
   - by apply consistency_from_valid_state_proj2.
 Qed.
 
-End sent_received_observed_capabilities.
+End sec_sent_received_observed_capabilities.
 
 Definition computable_messages_oracle
   `(vlsm : VLSM message)
@@ -1659,7 +1659,7 @@ Qed.
   composition are both finite. See [finite_index], [finite_validator].
 *)
 
-Section Composite.
+Section sec_composite.
 
 Context
   {message : Type}
@@ -1670,7 +1670,7 @@ Context
   `{forall i : index, (HasBeenReceivedCapability (IM i))}
   .
 
-Section StepwiseProps.
+Section sec_stepwise_props.
 
 Context
   [message_selectors: forall i : index, message -> vtransition_item (IM i) -> Prop]
@@ -1767,7 +1767,7 @@ Proof.
   by split_and!; [|exists suf|..].
 Qed.
 
-End StepwiseProps.
+End sec_stepwise_props.
 
 (**
   A message [has_been_sent] for a composite state if it [has_been_sent]
@@ -1820,7 +1820,7 @@ Proof.
   by apply Hproper_sent.
 Qed.
 
-Section composite_has_been_received.
+Section sec_composite_has_been_received.
 
 (**
   A message [has_been_received] for a composite state
@@ -1892,7 +1892,7 @@ Definition preloaded_composite_HasBeenReceivedCapability
     composite_has_been_received_dec
     (preloaded_composite_has_been_received_stepwise_props constraint seed).
 
-End composite_has_been_received.
+End sec_composite_has_been_received.
 
 (**
   A message [has_been_directly_observed] in a composite state if it
@@ -2399,7 +2399,7 @@ Proof.
     apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
 Qed.
 
-End Composite.
+End sec_composite.
 
 Lemma composite_has_been_directly_observed_sent_received_iff
   {message}
@@ -2586,7 +2586,7 @@ Qed.
 
 End sec_composite_computable_sent_received_observed.
 
-Section cannot_resend_message.
+Section sec_cannot_resend_message.
 
 Context
   {message : Type}
@@ -2785,9 +2785,9 @@ Proof.
   by destruct Hgen as [-> [<- _]].
 Qed.
 
-End cannot_resend_message.
+End sec_cannot_resend_message.
 
-Section has_been_sent_irrelevance.
+Section sec_has_been_sent_irrelevance.
 
 (**
   Since we have several ways of obtaining the [has_been_sent] property,
@@ -2814,9 +2814,9 @@ Proof.
   by apply proper_sent.
 Qed.
 
-End has_been_sent_irrelevance.
+End sec_has_been_sent_irrelevance.
 
-Section all_traces_to_valid_state_are_valid.
+Section sec_all_traces_to_valid_state_are_valid.
 
 Context
   {message : Type}
@@ -2855,9 +2855,9 @@ Proof.
   by exists is, tr, Htr.
 Qed.
 
-End all_traces_to_valid_state_are_valid.
+End sec_all_traces_to_valid_state_are_valid.
 
-Section has_been_received_in_state.
+Section sec_has_been_received_in_state.
 
 Context
   {message : Type}
@@ -2939,4 +2939,4 @@ Proof.
   by split; [| apply  Htr2].
 Qed.
 
-End has_been_received_in_state.
+End sec_has_been_received_in_state.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -18,7 +18,7 @@ From VLSM.Core Require Import SubProjectionTraces Equivocation Equivocation.NoEq
   (messages) available to it at the moment of production.
 *)
 
-Section fixed_equivocation_without_fullnode.
+Section sec_fixed_equivocation_without_fullnode.
 
 Context
   {message : Type}
@@ -107,7 +107,7 @@ Qed.
   the compositions constrained by the two [fixed_equivocation_constraint]s
   are trace-equivalent.
 *)
-Section strong_fixed_equivocation.
+Section sec_strong_fixed_equivocation.
 
 Definition sent_by_non_equivocating s m
   := exists i, i ∉ equivocating /\ has_been_sent (IM i) (s i) m.
@@ -205,12 +205,12 @@ Proof.
   apply strong_fixed_equivocation_constraint_subsumption.
 Qed.
 
-End strong_fixed_equivocation.
+End sec_strong_fixed_equivocation.
 
-End fixed_equivocation_without_fullnode.
+End sec_fixed_equivocation_without_fullnode.
 
 (** ** Extending the set of nodes allowed to equivocate *)
-Section fixed_equivocation_index_incl.
+Section sec_fixed_equivocation_index_incl.
 
 Context
   {message : Type}
@@ -265,7 +265,7 @@ Proof.
   apply fixed_equivocation_constraint_index_incl_subsumption.
 Qed.
 
-End fixed_equivocation_index_incl.
+End sec_fixed_equivocation_index_incl.
 
 (** ** Restricting Fixed valid traces to only the equivocators
 
@@ -279,7 +279,7 @@ End fixed_equivocation_index_incl.
   the obtained trace is valid for the composition of equivocators pre-loaded
   only with those messages sent by the non-equivocators in the original trace.
 *)
-Section fixed_equivocator_sub_projection.
+Section sec_fixed_equivocator_sub_projection.
 
 Context
   {message : Type}
@@ -368,7 +368,7 @@ Proof.
   - by apply emitted_messages_are_valid in Hemit.
 Qed.
 
-Section fixed_finite_valid_trace_sub_projection_helper_lemmas.
+Section sec_fixed_finite_valid_trace_sub_projection_helper_lemmas.
 
 (**
   The results in this section are not meant to be used directly. They are just
@@ -469,7 +469,7 @@ Proof.
     by apply (has_been_sent_step_update Hproject); left.
 Qed.
 
-End fixed_finite_valid_trace_sub_projection_helper_lemmas.
+End sec_fixed_finite_valid_trace_sub_projection_helper_lemmas.
 
 (**
   Using the lemmas above we can now prove (by induction) a generic result,
@@ -631,7 +631,7 @@ Proof.
   - done.
 Qed.
 
-End fixed_equivocator_sub_projection.
+End sec_fixed_equivocator_sub_projection.
 
 (**
   [strong_fixed_equivocation_constraint] is not actually stronger
@@ -646,7 +646,7 @@ End fixed_equivocator_sub_projection.
   in the conclusion.
 *)
 
-Section Fixed_eq_StrongFixed.
+Section sec_Fixed_eq_StrongFixed.
 
 Context
   {message : Type}
@@ -720,7 +720,7 @@ Proof.
   - apply StrongFixed_incl_Fixed.
 Qed.
 
-End Fixed_eq_StrongFixed.
+End sec_Fixed_eq_StrongFixed.
 
 (** ** Changing the behavior of equivocators within a trace
 
@@ -735,7 +735,7 @@ End Fixed_eq_StrongFixed.
   the non-equivocators remain in their corresponding component-state given by <<s>>
   (Lemma [EquivPreloadedBase_Fixed_weak_full_projection]).
 *)
-Section fixed_equivocator_lifting.
+Section sec_fixed_equivocator_lifting.
 
 Context
   {message : Type}
@@ -948,7 +948,7 @@ Proof.
       by eapply sent_by_non_equivocating_are_directly_observed.
 Qed.
 
-End fixed_equivocator_lifting.
+End sec_fixed_equivocator_lifting.
 
 (** ** Fixed equivocation over an empty set
 
@@ -956,7 +956,7 @@ End fixed_equivocator_lifting.
   that no message equivocation is allowed, since that would mean that at least
   one node would equivocate.
 *)
-Section fixed_equivocation_no_equivocators.
+Section sec_fixed_equivocation_no_equivocators.
 
 Context
   {message : Type}
@@ -1022,9 +1022,9 @@ Proof.
   - apply strong_fixed_equivocation_vlsm_composition_no_equivocators.
 Qed.
 
-End fixed_equivocation_no_equivocators.
+End sec_fixed_equivocation_no_equivocators.
 
-Section fixed_non_equivocator_lifting.
+Section sec_fixed_non_equivocator_lifting.
 
 Context
   {message : Type}
@@ -1122,4 +1122,4 @@ Proof.
   apply fixed_non_equivocating_projection_friendliness.
 Qed.
 
-End fixed_non_equivocator_lifting.
+End sec_fixed_non_equivocator_lifting.

--- a/theories/VLSM/Core/Equivocation/FullNode.v
+++ b/theories/VLSM/Core/Equivocation/FullNode.v
@@ -2,7 +2,7 @@ From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM VLSMProjections Composition.
 From VLSM.Core Require Import Equivocation.
 
-Section full_node_constraint.
+Section sec_full_node_constraint.
 
 Context
   `{EqDecision message}
@@ -125,4 +125,4 @@ Proof.
   apply preloaded_constraint_free_incl.
 Qed.
 
-End full_node_constraint.
+End sec_full_node_constraint.

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -114,7 +114,7 @@ Qed.
 
 End sec_basic_limited_message_equivocation.
 
-Section tracewise_limited_message_equivocation.
+Section sec_tracewise_limited_message_equivocation.
 
 Context
   {message : Type}
@@ -160,9 +160,9 @@ Proof.
   - apply LimitedEquivocationProp_impl_not_heavy.
 Qed.
 
-End tracewise_limited_message_equivocation.
+End sec_tracewise_limited_message_equivocation.
 
-Section fixed_limited_message_equivocation.
+Section sec_fixed_limited_message_equivocation.
 
 (** ** Fixed Message Equivocation implies Limited Message Equivocation
 
@@ -258,9 +258,9 @@ Proof.
   - apply StrongFixed_incl_Limited.
 Qed.
 
-End fixed_limited_message_equivocation.
+End sec_fixed_limited_message_equivocation.
 
-Section has_limited_equivocation.
+Section sec_has_limited_equivocation.
 
 (** ** Limited Equivocation derived from Fixed Equivocation
 
@@ -394,4 +394,4 @@ Proof.
     full_node_limited_equivocation_valid_state_weight.
 Qed.
 
-End has_limited_equivocation.
+End sec_has_limited_equivocation.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble StdppListSet.
 From VLSM.Core Require Import VLSM MessageDependencies VLSMProjections Composition Equivocation Equivocation.FixedSetEquivocation ProjectionTraces SubProjectionTraces.
 
-Section msg_dep_fixed_set_equivocation.
+Section sec_msg_dep_fixed_set_equivocation.
 
 Context
   `(IM : index -> VLSM message)
@@ -279,7 +279,7 @@ Proof.
   - by apply strong_msg_dep_fixed_equivocation_incl.
 Qed.
 
-End msg_dep_fixed_set_equivocation.
+End sec_msg_dep_fixed_set_equivocation.
 
 Section sec_full_node_fixed_set_equivocation.
 

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -4,7 +4,7 @@ From VLSM.Core Require Import VLSM VLSMProjections Composition Equivocation.
 
 (** * VLSM No Equivocation Composition Constraints *)
 
-Section no_equivocations.
+Section sec_no_equivocations.
 
 Context
   {message : Type}
@@ -41,7 +41,7 @@ Definition no_equivocations
   :=
   no_equivocations_except_from (fun m => False) l som.
 
-End no_equivocations.
+End sec_no_equivocations.
 
 (** ** No-Equivocation Invariants
 
@@ -51,7 +51,7 @@ End no_equivocations.
   - the [pre_loaded_with_all_messages_vlsm] is equal to the [no_equivocations] VLSM.
 
 *)
-Section NoEquivocationInvariants.
+Section sec_no_equivocation_invariants.
 
 Context
   message
@@ -157,9 +157,9 @@ Proof.
   by apply VLSM_eq_incl_iff.
 Qed.
 
-End NoEquivocationInvariants.
+End sec_no_equivocation_invariants.
 
-Section CompositeNoEquivocation.
+Section sec_composite_no_equivocation.
 
 Context
   {message : Type}
@@ -199,7 +199,7 @@ Definition composite_no_equivocations
   (resp. [has_been_directly_observed]) in a state also tests as [has_been_sent]
   in the same state.
  *)
-Section CompositeNoEquivocationInvariants.
+Section sec_composite_no_equivocation_invariants.
 
 Context
   `{forall i, HasBeenReceivedCapability (IM i)}
@@ -222,9 +222,9 @@ Proof.
   by intros l s0 om; apply Hsubsumed.
 Qed.
 
-End CompositeNoEquivocationInvariants.
+End sec_composite_no_equivocation_invariants.
 
-Section seeded_composite_vlsm_no_equivocation.
+Section sec_seeded_composite_vlsm_no_equivocation.
 
 (** ** Pre-loading a VLSM composition with no equivocations constraint
 
@@ -238,7 +238,7 @@ Context
   (X := free_composite_vlsm IM)
   .
 
-Section seeded_composite_vlsm_no_equivocation_definition.
+Section sec_seeded_composite_vlsm_no_equivocation_definition.
 
 Context
   (seed : message -> Prop)
@@ -279,7 +279,7 @@ Proof.
   by apply preloaded_constraint_subsumption_incl.
 Qed.
 
-End seeded_composite_vlsm_no_equivocation_definition.
+End sec_seeded_composite_vlsm_no_equivocation_definition.
 
 (** Adds a no-equivocations condition on top of an existing constraint. *)
 Definition no_equivocations_additional_constraint
@@ -315,6 +315,6 @@ Proof.
   split;apply Hincl;intros l [s [m|]] Hpv; apply Hpv.
 Qed.
 
-End seeded_composite_vlsm_no_equivocation.
+End sec_seeded_composite_vlsm_no_equivocation.
 
-End CompositeNoEquivocation.
+End sec_composite_no_equivocation.

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -16,7 +16,7 @@ From VLSM.Lib Require Import Preamble StdppExtras.
   and limited state equivocation.
 *)
 
-Section tracewise_equivocation.
+Section sec_tracewise_equivocation.
 
 Context
   `{EqDecision message}
@@ -363,4 +363,4 @@ Proof.
   apply incl_equivocating_validators_equivocation_fault.
 Qed.
 
-End tracewise_equivocation.
+End sec_tracewise_equivocation.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -26,7 +26,7 @@ From VLSM.Core Require Import NoEquivocation FixedSetEquivocation TraceWiseEquiv
   state for the composition of nodes under the [fixed_equivocation_constraint]
   induced by its set of equivocators.
 *)
-Section witnessed_equivocation.
+Section sec_witnessed_equivocation.
 
 Context
   `{EqDecision message}
@@ -81,7 +81,7 @@ Class WitnessedEquivocationCapability
       trace_witnessing_equivocation_prop is tr
   }.
 
-Section witnessed_equivocation_properties.
+Section sec_witnessed_equivocation_properties.
 
 Context
   (Hke : WitnessedEquivocationCapability)
@@ -609,9 +609,9 @@ Proof.
   by exists is, tr.
 Qed.
 
-End witnessed_equivocation_properties.
+End sec_witnessed_equivocation_properties.
 
-End witnessed_equivocation.
+End sec_witnessed_equivocation.
 
 (** ** Witnessed equivocation and fixed-set equivocation
 
@@ -622,7 +622,7 @@ End witnessed_equivocation.
   for the composition constrained by the [fixed_equivocation_constrained] induced
   by the [equivocating_validators] of its final state.
 *)
-Section witnessed_equivocation_fixed_set.
+Section sec_witnessed_equivocation_fixed_set.
 
 Context
   `{EqDecision message}
@@ -819,4 +819,4 @@ Proof.
   by apply strong_witness_has_fixed_equivocation.
 Qed.
 
-End witnessed_equivocation_fixed_set.
+End sec_witnessed_equivocation_fixed_set.

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -10,7 +10,7 @@ From VLSM.Core Require Import Composition VLSMProjections Validator ProjectionTr
   preserved by VLSM projections.
 *)
 
-Section projection_oracle.
+Section sec_projection_oracle.
 (** ** [VLSM_projection]s reflect message properties *)
 
 Context
@@ -21,7 +21,7 @@ Context
   (Hsimul : VLSM_projection (pre_loaded_with_all_messages_vlsm X) (pre_loaded_with_all_messages_vlsm Y) label_project state_project)
   .
 
-Section selectors.
+Section sec_selectors.
 
 Context
   (selectorX : message -> vtransition_item X -> Prop)
@@ -66,7 +66,7 @@ Proof.
   by apply Hselector.
 Qed.
 
-End selectors.
+End sec_selectors.
 
 Lemma VLSM_projection_has_been_sent_reflect
   `{HasBeenSentCapability message X}
@@ -106,9 +106,9 @@ Proof.
   - by apply has_been_directly_observed_stepwise_props.
 Qed.
 
-End projection_oracle.
+End sec_projection_oracle.
 
-Section weak_full_projection_oracle.
+Section sec_weak_full_projection_oracle.
 (** ** [VLSM_weak_full_projection]s preserve message properties *)
 
 Context
@@ -119,7 +119,7 @@ Context
   (Hsimul : VLSM_weak_full_projection (pre_loaded_with_all_messages_vlsm X) (pre_loaded_with_all_messages_vlsm Y) label_project state_project)
   .
 
-Section selectors.
+Section sec_selectors.
 
 Context
   (selectorX : message -> vtransition_item X -> Prop)
@@ -172,7 +172,7 @@ Proof.
   apply VLSM_weak_full_projection_selected_message_exists_in_some_preloaded_traces.
 Qed.
 
-End selectors.
+End sec_selectors.
 
 Lemma VLSM_weak_full_projection_has_been_sent
   `{HasBeenSentCapability message X}
@@ -218,9 +218,9 @@ Proof.
   - apply has_been_directly_observed_dec.
 Qed.
 
-End weak_full_projection_oracle.
+End sec_weak_full_projection_oracle.
 
-Section full_projection_oracle.
+Section sec_full_projection_oracle.
 (** ** [VLSM_full_projection]s both preserve and reflect message properties *)
 
 Context
@@ -277,9 +277,9 @@ Definition VLSM_full_projection_has_been_directly_observed_reflect
     forall m, has_been_directly_observed Y (state_project s) m -> has_been_directly_observed X s m
   := VLSM_projection_has_been_directly_observed_reflect  (VLSM_full_projection_is_projection Hsimul).
 
-End full_projection_oracle.
+End sec_full_projection_oracle.
 
-Section incl_oracle.
+Section sec_incl_oracle.
 (** ** [VLSM_incl]usions both preserve and reflect message properties *)
 
 Context
@@ -367,9 +367,9 @@ Proof.
       (VLSM_incl_is_full_projection Hincl)).
 Qed.
 
-End incl_oracle.
+End sec_incl_oracle.
 
-Section same_IM_oracle_properties.
+Section sec_same_IM_oracle_properties.
 
 Context
   {message : Type}
@@ -394,9 +394,9 @@ Proof.
   by specialize (VLSM_full_projection_has_been_sent Hproj _ Hs1 m Hbs1_m).
 Qed.
 
-End same_IM_oracle_properties.
+End sec_same_IM_oracle_properties.
 
-Section sender_safety_can_emit_projection.
+Section sec_sender_safety_can_emit_projection.
 
 Context
   {message : Type}
@@ -437,4 +437,4 @@ Proof.
   by eexists _,_, _.
 Qed.
 
-End sender_safety_can_emit_projection.
+End sec_sender_safety_can_emit_projection.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -29,7 +29,7 @@ From VLSM.Core Require Import Equivocators.MessageProperties.
   the label, and keeping only the copy of index 1 for each machine.
 *)
 
-Section fully_equivocating_composition.
+Section sec_fully_equivocating_composition.
 
 Context {message : Type}
   `{finite.Finite index}
@@ -66,7 +66,7 @@ Proof.
   congruence.
 Qed.
 
-Section equivocating_indices_BasicEquivocation.
+Section sec_equivocating_indices_BasicEquivocation.
 
 Context
   `{FinSet index Ci}
@@ -108,7 +108,7 @@ Proof.
   - by apply set_eq_fin_set; rewrite !equivocating_indices_equivocating_validators.
 Qed.
 
-End equivocating_indices_BasicEquivocation.
+End sec_equivocating_indices_BasicEquivocation.
 
 (**
   The statement below is obvious a transition cannot make an already equivocating
@@ -494,14 +494,14 @@ Proof.
   by exists eqv, emi.
 Qed.
 
-End fully_equivocating_composition.
+End sec_fully_equivocating_composition.
 
 #[export] Hint Rewrite @equivocator_descriptors_update_eq : state_update.
 #[export] Hint Rewrite @equivocator_descriptors_update_id using done : state_update.
 #[export] Hint Rewrite @equivocator_descriptors_update_neq using done : state_update.
 #[export] Hint Rewrite @equivocators_state_project_state_update_eqv using done : state_update.
 
-Section equivocators_sub_projections.
+Section sec_equivocators_sub_projections.
 
 Context {message : Type}
   `{EqDecision index}
@@ -523,4 +523,4 @@ Lemma sub_equivocator_IM_initial_state_commute is
   : composite_initial_state_prop sub_equivocator_IM is <-> composite_initial_state_prop sub_IM_equivocator is.
 Proof. done. Qed.
 
-End equivocators_sub_projections.
+End sec_equivocators_sub_projections.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -10,7 +10,7 @@ From VLSM.Core Require Import Equivocators.Composition.EquivocatorsComposition E
 
 (** * VLSM Equivocator Composition Projections *)
 
-Section equivocators_composition_projections.
+Section sec_equivocators_composition_projections.
 
 Context {message : Type}
   `{finite.Finite index}
@@ -1487,9 +1487,9 @@ Proof.
     by apply valid_trace_forget_last in HtrX.
 Qed.
 
-End equivocators_composition_projections.
+End sec_equivocators_composition_projections.
 
-Section equivocators_composition_sub_projections.
+Section sec_equivocators_composition_sub_projections.
 
 Context
   {message : Type}
@@ -1670,7 +1670,7 @@ Proof.
     apply finite_trace_sub_projection_app.
 Qed.
 
-Section seeded_equivocators_valid_trace_project.
+Section sec_seeded_equivocators_valid_trace_project.
 
 Context
   (seed : message -> Prop)
@@ -1878,11 +1878,11 @@ Proof.
     by inversion _Htr_project; subst.
 Qed.
 
-End seeded_equivocators_valid_trace_project.
+End sec_seeded_equivocators_valid_trace_project.
 
-End equivocators_composition_sub_projections.
+End sec_equivocators_composition_sub_projections.
 
-Section equivocators_composition_vlsm_projection.
+Section sec_equivocators_composition_vlsm_projection.
 
 Context {message : Type}
   `{finite.Finite index}
@@ -2148,4 +2148,4 @@ Proof.
     eapply equivocators_total_VLSM_projection_finite_trace_project, Htr.
 Qed.
 
-End equivocators_composition_vlsm_projection.
+End sec_equivocators_composition_vlsm_projection.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -181,7 +181,7 @@ Qed.
 
 End sec_equivocators_fixed_equivocations_vlsm.
 
-Section fixed_equivocation_with_fullnode.
+Section sec_fixed_equivocation_with_fullnode.
 
 (**
   This section instantiates the [full_node_condition_for_admissible_equivocators]
@@ -252,9 +252,9 @@ Proof.
   by eapply full_node_condition_for_admissible_equivocators_subsumption.
 Qed.
 
-End fixed_equivocation_with_fullnode.
+End sec_fixed_equivocation_with_fullnode.
 
-Section from_equivocators_to_nodes.
+Section sec_from_equivocators_to_nodes.
 
 (** ** From composition of equivocators to composition of simple nodes
 
@@ -1303,9 +1303,9 @@ Proof.
     apply (equivocators_total_VLSM_projection_finite_trace_project IM (proj1 Hpre_tr)).
 Qed.
 
-End from_equivocators_to_nodes.
+End sec_from_equivocators_to_nodes.
 
-Section all_equivocating.
+Section sec_all_equivocating.
 
 (** ** Fixed Equivocation for all Equivocators
 
@@ -1357,4 +1357,4 @@ Proof.
     apply strong_constraint_subsumption_fixed_all.
 Qed.
 
-End all_equivocating.
+End sec_all_equivocating.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -24,7 +24,7 @@ From VLSM.Core Require Import Equivocators.Composition.SimulatingFree.Simulating
   which is then used to satisfy the [replayable_message_prop]erty.
 *)
 
-Section fixed_equivocating.
+Section sec_fixed_equivocating.
 
 Context {message : Type}
   {index : Type}
@@ -373,7 +373,7 @@ Proof.
   - apply fixed_equivocation_has_replayable_message_prop.
 Qed.
 
-End fixed_equivocating.
+End sec_fixed_equivocating.
 
 (** ** No-equivocation simulation as a particular case of fixed-set simulation
 
@@ -382,7 +382,7 @@ End fixed_equivocating.
   no message-equivocation in which no component is allowed to state-equivocate.
 *)
 
-Section no_equivocation.
+Section sec_no_equivocation.
 
 Context {message : Type}
   `{finite.Finite index}
@@ -458,4 +458,4 @@ Proof.
         eqv_state_s Hstate_valid im) as Hsent.
 Qed.
 
-End no_equivocation.
+End sec_no_equivocation.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
@@ -24,7 +24,7 @@ From VLSM.Core Require Import Equivocators.Composition.LimitedEquivocation.Fixed
   equivocators with no message equivocation and limited state equivocation.
 *)
 
-Section fixed_limited_state_equivocation.
+Section sec_fixed_limited_state_equivocation.
 
 Context
   {message : Type}
@@ -68,9 +68,9 @@ Proof.
     by apply elem_of_remove_dups, Hfixed, Hi.
 Qed.
 
-End fixed_limited_state_equivocation.
+End sec_fixed_limited_state_equivocation.
 
-Section limited_equivocation_simulation.
+Section sec_limited_equivocation_simulation.
 
 Context
   {message : Type}
@@ -185,4 +185,4 @@ Proof.
   by apply valid_trace_last_pstate in Htr.
 Qed.
 
-End limited_equivocation_simulation.
+End sec_limited_equivocation_simulation.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
@@ -45,7 +45,7 @@ Proof.
   refine (fun i => equivocator_initial_state_project _ _ _ (Heqv i) (Hes i)).
 Qed.
 
-Section limited_state_equivocation.
+Section sec_limited_state_equivocation.
 
 Context
   {message : Type}
@@ -394,4 +394,4 @@ Qed.
 
 End sec_equivocators_projection_constrained_limited.
 
-End limited_state_equivocation.
+End sec_limited_state_equivocation.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -19,7 +19,7 @@ From VLSM.Core Require Import Equivocators.Composition.EquivocatorsCompositionPr
   satisfying some conditions.
 *)
 
-Section all_equivocating.
+Section sec_all_equivocating.
 
 Context {message : Type}
   `{finite.Finite index}
@@ -470,7 +470,7 @@ Proof.
     by rewrite state_update_neq; [| inversion 1].
 Qed.
 
-Section pre_loaded_constrained_projection.
+Section sec_pre_loaded_constrained_projection.
 (**
   By replaying a [valid_trace] on top of a [valid_state] we obtain a
   [valid_trace]. We derive this as a more general [VLSM_weak_full_projection]
@@ -563,7 +563,7 @@ Proof.
   by apply (VLSM_weak_full_projection_finite_valid_trace_from lift_equivocators_sub_weak_projection).
 Qed.
 
-End pre_loaded_constrained_projection.
+End sec_pre_loaded_constrained_projection.
 
 Lemma SeededXE_PreFreeE_weak_full_projection
   (full_replay_state : composite_state equivocator_IM)
@@ -598,7 +598,7 @@ Proof.
   - intros. apply any_message_is_valid_in_preloaded.
 Qed.
 
-Section seeded_no_equiv.
+Section sec_seeded_no_equiv.
 
 Context
   (SeededAllXE : VLSM message := composite_no_equivocation_vlsm_with_pre_loaded equivocator_IM (free_constraint _) seed)
@@ -678,6 +678,6 @@ Proof.
   by intros; apply SeededNoEquiv_subsumption.
 Qed.
 
-End seeded_no_equiv.
+End sec_seeded_no_equiv.
 
-End all_equivocating.
+End sec_all_equivocating.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -15,7 +15,7 @@ From VLSM.Core Require Import Equivocators.Composition.SimulatingFree.FullReplay
   the free composition of regular nodes.
 *)
 
-Section generalized_constraints.
+Section sec_generalized_constraints.
 
 (** ** Generic simulation
 
@@ -217,7 +217,7 @@ Proof.
     + by apply Hsubsumption.
 Qed.
 
-End generalized_constraints.
+End sec_generalized_constraints.
 
 (** ** VLSM Equivocators Simulating Free Composite
 
@@ -228,7 +228,7 @@ End generalized_constraints.
   we first prove an intermediate result, where both the composite VLSMs are
   pre-loaded with the same set of messages.
 *)
-Section seeded_all_equivocating.
+Section sec_seeded_all_equivocating.
 
 Context {message : Type}
   `{finite.Finite index}
@@ -361,9 +361,9 @@ Proof.
     by apply Exists_app; simpl; right; left.
 Qed.
 
-End seeded_all_equivocating.
+End sec_seeded_all_equivocating.
 
-Section all_equivocating.
+Section sec_all_equivocating.
 
 Context {message : Type}
   {index : Type}
@@ -419,4 +419,4 @@ Proof.
   by apply proj1 in Hc.
 Qed.
 
-End all_equivocating.
+End sec_all_equivocating.

--- a/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
@@ -11,7 +11,7 @@ From VLSM.Core Require Import Equivocation EquivocationProjections Equivocators.
   [equivocator_state_append]ing each state to the last state of the first trace.
 *)
 
-Section equivocator_state_append_projection.
+Section sec_equivocator_state_append_projection.
 
 Context
   {message : Type}
@@ -180,4 +180,4 @@ Proof.
   by specialize (VLSM_weak_full_projection_has_been_sent Hproj _ Hs _ Hm) as HmY.
 Qed.
 
-End equivocator_state_append_projection.
+End sec_equivocator_state_append_projection.

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -706,7 +706,7 @@ Ltac destruct_equivocator_state_extend_project es s i Hi :=
   destruct_equivocator_state_extend_project' es s i Hi Hpr
   ; clear Hpr.
 
-Section equivocator_vlsm_valid_state_projections.
+Section sec_equivocator_vlsm_valid_state_projections.
 
 Context
   {message : Type}
@@ -1213,7 +1213,7 @@ Proof.
   by apply equivocator_state_project_Some_rev in Hsi.
 Qed.
 
-End equivocator_vlsm_valid_state_projections.
+End sec_equivocator_vlsm_valid_state_projections.
 
 Arguments NewMachine {_ _} _: assert.
 Arguments Existing {_ _} _ : assert.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -4,7 +4,7 @@ From VLSM.Core Require Import VLSM VLSMProjections Equivocators.Equivocators.
 
 (** * VLSM Projecting Equivocator Traces *)
 
-Section equivocator_vlsm_projections.
+Section sec_equivocator_vlsm_projections.
 
 (**
   Given an [equivocator_vlsm] trace ending in a state <<s>>, we can obtain a
@@ -1113,4 +1113,4 @@ Proof.
   - apply H.
 Qed.
 
-End equivocator_vlsm_projections.
+End sec_equivocator_vlsm_projections.

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -7,7 +7,7 @@ From VLSM.Core Require Import Equivocators.Equivocators Equivocators.Equivocator
 
 (** * VLSM Message Properties *)
 
-Section equivocator_vlsm_message_properties.
+Section sec_equivocator_vlsm_message_properties.
 
 (** ** Lifting properties about sent messages to the equivocators
 
@@ -218,7 +218,7 @@ Proof.
   congruence.
 Qed.
 
-Section oracle_lifting.
+Section sec_oracle_lifting.
 
 Context
   selector
@@ -409,9 +409,9 @@ Proof.
             simpl in Hnot_last. congruence.
 Qed.
 
-End oracle_lifting.
+End sec_oracle_lifting.
 
-Section has_been_received_lifting.
+Section sec_has_been_received_lifting.
 
 (** ** Lifting the [HasBeenReceivedCapability] *)
 
@@ -449,9 +449,9 @@ Qed.
     equivocator_has_been_received_dec
     equivocator_has_been_received_stepwise_props.
 
-End has_been_received_lifting.
+End sec_has_been_received_lifting.
 
-Section has_been_sent_lifting.
+Section sec_has_been_sent_lifting.
 
 (** ** Lifting the [HasBeenSentCapability] *)
 
@@ -489,9 +489,9 @@ Qed.
     equivocator_has_been_sent_dec
     equivocator_has_been_sent_stepwise_props.
 
-End has_been_sent_lifting.
+End sec_has_been_sent_lifting.
 
-Section ComputableSentMessages_lifting.
+Section sec_ComputableSentMessages_lifting.
 
 (** ** Lifting the [ComputableSentMessages] property *)
 
@@ -547,6 +547,6 @@ Proof.
     by eapply equivocator_has_been_sent_stepwise_props.
 Qed.
 
-End ComputableSentMessages_lifting.
+End sec_ComputableSentMessages_lifting.
 
-End equivocator_vlsm_message_properties.
+End sec_equivocator_vlsm_message_properties.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -924,7 +924,7 @@ Qed.
 
 End sec_sub_composite_message_dependencies.
 
-Section sec_full_message_dependencies.
+Section sec_FullMessageDependencies.
 
 Context
   {message : Type}
@@ -942,13 +942,13 @@ Class FullMessageDependencies
       : forall m, NoDup (full_message_dependencies m)
   }.
 
-End sec_full_message_dependencies.
+End sec_FullMessageDependencies.
 
 (* given the message type, we can usually look up the functions for
 message dependencies *)
 #[global] Hint Mode FullMessageDependencies ! - - : typeclass_instances.
 
-Section sec_full_message_dependencies_happens_before.
+Section sec_FullMessageDependencies_happens_before.
 
 Context
   `{EqDecision message}
@@ -1021,7 +1021,7 @@ Proof.
   by transitivity dm; apply full_message_dependencies_happens_before.
 Qed.
 
-End sec_full_message_dependencies_happens_before.
+End sec_FullMessageDependencies_happens_before.
 
 (** ** Basic validation condition for free composition
 

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -948,7 +948,7 @@ End sec_full_message_dependencies.
 message dependencies *)
 #[global] Hint Mode FullMessageDependencies ! - - : typeclass_instances.
 
-Section full_message_dependencies_happens_before.
+Section sec_full_message_dependencies_happens_before.
 
 Context
   `{EqDecision message}
@@ -1021,7 +1021,7 @@ Proof.
   by transitivity dm; apply full_message_dependencies_happens_before.
 Qed.
 
-End full_message_dependencies_happens_before.
+End sec_full_message_dependencies_happens_before.
 
 (** ** Basic validation condition for free composition
 
@@ -1032,7 +1032,7 @@ End full_message_dependencies_happens_before.
   Thus, the node itself is a validator for the free composition.
 *)
 
-Section free_composition_validators.
+Section sec_free_composition_validators.
 
 Context
   {message : Type}
@@ -1168,7 +1168,7 @@ Proof.
     by eapply message_dependencies_are_sufficient.
 Qed.
 
-End free_composition_validators.
+End sec_free_composition_validators.
 
 Section sec_CompositeHasBeenObserved_dec.
 

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -5,7 +5,7 @@ From VLSM.Core Require Import VLSM.
 
 (** * VLSM Plans *)
 
-Section plans.
+Section sec_plans.
 
 Context
   {message : Type}
@@ -23,9 +23,9 @@ Record plan_item :=
     input_a : option message
   }.
 
-End plans.
+End sec_plans.
 
-Section apply_plans.
+Section sec_apply_plans.
 
 Context
   {message : Type}
@@ -157,9 +157,9 @@ Definition _messages_a
   list message :=
   ListExtras.cat_option (List.map input_a a).
 
-End apply_plans.
+End sec_apply_plans.
 
-Section valid_plans.
+Section sec_valid_plans.
 
 Context
   {message : Type}
@@ -432,4 +432,4 @@ Proof.
   - by apply Hpreserves.
 Qed.
 
-End valid_plans.
+End sec_valid_plans.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble StdppExtras.
 From VLSM.Core Require Import VLSM Composition VLSMProjections Validator.
 
-Section projections.
+Section sec_projections.
 
 (** * Composite VLSM induced projections
 
@@ -68,11 +68,11 @@ Proof.
     + by intros ? ? ? ? ? [_ ?].
 Qed.
 
-End projections.
+End sec_projections.
 
 (** ** VLSM Projection Traces *)
 
-Section PreLoadedProjectionTraces.
+Section sec_pre_loaded_projection_traces.
 
 Context
   {message : Type}
@@ -228,9 +228,9 @@ Proof.
   by state_update_simpl.
 Qed.
 
-End PreLoadedProjectionTraces.
+End sec_pre_loaded_projection_traces.
 
-Section ProjectionTraces_membership.
+Section sec_projection_traces_membership.
 
 Context
   {message : Type}
@@ -279,9 +279,9 @@ Proof.
   by inversion Hly.
 Qed.
 
-End ProjectionTraces_membership.
+End sec_projection_traces_membership.
 
-Section binary_free_composition_projections.
+Section sec_binary_free_composition_projections.
 
 (** ** Projections of Free composition of two VLSMs
 
@@ -299,9 +299,9 @@ Definition binary_free_composition_fst : VLSM message :=
 Definition binary_free_composition_snd : VLSM message :=
   pre_composite_vlsm_induced_projection_validator (binary_IM M1 M2) (free_constraint _) second.
 
-End binary_free_composition_projections.
+End sec_binary_free_composition_projections.
 
-Section fixed_projection.
+Section sec_fixed_projection.
 
 Context
   {message : Type}
@@ -511,9 +511,9 @@ Definition pre_loaded_with_all_messages_validator_component_proj_incl
   : VLSM_incl (pre_loaded_with_all_messages_vlsm (IM j)) Xj :=
   VLSM_eq_proj1 (pre_loaded_with_all_messages_validator_component_proj_eq Hvalidator).
 
-End fixed_projection.
+End sec_fixed_projection.
 
-Section projection_friendliness_sufficient_condition.
+Section sec_projection_friendliness_sufficient_condition.
 
 Context {message : Type}
         `{EqDecision index}
@@ -596,4 +596,4 @@ Proof.
   - by destruct Hv as [Hs [Homj [sX [Heqs [HsX [Hom Hv]]]]]].
 Qed.
 
-End projection_friendliness_sufficient_condition.
+End sec_projection_friendliness_sufficient_condition.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -7,7 +7,7 @@ From VLSM.Core Require Import Equivocation EquivocationProjections Equivocation.
 
 (** * VLSM Subcomposition *)
 
-Section sub_composition.
+Section sec_sub_composition.
 
 Context
   {message : Type}
@@ -336,7 +336,7 @@ Qed.
 
 End sec_induced_sub_projection.
 
-Section induced_sub_projection_subsumption.
+Section sec_induced_sub_projection_subsumption.
 
 Context
   (constraint1 : composite_label IM -> composite_state IM * option message -> Prop)
@@ -355,7 +355,7 @@ Proof.
   - by apply constraint_subsumption_incl.
 Qed.
 
-End induced_sub_projection_subsumption.
+End sec_induced_sub_projection_subsumption.
 
 Definition from_sub_projection : composite_transition_item IM -> Prop :=
   @pre_VLSM_projection_in_projection _ (composite_type IM) _ composite_label_sub_projection_option.
@@ -364,7 +364,7 @@ Definition finite_trace_sub_projection
   : list (composite_transition_item IM) -> list (composite_transition_item sub_IM) :=
   @pre_VLSM_projection_finite_trace_project _ (composite_type IM) _ composite_label_sub_projection_option composite_state_sub_projection.
 
-Section sub_projection_with_no_equivocation_constraints.
+Section sec_sub_projection_with_no_equivocation_constraints.
 
 Context
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
@@ -683,7 +683,7 @@ Proof.
     by unfold lst; subst.
 Qed.
 
-End sub_projection_with_no_equivocation_constraints.
+End sec_sub_projection_with_no_equivocation_constraints.
 
 Lemma lift_sub_state_initial
   (s : composite_state sub_IM)
@@ -758,7 +758,7 @@ Proof.
   by destruct (decide (i = j)); subst; state_update_simpl; case_decide; state_update_simpl.
 Qed.
 
-End sub_composition.
+End sec_sub_composition.
 
 #[export] Hint Rewrite @sub_IM_state_update_eq using done : state_update.
 #[export] Hint Rewrite @sub_IM_state_update_neq using done : state_update.
@@ -792,7 +792,7 @@ Arguments lift_sub_transition [message index]%type_scope {EqDecision0} IM%functi
   [PreSubFree_PreFree_weak_full_projection]).
 *)
 
-Section lift_sub_state_to_preloaded.
+Section sec_lift_sub_state_to_preloaded.
 
 Context
   {message : Type}
@@ -1022,9 +1022,9 @@ Proof.
   - by apply induced_sub_projection_transition_consistency_None.
 Qed.
 
-End lift_sub_state_to_preloaded.
+End sec_lift_sub_state_to_preloaded.
 
-Section sub_composition_incl.
+Section sec_sub_composition_incl.
 
 Context
   {message : Type}
@@ -1136,9 +1136,9 @@ Proof.
   - by apply lift_sub_incl_message_initial.
 Qed.
 
-End sub_composition_incl.
+End sec_sub_composition_incl.
 
-Section sub_composition_sender.
+Section sec_sub_composition_sender.
 
 Context
   {message : Type}
@@ -1375,9 +1375,9 @@ Proof.
       rewrite Hsender; itauto.
 Qed.
 
-End sub_composition_sender.
+End sec_sub_composition_sender.
 
-Section sub_composition_all.
+Section sec_sub_composition_all.
 (** ** A subcomposition with all the components
 
   If taking the subset of indices used for the sub-composition to be the entire
@@ -1480,9 +1480,9 @@ Proof.
   - by intros m [[i Hi] Him]; exists i.
 Qed.
 
-End sub_composition_all.
+End sec_sub_composition_all.
 
-Section sub_composition_element.
+Section sec_sub_composition_element.
 
 (** ** Relating a sub-composition with one of its components
 
@@ -1676,12 +1676,12 @@ Proof.
     by setoid_rewrite <- (induced_sub_projection_transition_is_composite _ _ constraint).
 Qed.
 
-End sub_composition_element.
+End sec_sub_composition_element.
 
 #[export] Hint Rewrite @sub_element_state_eq : state_update.
 #[export] Hint Rewrite @sub_element_state_neq using done : state_update.
 
-Section sub_composition_preloaded_lift.
+Section sec_sub_composition_preloaded_lift.
 
 Context
   {message : Type}
@@ -1790,9 +1790,9 @@ Proof.
   by apply (VLSM_full_projection_can_emit Hproj).
 Qed.
 
-End sub_composition_preloaded_lift.
+End sec_sub_composition_preloaded_lift.
 
-Section empty_sub_composition.
+Section sec_empty_sub_composition.
 
 (** ** A subcomposition with no components
 
@@ -1820,9 +1820,9 @@ Proof.
   intro sub_i; destruct_dec_sig sub_i i Hi Heqsub_i; subst; inversion Hi.
 Qed.
 
-End empty_sub_composition.
+End sec_empty_sub_composition.
 
-Section update_IM.
+Section sec_update_IM.
 
 Context
   {message : Type}
@@ -1862,4 +1862,4 @@ Proof.
   by eapply set_diff_elim2.
 Qed.
 
-End update_IM.
+End sec_update_IM.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -98,7 +98,7 @@ Definition pre_loaded_vlsm
   :=
   {| vmachine := VLSMMachine_pre_loaded_with_messages (vmachine X) initial |}.
 
-Section Traces.
+Section sec_traces.
 
 Context
   {message : Type}
@@ -217,13 +217,13 @@ Definition trace_nth (tr : Trace)
     | Infinite s st => Some (Str_nth n (Cons s (Streams.map destination st)))
     end.
 
-End Traces.
+End sec_traces.
 
 Arguments transition_item {message} {T} , {message} T.
 Arguments field_selector {_} {T} _ msg item / .
 Arguments item_sends_or_receives {_} {_} msg item /.
 
-Section TraceLemmas.
+Section sec_trace_lemmas.
 
 Context
   [message : Type]
@@ -368,9 +368,9 @@ Lemma unlock_finite_trace_last s tr:
 Proof. done. Qed.
 Opaque finite_trace_last.
 
-End TraceLemmas.
+End sec_trace_lemmas.
 
-Section vlsm_projections.
+Section sec_vlsm_projections.
 
 Context
   {message : Type}
@@ -398,7 +398,7 @@ Definition vvalid := @valid _ _ machine.
 Definition vtransition_item := @transition_item _ type.
 Definition vTrace := @Trace _ type.
 
-End vlsm_projections.
+End sec_vlsm_projections.
 
 Ltac unfold_vtransition H := (unfold vtransition in H; simpl in H).
 
@@ -410,7 +410,7 @@ Proof.
   by destruct X.
 Qed.
 
-Section VLSM.
+Section sec_VLSM.
 
 (** In this section we assume a fixed [VLSM]. *)
 
@@ -2411,7 +2411,7 @@ Class VLSM_vdecidable :=
   { valid_decidable : forall l som, {valid l som} + {~valid l som}
   }.
 (* end hide *)
-End VLSM.
+End sec_VLSM.
 
 (**
   Make all arguments of [valid_state_prop_ind] explicit
@@ -2505,7 +2505,7 @@ Class TraceWithStart
   Byzantine fault tolerance analysis.
 *)
 
-Section pre_loaded_with_all_messages_vlsm.
+Section sec_pre_loaded_with_all_messages_vlsm.
 
 Context
   {message : Type}
@@ -2689,7 +2689,7 @@ Proof.
     subst; cbn; itauto.
 Qed.
 
-End pre_loaded_with_all_messages_vlsm.
+End sec_pre_loaded_with_all_messages_vlsm.
 
 Lemma non_empty_valid_trace_from_can_produce
   `(X : VLSM message)
@@ -2734,13 +2734,13 @@ Qed.
   Below are some preliminary results; the actual projection is given in
   [VLSMProjections.same_VLSM_full_projection].
 *)
-Section same_VLSM.
+Section sec_same_VLSM.
 
 Context
   {message : Type}
   .
 
-Section definitions.
+Section sec_definitions.
 
 Context
   [X1 X2 : VLSM message]
@@ -2753,7 +2753,7 @@ Definition same_VLSM_label_rew (l1 : vlabel X1) : vlabel X2 :=
 Definition same_VLSM_state_rew (s1 : vstate X1) : vstate X2 :=
   eq_rect X1 _ s1 _ Heq.
 
-End definitions.
+End sec_definitions.
 
 Context
   (X1 X2 : VLSM message)
@@ -2779,7 +2779,7 @@ Lemma same_VLSM_initial_message_preservation m
   : vinitial_message_prop X1 m -> vinitial_message_prop X2 m.
 Proof. by subst. Qed.
 
-End same_VLSM.
+End sec_same_VLSM.
 
 Record ValidTransition `(X : VLSM message) l s1 iom s2 oom : Prop :=
   {
@@ -2792,7 +2792,7 @@ Inductive ValidTransitionNext `(X : VLSM message) (s1 s2 : state) : Prop :=
     forall l iom oom (Ht : ValidTransition X l s1 iom s2 oom),
       ValidTransitionNext X s1 s2.
 
-Section SecValidTransitionProps.
+Section sec_valid_transition_props.
 
 Context
   `(X : VLSM message)
@@ -2821,7 +2821,7 @@ Lemma input_valid_transition_forget_input :
     ValidTransition X l s1 iom s2 oom.
 Proof. by firstorder. Qed.
 
-End SecValidTransitionProps.
+End sec_valid_transition_props.
 
 Class HistoryVLSM `(X : VLSM message) : Prop :=
   {

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -7,7 +7,7 @@ From VLSM.Core Require Export VLSMEmbedding VLSMInclusion VLSMEquality.
 
 (** * VLSM Projection Properties *)
 
-Section same_VLSM_full_projection.
+Section sec_same_VLSM_full_projection.
 
 (** ** Same VLSM full projection *)
 
@@ -27,9 +27,9 @@ Proof.
   - by apply same_VLSM_initial_message_preservation.
 Qed.
 
-End same_VLSM_full_projection.
+End sec_same_VLSM_full_projection.
 
-Section transitivity_props.
+Section sec_transitivity_props.
 
 (** ** Transitivity properties *)
 
@@ -284,4 +284,4 @@ Lemma VLSM_eq_embedding_trans
   : VLSM_full_projection X Z project_labelYZ project_stateYZ.
 Proof. by apply VLSM_incl_embedding_trans; [apply VLSM_eq_proj1 |]. Qed.
 
-End transitivity_props.
+End sec_transitivity_props.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras StreamExtras StreamFilters.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMTotalProjection.
 
-Section VLSM_full_projection.
+Section sec_VLSM_full_projection.
 
 (** * VLSM Full Projection (Embedding)
 
@@ -23,7 +23,7 @@ Section VLSM_full_projection.
   [lift_to_composite_vlsm_full_projection] or [projection_friendliness_lift_to_composite_vlsm_full_projection]).
 *)
 
-Section pre_definitions.
+Section sec_pre_definitions.
 
 Context
   {message : Type}
@@ -85,9 +85,9 @@ Proof.
   by setoid_rewrite map_app; simpl; rewrite !finite_trace_last_output_is_last.
 Qed.
 
-End pre_definitions.
+End sec_pre_definitions.
 
-Section basic_definitions.
+Section sec_basic_definitions.
 
 Context
   {message : Type}
@@ -219,7 +219,7 @@ Proof.
   by apply initial_message_is_valid.
 Qed.
 
-End basic_definitions.
+End sec_basic_definitions.
 
 Definition VLSM_full_projection_transition_item_project
   {message : Type}
@@ -274,7 +274,7 @@ Proof.
     apply (pre_VLSM_full_projection_finite_trace_last _).
 Qed.
 
-Section weak_projection_properties.
+Section sec_weak_projection_properties.
 
 (** ** Weak projection properties *)
 
@@ -386,9 +386,9 @@ Proof.
   - apply emitted_messages_are_valid. revert Hemit. apply VLSM_weak_full_projection_can_emit.
 Qed.
 
-End weak_projection_properties.
+End sec_weak_projection_properties.
 
-Section full_projection_properties.
+Section sec_full_projection_properties.
 
 (** ** Full projection properties *)
 
@@ -548,9 +548,9 @@ Proof.
     + destruct om as [m|]; [| done]. by apply Hmessage.
 Qed.
 
-End full_projection_properties.
+End sec_full_projection_properties.
 
-End VLSM_full_projection.
+End sec_VLSM_full_projection.
 
 (**
   It is natural to look for sufficient conditions for VLSM projections
@@ -565,7 +565,7 @@ End VLSM_full_projection.
   like <<X>>'s [transition].
 *)
 
-Section basic_VLSM_full_projection.
+Section sec_basic_VLSM_full_projection.
 
 (** ** Basic full VLSM projection *)
 
@@ -581,7 +581,7 @@ Context
   (Htransition : weak_full_projection_transition_preservation X Y label_project state_project)
   .
 
-Section weak_full_projection.
+Section sec_weak_full_projection.
 
 (** ** Weak full VLSM projection *)
 
@@ -658,7 +658,7 @@ Proof.
   by apply (VLSM_weak_projection_finite_valid_trace_from Hproj) in H.
 Qed.
 
-End weak_full_projection.
+End sec_weak_full_projection.
 
 Lemma basic_VLSM_weak_full_projection_strengthen
   (Hweak : VLSM_weak_full_projection X Y label_project state_project)
@@ -681,7 +681,7 @@ Proof.
   by apply strong_projection_initial_state_preservation_weaken.
 Qed.
 
-End basic_VLSM_full_projection.
+End sec_basic_VLSM_full_projection.
 
 Lemma basic_VLSM_strong_full_projection
   {message : Type}

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -10,7 +10,7 @@ From VLSM.Core Require Import VLSM VLSMProjections.VLSMInclusion VLSMProjections
   Then VLSM <<X>> and VLSM <<Y>> are _equal_ if their [valid_trace]s are exactly the same.
 *)
 
-Section VLSM_equality.
+Section sec_VLSM_equality.
 
 Context
   {message : Type}
@@ -47,7 +47,7 @@ Lemma VLSM_eq_incl_iff
   : VLSM_eq X Y <-> VLSM_incl X Y /\ VLSM_incl Y X.
 Proof. firstorder. Qed.
 
-End VLSM_equality.
+End sec_VLSM_equality.
 
 Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
 
@@ -81,7 +81,7 @@ Proof.
   firstorder.
 Qed.
 
-Section VLSM_eq_properties.
+Section sec_VLSM_eq_properties.
 
 (** ** VLSM equality properties *)
 
@@ -241,9 +241,9 @@ Proof.
   - apply (VLSM_incl_valid_trace VLSM_eq_proj2).
 Qed.
 
-End VLSM_eq_properties.
+End sec_VLSM_eq_properties.
 
-Section VLSM_incl_preloaded_properties.
+Section sec_VLSM_incl_preloaded_properties.
 
 (** ** Inclusion properties for pre-loaded VLSMs *)
 
@@ -333,4 +333,4 @@ Proof.
   split; (apply VLSM_incl_valid_state_message; [|cbv;tauto]); apply Heq.
 Qed.
 
-End VLSM_incl_preloaded_properties.
+End sec_VLSM_incl_preloaded_properties.

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -9,7 +9,7 @@ From VLSM.Core Require Import VLSM VLSMProjections.VLSMEmbedding VLSMProjections
   Then VLSM <<X>> is _included_ in VLSM <<Y>> if every [valid_trace] available to <<X>>
   is also available to <<Y>>.
 *)
-Section VLSM_inclusion.
+Section sec_VLSM_inclusion.
 
 Context
   {message : Type}
@@ -108,11 +108,11 @@ Proof.
   by destruct a.
 Qed.
 
-End VLSM_inclusion.
+End sec_VLSM_inclusion.
 
 Notation VLSM_incl X Y := (VLSM_incl_part (machine X) (machine Y)).
 
-Section VLSM_incl_preservation.
+Section sec_VLSM_incl_preservation.
 
 (** ** VLSM inclusion preservation *)
 
@@ -145,9 +145,9 @@ Definition weak_incl_initial_message_preservation : Prop :=
 Definition strong_incl_initial_message_preservation : Prop :=
   strong_full_projection_initial_message_preservation X Y.
 
-End VLSM_incl_preservation.
+End sec_VLSM_incl_preservation.
 
-Section VLSM_incl_properties.
+Section sec_VLSM_incl_properties.
 
 (** ** VLSM inclusion properties *)
 
@@ -316,10 +316,10 @@ Proof.
   - apply VLSM_incl_infinite_valid_trace.
 Qed.
 
-End VLSM_incl_properties.
+End sec_VLSM_incl_properties.
 
 (** We instantiate the above for VLSM inclusions *)
-Section basic_VLSM_incl.
+Section sec_basic_VLSM_incl.
 
 Context
   {message : Type}
@@ -371,9 +371,9 @@ Proof.
            (basic_VLSM_full_projection_preloaded_with X Y _ _ PimpliesQ id id).
 Qed.
 
-End basic_VLSM_incl.
+End sec_basic_VLSM_incl.
 
-Section VLSM_incl_preloaded_properties.
+Section sec_VLSM_incl_preloaded_properties.
 
 Context
   {message : Type}
@@ -491,4 +491,4 @@ Proof.
   by destruct X.
 Qed.
 
-End VLSM_incl_preloaded_properties.
+End sec_VLSM_incl_preloaded_properties.

--- a/theories/VLSM/Core/VLSMProjections/VLSMPartialProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMPartialProjection.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM.
 
-Section VLSM_partial_projection.
+Section sec_VLSM_partial_projection.
 
 (** * VLSM Partial Projections
 
@@ -75,7 +75,7 @@ Record VLSM_partial_projection
         finite_valid_trace X sX trX -> finite_valid_trace Y sY trY
   }.
 
-Section weak_partial_projection_properties.
+Section sec_weak_partial_projection_properties.
 
 (** ** Weak partial projection properties *)
 
@@ -136,9 +136,9 @@ Proof.
   by eapply VLSM_weak_partial_projection_input_valid_transition.
 Qed.
 
-End weak_partial_projection_properties.
+End sec_weak_partial_projection_properties.
 
-Section partial_projection_properties.
+Section sec_partial_projection_properties.
 
 (** ** Partial projection properties *)
 
@@ -204,6 +204,6 @@ Definition VLSM_partial_projection_input_valid_transition
 Definition VLSM_partial_projection_input_valid
   := VLSM_weak_partial_projection_input_valid VLSM_partial_projection_weaken.
 
-End partial_projection_properties.
+End sec_partial_projection_properties.
 
-End VLSM_partial_projection.
+End sec_VLSM_partial_projection.

--- a/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras StreamExtras StreamFilters StdppExtras.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMPartialProjection.
 
-Section VLSM_projection.
+Section sec_VLSM_projection.
 
 (** * VLSM Total Projections
 
@@ -27,7 +27,7 @@ Section VLSM_projection.
   [equivocators_no_equivocations_vlsm_X_vlsm_projection]).
 *)
 
-Section pre_definitions.
+Section sec_pre_definitions.
 
 Context
   {message : Type}
@@ -138,7 +138,7 @@ Definition pre_VLSM_projection_finite_trace_project_in
     forall trX, In itemX trX -> In itemY (pre_VLSM_projection_finite_trace_project trX)
   := in_map_option_rev _.
 
-End pre_definitions.
+End sec_pre_definitions.
 
 Record VLSM_projection_type
   {message : Type}
@@ -156,7 +156,7 @@ Record VLSM_projection_type
 
 (** ** Projection definitions and properties *)
 
-Section projection_type_properties.
+Section sec_projection_type_properties.
 
 Definition VLSM_partial_trace_project_from_projection
   {message : Type}
@@ -192,9 +192,9 @@ Proof.
     apply H1.
 Qed.
 
-End projection_type_properties.
+End sec_projection_type_properties.
 
-Section projection_transition_consistency_None.
+Section sec_projection_transition_consistency_None.
 
 Context
   {message : Type}
@@ -228,9 +228,9 @@ Proof.
   apply (Hstrong lX Hl _ _ _ _ (proj2 Ht)).
 Qed.
 
-End projection_transition_consistency_None.
+End sec_projection_transition_consistency_None.
 
-Section VLSM_projection_definitions.
+Section sec_VLSM_projection_definitions.
 
 Context
   {message : Type}
@@ -335,9 +335,9 @@ Proof.
   by intros Hstrong lX lY Hl  s m [_ [Hm%Hstrong _]] HsY.
 Qed.
 
-End VLSM_projection_definitions.
+End sec_VLSM_projection_definitions.
 
-Section weak_projection_properties.
+Section sec_weak_projection_properties.
 
 Definition VLSM_weak_projection_trace_project
   {message : Type}
@@ -509,9 +509,9 @@ Proof.
   apply VLSM_weak_projection_finite_valid_trace_from_to.
 Qed.
 
-End weak_projection_properties.
+End sec_weak_projection_properties.
 
-Section projection_properties.
+Section sec_projection_properties.
 
 Definition VLSM_projection_finite_trace_project
   {message : Type}
@@ -709,7 +709,7 @@ Qed.
   projections of the valid traces of the source VLSM.
 *)
 
-Section projection_friendliness.
+Section sec_projection_friendliness.
 
 (**
   We axiomatize projection friendliness as the converse of
@@ -771,11 +771,11 @@ Proof.
   by apply VLSM_projection_finite_valid_trace.
 Qed.
 
-End projection_friendliness.
+End sec_projection_friendliness.
 
-End projection_properties.
+End sec_projection_properties.
 
-End VLSM_projection.
+End sec_VLSM_projection.
 
 (**
   For VLSM <<X>> to project to a VLSM <<Y>>, the following set of conditions is sufficient:
@@ -789,9 +789,9 @@ End VLSM_projection.
   - All non-projectable transitions preserve the projected state
 *)
 
-Section basic_VLSM_projection.
+Section sec_basic_VLSM_projection.
 
-Section basic_VLSM_projection_type.
+Section sec_basic_VLSM_projection_type.
 
 Context
   {message : Type}
@@ -820,7 +820,7 @@ Proof.
   by rewrite Hx.
 Qed.
 
-End basic_VLSM_projection_type.
+End sec_basic_VLSM_projection_type.
 
 Context
   {message : Type}
@@ -837,7 +837,7 @@ Context
     basic_VLSM_projection_type X (type Y) label_project state_project Htransition_None)
   .
 
-Section weak_projection.
+Section sec_weak_projection.
 
 Context
   (Hstate : weak_projection_initial_state_preservation X Y state_project)
@@ -901,7 +901,7 @@ Proof.
   apply basic_VLSM_projection_finite_valid_trace_from.
 Qed.
 
-End weak_projection.
+End sec_weak_projection.
 
 Lemma basic_VLSM_weak_projection_strengthen
   (Hweak : VLSM_weak_projection X Y label_project state_project)
@@ -924,7 +924,7 @@ Proof.
   by apply strong_projection_initial_state_preservation_weaken.
 Qed.
 
-End basic_VLSM_projection.
+End sec_basic_VLSM_projection.
 
 Lemma basic_VLSM_strong_projection
   {message : Type}

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -58,7 +58,7 @@ Record TransitionValidation
 
 End sec_input_validation_definitions.
 
-Section projection_validator.
+Section sec_projection_validator.
 
 Context
   `{X : VLSM message}
@@ -122,7 +122,7 @@ Proof.
   by eexists _, _.
 Qed.
 
-End projection_validator.
+End sec_projection_validator.
 
 (** ** Induced VLSM validators
 
@@ -324,7 +324,7 @@ Proof.
   - by destruct Hv as [_ [Hm _]]; apply initial_message_is_valid.
 Qed.
 
-Section projection_induced_friendliness.
+Section sec_projection_induced_friendliness.
 
 Context
   (Hproj := projection_induced_validator_is_projection)
@@ -368,7 +368,7 @@ Proof.
   - by apply induced_validator_trace_lift.
 Qed.
 
-End projection_induced_friendliness.
+End sec_projection_induced_friendliness.
 
 End sec_projection_induced_validator_as_projection.
 
@@ -484,7 +484,7 @@ End sec_projection_induced_validator_incl.
   that initial states of <<Y>> can be lifted to <<X>>.
 *)
 
-Section induced_validator_validators.
+Section sec_induced_validator_validators.
 
 Context
   `{X : VLSM message}
@@ -608,7 +608,7 @@ Proof.
   by apply validator_alt_free_states_are_projection_states.
 Qed.
 
-Section pre_loaded_with_all_messages_validator_proj.
+Section sec_pre_loaded_with_all_messages_validator_proj.
 
 Context
   (Hvalidator : projection_validator_prop Y label_project state_project)
@@ -658,9 +658,9 @@ Proof.
   - apply induced_validator_incl_preloaded_with_all_messages.
 Qed.
 
-End pre_loaded_with_all_messages_validator_proj.
+End sec_pre_loaded_with_all_messages_validator_proj.
 
-End induced_validator_validators.
+End sec_induced_validator_validators.
 
 (** ** Validator properties for the [component_projection].
 
@@ -668,7 +668,7 @@ End induced_validator_validators.
   components of a composition.
 *)
 
-Section component_projection_validator.
+Section sec_component_projection_validator.
 
 Context
   {message : Type}
@@ -760,7 +760,7 @@ Proof.
   - apply component_transition_projection_None.
 Qed.
 
-End component_projection_validator.
+End sec_component_projection_validator.
 
 Section sec_component_projection_validator_alt.
 
@@ -921,7 +921,7 @@ End sec_component_projection_validator_alt.
 
 (** ** VLSM self-validation *)
 
-Section self_validator_vlsm.
+Section sec_self_validator_vlsm.
 
 Context
   {message : Type}
@@ -996,4 +996,4 @@ Proof.
     apply Hincl.
 Qed.
 
-End self_validator_vlsm.
+End sec_self_validator_vlsm.

--- a/theories/VLSM/Lib/EquationsExtras.v
+++ b/theories/VLSM/Lib/EquationsExtras.v
@@ -2,7 +2,7 @@ From Equations Require Export Equations.
 
 (** * Equations utility definitions
 
-  Definition of [inspect] is available in Equations as of version 1.3+8.16.
+  The definition of [inspect] is available in Equations as of version 1.3+8.16.
   Notation <<eq:>> is not yet available (exists only in examples).
 *)
 

--- a/theories/VLSM/Lib/FinFunExtras.v
+++ b/theories/VLSM/Lib/FinFunExtras.v
@@ -41,7 +41,7 @@ Proof.
     apply f_surj.
 Qed.
 
-Section sum_listing.
+Section sec_sum_listing.
 (** 'Listing' for the sum type implies 'Listing' for each projection *)
 
 Context
@@ -77,4 +77,4 @@ Proof.
   by destruct a;simpl;congruence.
 Qed.
 
-End sum_listing.
+End sec_sum_listing.

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -4,12 +4,12 @@ From VLSM.Lib Require Import Preamble.
 
 (** * Finite set utility definitions and lemmas *)
 
-Section fin_set.
+Section sec_fin_set.
 
 Context
   `{FinSet A C}.
 
-Section general.
+Section sec_general.
 
 Lemma union_size_ge_size1
   (X Y : C) :
@@ -141,9 +141,9 @@ Proof.
     lia.
 Qed.
 
-End general.
+End sec_general.
 
-Section filter.
+Section sec_filter.
 
 Context
   (P P2 : A → Prop)
@@ -171,11 +171,11 @@ Proof.
   itauto.
 Qed.
 
-End filter.
+End sec_filter.
 
-End fin_set.
+End sec_fin_set.
 
-Section map.
+Section sec_map.
 
 Context
   `{FinSet A C}
@@ -208,4 +208,4 @@ Proof.
   by apply fmap_length.
 Qed.
 
-End map.
+End sec_map.

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -1497,7 +1497,7 @@ Proof.
   - by rewrite fold_left_app; apply Hstep.
 Qed.
 
-Section suffix_quantifiers.
+Section sec_suffix_quantifiers.
 
 (** ** Quantifiers for all suffixes
 
@@ -1546,7 +1546,7 @@ Proof.
     + by eapply IHl, InvIsStable.
 Qed.
 
-End suffix_quantifiers.
+End sec_suffix_quantifiers.
 
 Lemma ForAllSuffix_subsumption [A : Type] (P Q : list A -> Prop)
   (HPQ : forall l, P l -> Q l)

--- a/theories/VLSM/Lib/StdppListFinSet.v
+++ b/theories/VLSM/Lib/StdppListFinSet.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude.
 
 (** * Finite set implementation of a list set interface *)
 
-Section fst_defs.
+Section sec_fst_defs.
 
 Context `{FinSet A C}.
 
@@ -148,11 +148,11 @@ Proof.
   - by intros []; apply set_diff_intro.
 Qed.
 
-End fst_defs.
+End sec_fst_defs.
 
 Arguments set : clear implicits.
 
-Section other_defs.
+Section sec_other_defs.
 
 Context 
   `{FinSet A C}
@@ -163,4 +163,4 @@ Context
 Definition set_prod (X : C) (Y : D) : CD :=
   list_to_set (list_prod (elements X) (elements Y)).
 
-End other_defs.
+End sec_other_defs.

--- a/theories/VLSM/Lib/StdppListSet.v
+++ b/theories/VLSM/Lib/StdppListSet.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
 
-Section fst_defs.
+Section sec_fst_defs.
 
 Context `{EqDecision A}.
 
@@ -206,11 +206,11 @@ Proof.
   - by case_decide; [done |]; apply set_add_nodup.
 Qed.
 
-End fst_defs.
+End sec_fst_defs.
 
 Arguments set : clear implicits.
 
-Section other_defs.
+Section sec_other_defs.
 
 Definition set_prod : forall {A B : Type}, set A -> set B -> set (A * B) :=
   list_prod.
@@ -221,4 +221,4 @@ Definition set_fold_right {A B : Type} (f : A -> B -> B) (x : set A) (b : B) : B
 Definition set_map {A B : Type} `{EqDecision B} (f : A -> B) (x : set A) : set B :=
   set_fold_right (fun a => set_add (f a)) x empty_set.
 
-End other_defs.
+End sec_other_defs.

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -677,7 +677,7 @@ Proof.
   by inversion Hlast.
 Qed.
 
-Section infinitely_often.
+Section sec_infinitely_often.
 
 Context
   [A : Type]
@@ -710,7 +710,7 @@ Definition InfinitelyOften_nth_tl
   : forall n s, InfinitelyOften s -> InfinitelyOften (Str_nth_tl n s)
   := (@ForAll_Str_nth_tl _ (Exists1 P)).
 
-End infinitely_often.
+End sec_infinitely_often.
 
 Lemma InfinitelyOften_impl [A : Type] (P Q : A -> Prop) (HPQ : forall a, P a -> Q a)
   : forall s, InfinitelyOften P s -> InfinitelyOften Q s.

--- a/theories/VLSM/Lib/StreamFilters.v
+++ b/theories/VLSM/Lib/StreamFilters.v
@@ -310,7 +310,7 @@ Qed.
   2004, pp.21. ffinria-00070658 https://hal.inria.fr/inria-00070658/document
 *)
 
-Section stream_filter_positions.
+Section sec_stream_filter_positions.
 
 Context
   [A : Type]
@@ -528,9 +528,9 @@ Definition stream_filter
   : Stream A :=
   stream_filter_map proj1_sig s Hinf.
 
-End stream_filter_positions.
+End sec_stream_filter_positions.
 
-Section stream_map_option.
+Section sec_stream_map_option.
 
 (** ** Mapping a partial function on a stream
 
@@ -578,7 +578,7 @@ Definition bounded_stream_map_option
   : list B :=
   map_option f (stream_prefix s (` Hfin)).
 
-End stream_map_option.
+End sec_stream_map_option.
 
 (**
   For a totally defined function, [stream_map_option] corresponds to the

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -19,7 +19,7 @@ From VLSM.Lib Require Import Preamble ListExtras ListSetExtras StdppListSet Stdp
   (Lemmas [top_sort_precedes] and [top_sort_precedes_before]).
 *)
 
-Section min_predecessors.
+Section sec_min_predecessors.
 (** ** Finding an element with a minimal number of predecessors *)
 
 (**
@@ -233,7 +233,7 @@ Proof.
   lia.
 Qed.
 
-End min_predecessors.
+End sec_min_predecessors.
 
 #[export] Instance precedes_P_transitive
   `{Transitive A preceeds} (P : A -> Prop)
@@ -258,7 +258,7 @@ Proof.
   split; typeclasses eauto.
 Qed.
 
-Section topologically_sorted.
+Section sec_topologically_sorted.
 
 (** ** Topologically sorted lists. Definition and properties. *)
 
@@ -286,7 +286,7 @@ Context
   {Hso : StrictOrder (precedes_P precedes P)}
   .
 
-Section topologically_sorted_fixed_list.
+Section sec_topologically_sorted_fixed_list.
 
 Context
   (Hl : Forall P l)
@@ -364,8 +364,8 @@ Proof.
   exists l1, l2, l3. by rewrite Hb', <- app_assoc.
 Qed.
 
-End topologically_sorted_fixed_list.
-End topologically_sorted.
+End sec_topologically_sorted_fixed_list.
+End sec_topologically_sorted.
 
 Lemma toplogically_sorted_remove_last
   {A : Type}
@@ -438,7 +438,7 @@ Proof.
   rewrite !app_length in Heq. cbn in Heq. lia.
 Qed.
 
-Section top_sort.
+Section sec_top_sort.
 (** ** The topological sorting algorithm *)
 
 Context {A} `{EqDecision A} (precedes : relation A) `{!RelDecision precedes}.
@@ -750,7 +750,7 @@ Proof.
        (min_predecessors precedes (a :: l0) l0 a)). itauto.
 Qed.
 
-End top_sort.
+End sec_top_sort.
 
 (**
   Some of the results above depend on the <<precedes>> relation being a

--- a/theories/VLSM/Lib/TraceClassicalProperties.v
+++ b/theories/VLSM/Lib/TraceClassicalProperties.v
@@ -7,7 +7,7 @@ Import Prenex Implicits.
 
 (** * Properties of possibly-infinite traces requiring classical logic *)
 
-Section TraceClassicalProperties.
+Section sec_trace_classical_properties.
 
 Context {A B : Type}.
 
@@ -77,4 +77,4 @@ move => [f1 hf1] [f2 hf2] [f3 hf3] tr0 /= h1.
 exact: appendT_assoc_R.
 Qed.
 
-End TraceClassicalProperties.
+End sec_trace_classical_properties.

--- a/theories/VLSM/Lib/TraceProperties.v
+++ b/theories/VLSM/Lib/TraceProperties.v
@@ -12,7 +12,7 @@ Import Prenex Implicits.
   #<a href="https://arxiv.org/abs/1412.6579">A Hoare logic for the coinductive trace-based big-step semantics of While</a>#.
 *)
 
-Section TraceProperties.
+Section sec_trace_properties.
 
 Context {A B : Type}.
 
@@ -1166,7 +1166,7 @@ cofix CIH. dependent inversion h; subst => tr0 hm.
   exact: followsT_delay _ _ (CIH _ _ _ _ h1 _ _).
 Qed.
 
-End TraceProperties.
+End sec_trace_properties.
 
 (** ** Trace property operators and notations *)
 

--- a/theories/VLSM/Lib/Traces.v
+++ b/theories/VLSM/Lib/Traces.v
@@ -8,7 +8,7 @@ Import Prenex Implicits.
 
 Ltac invs h := inversion h; subst => {h}.
 
-Section Traces.
+Section sec_traces.
 
 Context {A B : Type}.
 
@@ -109,6 +109,6 @@ move => tr1 tr2 tr3 tr4 [a1 | a1 b1 tr1' tr2' Hbs1'] Hbs2.
   exact/bisim_cons/CIH.
 Qed.
 
-End Traces.
+End sec_traces.
 
 Infix "+++" := trace_append (at level 60, right associativity).


### PR DESCRIPTION
Now all sections are written like `sec_camel_case`.