### PR TITLE
Standardize classes

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -70,7 +70,7 @@ Section sec_ELMOComponent_lemmas.
 - CamelCase name
 - field declaration with C-style naming on separate line, with 2 spaces of indentation
 - the `;` in the last field should not be omitted
-- the sort annotation should not be omitted
+- it's recommended to include the sort annotation, especially when it's `Prop`
 
 Example:
 ```coq
@@ -146,7 +146,6 @@ Lemma sync_some (s : vstate X) (from to : index) :
 - CamelCase for constructor name
 - field declaration with C-style naming on separate line, with 2 spaces of indentation
 - the `;` in the last field should not be omitted
-- the sort annotation should not be omitted
 - it's recommended to include the sort annotation, especially when it's `Prop`
 
 Example:

--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -70,6 +70,7 @@ Section sec_ELMOComponent_lemmas.
 - CamelCase name
 - field declaration with C-style naming on separate line, with 2 spaces of indentation
 - the `;` in the last field should not be omitted
+- the sort annotation should not be omitted
 
 Example:
 ```coq

--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -68,13 +68,15 @@ Section sec_ELMOComponent_lemmas.
 ### Type classes
 
 - CamelCase name
-- field declaration with C-style naming on separate line
+- field declaration with C-style naming on separate line, with 2 spaces of indentation
+- the `;` in the last field should not be omitted
 
 Example:
 ```coq
-Class TotalOrder {A} (R : relation A) : Prop := {
+Class TotalOrder {A} (R : relation A) : Prop :=
+{
   total_order_partial :> PartialOrder R;
-  total_order_trichotomy :> Trichotomy (strict R)
+  total_order_trichotomy :> Trichotomy (strict R);
 }.
 ```
 

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -24,10 +24,11 @@ Qed.
 
 (** ** Basic equivocation *)
 
-Class ReachableThreshold V `{Hm : Measurable V} :=
-  { threshold : {r | (r >= 0)%R}
-  ; reachable_threshold : exists (vs:list V), NoDup vs /\ (sum_weights vs > proj1_sig threshold)%R
-  }.
+Class ReachableThreshold V `{Hm : Measurable V} : Set :=
+{
+  threshold : {r | (r >= 0)%R};
+  reachable_threshold : exists (vs :list V), NoDup vs /\ (sum_weights vs > proj1_sig threshold)%R;
+}.
 
 (**
   Assuming a set of <<state>>s, and a set of <<validator>>s,
@@ -57,26 +58,20 @@ Class BasicEquivocation
   {measurable_V : Measurable validator}
   {reachable_threshold : ReachableThreshold validator}
   `{FinSet validator Cm}
-  :=
-  { is_equivocating (s : state) (v : validator) : Prop
-  ; is_equivocating_dec : RelDecision is_equivocating
+  : Type :=
+{
+  is_equivocating (s : state) (v : validator) : Prop;
+  is_equivocating_dec : RelDecision is_equivocating;
   (** retrieves a set containing all possible validators for a state *)
-  ; state_validators (s : state) : Cm
+  state_validators (s : state) : Cm;
   (** all validators which are equivocating in a given composite state *)
-  ; equivocating_validators
-      (s : state)
-      : Cm
-      := filter (fun v => is_equivocating s v) (state_validators s)
+  equivocating_validators (s : state) : Cm :=
+    filter (fun v => is_equivocating s v) (state_validators s);
   (** equivocation fault sum: the sum of the weights of equivocating validators *)
-  ; equivocation_fault
-      (s : state)
-      : R
-      :=
-      sum_weights (elements (equivocating_validators s))
-  ; not_heavy
-      (s : state)
-      := (equivocation_fault s <= proj1_sig threshold)%R
- }.
+  equivocation_fault (s : state) : R :=
+    sum_weights (elements (equivocating_validators s));
+  not_heavy (s : state) : Prop := (equivocation_fault s <= proj1_sig threshold)%R
+}.
 
 Lemma eq_equivocating_validators_equivocation_fault
    `{BasicEquivocation st validator Cm}
@@ -401,20 +396,20 @@ Definition has_not_been_received_prop : state_message_oracle -> state -> message
   [has_been_sent] and [has_not_been_sent].
 *)
 
-Class HasBeenSentCapability := {
-  has_been_sent: state_message_oracle;
+Class HasBeenSentCapability : Type :=
+{
+  has_been_sent : state_message_oracle;
   has_been_sent_dec :> RelDecision has_been_sent;
 
-  proper_sent:
+  proper_sent :
     forall (s : state)
            (Hs : valid_state_prop pre_vlsm s)
            (m : message),
            (has_been_sent_prop has_been_sent s m);
+  has_not_been_sent: state_message_oracle :=
+    fun (s : state) (m : message) => ~ has_been_sent s m;
 
-  has_not_been_sent: state_message_oracle
-    := fun (s : state) (m : message) => ~ has_been_sent s m;
-
-  proper_not_sent:
+  proper_not_sent :
     forall (s : state)
            (Hs : valid_state_prop pre_vlsm s)
            (m : message),
@@ -548,20 +543,21 @@ Proof.
   by apply not_iff_compat, (iff_trans proper_sent).
 Qed.
 
-Class HasBeenReceivedCapability := {
+Class HasBeenReceivedCapability : Type :=
+{
   has_been_received: state_message_oracle;
   has_been_received_dec :> RelDecision has_been_received;
 
-  proper_received:
+  proper_received :
     forall (s : state)
            (Hs : valid_state_prop pre_vlsm s)
            (m : message),
            (has_been_received_prop has_been_received s m);
 
-  has_not_been_received: state_message_oracle
-    := fun (s : state) (m : message) => ~ has_been_received s m;
+  has_not_been_received : state_message_oracle :=
+    fun (s : state) (m : message) => ~ has_been_received s m;
 
-  proper_not_received:
+  proper_not_received :
     forall (s : state)
            (Hs : valid_state_prop pre_vlsm s)
            (m : message),
@@ -1141,12 +1137,13 @@ Qed.
   or received during any trace leading to the given state.
 *)
 
-Class HasBeenDirectlyObservedCapability {message} (vlsm: VLSM message) :=
-  {
+Class HasBeenDirectlyObservedCapability {message} (vlsm : VLSM message) : Type :=
+{
   has_been_directly_observed: state_message_oracle vlsm;
   has_been_directly_observed_dec :> RelDecision has_been_directly_observed;
   has_been_directly_observed_stepwise_props: oracle_stepwise_props item_sends_or_receives has_been_directly_observed;
-  }.
+}.
+
 Arguments has_been_directly_observed {message} vlsm {_}.
 Arguments has_been_directly_observed_dec {message} vlsm {_}.
 Arguments has_been_directly_observed_stepwise_props {message} vlsm {_}.
@@ -1371,7 +1368,7 @@ Definition computable_messages_oracle
   (message_selector : message -> transition_item -> Prop) : Prop :=
     oracle_stepwise_props message_selector (fun s m => m ∈ oracle_set s).
 
-Class ComputableSentMessages `(vlsm : VLSM message) :=
+Class ComputableSentMessages `(vlsm : VLSM message) : Type :=
 {
   sent_messages_set : vstate vlsm -> list message;
   csm_computable_oracle :
@@ -1380,7 +1377,7 @@ Class ComputableSentMessages `(vlsm : VLSM message) :=
 
 Global Hint Mode ComputableSentMessages - ! : typeclass_instances.
 
-Class ComputableReceivedMessages `(vlsm : VLSM message) :=
+Class ComputableReceivedMessages `(vlsm : VLSM message) : Type :=
 {
   received_messages_set : vstate vlsm -> list message;
   crm_computable_oracle :

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -74,13 +74,13 @@ Qed.
   A composition of VLSMs has the witnessed equivocation capability if towards any
   valid states there exist a trace witnessing its equivocation.
 *)
-Class WitnessedEquivocationCapability
-  :=
-  { is_equivocating_tracewise_witness :
+Class WitnessedEquivocationCapability : Prop :=
+{
+  is_equivocating_tracewise_witness :
     forall s, valid_state_prop PreFree s ->
     exists is tr, finite_valid_trace_init_to PreFree is s tr /\
       trace_witnessing_equivocation_prop is tr
-  }.
+}.
 
 Section sec_witnessed_equivocation_properties.
 

--- a/theories/VLSM/Core/FinSetMessageDependencies.v
+++ b/theories/VLSM/Core/FinSetMessageDependencies.v
@@ -7,12 +7,16 @@ Class FinSetFullMessageDependencies
   `{HfinSetMessage : FinSet message Cm}
   (message_dependencies : message -> Cm)
   (full_message_dependencies : message -> Cm)
-  :=
-  { fin_set_full_message_dependencies_happens_before
-      : forall dm m, dm ∈ full_message_dependencies m <-> msg_dep_happens_before (elements ∘ message_dependencies) dm m
-  ; fin_set_full_message_dependencies_irreflexive
-      : forall m, m ∉ full_message_dependencies m
-  }.
+  : Prop :=
+{
+  fin_set_full_message_dependencies_happens_before :
+    forall dm m,
+      dm ∈ full_message_dependencies m
+        <->
+      msg_dep_happens_before (elements ∘ message_dependencies) dm m;
+  fin_set_full_message_dependencies_irreflexive :
+    forall m, m ∉ full_message_dependencies m
+}.
 
 (** Given the message type, we can usually look up the functions for message dependencies. *)
 #[global] Hint Mode FinSetFullMessageDependencies ! - - - - - - - - - - - - : typeclass_instances.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -62,14 +62,15 @@ Class MessageDependencies
   `{!HasBeenSentCapability X}
   `{!HasBeenReceivedCapability X}
   `{!Irreflexive (msg_dep_happens_before message_dependencies)}
-  :=
-  { message_dependencies_are_necessary (m : message)
-      `(can_produce (pre_loaded_with_all_messages_vlsm X) s' m)
-      : message_dependencies_full_node_condition X message_dependencies s' m
-  ; message_dependencies_are_sufficient (m : message)
-      `(can_emit (pre_loaded_with_all_messages_vlsm X) m)
-      : can_emit (pre_loaded_vlsm X (fun msg => msg ∈ message_dependencies m)) m
-  }.
+  : Prop :=
+{
+  message_dependencies_are_necessary (m : message)
+    `(can_produce (pre_loaded_with_all_messages_vlsm X) s' m)
+    : message_dependencies_full_node_condition X message_dependencies s' m;
+  message_dependencies_are_sufficient (m : message)
+    `(can_emit (pre_loaded_with_all_messages_vlsm X) m)
+    : can_emit (pre_loaded_vlsm X (fun msg => msg ∈ message_dependencies m)) m
+}.
 
 (*
   Given the VLSM for which it's defined, the other arguments (message,
@@ -934,14 +935,15 @@ Context
 Class FullMessageDependencies
   (message_dependencies : message -> set message)
   (full_message_dependencies : message -> set message)
-  :=
-  { full_message_dependencies_happens_before
-      : forall dm m, dm ∈ full_message_dependencies m <-> msg_dep_happens_before message_dependencies dm m
-  ; full_message_dependencies_irreflexive
-      : forall m, m ∉ full_message_dependencies m
-  ; full_message_dependencies_nodups
-      : forall m, NoDup (full_message_dependencies m)
-  }.
+  : Prop :=
+{
+  full_message_dependencies_happens_before :
+    forall dm m, dm ∈ full_message_dependencies m <-> msg_dep_happens_before message_dependencies dm m;
+  full_message_dependencies_irreflexive :
+    forall m, m ∉ full_message_dependencies m;
+  full_message_dependencies_nodups :
+    forall m, NoDup (full_message_dependencies m);
+}.
 
 End sec_FullMessageDependencies.
 

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -20,7 +20,7 @@ From VLSM.Core Require Import VLSM Composition VLSMEmbedding.
 (**
   A class with a measure of size for states which is monotonic for valid transitions.
 *)
-Class TransitionMonotoneVLSM `(X : VLSM message) (state_size : vstate X -> nat) :=
+Class TransitionMonotoneVLSM `(X : VLSM message) (state_size : vstate X -> nat) : Prop :=
 {
   transition_monotonicity :
     forall s1 s2 : vstate X, ValidTransitionNext X s1 s2 -> state_size s1 < state_size s2
@@ -74,7 +74,8 @@ Qed.
 Class TraceableVLSM
   `(X : VLSM message)
   (state_destructor : vstate X -> list (vtransition_item X * vstate X))
-  (state_size : vstate X -> nat) :=
+  (state_size : vstate X -> nat)
+  : Prop :=
 {
   tv_monotone :> TransitionMonotoneVLSM X state_size;
   tv_state_destructor_destination :
@@ -88,7 +89,7 @@ Class TraceableVLSM
         input_valid_transition_item (pre_loaded_with_all_messages_vlsm X) s item;
   tv_state_destructor_initial :
     forall (s : vstate X) (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm X) s),
-      vinitial_state_prop X s <-> state_destructor s = []
+      vinitial_state_prop X s <-> state_destructor s = [];
 }.
 
 #[global] Hint Mode TraceableVLSM - ! - - : typeclass_instances.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -42,10 +42,10 @@ Class VLSMType (message : Type) : Type :=
 Class VLSMMachine {message : Type} (vtype : VLSMType message) : Type :=
 {
   initial_state_prop : state -> Prop;
-  initial_state := { s : state | initial_state_prop s };
+  initial_state : Type := {s : state | initial_state_prop s};
   s0 : Inhabited initial_state;
   initial_message_prop : message -> Prop;
-  initial_message := { m : message | initial_message_prop m };
+  initial_message : Type := {m : message | initial_message_prop m};
   transition : label -> state * option message -> state * option message;
   valid : label -> state * option message -> Prop;
 }.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -20,10 +20,11 @@ From VLSM.Lib Require Import Preamble ListExtras StreamExtras.
   easily shared by multiple VLSMs during composition.
 *)
 
-Class VLSMType (message : Type) :=
-  { state : Type
-  ; label : Type
-  }.
+Class VLSMType (message : Type) : Type :=
+{
+  state : Type;
+  label : Type;
+}.
 
 (** *** VLSM class definition
 
@@ -38,15 +39,16 @@ Class VLSMType (message : Type) :=
   and the [transition] function and [valid] predicate.
 *)
 
-Class VLSMMachine {message : Type} (vtype : VLSMType message) :=
-  { initial_state_prop : state -> Prop
-  ; initial_state := { s : state | initial_state_prop s }
-  ; s0 : Inhabited initial_state
-  ; initial_message_prop : message -> Prop
-  ; initial_message := { m : message | initial_message_prop m }
-  ; transition : label -> state * option message -> state * option message
-  ; valid : label -> state * option message -> Prop
-  }.
+Class VLSMMachine {message : Type} (vtype : VLSMType message) : Type :=
+{
+  initial_state_prop : state -> Prop;
+  initial_state := { s : state | initial_state_prop s };
+  s0 : Inhabited initial_state;
+  initial_message_prop : message -> Prop;
+  initial_message := { m : message | initial_message_prop m };
+  transition : label -> state * option message -> state * option message;
+  valid : label -> state * option message -> Prop;
+}.
 
 (* The & is a "bidirectionality hint", so that typechecking
    a VLSMMachine record definition will try to use the expected
@@ -2406,9 +2408,11 @@ Definition composition_constraint : Type :=
 
 (* Decidable VLSMs *)
 
-Class VLSM_vdecidable :=
-  { valid_decidable : forall l som, {valid l som} + {~valid l som}
-  }.
+Class VLSM_vdecidable : Type :=
+{
+  valid_decidable : forall l som, {valid l som} + {~valid l som}
+}.
+
 (* end hide *)
 End sec_VLSM.
 
@@ -2431,19 +2435,22 @@ Arguments extend_right_finite_trace_from [message] (X) [s1] [ts] (Ht12) [l3] [io
 Arguments extend_right_finite_trace_from_to [message] (X) [s1] [s2] [ts] (Ht12) [l3] [iom3] [s3] [oom3] (Hv23).
 
 Class TraceWithLast
-      (base_prop : forall {message} (X: VLSM message),
-      @state _ (@type _ X) -> list transition_item -> Prop)
-      (trace_prop : forall {message} (X: VLSM message),
-        state -> state -> list transition_item -> Prop) :=
-  {valid_trace_add_last: forall [msg] [X: VLSM msg] [s f tr],
-     base_prop X s tr -> finite_trace_last s tr = f -> trace_prop X s f tr;
-   valid_trace_get_last: forall [msg] [X: VLSM msg] [s f tr],
-     trace_prop X s f tr -> finite_trace_last s tr = f;
-   valid_trace_last_pstate: forall [msg] [X: VLSM msg] [s f tr],
-     trace_prop X s f tr -> valid_state_prop X f;
-   valid_trace_forget_last: forall [msg] [X: VLSM msg] [s f tr],
-     trace_prop X s f tr -> base_prop X s tr
-  }.
+  (base_prop : forall {message} (X : VLSM message),
+    @state _ (@type _ X) -> list transition_item -> Prop)
+  (trace_prop : forall {message} (X : VLSM message),
+    state -> state -> list transition_item -> Prop)
+  : Prop :=
+{
+  valid_trace_add_last : forall [msg] [X: VLSM msg] [s f tr],
+    base_prop X s tr -> finite_trace_last s tr = f -> trace_prop X s f tr;
+  valid_trace_get_last : forall [msg] [X: VLSM msg] [s f tr],
+    trace_prop X s f tr -> finite_trace_last s tr = f;
+  valid_trace_last_pstate : forall [msg] [X: VLSM msg] [s f tr],
+    trace_prop X s f tr -> valid_state_prop X f;
+  valid_trace_forget_last : forall [msg] [X: VLSM msg] [s f tr],
+    trace_prop X s f tr -> base_prop X s tr;
+}.
+
 #[global] Hint Mode TraceWithLast - ! : typeclass_instances.
 #[global] Hint Mode TraceWithLast ! - : typeclass_instances.
 
@@ -2472,12 +2479,15 @@ Defined.
      }.
 
 Class TraceWithStart
-     {message} {X : VLSM message}
-     (start : @state message (type X))
-     (trace_prop : list (transition_item (type X)) -> Prop) :=
- {valid_trace_first_pstate:
+  {message} {X : VLSM message}
+  (start : @state message (type X))
+  (trace_prop : list (transition_item (type X)) -> Prop)
+  : Prop :=
+{
+  valid_trace_first_pstate :
     forall [tr], trace_prop tr -> valid_state_prop X start
- }.
+}.
+
 #[global] Hint Mode TraceWithStart - - - ! : typeclass_instances.
 
 #[export] Instance trace_with_start_valid_trace_from message (X: VLSM message) s:
@@ -2823,16 +2833,16 @@ Proof. by firstorder. Qed.
 End sec_valid_transition_props.
 
 Class HistoryVLSM `(X : VLSM message) : Prop :=
-  {
-    not_ValidTransitionNext_initial :
-      forall s2, vinitial_state_prop X s2 ->
-      forall s1, ~ ValidTransitionNext X s1 s2;
-    unique_transition_to_state :
-      forall [s : vstate X],
-      forall [l1 s1 iom1 oom1], ValidTransition X l1 s1 iom1 s oom1 ->
-      forall [l2 s2 iom2 oom2], ValidTransition X l2 s2 iom2 s oom2 ->
-      l1 = l2 /\ s1 = s2 /\ iom1 = iom2 /\ oom1 = oom2
-  }.
+{
+  not_ValidTransitionNext_initial :
+    forall s2, vinitial_state_prop X s2 ->
+    forall s1, ~ ValidTransitionNext X s1 s2;
+  unique_transition_to_state :
+    forall [s : vstate X],
+    forall [l1 s1 iom1 oom1], ValidTransition X l1 s1 iom1 s oom1 ->
+    forall [l2 s2 iom2 oom2], ValidTransition X l2 s2 iom2 s oom2 ->
+    l1 = l2 /\ s1 = s2 /\ iom1 = iom2 /\ oom1 = oom2;
+}.
 
 #[global] Hint Mode HistoryVLSM - ! : typeclass_instances.
 

--- a/theories/VLSM/Lib/Measurable.v
+++ b/theories/VLSM/Lib/Measurable.v
@@ -6,7 +6,11 @@ From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras.
 
 Definition pos_R := {r : R | (r > 0)%R}.
 
-Class Measurable V := { weight : V -> pos_R}.
+Class Measurable (V : Type) : Type :=
+{
+  weight : V -> pos_R;
+}.
+
 #[global] Hint Mode Measurable ! : typeclass_instances.
 
 Definition sum_weights `{Measurable V} (l : list V) : R :=


### PR DESCRIPTION
This is basically the same thing as in https://github.com/runtimeverification/vlsm/pull/130: the style of `Class`es was pretty inconsistent, so I attempted to make it more uniform, changing older code to match newer code.