### PR TITLE
Standardize indentation for (co)inductive types

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -96,13 +96,14 @@ Program Instance base_params (p : param) : BaseParams := {
 }.
 ```
 
-### Inductive and CoInductive types
+### Inductive and coinductive types
 
 - C-style type name
 - CamelCase constructors
-- to avoid name clashes, constructor names can be prefixed with an abbreviation of the type name
+- to avoid name clashes, constructor names can be prefixed with an abbreviation of the type name followed by `_`
 - no indentation in constructor declarations
 - the first `|` in constructor declarations should not be omitted
+- it's preferred to include the sort annotation
 
 Example:
 ```coq

--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -103,7 +103,7 @@ Program Instance base_params (p : param) : BaseParams := {
 - to avoid name clashes, constructor names can be prefixed with an abbreviation of the type name followed by `_`
 - no indentation in constructor declarations
 - the first `|` in constructor declarations should not be omitted
-- it's preferred to include the sort annotation
+- it's recommended to include the sort annotation, especially when it's `Prop`
 
 Example:
 ```coq

--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -96,18 +96,20 @@ Program Instance base_params (p : param) : BaseParams := {
 }.
 ```
 
-### Inductive types
+### Inductive and CoInductive types
 
 - C-style type name
 - CamelCase constructors
-- one space indentation for each constructor declaration
+- to avoid name clashes, constructor names can be prefixed with an abbreviation of the type name
+- no indentation in constructor declarations
+- the first `|` in constructor declarations should not be omitted
 
 Example:
 ```coq
 Inductive lv_event_type : Type :=
- | State
- | Sent
- | Received.
+| State
+| Sent
+| Received.
 ```
 
 ### Definitions

--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -22,8 +22,8 @@ Context
 
 (** Messages can be labeled as either sent or received. *)
 Inductive Label : Type :=
- | Receive
- | Send.
+| Receive
+| Send.
 
 Inductive State : Type := MkState
 {

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -63,8 +63,8 @@ match l, om with
 end.
 
 Inductive UMOComponentValid : Label -> State -> option Message -> Prop :=
- | OCV_Send    : forall st : State, UMOComponentValid Send st None
- | OCV_Receive : forall (st : State) (msg : Message), UMOComponentValid Receive st (Some msg).
+| OCV_Send    : forall st : State, UMOComponentValid Send st None
+| OCV_Receive : forall (st : State) (msg : Message), UMOComponentValid Receive st (Some msg).
 
 Ltac invert_UMOComponentValid :=
 repeat match goal with

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -42,7 +42,7 @@ Context
   .
 
 Inductive LimitedEquivocationProp (s : composite_state IM) : Prop :=
-  limited_equivocation :
+| limited_equivocation :
     forall (vs : set validator)
       (Hnodup_vs : NoDup vs)
       (Heqv_vs : forall v, equivocating s v -> v ∈ vs)

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -43,9 +43,9 @@ Context
     using label <<l>>.
 *)
 Inductive EquivocatorLabel : Type :=
-  | Spawn : vstate X -> EquivocatorLabel
-  | ContinueWith : nat -> vlabel X -> EquivocatorLabel
-  | ForkWith : nat -> vlabel X -> EquivocatorLabel.
+| Spawn : vstate X -> EquivocatorLabel
+| ContinueWith : nat -> vlabel X -> EquivocatorLabel
+| ForkWith : nat -> vlabel X -> EquivocatorLabel.
 
 Definition equivocator_type : VLSMType message :=
   {| state := bounded_state_copies ;
@@ -727,10 +727,9 @@ Context
     copy being tracked
   - [Existing] <<i>> indicates that we're currently tracking copy <<i>>
 *)
-Inductive MachineDescriptor : Type
-  :=
-  | NewMachine : vstate X -> MachineDescriptor
-  | Existing : nat -> MachineDescriptor.
+Inductive MachineDescriptor : Type :=
+| NewMachine : vstate X -> MachineDescriptor
+| Existing : nat -> MachineDescriptor.
 
 (**
   The [MachineDescriptor] associated to an [equivocator_label] tells us

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -1051,11 +1051,11 @@ Context
   message.
 *)
 Inductive Emittable_from_dependencies_prop (m : message) : Prop :=
-  | efdp : forall (v : validator) (Hsender : sender m = Some v)
-              (Hemittable : can_emit
-                (pre_loaded_vlsm (IM (A v)) (fun dm => dm ∈ message_dependencies m))
-                m),
-               Emittable_from_dependencies_prop m.
+| efdp : forall (v : validator) (Hsender : sender m = Some v)
+            (Hemittable : can_emit
+              (pre_loaded_vlsm (IM (A v)) (fun dm => dm ∈ message_dependencies m))
+              m),
+             Emittable_from_dependencies_prop m.
 
 Definition emittable_from_dependencies_prop (m : message) : Prop :=
   match sender m with

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -1512,12 +1512,12 @@ Context
   .
 
 Inductive ExistsSuffix : list A -> Prop :=
-  | SHere : forall l, P l -> ExistsSuffix l
-  | SFurther : forall a l, ExistsSuffix l -> ExistsSuffix (a :: l).
+| SHere : forall l, P l -> ExistsSuffix l
+| SFurther : forall a l, ExistsSuffix l -> ExistsSuffix (a :: l).
 
 Inductive ForAllSuffix : list A -> Prop :=
-  | SNil : P [] -> ForAllSuffix []
-  | SHereAndFurther : forall a l, P (a :: l) -> ForAllSuffix l -> ForAllSuffix (a :: l).
+| SNil : P [] -> ForAllSuffix []
+| SHereAndFurther : forall a l, P (a :: l) -> ForAllSuffix l -> ForAllSuffix (a :: l).
 
 Lemma fsHere : forall l, ForAllSuffix l -> P l.
 Proof. by inversion 1. Qed.

--- a/theories/VLSM/Lib/Temporal.v
+++ b/theories/VLSM/Lib/Temporal.v
@@ -7,11 +7,11 @@ From Coq Require Import Streams Classical.
 Set Implicit Arguments.
 
 Inductive Eventually [A:Type] (P: Stream A -> Prop) : Stream A -> Prop :=
-  | ehere : forall s, P s -> Eventually P s
-  | elater : forall s, Eventually P s -> forall a, Eventually P (Cons a s).
+| ehere : forall s, P s -> Eventually P s
+| elater : forall s, Eventually P s -> forall a, Eventually P (Cons a s).
 
 CoInductive Forever [A:Type] (P: Stream A -> Prop) : Stream A -> Prop :=
-  fcons : forall s, P s -> Forever P (tl s) -> Forever P s.
+| fcons : forall s, P s -> Forever P (tl s) -> Forever P s.
 
 Lemma fhere [A:Type] (P: Stream A -> Prop) : forall s, Forever P s -> P s.
 Proof.


### PR DESCRIPTION
The coding conventions said that we should have 1 space of indentation for constructors of inductives, but most code (and all new code) used zero spaces, whereas some old code used two spaces. I chose to follow the new code and use zero spaces everywhere and update the coding conventions accordingly.

In case you don't like my choice this can be changed to whatever other convention, I just wanted to make things consistent.