### PR TITLE
Replace the finishers easy and now with done and by.

### DIFF
--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -390,7 +390,7 @@ Lemma sentMessages_addObservation :
 Proof.
   intros s ob.
   unfold sentMessages, sentMessages'; cbn.
-  now destruct (decide (isSend ob)).
+  by destruct (decide (isSend ob)).
 Qed.
 
 (**
@@ -429,7 +429,7 @@ Lemma receivedMessages_addObservation :
 Proof.
   intros s ob.
   unfold receivedMessages, receivedMessages'; cbn.
-  now destruct (decide (isReceive ob)).
+  by destruct (decide (isReceive ob)).
 Qed.
 
 Lemma elem_of_messages :
@@ -457,7 +457,7 @@ Qed.
 Lemma messages_addObservation :
   forall (s : State) (ob : Observation),
     messages (s <+> ob) = message ob :: messages s.
-Proof. easy. Qed.
+Proof. done. Qed.
 
 (**
   An address in [receivedAddresses (s <+> ob)] is either in
@@ -486,7 +486,7 @@ Lemma receivedAddresses_addObservation :
 Proof.
   intros s ob.
   unfold receivedAddresses; cbn.
-  now destruct (decide (isReceive ob)).
+  by destruct (decide (isReceive ob)).
 Qed.
 
 End sec_base_ELMO.

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -415,14 +415,14 @@ Lemma dsig_compare_reflexive
   {X} `{StrictlyComparable X} (P : X -> Prop) {Pdec : forall x, Decision (P x)}
   : CompareReflexive (dsig_compare P).
 Proof.
-  now intros x y; unfold dsig_compare; rewrite dsig_eq, compare_eq.
+  by intros x y; unfold dsig_compare; rewrite dsig_eq, compare_eq.
 Qed.
 
 Lemma dsig_compare_transitive
   {X} `{StrictlyComparable X} (P : X -> Prop) {Pdec : forall x, Decision (P x)}
   : CompareTransitive (dsig_compare P).
 Proof.
-  now intros x y z; unfold dsig_compare; apply compare_transitive.
+  by intros x y z; unfold dsig_compare; apply compare_transitive.
 Qed.
 
 Lemma CompareStrictOrder_dsig_compare


### PR DESCRIPTION
I saw `easy` and `now` from the standard library used in a few places whereas we prefer `done` and `by` from stdpp.