### PR TITLE
Standardize the use of finishers across the VLSM codebase

### DIFF
--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -116,8 +116,8 @@ Lemma annotate_trace_from_app sa tr1 tr2
       annotate_trace_from (finite_trace_last sa ( annotate_trace_from sa tr1)) tr2.
 Proof.
   revert sa.
-  induction tr1 as [| item tr1]; [done | intro sa].
-  by rewrite <- app_comm_cons, !annotate_trace_from_unroll
+  induction tr1 as [| item tr1]; [done |].
+  by intro sa; rewrite <- app_comm_cons, !annotate_trace_from_unroll
   ; simpl; rewrite IHtr1, finite_trace_last_cons.
 Qed.
 
@@ -138,7 +138,7 @@ Definition annotate_trace (s : vstate X) (tr : list (vtransition_item X))
 Lemma annotate_trace_last_original_state s s' tr
   : original_state (finite_trace_last s (annotate_trace s' tr)) =
     finite_trace_last (original_state s) tr.
-Proof. apply annotate_trace_from_last_original_state. Qed.
+Proof. by apply annotate_trace_from_last_original_state. Qed.
 
 Lemma annotate_trace_project is tr
   : pre_VLSM_full_projection_finite_trace_project
@@ -150,7 +150,7 @@ Proof.
   ; remember {| original_state := is |} as sa; clear Heqsa; revert sa.
   induction tr as [| item]; [done | intro sa].
   setoid_rewrite annotate_trace_item_project; f_equal.
-  apply IHtr.
+  by apply IHtr.
 Qed.
 
 End sec_annotated_vlsm.
@@ -174,8 +174,7 @@ Context
 Definition forget_annotations_projection
   : VLSM_full_projection AnnotatedX X id original_state.
 Proof.
-  apply basic_VLSM_strong_full_projection.
-  1, 3-4: cbv; itauto.
+  apply basic_VLSM_strong_full_projection; cycle 1; [| by cbv; itauto..].
   intros l [s a] om [s' a'] om'.
   cbn; unfold annotated_transition; cbn
   ; destruct (vtransition _ _ _) as (_s', _om').
@@ -250,15 +249,15 @@ Proof.
     by state_update_simpl.
   - intros [j lj].
     unfold annotated_composite_label_project, composite_project_label; cbn.
-    case_decide as Hij; [congruence |].
+    case_decide as Hij; [by congruence |].
     intros _ [s ann] iom [s' ann'] oom.
     unfold input_valid_transition; cbn
     ; unfold annotated_transition; cbn
     ; destruct (vtransition _ _ _) as (si', om').
     intros [_ Ht]; inversion Ht.
     by state_update_simpl.
-  - intros [s ann] [Hs _]; cbn; apply Hs.
-  - intro; intros; apply any_message_is_valid_in_preloaded.
+  - by intros [s ann] [Hs _]; cbn; apply Hs.
+  - by intro; intros; apply any_message_is_valid_in_preloaded.
 Qed.
 
 Definition annotated_composite_induced_validator : VLSM message
@@ -271,7 +270,7 @@ Lemma annotated_composite_induced_validator_transition_None
 Proof.
   intros [j lj].
   unfold annotated_composite_label_project, composite_project_label; cbn.
-  case_decide as Hij; [congruence |].
+  case_decide as Hij; [by congruence |].
   intros _ sX omX s'X om'X [_ Ht]; revert Ht; cbn.
   unfold annotated_transition; cbn
   ; destruct (vtransition _ _ _) as (si', om')
@@ -281,11 +280,11 @@ Qed.
 
 Lemma annotated_composite_induced_validator_label_lift
   : induced_validator_label_lift_prop annotated_composite_label_project annotated_composite_label_lift.
-Proof. apply component_label_projection_lift. Qed.
+Proof. by apply component_label_projection_lift. Qed.
 
 Lemma annotated_composite_induced_validator_state_lift
   : induced_validator_state_lift_prop annotated_composite_state_project annotated_composite_state_lift.
-Proof. intros si; apply state_update_eq. Qed.
+Proof. by intros si; apply state_update_eq. Qed.
 
 Lemma annotated_composite_induced_validator_initial_lift
   : strong_projection_initial_state_preservation (IM i) AnnotatedFree
@@ -302,9 +301,9 @@ Lemma annotated_composite_induced_validator_transition_consistency
 Proof.
   intros [i1 li1] [i2 li2] li.
   unfold annotated_composite_label_project, composite_project_label; cbn.
-  case_decide as Hi1; [| congruence].
+  case_decide as Hi1; [| by congruence].
   subst i1; cbn; inversion_clear 1.
-  case_decide as Hi2; [| congruence].
+  case_decide as Hi2; [| by congruence].
   subst i2; cbn; inversion_clear 1.
   intros [s1 ann1] [s2 ann2]
   ; unfold annotated_transition; cbn
@@ -325,12 +324,12 @@ Lemma annotated_projection_validator_prop_alt_iff
   : annotated_projection_validator_prop_alt <-> annotated_projection_validator_prop.
 Proof.
   apply projection_validator_prop_alt_iff.
-  - apply annotated_composite_induced_validator_transition_None.
-  - apply annotated_composite_induced_validator_label_lift.
-  - apply annotated_composite_induced_validator_state_lift.
-  - apply annotated_composite_induced_validator_initial_lift.
-  - apply annotated_composite_induced_validator_transition_consistency.
-  - apply annotated_composite_preloaded_projection.
+  - by apply annotated_composite_induced_validator_transition_None.
+  - by apply annotated_composite_induced_validator_label_lift.
+  - by apply annotated_composite_induced_validator_state_lift.
+  - by apply annotated_composite_induced_validator_initial_lift.
+  - by apply annotated_composite_induced_validator_transition_consistency.
+  - by apply annotated_composite_preloaded_projection.
 Qed.
 
 End sec_composite_annotated_vlsm_projections.

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -211,7 +211,7 @@ Qed.
 Lemma alt_proj_option_valid_message
     (m : option message)
     : option_valid_message_prop Alt1 m.
-Proof. apply any_message_is_valid_in_preloaded. Qed.
+Proof. by apply any_message_is_valid_in_preloaded. Qed.
 
 (**
   Next we define the "lifting" of a [state] <<s>> from <<M>> to <<Alt>>,
@@ -242,10 +242,9 @@ Proof.
     assert (option_valid_message_prop Alt om0) as Hom0
       by apply alt_option_valid_message.
     cut (input_valid_transition Alt (existT first l) (lifted_alt_state s,om0) (lifted_alt_state s', om'))
-      ;[apply input_valid_transition_outputs_valid_state_message|].
+      ; [by apply input_valid_transition_outputs_valid_state_message |].
     split.
-    + split_and!; [done ..|].
-      by split; [cbn; apply Ht|].
+    + by repeat split; [.. | apply Ht].
     + simpl.
       replace (lifted_alt_state s first) with s
         by (unfold lifted_alt_state,lift_to_composite_state'; state_update_simpl; done).
@@ -253,7 +252,7 @@ Proof.
       change (vtransition M l (s: vstate M,om0) = (s',om')) in Ht.
       rewrite Ht.
       f_equal.
-      apply state_update_twice.
+      by apply state_update_twice.
 Qed.
 
 (**
@@ -265,13 +264,13 @@ Lemma pre_loaded_with_all_messages_alt_incl
 Proof.
   apply (basic_VLSM_incl (machine PreLoaded) (machine Alt1))
   ; intro; intros; [done | | | apply H].
-  - apply alt_proj_option_valid_message.
+  - by apply alt_proj_option_valid_message.
   - exists (lifted_alt_state s).
     split; [done |].
     destruct Hv as [[_om Hps] [Hpm Hv]].
     repeat split; [| | done].
     + by apply preloaded_alt_valid_state with _om.
-    + apply alt_option_valid_message.
+    + by apply alt_option_valid_message.
 Qed.
 
 (** Hence, <<Preloaded>> and <<Alt1>> are actually trace-equal. *)
@@ -280,8 +279,8 @@ Lemma pre_loaded_with_all_messages_alt_eq
     .
 Proof.
   split.
-  - apply pre_loaded_with_all_messages_alt_incl.
-  - apply alt_pre_loaded_with_all_messages_incl.
+  - by apply pre_loaded_with_all_messages_alt_incl.
+  - by apply alt_pre_loaded_with_all_messages_incl.
 Qed.
 
 End sec_pre_loaded_with_all_messages_byzantine_alt.
@@ -322,7 +321,7 @@ Proof.
       (VLSM_incl_valid_trace
           (pre_loaded_with_all_messages_validator_component_proj_incl _ _ _ Hvalidator)).
   revert Htr.
-  simpl. apply byzantine_pre_loaded_with_all_messages.
+  by simpl; apply byzantine_pre_loaded_with_all_messages.
 Qed.
 
 (** ** Byzantine fault tolerance for a composition of validators
@@ -359,7 +358,7 @@ Lemma validator_pre_loaded_with_all_messages_incl
 Proof.
   apply VLSM_incl_finite_traces_characterization.
   intros.
-  split; [|apply H].
+  split; [| by apply H].
   destruct H as [Htr Hs].
   induction Htr using finite_valid_trace_from_rev_ind.
   - by apply (finite_valid_trace_from_empty X), initial_state_is_valid.
@@ -373,7 +372,7 @@ Proof.
     | valid_state_prop _ ?s => remember s as lst
     end.
     split; [done |].
-    repeat split; [|apply Hvx|apply Hvx].
+    repeat split; [| by apply Hvx | by apply Hvx].
     destruct Hvx as [Hlst [_ [Hv _]]].
     destruct l as (i, li). simpl in *.
     specialize (valid_state_project_preloaded_to_preloaded _ IM constraint lst i Hlst)
@@ -381,7 +380,7 @@ Proof.
     destruct iom as [im |]; [| apply option_valid_message_None].
     eapply Hvalidator; split; [done |]; split; [| done].
     eexists _.
-    apply (pre_loaded_with_all_messages_message_valid_initial_state_message (IM i)).
+    by apply (pre_loaded_with_all_messages_message_valid_initial_state_message (IM i)).
 Qed.
 
 (**

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -166,11 +166,11 @@ Proof.
   - intros Hs sub_i.
     destruct Hs as [sX [HeqsX Hinitial]].
     subst.
-    apply Hinitial.
+  - by apply Hinitial.
   - intros Hs.
     exists (lift_sub_state fixed_byzantine_IM non_byzantine s).
     split.
-    + apply composite_state_sub_projection_lift_to.
+    + by apply composite_state_sub_projection_lift_to.
     + by apply (lift_sub_state_initial fixed_byzantine_IM non_byzantine).
 Qed.
 
@@ -199,12 +199,12 @@ Proof.
   apply induced_sub_projection_friendliness.
   apply induced_sub_projection_lift.
   intros s1 s2 Heq l om.
-  destruct om as [m|]; [|itauto].
+  destruct om as [m |]; [| by itauto].
   cbn.
-  destruct (sender m) as [v|]; [|itauto].
+  destruct (sender m) as [v |]; [| by itauto].
   simpl.
-  case_decide as HAv; [|itauto].
-  replace (s2 (A v)) with (s1 (A v)); [itauto|].
+  case_decide as HAv; [| by itauto].
+  replace (s2 (A v)) with (s1 (A v)); [by itauto |].
   exact (equal_f_dep Heq (dexist (A v) HAv)).
 Qed.
 
@@ -221,7 +221,7 @@ Lemma fixed_byzantine_trace_char1 is tr
 Proof.
   apply and_comm.
   apply (projection_friendly_trace_char (induced_sub_projection_is_projection _ _ _)).
-  apply fixed_non_byzantine_projection_friendliness.
+  by apply fixed_non_byzantine_projection_friendliness.
 Qed.
 
 End sec_fixed_byzantine_traces_as_projections.
@@ -273,7 +273,7 @@ Qed.
 Lemma non_byzantine_nodes_same_sym
   : forall sub_i, sub_IM IM non_byzantine sub_i = sub_IM fixed_byzantine_IM non_byzantine sub_i.
 Proof.
-  intro. symmetry. apply non_byzantine_nodes_same.
+  by intro; symmetry; apply non_byzantine_nodes_same.
 Qed.
 
 Lemma pre_loaded_fixed_non_byzantine_vlsm_full_projection
@@ -287,8 +287,8 @@ Proof.
   intros s1 Hs1 l1 om [Hom _].
   split; [| done].
   destruct om as [m |]; [| done].
-  destruct Hom as [Hsent | Hseeded]; [left | by right].
-  by eapply same_IM_composite_has_been_sent_preservation.
+  destruct Hom as [Hsent | Hseeded]; [| by right].
+  by left; eapply same_IM_composite_has_been_sent_preservation.
 Qed.
 
 Lemma pre_loaded_fixed_non_byzantine_vlsm_full_projection'
@@ -302,8 +302,8 @@ Proof.
   intros s1 Hs1 l1 om [Hom _].
   split; [| done].
   destruct om as [m |]; [| done].
-  destruct Hom as [Hsent | Hseeded]; [left | by right].
-  by eapply same_IM_composite_has_been_sent_preservation.
+  destruct Hom as [Hsent | Hseeded]; [| by right].
+  by left; eapply same_IM_composite_has_been_sent_preservation.
 Qed.
 
 (**
@@ -382,7 +382,7 @@ Proof.
             A sender fixed_byzantine_IM_sender_safety)
     ; [| done | done].
     eapply (VLSM_incl_valid_state); [| done].
-    eapply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
+    by eapply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
   - contradict HAv; clear -Hseeded Hsender.
     destruct Hseeded as [(i & Hi & Hm) _].
     unfold channel_authenticated_message in Hm.
@@ -434,7 +434,7 @@ Proof.
     simpl.
     rewrite @decide_True by done.
     cbn. unfold all_messages_transition.
-    inversion 1; itauto.
+    by inversion 1; itauto.
 Qed.
 
 (**
@@ -466,19 +466,18 @@ Proof.
     exists (lift_sub_label fixed_byzantine_IM non_byzantine l).
     exists (lift_sub_state fixed_byzantine_IM non_byzantine s).
     split.
-    + apply composite_label_sub_projection_option_lift.
-    + apply composite_state_sub_projection_lift.
+    + by apply composite_label_sub_projection_option_lift.
+    + by apply composite_state_sub_projection_lift.
     + by apply (VLSM_full_projection_input_valid pre_loaded_fixed_non_byzantine_vlsm_lift).
-  - intros l s om s' om' [_ Ht].
-    by apply induced_sub_projection_transition_preservation.
+  - by intros l s om s' om' [_ Ht]; apply induced_sub_projection_transition_preservation.
 Qed.
 
 Lemma fixed_non_byzantine_pre_loaded_eq
   : VLSM_eq fixed_non_byzantine_projection pre_loaded_fixed_non_byzantine_vlsm'.
 Proof.
   apply VLSM_eq_incl_iff. split.
-  - apply fixed_non_byzantine_pre_loaded_incl.
-  - apply pre_loaded_fixed_non_byzantine_incl.
+  - by apply fixed_non_byzantine_pre_loaded_incl.
+  - by apply pre_loaded_fixed_non_byzantine_incl.
 Qed.
 
 End sec_fixed_byzantine_traces_as_pre_loaded.
@@ -567,24 +566,22 @@ Lemma fixed_non_equivocating_incl_fixed_non_byzantine
 Proof.
   apply basic_VLSM_incl.
   - intros s (sX & <- & Hinitial) sub_i.
-    apply Hinitial.
+  - by apply Hinitial.
   - intro; intros.
     apply (VLSM_incl_input_valid fixed_non_equivocating_incl_sub_non_equivocating)
       in Hv as (Hs & _ & Hv).
-    apply sub_IM_no_equivocation_preservation in Hv as Hnoeqv.
-    2-4: done.
+    apply sub_IM_no_equivocation_preservation in Hv as Hnoeqv; [| done..].
     destruct Hnoeqv as [Hsent | Hseeded].
     + by eapply preloaded_composite_sent_valid.
     + apply initial_message_is_valid.
-      by right; split; [|eapply induced_sub_projection_valid_projection; apply Hv].
+      by right; split; [| eapply induced_sub_projection_valid_projection, Hv].
   - intros l s om Hv.
     apply (VLSM_incl_input_valid fixed_non_equivocating_incl_sub_non_equivocating)
        in Hv as (_ & _ & Hv).
     split.
     + by eapply induced_sub_projection_valid_preservation.
     + split; [| done].
-      apply sub_IM_no_equivocation_preservation in Hv as Hnoequiv.
-      2-4: done.
+      apply sub_IM_no_equivocation_preservation in Hv as Hnoequiv; [| done..].
       destruct om as [m |]; [| done].
       destruct Hnoequiv as [Hsent|Hseeded]; [by left | right].
       by split; [|eapply induced_sub_projection_valid_projection; apply Hv].
@@ -627,7 +624,7 @@ Lemma fixed_non_byzantine_vlsm_lift_valid
 Proof.
   intros l s om Hv HsY HomY.
   split.
-  - apply lift_sub_valid. apply Hv.
+  - by apply lift_sub_valid, Hv.
   - destruct om as [m|]; [| done].
     apply proj2 in Hv as Hc.
     destruct Hc as [_ [_ [Hc _]]].
@@ -651,14 +648,14 @@ Proof.
       apply can_emit_composite_project in Hiom as [_v Hiom].
       destruct Hseeded as [[i [Hi Hsigned]] _].
       unfold channel_authenticated_message in Hsigned.
-      destruct (sender m) as [v|] eqn:Hsender; simpl in Hsigned; [|congruence].
+      destruct (sender m) as [v |] eqn: Hsender; simpl in Hsigned; [| by congruence].
       apply Some_inj in Hsigned.
       specialize (Hsender_safety _ _ Hsender _ Hiom) as Heq_v.
       rewrite Hsigned in Heq_v. subst _v.
       eapply message_dependencies_are_sufficient in Hiom.
       revert Hiom.
       rewrite set_diff_iff in Hi.
-      apply not_and_r in Hi as [Hi | Hi]; [elim Hi; apply elem_of_enum|].
+      apply not_and_r in Hi as [Hi | Hi]; [by elim Hi; apply elem_of_enum |].
       apply dec_stable in Hi.
       apply can_emit_with_more; [done |].
       intros dm Hdm.
@@ -681,7 +678,7 @@ Lemma preloaded_non_byzantine_vlsm_lift
 Proof.
   apply basic_VLSM_strong_full_projection; [| | | done].
   - intros l s om [Hv _].
-    by split; [apply lift_sub_valid|].
+  - by split; [apply lift_sub_valid |].
   - by intro; intros; rapply lift_sub_transition.
   - by intro; intros; apply (lift_sub_state_initial IM).
 Qed.
@@ -708,7 +705,7 @@ Proof.
   - by intro; intros; apply fixed_non_byzantine_vlsm_lift_valid.
   - by intro; intros * []; rapply lift_sub_transition.
   - by intro; intros; apply (lift_sub_state_initial IM).
-  - intros; apply Hfixed_non_byzantine_vlsm_lift_initial_message.
+  - by intros; apply Hfixed_non_byzantine_vlsm_lift_initial_message.
 Qed.
 
 Lemma fixed_non_byzantine_incl_fixed_non_equivocating_from_initial
@@ -718,17 +715,17 @@ Proof.
   - intro; intros.
     exists (lift_sub_state IM (set_diff (enum index) selection) s).
     split.
-    + apply composite_state_sub_projection_lift_to.
+    + by apply composite_state_sub_projection_lift_to.
     + by apply (lift_sub_state_initial IM).
   - by intro; intros; apply initial_message_is_valid.
   - intros l s om Hv HsY HomY.
     exists (lift_sub_label IM (set_diff (enum index) selection) l).
     exists (lift_sub_state IM (set_diff (enum index) selection) s).
     split.
-    + apply composite_label_sub_projection_option_lift.
-    + apply composite_state_sub_projection_lift.
+    + by apply composite_label_sub_projection_option_lift.
+    + by apply composite_state_sub_projection_lift.
     + apply @VLSM_full_projection_input_valid; [| done].
-      apply fixed_non_byzantine_vlsm_lift_from_initial.
+      by apply fixed_non_byzantine_vlsm_lift_from_initial.
   - intros l s om s' om' [_ Ht].
     by apply induced_sub_projection_transition_preservation.
 Qed.
@@ -738,8 +735,8 @@ Lemma fixed_non_byzantine_eq_fixed_non_equivocating_from_initial
 Proof.
   apply VLSM_eq_incl_iff.
   split.
-  - apply fixed_non_byzantine_incl_fixed_non_equivocating_from_initial.
-  - apply fixed_non_equivocating_incl_fixed_non_byzantine.
+  - by apply fixed_non_byzantine_incl_fixed_non_equivocating_from_initial.
+  - by apply fixed_non_equivocating_incl_fixed_non_byzantine.
 Qed.
 
 End sec_assuming_initial_messages_lift.
@@ -778,7 +775,7 @@ Lemma validator_fixed_non_byzantine_eq_fixed_non_equivocating
   : VLSM_eq PreNonByzantine FixedNonEquivocating.
 Proof.
   apply fixed_non_byzantine_eq_fixed_non_equivocating_from_initial.
-  apply validator_fixed_non_byzantine_vlsm_lift_initial_message.
+  by apply validator_fixed_non_byzantine_vlsm_lift_initial_message.
 Qed.
 
 (** ** The main result

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -166,7 +166,7 @@ Proof.
   - intros Hs sub_i.
     destruct Hs as [sX [HeqsX Hinitial]].
     subst.
-  - by apply Hinitial.
+    by apply Hinitial.
   - intros Hs.
     exists (lift_sub_state fixed_byzantine_IM non_byzantine s).
     split.
@@ -566,7 +566,7 @@ Lemma fixed_non_equivocating_incl_fixed_non_byzantine
 Proof.
   apply basic_VLSM_incl.
   - intros s (sX & <- & Hinitial) sub_i.
-  - by apply Hinitial.
+    by apply Hinitial.
   - intro; intros.
     apply (VLSM_incl_input_valid fixed_non_equivocating_incl_sub_non_equivocating)
       in Hv as (Hs & _ & Hv).
@@ -678,7 +678,7 @@ Lemma preloaded_non_byzantine_vlsm_lift
 Proof.
   apply basic_VLSM_strong_full_projection; [| | | done].
   - intros l s om [Hv _].
-  - by split; [apply lift_sub_valid |].
+    by split; [apply lift_sub_valid |].
   - by intro; intros; rapply lift_sub_transition.
   - by intro; intros; apply (lift_sub_state_initial IM).
 Qed.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -223,7 +223,7 @@ Proof.
   - unfold lift_sub_state.
     rewrite composite_state_sub_projection_lift_to.
     split; [done |].
-    symmetry. apply composite_trace_sub_projection_lift.
+    by symmetry; apply composite_trace_sub_projection_lift.
 Qed.
 
 (** ** The main result
@@ -247,7 +247,7 @@ Proof.
   apply validator_fixed_limited_non_byzantine_traces_are_limited_non_equivocating
     in Hlimited
     as [bs [btr [Hlimited [Hs_pr Htr_pr]]]].
-  exists bs, btr; eauto.
+  by exists bs, btr; eauto.
 Qed.
 
 End sec_limited_byzantine_traces.
@@ -308,11 +308,10 @@ Proof.
   repeat split; cbn.
   - done.
   - destruct iom as [im |]; [| apply option_valid_message_None].
-    eapply Hvalidator,
-      pre_loaded_sub_composite_input_valid_projection, Ht_sub.
+    by eapply Hvalidator, pre_loaded_sub_composite_input_valid_projection, Ht_sub.
   - unfold lift_sub_state in Hann_s_pr.
     rewrite Hann_s_pr, (lift_sub_state_to_eq _ _ _ _ _ Hi).
-    apply Ht_sub.
+    by apply Ht_sub.
   - apply Rle_trans with (sum_weights (remove_dups byzantine))
     ; [| done].
     apply sum_weights_subseteq.
@@ -323,8 +322,8 @@ Proof.
         by apply set_union_nodup_left.
       }
       by eapply coeqv_limited_equivocation_state_annotation_nodup.
-    + apply NoDup_remove_dups.
-    + intro; rewrite elem_of_remove_dups; apply Heqv_byzantine.
+    + by apply NoDup_remove_dups.
+    + by intro; rewrite elem_of_remove_dups; apply Heqv_byzantine.
   - clear -Ht_sub Hann_s_pr.
     destruct Ht_sub as [_ Ht_sub]; revert Ht_sub
     ; unfold annotated_transition; cbn
@@ -401,20 +400,17 @@ Proof.
       apply finite_valid_trace_from_app_iff; split; [done |].
       subst x; cbn; apply finite_valid_trace_singleton.
       replace (finite_trace_last _ _) with lst.
-      eapply lift_pre_loaded_fixed_non_byzantine_valid_transition_to_limited.
-      1-2, 4-5: done.
-      by subst lst; apply finite_valid_trace_last_pstate.
+      by eapply lift_pre_loaded_fixed_non_byzantine_valid_transition_to_limited;
+        [| | subst lst; apply finite_valid_trace_last_pstate | |].
     }
     destruct iom as [im |]; [| done].
     apply set_union_subseteq_iff; split; [done |].
     unfold coeqv_message_equivocators
-    ; case_decide as Hnobs; [apply list_subseteq_nil |].
-    rewrite (full_node_msg_dep_coequivocating_senders _ _ _ _ Hfull _ _ i li).
-    2: cbn; rewrite Hlsti
-    ; eapply @pre_loaded_sub_composite_input_valid_projection, Hx.
+    ; case_decide as Hnobs; [by apply list_subseteq_nil |].
+    rewrite (full_node_msg_dep_coequivocating_senders _ _ _ _ Hfull _ _ i li);
+      [| by cbn; rewrite Hlsti; eapply @pre_loaded_sub_composite_input_valid_projection, Hx].
     rewrite app_nil_r; cbn.
-    destruct (sender im) as [i_im |] eqn: Hsender
-    ; [| apply list_subseteq_nil].
+    destruct (sender im) as [i_im |] eqn: Hsender; [| by apply list_subseteq_nil].
     intro _i_im; rewrite elem_of_list_singleton; intro; subst _i_im.
     destruct Hx as [(_ & _ & _ & [Hsent | [Hsigned _]] & _) _].
     + contradict Hnobs.
@@ -429,9 +425,8 @@ Proof.
       unfold channel_authenticated_message in Hauth
       ; rewrite Hsender in Hauth.
       apply Some_inj in Hauth; subst _i_im.
-      destruct (decide (i_im ∈ byzantine)) as [Hi_im | Hni_im]
-      ; [done | contradict H_i_im].
-      apply set_diff_intro; [apply elem_of_enum | done].
+      destruct (decide (i_im ∈ byzantine)) as [Hi_im | Hni_im]; [done |].
+      by contradict H_i_im; apply set_diff_intro; [apply elem_of_enum |].
 Qed.
 
 (**
@@ -463,7 +458,7 @@ Proof.
       by rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi).
     + subst Limited.
       rewrite msg_dep_annotate_trace_with_equivocators_project.
-      symmetry; apply composite_trace_sub_projection_lift.
+      by symmetry; apply composite_trace_sub_projection_lift.
   - intros (bs & btr & byzantine & Hbtr & Heqv_byzantine & Hlimited & His_pr & Htr_pr).
     exists byzantine; split; [done |].
     eapply VLSM_incl_finite_valid_trace

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -111,8 +111,8 @@ Lemma state_update_id
 Proof.
   apply functional_extensionality_dep_good.
   intro j.
-  destruct (decide (j = i)).
-  - subst. apply state_update_eq.
+  destruct (decide (j = i)); subst.
+  - by apply state_update_eq.
   - by apply state_update_neq.
 Qed.
 
@@ -125,7 +125,7 @@ Proof.
   apply functional_extensionality_dep_good.
   intro j.
   destruct (decide (j = i)).
-  - subst. rewrite state_update_eq. symmetry. apply state_update_eq.
+  - by subst; rewrite state_update_eq; symmetry; apply state_update_eq.
   - by rewrite !state_update_neq.
 Qed.
 
@@ -276,7 +276,7 @@ Lemma composite_transition_state_eq
   (Ht : composite_transition (existT i li) (s, om) = (s', om'))
   : s' i = fst (vtransition (IM i) li (s i, om)).
 Proof.
-  cbn in Ht; destruct (vtransition _ _ _); inversion Ht; apply state_update_eq.
+  by cbn in Ht; destruct (vtransition _ _ _); inversion Ht; apply state_update_eq.
 Qed.
 
 (**
@@ -379,11 +379,14 @@ Lemma lift_to_composite_vlsm_full_projection j
   : VLSM_full_projection (IM j) free_composite_vlsm (lift_to_composite_label j) (lift_to_composite_state' j).
 Proof.
   apply basic_VLSM_strong_full_projection; intro; intros.
-  - split; [| done]. simpl.
-    unfold lift_to_composite_state'. rewrite state_update_eq. apply H.
-  - unfold vtransition. simpl. unfold lift_to_composite_state' at 1.
-    rewrite state_update_eq. replace (vtransition _ _ _) with (s', om').
-    f_equal. unfold lift_to_composite_state'. apply state_update_twice.
+  - split; [| done].
+    cbn; unfold lift_to_composite_state'.
+    by rewrite state_update_eq.
+  - unfold vtransition; cbn; unfold lift_to_composite_state' at 1.
+    rewrite state_update_eq.
+    replace (vtransition _ _ _) with (s', om').
+    unfold lift_to_composite_state'.
+    by rewrite state_update_twice.
   - by apply composite_initial_state_prop_lift.
   - by exists j, (exist _ _ H).
 Qed.
@@ -399,7 +402,7 @@ Lemma constraint_free_incl
   (constraint : composite_label -> composite_state  * option message -> Prop)
   : VLSM_incl (composite_vlsm constraint) free_composite_vlsm.
 Proof.
-  apply basic_VLSM_strong_incl; firstorder.
+  by apply basic_VLSM_strong_incl; firstorder.
 Qed.
 
 Lemma composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages
@@ -407,7 +410,7 @@ Lemma composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages
   (P : message -> Prop)
   : VLSM_incl (pre_loaded_vlsm (composite_vlsm constraint) P) (pre_loaded_with_all_messages_vlsm free_composite_vlsm).
 Proof.
-  by apply basic_VLSM_strong_incl; cbv; [..|itauto|].
+  by apply basic_VLSM_strong_incl; cbv; [.. | itauto |].
 Qed.
 
 Lemma constraint_free_valid_state_message_preservation
@@ -506,7 +509,7 @@ Proof.
   apply basic_VLSM_incl.
   - by intros s Hs.
   - by intros _ _ m _ _ Hm; apply initial_message_is_valid.
-  - split; [apply Hv | auto].
+  - by split; [apply Hv | auto].
   - by intros l s om s' om' Ht; apply Ht.
 Qed.
 
@@ -570,24 +573,24 @@ Lemma weak_constraint_subsumption_weakest
   (Hsubsumption : input_valid_constraint_subsumption constraint1 constraint2)
   : weak_input_valid_constraint_subsumption constraint1 constraint2.
 Proof.
-  intros l som Hv _ _. auto.
+  by intros l som Hv _ _; auto.
 Qed.
 
 Lemma preloaded_constraint_subsumption_stronger
   (Hpre_subsumption : preloaded_constraint_subsumption constraint1 constraint2)
   : input_valid_constraint_subsumption constraint1 constraint2.
 Proof.
-  intros l som Hv. apply (Hpre_subsumption l som).
-  destruct som.
-  revert Hv.
-  apply (VLSM_incl_input_valid (vlsm_incl_pre_loaded_with_all_messages_vlsm (composite_vlsm constraint1))).
+  intros l som Hv; apply (Hpre_subsumption l som); destruct som.
+  by revert Hv; apply (VLSM_incl_input_valid
+    (vlsm_incl_pre_loaded_with_all_messages_vlsm (composite_vlsm constraint1))).
 Qed.
 
 Lemma strong_constraint_subsumption_strongest
   (Hstrong_subsumption : strong_constraint_subsumption constraint1 constraint2)
   : preloaded_constraint_subsumption constraint1 constraint2.
 Proof.
-  intros l (s, om) [_ [_ [_ Hc]]]. revert Hc. apply Hstrong_subsumption.
+  intros l (s, om) [_ [_ [_ Hc]]].
+  by revert Hc; apply Hstrong_subsumption.
 Qed.
 
 Lemma constraint_subsumption_byzantine_message_prop
@@ -597,7 +600,7 @@ Lemma constraint_subsumption_byzantine_message_prop
   : byzantine_message_prop X2 m.
 Proof.
   revert Hm.
-  apply (VLSM_incl_can_emit (preloaded_constraint_subsumption_incl Hpre_subsumption)).
+  by apply (VLSM_incl_can_emit (preloaded_constraint_subsumption_incl Hpre_subsumption)).
 Qed.
 
 (* end hide *)
@@ -621,8 +624,8 @@ Lemma constraint_preloaded_free_incl
   : VLSM_incl (composite_vlsm constraint) (pre_loaded_with_all_messages_vlsm free_composite_vlsm).
 Proof.
   eapply VLSM_incl_trans.
-  - apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
-  - apply preloaded_constraint_free_incl.
+  - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  - by apply preloaded_constraint_free_incl.
 Qed.
 
 Lemma lift_to_composite_generalized_preloaded_vlsm_full_projection
@@ -634,10 +637,12 @@ Proof.
   apply basic_VLSM_full_projection_preloaded_with; intro; intros.
   - by apply PimpliesQ.
   - split; cbn; [| done].
-    unfold lift_to_composite_state'. rewrite state_update_eq. apply H.
-  - unfold vtransition. simpl. unfold lift_to_composite_state' at 1.
-    rewrite state_update_eq. replace (vtransition (IM j) l _) with (s', om').
-    f_equal. unfold lift_to_composite_state'. apply state_update_twice.
+    by unfold lift_to_composite_state'; rewrite state_update_eq.
+  - unfold vtransition; cbn; unfold lift_to_composite_state' at 1.
+    rewrite state_update_eq.
+    replace (vtransition (IM j) l _) with (s', om').
+    unfold lift_to_composite_state'.
+    by rewrite state_update_twice.
   - by apply composite_initial_state_prop_lift.
   - by exists j, (exist _ _ H).
 Qed.
@@ -647,11 +652,15 @@ Lemma lift_to_composite_preloaded_vlsm_full_projection
   : VLSM_full_projection (pre_loaded_with_all_messages_vlsm (IM j)) (pre_loaded_with_all_messages_vlsm free_composite_vlsm) (lift_to_composite_label j) (lift_to_composite_state' j).
 Proof.
   apply basic_VLSM_full_projection_preloaded.
-  - intro; intros. split; [| done]. simpl.
-    unfold lift_to_composite_state'. rewrite state_update_eq. apply H.
-  - intro; intros. unfold vtransition. simpl. unfold vtransition. simpl. unfold lift_to_composite_state' at 1.
-    rewrite state_update_eq. replace (transition l _) with (s', om').
-    f_equal. unfold lift_to_composite_state'. apply state_update_twice.
+  - intro; intros. split; [| done].
+    unfold lift_to_composite_state'; cbn.
+    by rewrite state_update_eq.
+  - intro; intros; cbn.
+    unfold vtransition; cbn; unfold vtransition; cbn; unfold lift_to_composite_state' at 1.
+    rewrite state_update_eq.
+    replace (transition l _) with (s', om').
+    unfold lift_to_composite_state'.
+    by rewrite state_update_twice.
   - by intros s H; apply composite_initial_state_prop_lift.
 Qed.
 
@@ -670,10 +679,10 @@ Proof.
   intros j m Hm.
   eapply VLSM_incl_can_emit.
   - apply (pre_loaded_vlsm_incl_relaxed _ (fun m => Q m \/ P m)).
-    itauto.
+  - by itauto.
   - eapply VLSM_full_projection_can_emit; [| done].
     apply lift_to_composite_generalized_preloaded_vlsm_full_projection.
-    itauto.
+    by itauto.
 Qed.
 
 (**
@@ -690,12 +699,12 @@ Lemma free_valid_preloaded_lifts_can_be_emitted
 Proof.
   intros.
   eapply VLSM_incl_can_emit.
-  - eapply VLSM_eq_proj2, (vlsm_is_pre_loaded_with_False free_composite_vlsm).
+  - by eapply VLSM_eq_proj2, (vlsm_is_pre_loaded_with_False free_composite_vlsm).
   - eapply valid_preloaded_lifts_can_be_emitted; [| done].
     intros dm Hdm.
     eapply VLSM_incl_valid_message.
-    + apply VLSM_eq_proj1, (vlsm_is_pre_loaded_with_False free_composite_vlsm).
-    + cbv; itauto.
+    + by apply VLSM_eq_proj1, (vlsm_is_pre_loaded_with_False free_composite_vlsm).
+    + by cbv; itauto.
     + by apply Hdeps.
 Qed.
 
@@ -891,8 +900,7 @@ Proof.
   intros [om Hproto].
   apply preloaded_valid_state_prop_iff.
   induction Hproto.
-  - apply preloaded_valid_initial_state.
-    apply (Hs i).
+  - by apply preloaded_valid_initial_state, (Hs i).
   - destruct l as [j lj].
     simpl in Ht. unfold vtransition in Ht. simpl in Ht.
     destruct (vtransition (IM j) _ _) as (si', _om') eqn:Hti.
@@ -958,7 +966,7 @@ Proof.
   intro Hptrans.
   apply preloaded_weaken_input_valid_transition in Hptrans.
   revert Hptrans.
-  apply input_valid_transition_preloaded_project_active.
+  by apply input_valid_transition_preloaded_project_active.
 Qed.
 
 Lemma input_valid_transition_preloaded_project_any {V} (i:V)
@@ -980,7 +988,7 @@ Proof.
     exists lj.
     split; [done |].
     revert Hptrans.
-    apply input_valid_transition_preloaded_project_active.
+    by apply input_valid_transition_preloaded_project_active.
   - left.
     destruct Hptrans as [Hpvalid Htrans].
     cbn in Htrans.
@@ -1003,7 +1011,7 @@ Proof.
   intro Hproto.
   apply preloaded_weaken_input_valid_transition in Hproto.
   revert Hproto.
-  apply input_valid_transition_preloaded_project_any.
+  by apply input_valid_transition_preloaded_project_any.
 Qed.
 
 (**
@@ -1023,7 +1031,7 @@ Proof.
   apply can_emit_iff.
   exists (s2 (projT1 l)).
   exists (s1 (projT1 l), oim), (projT2 l).
-  revert Ht. apply input_valid_transition_preloaded_project_active.
+  by eapply input_valid_transition_preloaded_project_active.
 Qed.
 
 Section sec_binary_free_composition.
@@ -1092,7 +1100,7 @@ Proof.
     split; intros [i Hm]; exists i.
     + by exists (exist _ _ Hm).
     + by destruct Hm as [[im Hinit] [= ->]].
-  - apply @Exists_dec. intro i. apply Hdec_init.
+  - by apply @Exists_dec; intro i; apply Hdec_init.
 Qed.
 
 End sec_composite_decidable_initial_message.
@@ -1138,7 +1146,7 @@ Proof.
   simpl in i.
   unfold i in Heq.
   rewrite <- Heq.
-  itauto.
+  by itauto.
 Qed.
 
 (* The effect of the transition is also the same. *)
@@ -1195,8 +1203,7 @@ Proof.
   - assert (Ht' : input_valid_transition Free label_a (s', input_a) (s0, o)). {
       unfold input_valid_transition in *.
       destruct Ht as [Hpr_valid Htrans].
-      apply relevant_component_transition with (s' := s') in Hpr_valid.
-      all : itauto.
+      by apply relevant_component_transition with (s' := s') in Hpr_valid; itauto.
     }
 
     apply finite_valid_trace_from_extend; [| done].
@@ -1212,7 +1219,7 @@ Proof.
     | let (_, _) := ?t in _ => replace t with (s0, o) in Hrel
     end.
     unfold i.
-    itauto.
+    by itauto.
 Qed.
 
 (**
@@ -1258,7 +1265,7 @@ Lemma irrelevant_components
   (res i) = (s i).
 Proof.
   induction a using rev_ind.
-  - simpl; itauto.
+  - by simpl; itauto.
   - simpl in *.
     rewrite (composite_apply_plan_app IM).
     destruct (composite_apply_plan IM s a) as (tra, sa) eqn : eq_a; simpl in *.
@@ -1284,7 +1291,7 @@ Proof.
     rewrite elem_of_app in Hdif; simpl in Hdif.
     contradict Hdif.
     subst.
-    right; left.
+    by right; left.
 Qed.
 
 (* Same as relevant_components_one but for multiple transitions. *)
@@ -1315,7 +1322,7 @@ Proof.
       unfold a_indices.
       intros e H; simpl.
       rewrite 2 map_app, elem_of_app.
-      itauto.
+      by itauto.
     }
 
     spec IHa; [done |].
@@ -1324,10 +1331,7 @@ Proof.
 
     specialize (relevant_components_one (snd (apply_plan Free s a)) (snd (apply_plan Free s' a))) as Hrel.
 
-    spec Hrel. {
-      apply apply_plan_last_valid.
-      all : itauto.
-    }
+    spec Hrel; [by apply apply_plan_last_valid; itauto |].
 
     specialize (Hrel x); simpl in *.
 
@@ -1338,15 +1342,13 @@ Proof.
       specialize (Hincl (projT1 (label_a x))).
       apply Hincl.
       unfold a_indices.
-      rewrite 2 map_app, elem_of_app.
-      right; left.
+      by rewrite 2 map_app, elem_of_app; right; left.
     }
 
     specialize (Hrel Hsingle).
     destruct Hrel as [Hrelpr Hrelind].
     split.
-    + apply finite_valid_plan_from_app_iff.
-      split; itauto.
+    + by apply finite_valid_plan_from_app_iff; split.
     + intros i Hi.
       specialize (IHaind i Hi).
       specialize (Heq i Hi).
@@ -1363,7 +1365,7 @@ Proof.
         as (trx', sx') eqn : eq_xsa'.
       simpl in *.
       destruct (decide (i = (projT1 (label_a x)))).
-      * rewrite e; itauto.
+      * by rewrite e.
       * specialize (irrelevant_components_one sa) as Hdiff.
         specialize (Hdiff x i n).
 
@@ -1395,33 +1397,33 @@ Lemma empty_composition_no_index
   (i : index)
   : False.
 Proof.
-  specialize (elem_of_enum i); rewrite Hempty_index; apply not_elem_of_nil.
+  by specialize (elem_of_enum i); rewrite Hempty_index; apply not_elem_of_nil.
 Qed.
 
 Lemma empty_composition_single_state
   (s : composite_state IM)
   : s = (proj1_sig (composite_s0 IM)).
 Proof.
-  extensionality i; elim (empty_composition_no_index i).
+  by extensionality i; elim (empty_composition_no_index i).
 Qed.
 
 Lemma empty_composition_no_label
   (l : composite_label IM)
   : False.
 Proof.
-  destruct l as (i, _). elim (empty_composition_no_index i).
+  by destruct l as [i _]; elim (empty_composition_no_index i).
 Qed.
 
 Lemma empty_composition_no_initial_message
   : forall m, ~ composite_initial_message_prop IM m.
 Proof.
-  intros m [i _]. elim (empty_composition_no_index i).
+  by intros m [i _]; elim (empty_composition_no_index i).
 Qed.
 
 Lemma empty_composition_no_emit
   : forall m, ~ can_emit X m.
 Proof.
-  intros m [s' [l _]]; elim (empty_composition_no_label l).
+  by intros m [s' [l _]]; elim (empty_composition_no_label l).
 Qed.
 
 Lemma empty_composition_no_valid_message
@@ -1429,8 +1431,8 @@ Lemma empty_composition_no_valid_message
 Proof.
   intros m Hm.
   apply emitted_messages_are_valid_iff in Hm as [Hinit | Hemit].
-  - elim (empty_composition_no_initial_message _ Hinit).
-  - elim (empty_composition_no_emit _ Hemit).
+  - by elim (empty_composition_no_initial_message _ Hinit).
+  - by elim (empty_composition_no_emit _ Hemit).
 Qed.
 
 Lemma pre_loaded_empty_composition_no_emit
@@ -1438,13 +1440,13 @@ Lemma pre_loaded_empty_composition_no_emit
   (PreX := pre_loaded_vlsm X seed)
   : forall m, ~ can_emit PreX m.
 Proof.
-  intros m [s' [l _]]; elim (empty_composition_no_label l).
+  by intros m [s' [l _]]; elim (empty_composition_no_label l).
 Qed.
 
 Lemma pre_loaded_with_all_empty_composition_no_emit
   : forall m, ~ can_emit (pre_loaded_with_all_messages_vlsm X) m.
 Proof.
-  intros m [s' [l _]]; elim (empty_composition_no_label l).
+  by intros m [s' [l _]]; elim (empty_composition_no_label l).
 Qed.
 
 End sec_empty_composition_properties.
@@ -1498,10 +1500,10 @@ Proof.
   - destruct Hv as [Hs [Hom [Hv Hc]]].
     apply constraint_projection in Hc; cycle 1.
     + apply VLSM_incl_valid_state; [| done].
-      apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
+      by apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
     + split; [| done].
       clear Hc. revert Hv. destruct l as (i, li). cbn.
-      apply same_VLSM_valid_preservation.
+      by apply same_VLSM_valid_preservation.
   - apply proj2 in H. revert H. destruct l as (i, li). cbn.
     destruct (vtransition (IM1 i) _ _) as (si'1, _om') eqn: Ht1.
     unfold same_IM_state_rew at 1.
@@ -1510,14 +1512,14 @@ Proof.
     f_equal. extensionality j.
     unfold same_IM_state_rew at 2.
     by destruct (decide (i = j)); subst; state_update_simpl.
-  - intros i. apply same_VLSM_initial_state_preservation, H.
+  - by intros i; apply same_VLSM_initial_state_preservation, H.
   - apply initial_message_is_valid.
     destruct HmX as [[i [[im Him] Hi]] | Hseed]; [| by right].
     simpl in Hi. subst im.
     cbn. unfold composite_initial_message_prop.
     left. exists i.
     assert (Hm : vinitial_message_prop (IM2 i) m).
-    + eapply same_VLSM_initial_message_preservation; eauto.
+    + by eapply same_VLSM_initial_message_preservation; eauto.
     + by exists (exist _ m Hm).
 Qed.
 
@@ -1598,7 +1600,7 @@ Lemma composite_valid_transition_projection :
     ValidTransition (IM (projT1 l)) (projT2 l) (s1 (projT1 l)) iom (s2 (projT1 l)) oom /\
     s2 = state_update IM s1 (projT1 l) (s2 (projT1 l)).
 Proof.
-  intros [i li] * [Hv Ht]; cbn in Ht; destruct (vtransition _ _ _) eqn:Hti.
+  intros [i li] * [Hv Ht]; cbn in Ht; destruct (vtransition _ _ _) eqn: Hti.
   by inversion Ht; subst; cbn; state_update_simpl.
 Qed.
 
@@ -1708,7 +1710,7 @@ Proof.
       assert (Hss1 : input_valid_transition RFree (existT i li)
                   (state_update IM s j (s1 j), om) (s1, om')).
       {
-        repeat split; [apply IHHs2 | apply any_message_is_valid_in_preloaded |..]
+        repeat split; [by apply IHHs2 | by apply any_message_is_valid_in_preloaded |..]
         ; cbn; state_update_simpl; [done |].
         replace (vtransition _ _ _) with (s' i, om').
         f_equal; extensionality k; apply f_equal with (f := fun s => s k) in Heqs'.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -679,7 +679,7 @@ Proof.
   intros j m Hm.
   eapply VLSM_incl_can_emit.
   - apply (pre_loaded_vlsm_incl_relaxed _ (fun m => Q m \/ P m)).
-  - by itauto.
+    by itauto.
   - eapply VLSM_full_projection_can_emit; [| done].
     apply lift_to_composite_generalized_preloaded_vlsm_full_projection.
     by itauto.

--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -72,17 +72,17 @@ Qed.
 
 (** [Label]s, [State]s, [Observation]s and [Message]s have decidable equality. *)
 #[export] Instance EqDecision_Label : EqDecision Label.
-Proof. intros x y; unfold Decision; decide equality. Defined.
+Proof. by intros x y; unfold Decision; decide equality. Defined.
 
 #[local] Lemma State_eq_dec : forall x y : State, {x = y} + {x <> y}
 with Observation_eq_dec : forall x y : Observation, {x = y} + {x <> y}
 with Message_eq_dec : forall x y : Message, {x = y} + {x <> y}.
 Proof.
   - intros x y; decide equality.
-    + apply EqDecision0.
-    + decide equality.
-  - do 2 decide equality.
-  - intros x y; decide equality.
+    + by apply EqDecision0.
+    + by decide equality.
+  - by do 2 decide equality.
+  - by intros x y; decide equality.
 Defined.
 
 #[export] Instance EqDecision_State : EqDecision State := State_eq_dec.
@@ -154,9 +154,8 @@ Lemma addObservation_ind (P : State -> Prop)
   forall obs, P obs.
 Proof.
   intros [obs a].
-  induction obs using addObservation'_ind.
-  - done.
-  - by apply (Hadd ob) in IHobs.
+  induction obs using addObservation'_ind; [done |].
+  by apply (Hadd ob) in IHobs.
 Qed.
 
 Lemma addObservation_rec (P : State -> Set)
@@ -309,12 +308,12 @@ end.
 
 #[export] Instance isSend_dec (ob : Observation) : Decision (isSend ob).
 Proof.
-  destruct ob as [[] m]; cbn; typeclasses eauto.
+  by destruct ob as [[] m]; cbn; typeclasses eauto.
 Defined.
 
 #[export] Instance isReceive_dec (ob : Observation) : Decision (isReceive ob).
 Proof.
-  destruct ob as [[] m]; cbn; typeclasses eauto.
+  by destruct ob as [[] m]; cbn; typeclasses eauto.
 Defined.
 
 Definition messages' (obs : list Observation) : list Message :=
@@ -546,7 +545,7 @@ Proof.
   induction s using addObservation_ind; inversion 1; subst.
   - by destruct ob as [? []]; unfold sizeState; cbn; lia.
   - etransitivity; [by apply IHs |].
-    destruct s, ob as [? []]; unfold sizeState; cbn; lia.
+    by destruct s, ob as [? []]; unfold sizeState; cbn; lia.
 Qed.
 
 Lemma messages_sizeState :

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -332,7 +332,7 @@ Proof.
   - intros l s im s' om [(Hvsp & Hovmp & Hv) Ht] m; cbn in *.
     destruct l, im; cbn in *; [| by exfalso; inversion Hv..|];
     inversion_clear Ht; destruct s; cbn.
-    + rewrite decide_False; cbn; firstorder congruence.
+    + by rewrite decide_False; cbn; firstorder congruence.
     + rewrite decide_True by done; cbn.
       unfold Message; rewrite elem_of_cons.
       by firstorder congruence.
@@ -786,9 +786,9 @@ Lemma local_equivocators_iff_full (s : State) :
   forall a, local_equivocators s a <-> local_equivocators_full s a.
 Proof.
   intros Hs a.
-  rewrite local_equivocators_iff_simple
-  ; [apply local_equivocators_simple_iff_full |]
-  ; revert Hs; apply UMO_reachable_impl; itauto.
+  by rewrite local_equivocators_iff_simple;
+    [apply local_equivocators_simple_iff_full |];
+    revert Hs; apply UMO_reachable_impl; itauto.
 Qed.
 
 (**
@@ -1216,7 +1216,7 @@ Qed.
   TraceableVLSM Ei ELMOComponent_state_destructor sizeState.
 Proof.
   constructor.
-  - typeclasses eauto.
+  - by typeclasses eauto.
   - by intros [[| [[] ?] ?] ?] *; [inversion 1 |..];
       intro Hitem; apply elem_of_list_singleton in Hitem;
       inversion_clear Hitem.
@@ -1357,7 +1357,7 @@ Proof.
     - by destruct Hequ as (m & Hadr & (k & l & Hrec_obs) & Hnot_sent); eauto.
   }
   pose proof @rec_obs_exists_dec.
-  typeclasses eauto.
+  by typeclasses eauto.
 Defined.
 
 Set Warnings "-cannot-define-projection".
@@ -1575,9 +1575,9 @@ Lemma ELMO_state_to_minimal_equivocation_trace_equivocation_monotonic :
         (destination item) v.
 Proof.
   eapply state_to_minimal_equivocation_trace_equivocation_monotonic.
-  - intro; apply MessageDependencies_ELMOComponent.
-  - typeclasses eauto.
-  - apply ELMO_channel_authentication_prop.
+  - by intro; apply MessageDependencies_ELMOComponent.
+  - by typeclasses eauto.
+  - by apply ELMO_channel_authentication_prop.
 Qed.
 
 (**
@@ -1597,7 +1597,7 @@ Proof.
   - destruct Hequiv as (m & Hadr & (k & l & Hrobs) & Hnot_sent).
     enough (composite_has_been_received _ s m) by (econstructor; done).
     assert (m ∈ messages (s k)) as Hm.
-    + by apply full_node_messages_iff_rec_obs;[| eexists].
+    + by apply full_node_messages_iff_rec_obs; [| eexists].
     + by apply elem_of_messages in Hm as [|];
         [contradict Hnot_sent |]; exists k.
   - destruct Hequiv as [m Hadr [i_rec Hrecv] Hnot_sent].
@@ -1691,7 +1691,7 @@ Proof.
   rewrite ELMO_global_equivocators_iff_msg_dep_equivocation by done.
   rewrite <- global_equivocators_simple_iff_full_node_equivocation by done.
   pose proof @ELMOComponent_message_dependencies_full_node_condition.
-  by rewrite full_node_is_globally_equivocating_iff;[| typeclasses eauto |..].
+  by rewrite full_node_is_globally_equivocating_iff; [| typeclasses eauto |..].
 Qed.
 
 (**
@@ -1756,7 +1756,7 @@ Proof.
     apply Forall_forall; intros item Hitem m Hobs.
     eapply directly_observed_valid; [done |].
     unshelve eapply EquivocationProjections.VLSM_incl_has_been_directly_observed_reflect; cycle 3;
-      [apply preloaded_constraint_free_incl |..| typeclasses eauto | typeclasses eauto].
+      [by apply preloaded_constraint_free_incl | .. | by typeclasses eauto | by typeclasses eauto].
     - by generalize Hs; apply VLSM_incl_valid_state, vlsm_incl_pre_loaded_with_all_messages_vlsm.
     - eapply has_been_directly_observed_examine_one_trace; [done |].
       by apply Exists_exists; eexists; cbn; eauto.
@@ -2057,7 +2057,7 @@ Proof.
     unfold ELMO_global_constraint.
     replace (composite_transition _ _ _) with (state_update ELMOComponent sf i si, oom).
     unfold ELMO_not_heavy, not_heavy; etransitivity; [| done].
-    apply sum_weights_subseteq; [apply NoDup_elements.. |].
+    apply sum_weights_subseteq; [by apply NoDup_elements.. |].
     by intro; rewrite !elem_of_elements; apply Hsfisi_eqvs.
   }
   apply (VLSM_incl_finite_valid_trace_init_to Hincl) in Htr_min as Htr_min_pre.
@@ -2099,7 +2099,7 @@ Proof.
   destruct (decide (i_a = i)); [by subst; right | left].
   contradict ges_not_sent.
   eapply has_been_sent_iff_by_sender in ges_not_sent; cycle 1.
-  - apply channel_authentication_sender_safety, ELMO_channel_authentication_prop.
+  - by apply channel_authentication_sender_safety, ELMO_channel_authentication_prop.
   - done.
   - done.
   - rewrite ges_adr, ELMO_A_inv in ges_not_sent by done.
@@ -2188,9 +2188,9 @@ Proof.
     Forall (fun item => forall m, item_sends_or_receives m item ->
       valid_message_prop ELMOProtocol m) tr_m).
   {
-    eapply Forall_impl; cbn; [apply Hall_messages_observed |].
+    eapply Forall_impl; cbn; [by apply Hall_messages_observed |].
     intros item Hobs dm Hdm.
-    eapply directly_observed_valid; [apply Hs |].
+    eapply directly_observed_valid; [by apply Hs |].
     by apply Hobs, elem_of_messages in Hdm as []; [left | right]; eexists i.
   }
   assert (Heqis_m : is_m = MkState [] (idx i_m))
@@ -2338,7 +2338,7 @@ Proof.
       unfold ELMO_not_heavy, not_heavy.
       etransitivity; [| done].
       apply sum_weights_subseteq; [by apply NoDup_elements.. |].
-      intro; rewrite !elem_of_elements; apply Hsf_bounded_eqv.
+      by intro; rewrite !elem_of_elements; apply Hsf_bounded_eqv.
     - cbn; state_update_simpl.
       replace (UMOComponent_transition _ _ _) with (sf, oom).
       by rewrite state_update_twice.
@@ -2347,10 +2347,10 @@ Proof.
     (input_valid_transition ELMOProtocol (existT i_m Send)
       (lift_to_composite_state ELMOComponent s i_m (state m), None)
       (lift_to_composite_state ELMOComponent s i_m (state m <+> MkObservation Send m), Some m)
-    ); [apply input_valid_transition_out |].
+    ); [by apply input_valid_transition_out |].
   repeat split.
   - by apply finite_valid_trace_from_to_last_pstate in Htr_m_lift.
-  - apply option_valid_message_None.
+  - by apply option_valid_message_None.
   - by constructor.
   - by cbn; state_update_simpl; rewrite state_update_twice; destruct m.
 Qed.
@@ -2583,7 +2583,7 @@ Proof.
     by (eapply Htr_m_inputs_in_sigma;
       [apply elem_of_app; right; apply elem_of_list_singleton |]; done).
   edestruct IHHtr_m as [Htr Hall];
-    [..| split; [eapply finite_valid_trace_from_to_app; [apply Htr |] |]].
+    [..| split; [eapply finite_valid_trace_from_to_app; [by apply Htr |] |]].
   - done.
   - intros item msg Hitem Hmsg.
     by eapply Htr_m_inputs_in_sigma; [apply elem_of_app; left |].
@@ -2891,7 +2891,7 @@ Proof.
         unfold local_equivocation_limit_ok, not_heavy in Hlocal_ok.
         unfold ELMO_not_heavy, not_heavy.
         etransitivity; [| done].
-        apply sum_weights_subseteq; [apply NoDup_elements.. |].
+        apply sum_weights_subseteq; [by apply NoDup_elements.. |].
         intros x; rewrite !elem_of_elements.
         unfold equivocating_validators, is_equivocating; cbn.
         apply filter_subprop; intros; rewrite <- Heq_i in *.
@@ -2997,7 +2997,7 @@ Proof.
         -- split; [| by left].
            intros [| [_ Hnsnd]]; [done |].
            by contradict Hnsnd; exists i_m; state_update_simpl; left.
-      * etransitivity; [apply Hchi_eqvs |].
+      * etransitivity; [by apply Hchi_eqvs |].
         rewrite Heqi; split.
         -- by intros Heqv; eapply local_equivocators_full_step_update; [constructor | left].
         -- intros Heqv.
@@ -3023,8 +3023,8 @@ Proof.
   inversion Hvi; subst; inversion Hti as [Heqs'i]; subst;
     symmetry in Heqs'i; destruct (Htransitions _ Heqs'i) as [Hvs'0 Hvt0];
     inversion Hvt0 as [? ? ? ? Hvt | ? ? ? ? Hvt].
-  - repeat split; [done | | apply Hvt..].
-    eapply composite_received_valid; [apply Hs' |].
+  - repeat split; [done | | by apply Hvt..].
+    eapply composite_received_valid; [by apply Hs' |].
     by eexists; eapply has_been_received_step_update; [| left].
   - by repeat split; [| apply option_valid_message_None | apply Hvt].
 Qed.

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -126,13 +126,13 @@ Lemma MO_msg_valid_alt_sends_shorten :
 Proof.
   split.
   - unfold MO_msg_valid_alt_sends, MO_msg_valid_alt_sends_bounded.
-    intros Hs k suffix m' _ Hlast. by eapply Hs.
+    by intros Hs k suffix m' _ Hlast; eapply Hs.
   - unfold MO_msg_valid_alt_sends, MO_msg_valid_alt_sends_bounded.
     intros Hs k suffix m' Hlast.
     destruct (decide (k <= length (obs (state m)))).
     + by eapply Hs.
     + apply (Hs (length (obs (state m)))); [lia |].
-      rewrite lastn_ge in *; [done | lia | lia].
+      by rewrite lastn_ge in *; [| lia | lia].
 Qed.
 
 Lemma MO_msg_valid_alt_recvs_shorten :
@@ -141,13 +141,13 @@ Lemma MO_msg_valid_alt_recvs_shorten :
 Proof.
   split.
   - unfold MO_msg_valid_alt_recvs, MO_msg_valid_alt_recvs', MO_msg_valid_alt_recvs_bounded.
-    intros Hr k suffix m' _ Hlast. by eapply Hr.
+    by intros Hr k suffix m' _ Hlast; eapply Hr.
   - unfold MO_msg_valid_alt_recvs, MO_msg_valid_alt_recvs', MO_msg_valid_alt_recvs_bounded.
     intros Hr k suffix m' Hlast.
     destruct (decide (k <= length (obs (state m)))).
     + by eapply Hr.
     + apply (Hr (length (obs (state m))) suffix); [lia |].
-      rewrite lastn_ge in *; [done | lia | lia].
+      by rewrite lastn_ge in *; [| lia | lia].
 Qed.
 
 (**
@@ -216,7 +216,8 @@ Proof.
   unfold MO_msg_valid_alt_recvs, MO_msg_valid_alt_recvs'; cbn; unfold addObservation'.
   intros Hv k suffix m' Hlen Hlast.
   destruct (decide (1 + length (obs (state m)) <= k)); [lia |].
-  apply (Hv k suffix). rewrite lastn_cons. by case_decide; [lia |].
+  apply (Hv k suffix). rewrite lastn_cons.
+  by case_decide; [lia |].
 Qed.
 
 Lemma MO_msg_valid_alt_Send_conv :
@@ -279,7 +280,8 @@ Proof.
   unfold MO_msg_valid_alt_sends; cbn; unfold addObservation'.
   intros Hv k suffix m' Hlen Hlast.
   destruct (decide (1 + length (obs (state m)) <= k)); [lia |].
-  apply Hv with k. rewrite lastn_cons. by case_decide; [lia |].
+  apply Hv with k.
+  by rewrite lastn_cons; case_decide; [lia |].
 Qed.
 
 Lemma MO_msg_valid_alt_recvs_Receive_conv :
@@ -293,7 +295,8 @@ Proof.
   intros Hv; split.
   - intros k suffix m' Hlen Hlast.
     destruct (decide (1 + length (obs (state m)) <= k)); [lia |].
-    apply (Hv k suffix). rewrite lastn_cons. by case_decide; [lia |].
+    apply (Hv k suffix). rewrite lastn_cons.
+    by case_decide; [lia |].
   - apply (Hv (1 + length (obs (state m))) (obs (state m))).
     by rewrite lastn_ge; cbn; [| lia ].
 Qed.
@@ -323,7 +326,7 @@ Proof.
   specialize (Hvs (1 + length (obs (state m1))) (obs (state m1)) m2).
   rewrite lastn_cons in Hvs; case_decide; [| lia].
   destruct (Hvs eq_refl) as [].
-  destruct m1 as [[]], m2 as [[]]; cbn in *; congruence.
+  by destruct m1 as [[]], m2 as [[]]; cbn in *; congruence.
 Qed.
 
 (**
@@ -341,7 +344,7 @@ Lemma MO_msg_valid__MO_msg_valid_alt :
 Proof.
   split; [| revert m].
   - induction 1 as [m Hobs | m Hm IH | m mr Hm IHm Hmr IHmr].
-    + constructor; [done | |]
+    + by constructor; [done | |]
       ; intros k suffix m' Hlast
       ; rewrite Hobs, lastn_nil in Hlast; inversion Hlast.
     + by apply MO_msg_valid_alt_Send.
@@ -415,7 +418,7 @@ Context
 Lemma VLSM_incl_Mi_RMi :
   VLSM_incl_part (vmachine Mi) (vmachine RMi).
 Proof.
-  apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
 (** The initial state of [RMi] is unique. *)
@@ -424,7 +427,7 @@ Lemma vs0_uniqueness :
     UMOComponent_initial_state_prop i is ->
       is = ``(vs0 RMi).
 Proof.
-  intros []; inversion 1; cbv in *; by subst.
+  by intros []; inversion 1; cbv in *; subst.
 Qed.
 
 (** *** Properties of transitions and traces *)
@@ -440,7 +443,7 @@ Proof.
   intros s Hvsp.
   red; cbn; split_and!; [done | | | done].
   - by exists (MkState [] i); constructor.
-  - do 2 constructor.
+  - by do 2 constructor.
 Qed.
 
 (** In a valid state <<s>>, we can receive any valid message. *)
@@ -470,7 +473,7 @@ Proof.
     by apply input_valid_transition_Send_RMi, IH.
   - apply (@input_valid_transition_destination _ RMi Receive (state m) _ (Some mr) None).
     destruct m as [s]; cbn in *.
-    apply input_valid_transition_Receive_RMi; itauto.
+    by apply input_valid_transition_Receive_RMi; itauto.
 Qed.
 
 (** Valid transitions and valid traces lead to bigger states. *)
@@ -503,7 +506,7 @@ Proof.
   induction 1; [by left |].
   assert (sizeState s' < sizeState s)
       by (eapply input_valid_transition_size_RMi; done).
-  destruct IHfinite_valid_trace_from_to; [itauto congruence | itauto lia].
+  by destruct IHfinite_valid_trace_from_to; [itauto congruence | itauto lia].
 Qed.
 
 (**
@@ -523,7 +526,7 @@ Proof.
   ; inversion Ht1; subst; clear Ht1
   ; inversion Ht2; subst; clear Ht2
   ; inversion Hvalid1; inversion Hvalid2; invert_MOComponentValid; auto.
-  destruct s1, s2; cbn in *; subst; itauto.
+  by destruct s1, s2; cbn in *; subst; itauto.
 Qed.
 
 (** Trace segments between any two states are unique. *)
@@ -535,11 +538,11 @@ Lemma finite_valid_trace_from_to_unique_RMi :
 Proof.
   intros s1 s2 tr1 tr2 Hfvt1 Hfvt2; revert tr2 Hfvt2.
   induction Hfvt1 using finite_valid_trace_from_to_rev_ind; intros.
-  - apply finite_valid_trace_from_to_size_RMi in Hfvt2; itauto (congruence + lia).
+  - by apply finite_valid_trace_from_to_size_RMi in Hfvt2; itauto (congruence + lia).
   - destruct Hfvt2 using finite_valid_trace_from_to_rev_ind; [| clear IHHfvt2].
     + apply finite_valid_trace_from_to_size_RMi in Hfvt1.
       apply input_valid_transition_size_RMi in Ht.
-      decompose [and or] Hfvt1; subst; clear Hfvt1; lia.
+      by decompose [and or] Hfvt1; subst; clear Hfvt1; lia.
     + assert (l = l0 /\ s = s0 /\ iom = iom0 /\ oom = oom0)
           by (eapply input_valid_transition_deterministic_conv_RMi; done).
       decompose [and] H; subst; clear H.
@@ -570,7 +573,7 @@ Proof.
   intros s Hvsp.
   red; cbn; split_and!; [done | | | done].
   - by exists (MkState [] i); constructor.
-  - do 2 constructor.
+  - by do 2 constructor.
 Qed.
 
 Lemma input_valid_transition_size_Mi :
@@ -580,7 +583,7 @@ Lemma input_valid_transition_size_Mi :
 Proof.
   intros s1 s2 iom oom lbl Hivt.
   eapply input_valid_transition_size_RMi.
-  apply (@VLSM_incl_input_valid_transition _ (vtype Mi) (vmachine Mi) (vmachine RMi))
+  by apply (@VLSM_incl_input_valid_transition _ (vtype Mi) (vmachine Mi) (vmachine RMi))
   ; eauto using VLSM_incl_Mi_RMi.
 Qed.
 
@@ -593,7 +596,7 @@ Lemma finite_valid_trace_from_to_size_Mi :
 Proof.
   intros s1 s2 tr Hfvt.
   eapply finite_valid_trace_from_to_size_RMi.
-  apply (@VLSM_incl_finite_valid_trace_from_to _ (vtype Mi) (vmachine Mi) (vmachine RMi))
+  by apply (@VLSM_incl_finite_valid_trace_from_to _ (vtype Mi) (vmachine Mi) (vmachine RMi))
   ; eauto using VLSM_incl_Mi_RMi.
 Qed.
 
@@ -604,7 +607,7 @@ Lemma input_valid_transition_deterministic_conv_Mi :
       lbl1 = lbl2 /\ s1 = s2 /\ iom1 = iom2 /\ oom1 = oom2.
 Proof.
   intros s1 s2 f iom1 iom2 oom1 oom2 lbl1 lbl2 Hivt1 Hivt2.
-  eapply input_valid_transition_deterministic_conv_RMi
+  by eapply input_valid_transition_deterministic_conv_RMi
   ; apply (@VLSM_incl_input_valid_transition _ (vtype Mi) (vmachine Mi) (vmachine RMi))
   ; eauto using VLSM_incl_Mi_RMi.
 Qed.
@@ -615,7 +618,7 @@ Lemma finite_valid_trace_from_to_unique_Mi :
     finite_valid_trace_from_to Mi s1 s2 l2 ->
       l1 = l2.
 Proof.
-  intros s1 s2 l1 l2 Hfvt1 Hfvt2
+  by intros s1 s2 l1 l2 Hfvt1 Hfvt2
   ; eapply finite_valid_trace_from_to_unique_RMi
   ; apply VLSM_incl_finite_valid_trace_from_to
   ; eauto using VLSM_incl_Mi_RMi.
@@ -627,7 +630,7 @@ Lemma finite_valid_trace_init_to_unique_Mi :
     finite_valid_trace_init_to Mi s f l2 ->
       l1 = l2.
 Proof.
-  intros s f l1 l2 Hfvit1 Hfvit2
+  by intros s f l1 l2 Hfvit1 Hfvit2
   ; eapply finite_valid_trace_init_to_unique_RMi
   ; apply VLSM_incl_finite_valid_trace_init_to
   ; eauto using VLSM_incl_Mi_RMi.
@@ -646,18 +649,17 @@ Proof.
   induction Hfv using finite_valid_trace_from_to_rev_ind; intros.
   - inversion Hinit; clear Hinit.
     destruct si; cbn in *; subst; cbn.
-    repeat constructor. exists None. repeat constructor.
+    repeat constructor. exists None.
+    by repeat constructor.
   - specialize (IHHfv Hinit).
     destruct Ht as [Hvalid Ht]; cbn in Ht.
     destruct s as [obs adr], l, iom as [im |]
     ; inversion Ht; subst; clear Ht; cbn in *
     ; cycle 1; [done | done | |].
     + constructor; [| done].
-      eapply extend_right_finite_trace_from_to
-      ; [apply IHHfv | split]; auto.
+      by eapply extend_right_finite_trace_from_to; [apply IHHfv |]; auto.
     + constructor; [| done].
-      eapply extend_right_finite_trace_from_to
-      ; [apply IHHfv | split]; auto.
+      by eapply extend_right_finite_trace_from_to; [apply IHHfv |]; auto.
 Qed.
 
 (** The trace extracted from the final state of another trace is equal to that trace. *)
@@ -684,7 +686,7 @@ Proof.
   apply valid_state_has_trace in Hs as (is & tr & Htr).
   apply finite_valid_trace_init_to_state2trace_RMi_inv in Htr as Heqtr; subst.
   replace (``(vs0 RMi)) with is; [done |].
-  apply vs0_uniqueness, Htr.
+  by apply vs0_uniqueness, Htr.
 Qed.
 
 Lemma valid_state_contains_unique_valid_trace_RMi :
@@ -741,7 +743,7 @@ Proof.
   }
   destruct H1 as [H11 H12], H2 as [H21 H22].
   split.
-  - constructor; [congruence |].
+  - constructor; [by congruence |].
     rewrite H11, H21; cbn.
     split.
     + by apply suffix_app_r, suffix_cons_r.
@@ -1121,11 +1123,12 @@ Proof.
   induction is as [| i is']; cbn; intros us Hall Hvsp.
   - replace us with (λ n : index, MkState [] (idx n)).
     + by constructor; apply initial_state_is_valid; compute.
-    + extensionality i. rewrite Hall; [done |]. apply not_elem_of_nil.
+    + extensionality i; rewrite Hall; [done |].
+      by apply not_elem_of_nil.
   - eapply finite_valid_trace_from_to_app.
     + apply IHis'.
       * intros j Hj. destruct (decide (i = j)); subst; state_update_simpl; [done |].
-        apply Hall. rewrite elem_of_cons. by intros [].
+        by apply Hall; rewrite elem_of_cons; intros [].
       * apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True MO)).
         apply pre_composite_free_update_state_with_initial; [| by compute].
         by apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True MO)).
@@ -1134,7 +1137,7 @@ Proof.
       apply (valid_state_project_preloaded_to_preloaded _ _ _ us i) in Hvsp as Hvsp'.
       apply valid_state_has_trace in Hvsp' as (s & tr & [Hfvt Hinit]).
       replace s with (MkState [] (idx i)) in *; cycle 1.
-      * inversion Hinit. by destruct s; cbn in *; subst.
+      * by inversion Hinit; destruct s; cbn in *; subst.
       * by eapply finite_valid_trace_init_to_state2trace_RMi.
 Qed.
 

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -94,14 +94,14 @@ Lemma UMOComponent_initial_state_unique :
     UMOComponent_initial_state_prop i s2 ->
       s1 = s2.
 Proof.
-  do 2 inversion 1. by destruct s1, s2; cbn in *; subst.
+  by do 2 inversion 1; destruct s1, s2; cbn in *; subst.
 Qed.
 
 Lemma UMOComponent_initial_state_spec :
   forall {i : Address} {s : State},
     UMOComponent_initial_state_prop i s -> s = MkState [] i.
 Proof.
-  inversion 1. by destruct s; cbn in *; subst.
+  by inversion 1; destruct s; cbn in *; subst.
 Qed.
 
 #[export]
@@ -114,9 +114,10 @@ Proof.
   - intros l s im s' om [(Hvsp & Hovmp & Hv) Ht] m; cbn in *.
     destruct l, im; cbn in *; invert_UMOComponentValid
     ; inversion Ht; subst; clear Ht; cbn.
-    + rewrite decide_False; cbn; firstorder congruence.
+    + by rewrite decide_False; cbn; firstorder congruence.
     + rewrite decide_True by done; cbn.
-      unfold Message; rewrite elem_of_cons. firstorder congruence.
+      unfold Message; rewrite elem_of_cons.
+      by firstorder congruence.
 Defined.
 
 #[export]
@@ -130,8 +131,9 @@ Proof.
     destruct l, im; cbn in *; invert_UMOComponentValid
     ; inversion Ht; subst; clear Ht; cbn.
     + rewrite decide_True by done; cbn.
-      unfold Message; rewrite elem_of_cons. firstorder congruence.
-    + rewrite decide_False; cbn; firstorder congruence.
+      unfold Message; rewrite elem_of_cons.
+      by firstorder congruence.
+    + by rewrite decide_False; cbn; firstorder congruence.
 Defined.
 
 #[export]
@@ -307,7 +309,7 @@ Context
 Lemma VLSM_incl_Ui_Ri :
   VLSM_incl_part (vmachine Ui) (vmachine Ri).
 Proof.
-  apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
 Lemma UMO_reachable_Ui :
@@ -336,7 +338,7 @@ Lemma vs0_uniqueness :
     UMOComponent_initial_state_prop i is ->
       is = ``(vs0 Ri).
 Proof.
-  intros []; inversion 1; cbv in *; by subst.
+  by intros []; inversion 1; cbv in *; by subst.
 Qed.
 
 (** Transitions of an UMO component preserve the address of the component. *)
@@ -450,7 +452,7 @@ Proof.
   induction 1; [by left |].
   assert (sizeState s' < sizeState s)
       by (eapply input_valid_transition_size_Ri; done).
-  destruct IHfinite_valid_trace_from_to; [itauto congruence | itauto lia].
+  by destruct IHfinite_valid_trace_from_to; [itauto congruence | itauto lia].
 Qed.
 
 (** If a trace leads from a state to itself, then it is empty. *)
@@ -459,7 +461,7 @@ Lemma finite_valid_trace_from_to_inv_Ri :
   forall (s : State) (tr : list transition_item),
     finite_valid_trace_from_to Ri s s tr -> tr = [].
 Proof.
-  intros s tr Hfvt. apply finite_valid_trace_from_to_size_Ri in Hfvt. itauto lia.
+  by intros s tr Hfvt; apply finite_valid_trace_from_to_size_Ri in Hfvt; itauto lia.
 Qed.
 
 (**
@@ -474,7 +476,7 @@ Lemma input_valid_transition_size_Ui :
 Proof.
   intros s1 s2 iom oom lbl Hivt.
   eapply input_valid_transition_size_Ri.
-  apply (@VLSM_incl_input_valid_transition _ (vtype Ui) (vmachine Ui) (vmachine Ri))
+  by apply (@VLSM_incl_input_valid_transition _ (vtype Ui) (vmachine Ui) (vmachine Ri))
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -487,7 +489,7 @@ Lemma finite_valid_trace_from_to_size_Ui :
 Proof.
   intros s1 s2 tr Hfvt.
   eapply finite_valid_trace_from_to_size_Ri.
-  apply (@VLSM_incl_finite_valid_trace_from_to _ (vtype Ui) (vmachine Ui) (vmachine Ri))
+  by apply (@VLSM_incl_finite_valid_trace_from_to _ (vtype Ui) (vmachine Ui) (vmachine Ri))
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -497,7 +499,7 @@ Lemma finite_valid_trace_from_to_inv_Ui :
 Proof.
   intros s tr Hfvt.
   eapply finite_valid_trace_from_to_inv_Ri.
-  apply (@VLSM_incl_finite_valid_trace_from_to _ (vtype Ui) (vmachine Ui) (vmachine Ri))
+  by apply (@VLSM_incl_finite_valid_trace_from_to _ (vtype Ui) (vmachine Ui) (vmachine Ri))
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -524,7 +526,7 @@ Proof.
   ; inversion Ht1; subst; clear Ht1
   ; inversion Ht2; subst; clear Ht2
   ; invert_UMOComponentValid; auto.
-  destruct s1, s2; cbn in *; subst; itauto.
+  by destruct s1, s2; cbn in *; subst; itauto.
 Qed.
 
 Lemma input_valid_transition_deterministic_conv_Ui :
@@ -534,7 +536,7 @@ Lemma input_valid_transition_deterministic_conv_Ui :
       lbl1 = lbl2 /\ s1 = s2 /\ iom1 = iom2 /\ oom1 = oom2.
 Proof.
   intros s1 s2 f iom1 iom2 oom1 oom2 lbl1 lbl2 Hivt1 Hivt2.
-  eapply input_valid_transition_deterministic_conv_Ri
+  by eapply input_valid_transition_deterministic_conv_Ri
   ; apply (@VLSM_incl_input_valid_transition _ (vtype Ui) (vmachine Ui) (vmachine Ri))
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
@@ -549,11 +551,11 @@ Lemma finite_valid_trace_from_to_unique_Ri :
 Proof.
   intros s1 s2 l1 l2 Hfvt1 Hfvt2; revert l2 Hfvt2.
   induction Hfvt1 using finite_valid_trace_from_to_rev_ind; intros.
-  - apply finite_valid_trace_from_to_size_Ri in Hfvt2; itauto (congruence + lia).
+  - by apply finite_valid_trace_from_to_size_Ri in Hfvt2; itauto (congruence + lia).
   - destruct Hfvt2 using finite_valid_trace_from_to_rev_ind; [| clear IHHfvt2].
     + apply finite_valid_trace_from_to_size_Ri in Hfvt1.
       apply input_valid_transition_size_Ri in Ht.
-      decompose [and or] Hfvt1; subst; clear Hfvt1; lia.
+      by decompose [and or] Hfvt1; subst; clear Hfvt1; lia.
     + assert (l = l0 /\ s = s0 /\ iom = iom0 /\ oom = oom0)
           by (eapply input_valid_transition_deterministic_conv_Ri; done).
       decompose [and] H; subst; clear H.
@@ -566,7 +568,7 @@ Lemma finite_valid_trace_from_to_unique_Ui :
     finite_valid_trace_from_to Ui s1 s2 l2 ->
       l1 = l2.
 Proof.
-  intros s1 s2 l1 l2 Hfvt1 Hfvt2
+  by intros s1 s2 l1 l2 Hfvt1 Hfvt2
   ; eapply finite_valid_trace_from_to_unique_Ri
   ; apply VLSM_incl_finite_valid_trace_from_to
   ; eauto using VLSM_incl_Ui_Ri.
@@ -591,7 +593,7 @@ Lemma finite_valid_trace_init_to_unique_Ui :
     finite_valid_trace_init_to Ui s f l2 ->
       l1 = l2.
 Proof.
-  intros s f l1 l2 Hfvit1 Hfvit2
+  by intros s f l1 l2 Hfvit1 Hfvit2
   ; eapply finite_valid_trace_init_to_unique_Ri
   ; apply VLSM_incl_finite_valid_trace_init_to
   ; eauto using VLSM_incl_Ui_Ri.
@@ -607,18 +609,17 @@ Proof.
   induction Hfv using finite_valid_trace_from_to_rev_ind; intros.
   - inversion Hinit; clear Hinit.
     destruct si; cbn in *; subst; cbn.
-    repeat constructor. exists None. repeat constructor.
+    repeat constructor. exists None.
+    by repeat constructor.
   - specialize (IHHfv Hinit).
     destruct Ht as [Hvalid Ht]; cbn in Ht.
     destruct s as [obs adr], l, iom as [im |]
     ; inversion Ht; subst; clear Ht; cbn in *
     ; cycle 1; [done | done | |].
     + constructor; [| done].
-      eapply extend_right_finite_trace_from_to
-      ; [apply IHHfv | split]; auto.
+      by eapply extend_right_finite_trace_from_to; [apply IHHfv |]; auto.
     + constructor; [| done].
-      eapply extend_right_finite_trace_from_to
-      ; [apply IHHfv | split]; auto.
+      by eapply extend_right_finite_trace_from_to; [apply IHHfv |]; auto.
 Qed.
 
 Lemma finite_valid_trace_init_to_state2trace_Ui :
@@ -630,18 +631,17 @@ Proof.
   induction Hfv using finite_valid_trace_from_to_rev_ind; intros.
   - inversion Hinit; clear Hinit.
     destruct si; cbn in *; subst; cbn.
-    repeat constructor. exists None. repeat constructor.
+    repeat constructor. exists None.
+    by repeat constructor.
   - specialize (IHHfv Hinit).
     destruct Ht as [Hvalid Ht]; cbn in Ht.
     destruct s as [obs adr], l, iom as [im |]
     ; inversion Ht; subst; clear Ht; cbn in *
     ; cycle 1; [done | done | |].
     + constructor; [| done].
-      eapply extend_right_finite_trace_from_to
-      ; [apply IHHfv | split]; auto.
+      by eapply extend_right_finite_trace_from_to; [apply IHHfv |]; auto.
     + constructor; [| done].
-      eapply extend_right_finite_trace_from_to
-      ; [apply IHHfv | split]; auto.
+      by eapply extend_right_finite_trace_from_to; [apply IHHfv |]; auto.
 Qed.
 
 (** The trace extracted from the final state of another trace is equal to that trace. *)
@@ -662,7 +662,7 @@ Lemma finite_valid_trace_init_to_state2trace_Ui_inv :
     finite_valid_trace_init_to Ui is s tr ->
       state2trace s = tr.
 Proof.
-  intros is s tr Hfvti
+  by intros is s tr Hfvti
   ; eapply finite_valid_trace_init_to_state2trace_Ri_inv
   ; apply VLSM_incl_finite_valid_trace_init_to
   ; eauto using VLSM_incl_Ui_Ri.
@@ -680,7 +680,7 @@ Proof.
   apply valid_state_has_trace in Hs as (is & tr & Htr).
   apply finite_valid_trace_init_to_state2trace_Ri_inv in Htr as Heqtr; subst.
   replace (``(vs0 Ri)) with is; [done |].
-  apply vs0_uniqueness, Htr.
+  by apply vs0_uniqueness, Htr.
 Qed.
 
 Lemma valid_state_contains_unique_valid_trace_Ri :
@@ -709,7 +709,7 @@ Proof.
   apply valid_state_has_trace in Hs as (is & tr & Htr).
   apply finite_valid_trace_init_to_state2trace_Ui_inv in Htr as Heqtr; subst.
   replace (``(vs0 Ri)) with is; [done|].
-  apply vs0_uniqueness, Htr.
+  by apply vs0_uniqueness, Htr.
 Qed.
 
 Lemma valid_state_contains_unique_valid_trace_Ui :
@@ -768,13 +768,14 @@ Qed.
   Transitive state_suffix.
 Proof.
   intros s1 s2 s3 (Hadr12 & Hobs12 & Hobs12') (Hadr23 & Hobs23 & Hobs23').
-  split; [congruence |]. by transitivity (obs s2).
+  split; [by congruence |].
+  by transitivity (obs s2).
 Qed.
 
 #[export] Instance StrictOrder_state_suffix :
   StrictOrder state_suffix.
 Proof.
-  split; typeclasses eauto.
+  by split; typeclasses eauto.
 Qed.
 
 Lemma state_suffix_empty_minimal :
@@ -855,10 +856,10 @@ Lemma state_suffix_of_finite_valid_trace_from_to_Ri :
       s1 = s2 \/ state_suffix s1 s2.
 Proof.
   induction 1; [by left |].
-  - destruct IHfinite_valid_trace_from_to as [-> | IH]; right.
-    + by eapply state_suffix_of_input_valid_transition_Ri; eauto.
-    + transitivity s; [| done].
-      by eapply state_suffix_of_input_valid_transition_Ri; eauto.
+  destruct IHfinite_valid_trace_from_to as [-> | IH]; right.
+  - by eapply state_suffix_of_input_valid_transition_Ri; eauto.
+  - transitivity s; [| done].
+    by eapply state_suffix_of_input_valid_transition_Ri; eauto.
 Qed.
 
 (**
@@ -923,7 +924,7 @@ Proof.
   inversion Hadd.
   replace (state m) with (state (message ob')) by (rewrite <- H0; cbn; done).
   rewrite Hlbl; [by apply eq_State |].
-  destruct lbl, iom; cbn in *; inversion Ht; subst; [| | done]
+  by destruct lbl, iom; cbn in *; inversion Ht; subst; [| | done]
   ; apply (f_equal (fun x => length (obs x))) in Hadd; cbn in Hadd; lia.
 Qed.
 
@@ -991,9 +992,9 @@ Proof.
   cbn in *; rewrite <- Hm1, <- Hm2 by done
   ; clear Hvsp Hm1 Hm2; split.
   - rewrite addObservations_app.
-    apply state_suffix_addObservations. apply ListExtras.last_not_null.
+    by apply state_suffix_addObservations, ListExtras.last_not_null.
   - rewrite (addObservations_app _ _ obs3).
-    apply state_suffix_addObservations. apply ListExtras.last_not_null.
+    by apply state_suffix_addObservations, ListExtras.last_not_null.
 Qed.
 
 (** [state_suffix_totally_orders_sent_messages_Ri] easily carries over to valid states. *)
@@ -1099,9 +1100,8 @@ Lemma directly_observable_addObservation :
       <->
     directly_observable m (MkMessage s) \/ m = message ob.
 Proof.
-  unfold directly_observable.
-  intros m s ob; cbn.
-  unfold Message; rewrite elem_of_cons; itauto.
+  unfold directly_observable, Message.
+  by intros m s ob; cbn; rewrite elem_of_cons; itauto.
 Qed.
 
 (**
@@ -1114,9 +1114,8 @@ Lemma directly_observable_addObservations :
       <->
     directly_observable m (MkMessage s) \/ m ∈ map message obs'.
 Proof.
-  unfold directly_observable.
-  intros m s obs'; cbn.
-  unfold Message; rewrite map_app, elem_of_app; itauto.
+  unfold directly_observable, Message.
+  by intros m s obs'; cbn; rewrite map_app, elem_of_app; itauto.
 Qed.
 
 (**
@@ -1136,7 +1135,7 @@ Proof.
   apply addObservation_message in Hvsp as Heq'; [| done].
   cbn in Heq'; subst; clear Heq Hvsp.
   repeat (rewrite ?directly_observable_addObservations, ?directly_observable_addObservation); cbn.
-  itauto.
+  by itauto.
 Qed.
 
 (**
@@ -1312,7 +1311,7 @@ Proof.
     eapply elem_of_valid_obs_Send_split in Hsent as (obs' & ->); [| done].
     destruct obs' as [| ob' obs']; cbn.
     + by right.
-    + left; apply state_suffix_addObservations; inversion 1.
+    + by left; apply state_suffix_addObservations; inversion 1.
   - intros [(Hadr & Hsuf & Hnsuf) | Heq]; cbn in *.
     + constructor; [done |].
       apply elem_of_sentMessages.
@@ -1578,7 +1577,8 @@ Proof.
   induction is as [| i is']; cbn; intros us Hall Hvsp.
   - replace us with (λ n : index, MkState [] (idx n)).
     + by constructor; apply initial_state_is_valid; compute.
-    + extensionality i. rewrite Hall; [done |]. apply not_elem_of_nil.
+    + extensionality i; rewrite Hall; [done |].
+      by apply not_elem_of_nil.
   - eapply finite_valid_trace_from_to_app.
     + apply IHis'.
       * intros j Hj. destruct (decide (i = j)); subst; state_update_simpl; [done |].
@@ -1591,7 +1591,7 @@ Proof.
       apply (valid_state_project_preloaded_to_preloaded _ _ _ us i) in Hvsp as Hvsp'.
       apply valid_state_has_trace in Hvsp' as (s & tr & [Hfvt Hinit]).
       replace s with (MkState [] (idx i)) in *; cycle 1.
-      * inversion Hinit. by destruct s; cbn in *; subst.
+      * by inversion Hinit; destruct s; cbn in *; subst.
       * by eapply finite_valid_trace_init_to_state2trace_Ri.
 Qed.
 
@@ -1608,7 +1608,7 @@ Proof.
   apply all_pre_traces_to_valid_state_are_valid; [typeclasses eauto | done |].
   apply finite_valid_trace_from_to_UMO_state2trace_RUMO.
   eapply (@VLSM_incl_valid_state _ (vtype UMO) (vmachine UMO) (vmachine RUMO)); [| done].
-  apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
 Fixpoint UMO_obs_aux (us : UMO_state) (is : list index) : list Observation :=
@@ -1712,7 +1712,7 @@ Proof.
   intros us m i Hvsp Hidx.
   rewrite elem_of_UMO_sentMessages by done.
   rewrite <- sentMessages_characterization; [done |].
-  apply @UMO_reachable_Ri with (idx i),
+  by apply @UMO_reachable_Ri with (idx i),
     (preloaded_valid_state_projection _ _ _ Hvsp).
 Qed.
 

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -159,16 +159,16 @@ Proof.
       by rewrite elem_of_list_In, in_one_element_decompositions_iff.
   - apply Exists_dec. intros ((prefix, item), suffix).
     apply Decision_and.
-    + apply option_eq_dec.
+    + by apply option_eq_dec.
     + apply Decision_not. apply Exists_dec. intros pitem.
-      apply option_eq_dec.
+      by apply option_eq_dec.
 Qed.
 
 Lemma no_equivocation_in_empty_trace m
   : ~ equivocation_in_trace m [].
 Proof.
   intros [prefix [suffix [item [Hitem _]]]].
-  destruct prefix; inversion Hitem.
+  by destruct prefix; inversion Hitem.
 Qed.
 
 Lemma equivocation_in_trace_prefix
@@ -196,7 +196,7 @@ Proof.
     + by apply app_inj_tail in Heq_tr_item' as [-> ->]; right.
     + rewrite app_comm_cons, !app_assoc in Heq_tr_item'.
       apply app_inj_tail in Heq_tr_item' as [-> ->].
-      left. by exists prefix, item', suffix'.
+      by left; exists prefix, item', suffix'.
   - intros
       [[prefix [item' [suffix [-> [Hinput Hnoutput]]]]]
       | [Hinput Hnoutput]].
@@ -288,7 +288,7 @@ Lemma selected_message_exists_preloaded_not_some_iff_no
   : ~ selected_message_exists_in_some_preloaded_traces message_selector s m
     <-> selected_message_exists_in_no_preloaded_trace message_selector s m.
 Proof.
-  apply selected_message_exists_not_some_iff_no.
+  by apply selected_message_exists_not_some_iff_no.
 Qed.
 
 (** Sufficient condition for [specialized_selected_message_exists_in_some_traces]. *)
@@ -431,7 +431,7 @@ Proof.
   apply valid_state_has_trace in Hs.
   destruct Hs as [is [tr Htr]].
   exists _, _, Htr.
-  apply (Hall _ _ Htr).
+  by apply (Hall _ _ Htr).
 Qed.
 
 Lemma has_been_sent_consistency
@@ -462,7 +462,7 @@ Proof.
   apply has_been_sent_consistency; [done |].
   apply non_empty_valid_trace_from_can_produce in Hsm.
   destruct Hsm as [is [tr [lst_tr [Htr [Hlst [Hs Hm]]]]]].
-  destruct_list_last tr tr' _lst_tr Heqtr; [inversion Hlst|].
+  destruct_list_last tr tr' _lst_tr Heqtr; [by inversion Hlst |].
   rewrite last_error_is_last in Hlst.
   inversion Hlst; subst _lst_tr; clear Hlst.
   apply valid_trace_add_default_last in Htr.
@@ -495,8 +495,7 @@ Proof.
   revert Htr.
   unfold pre_vlsm;clear.
   destruct vlsm as (T,M).
-  apply VLSM_incl_finite_valid_trace_init_to.
-  apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  by apply VLSM_incl_finite_valid_trace_init_to, vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
 (**
@@ -521,8 +520,7 @@ Proof.
   revert Htr.
   unfold pre_vlsm;clear.
   destruct vlsm as (T,M).
-  apply VLSM_incl_finite_valid_trace_init_to.
-  apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  by apply VLSM_incl_finite_valid_trace_init_to, vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
 Lemma has_been_sent_consistency_proper_not_sent
@@ -706,12 +704,12 @@ Proof.
   - intro m.
     unfold trace_has_message.
     rewrite Exists_nil.
-    itauto.
+  - by itauto.
   - intro m. specialize (IHHtr m).
     unfold trace_has_message.
     rewrite Exists_cons.
     apply (Horacle.(oracle_step_update)) with (msg:=m) in Ht.
-    itauto.
+    by itauto.
 Qed.
 
 Lemma oracle_initial_trace_update
@@ -727,7 +725,7 @@ Proof.
   intros m.
   pose proof (oracle_partial_trace_update Horacle _ _ _ (proj1 Htr) m).
   pose proof (oracle_no_inits Horacle s0 (proj2 Htr) m).
-  clear -H H0. itauto.
+  by clear -H H0; itauto.
 Qed.
 
 (* TODO(wkolowski): make notation uniform accross the file. *)
@@ -782,9 +780,7 @@ Proof.
   intro m.
   destruct Htr as [Htr Hinit].
   rewrite (oracle_partial_trace_update oracle_props _ _ _ Htr).
-  assert (~oracle s0 m).
-  apply oracle_props, Hinit.
-  itauto.
+  by firstorder.
 Qed.
 
 Lemma prove_all_have_message_from_stepwise:
@@ -930,14 +926,14 @@ Proof.
   clear.
   progress cbn. unfold trace_has_message.
   rewrite Exists_app, Exists_cons, Exists_nil.
-  itauto.
+  by itauto.
 Qed.
 
 Lemma stepwise_props_from_trace : oracle_stepwise_props selector oracle.
 Proof.
   constructor.
-  refine oracle_no_inits_from_trace.
-  refine oracle_step_property_from_trace.
+  - by apply oracle_no_inits_from_trace.
+  - by apply oracle_step_property_from_trace.
 Defined.
 
 End sec_stepwise_from_trace.
@@ -982,7 +978,7 @@ Proof.
   apply stepwise_props_from_trace.
   apply has_been_sent_dec.
   apply proper_sent.
-  apply proper_not_sent.
+  by apply proper_not_sent.
 Defined.
 
 Lemma preloaded_has_been_sent_stepwise_props
@@ -1004,8 +1000,8 @@ Qed.
   HasBeenSentCapability (pre_loaded_vlsm vlsm seed).
 Proof.
   eapply HasBeenSentCapability_from_stepwise.
-  - apply (has_been_sent_dec vlsm).
-  - apply preloaded_has_been_sent_stepwise_props.
+  - by apply (has_been_sent_dec vlsm).
+  - by apply preloaded_has_been_sent_stepwise_props.
 Defined.
 
 Lemma has_been_sent_step_update
@@ -1027,9 +1023,9 @@ Lemma has_been_sent_examine_one_trace
     trace_has_message (field_selector output) m tr.
 Proof.
   apply examine_one_trace.
-  - apply has_been_sent_dec.
-  - apply proper_sent.
-  - apply proper_not_sent.
+  - by apply has_been_sent_dec.
+  - by apply proper_sent.
+  - by apply proper_not_sent.
 Qed.
 
 (** ** Stepwise view of [HasBeenReceivedCapability] *)
@@ -1058,9 +1054,9 @@ Lemma has_been_received_stepwise_from_trace
   oracle_stepwise_props (field_selector input) (has_been_received vlsm).
 Proof.
   apply stepwise_props_from_trace.
-  - apply has_been_received_dec.
-  - apply proper_received.
-  - apply proper_not_received.
+  - by apply has_been_received_dec.
+  - by apply proper_received.
+  - by apply proper_not_received.
 Defined.
 
 Lemma preloaded_has_been_received_stepwise_props
@@ -1082,8 +1078,8 @@ Qed.
   HasBeenReceivedCapability (pre_loaded_vlsm vlsm seed).
 Proof.
   eapply HasBeenReceivedCapability_from_stepwise.
-  - apply (has_been_received_dec vlsm).
-  - apply preloaded_has_been_received_stepwise_props.
+  - by apply (has_been_received_dec vlsm).
+  - by apply preloaded_has_been_received_stepwise_props.
 Defined.
 
 Lemma has_been_received_step_update
@@ -1105,9 +1101,9 @@ Lemma has_been_received_examine_one_trace
     trace_has_message (field_selector input) m tr.
 Proof.
   apply examine_one_trace.
-  - apply has_been_received_dec.
-  - apply proper_received.
-  - apply proper_not_received.
+  - by apply has_been_received_dec.
+  - by apply proper_received.
+  - by apply proper_not_received.
 Qed.
 
 Lemma trace_to_initial_state_has_no_inputs
@@ -1169,7 +1165,7 @@ Lemma proper_directly_observed {message} (vlsm : VLSM message) `{HasBeenDirectly
 Proof.
   intros.
   apply prove_all_have_message_from_stepwise; [| done].
-  apply has_been_directly_observed_stepwise_props.
+  by apply has_been_directly_observed_stepwise_props.
 Qed.
 
 Lemma proper_not_directly_observed `(vlsm : VLSM message) `{HasBeenDirectlyObservedCapability message vlsm}:
@@ -1181,7 +1177,7 @@ Lemma proper_not_directly_observed `(vlsm : VLSM message) `{HasBeenDirectlyObser
 Proof.
   intros.
   apply prove_none_have_message_from_stepwise; [| done].
-  apply has_been_directly_observed_stepwise_props.
+  by apply has_been_directly_observed_stepwise_props.
 Qed.
 
 Lemma has_been_directly_observed_examine_one_trace
@@ -1193,9 +1189,9 @@ Lemma has_been_directly_observed_examine_one_trace
     trace_has_message item_sends_or_receives m tr.
 Proof.
   apply examine_one_trace.
-  - apply has_been_directly_observed_dec.
-  - apply proper_directly_observed.
-  - apply proper_not_directly_observed.
+  - by apply has_been_directly_observed_dec.
+  - by apply proper_directly_observed.
+  - by apply proper_not_directly_observed.
 Qed.
 
 (**
@@ -1220,7 +1216,7 @@ Lemma no_additional_equivocations_dec
   `{HasBeenDirectlyObservedCapability message vlsm}
   : RelDecision (no_additional_equivocations vlsm).
 Proof.
-  apply has_been_directly_observed_dec.
+  by apply has_been_directly_observed_dec.
 Qed.
 
 Definition no_additional_equivocations_constraint
@@ -1261,10 +1257,12 @@ Proof.
     destruct Hexists as [Hsent | Hreceived].
     + left. specialize (has_been_received_consistency vlsm _ Hs m) as Hcons.
       apply proper_received; [done |].
-      apply Hcons. by exists is, tr, Htr.
+      apply Hcons.
+      by exists is, tr, Htr.
     + right. specialize (has_been_sent_consistency vlsm _ Hs m) as Hcons.
       apply proper_sent; [done |].
-      apply Hcons. by exists is, tr, Htr.
+      apply Hcons.
+      by exists is, tr, Htr.
   - intros [Hreceived | Hsent]; apply Hall; intros is tr Htr.
     + apply proper_received in Hreceived; [| done].
       apply Exists_or. left.
@@ -1285,15 +1283,15 @@ Lemma has_been_directly_observed_from_sent_received_dec
 Proof.
   intros s m.
   apply Decision_or.
-  - apply has_been_sent_dec.
-  - apply has_been_received_dec.
+  - by apply has_been_sent_dec.
+  - by apply has_been_received_dec.
 Qed.
 
 Lemma has_been_directly_observed_from_sent_received_stepwise_props
   : oracle_stepwise_props item_sends_or_receives has_been_directly_observed_from_sent_received.
 Proof.
   apply stepwise_props_from_trace
-  ; [apply has_been_directly_observed_from_sent_received_dec|..]
+  ; [by apply has_been_directly_observed_from_sent_received_dec | ..]
   ; intros; split.
   - intros [Hsent | Hreceived] start tr Htr.
     + apply proper_sent in Hsent; [| done].
@@ -1448,8 +1446,8 @@ Definition ComputableSentMessages_has_been_sent
   : HasBeenSentCapability vlsm.
 Proof.
   eapply HasBeenSentCapability_from_stepwise; cycle 1.
-  - apply csm_computable_oracle.
-  - typeclasses eauto.
+  - by apply csm_computable_oracle.
+  - by typeclasses eauto.
 Defined.
 
 Lemma elem_of_sent_messages_set
@@ -1487,8 +1485,8 @@ Definition ComputableReceivedMessages_has_been_sent
   : HasBeenReceivedCapability vlsm.
 Proof.
   eapply HasBeenReceivedCapability_from_stepwise; cycle 1.
-  - apply crm_computable_oracle.
-  - typeclasses eauto.
+  - by apply crm_computable_oracle.
+  - by typeclasses eauto.
 Defined.
 
 Lemma has_been_received_messages_set_iff
@@ -1559,9 +1557,9 @@ Proof.
   apply valid_state_has_trace in Hs as (is & tr & Htr).
   assert (Hpre_tr: finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm X) is s tr).
   {
-    clear -Htr; destruct X;
-      by eapply VLSM_incl_finite_valid_trace_init_to;
-        [apply vlsm_incl_pre_loaded_with_all_messages_vlsm |].
+    by clear -Htr; destruct X;
+      eapply VLSM_incl_finite_valid_trace_init_to;
+      [apply vlsm_incl_pre_loaded_with_all_messages_vlsm |].
   }
   eapply has_been_sent_examine_one_trace, Exists_exists in Hsent
     as (item_z & Hitem_z & Hz); [| done].
@@ -1613,12 +1611,12 @@ Proof.
   induction Hs using valid_state_prop_ind.
   - contradict Hreceived.
     eapply oracle_no_inits; [| done].
-    apply has_been_received_stepwise_from_trace.
+    by apply has_been_received_stepwise_from_trace.
   - apply input_valid_transition_in in Ht as Hom'.
     apply preloaded_weaken_input_valid_transition in Ht.
     erewrite oracle_step_update in Hreceived
     ; [| apply has_been_received_stepwise_from_trace | done].
-    destruct Hreceived as [[= ->] |]; auto.
+    by destruct Hreceived as [[= ->] |]; auto.
 Qed.
 
 Lemma directly_observed_valid
@@ -1691,7 +1689,7 @@ Proof.
     intros s Hs m [i Horacle].
     revert Horacle.
     apply (oracle_no_inits (stepwise_props i)).
-    apply Hs.
+    by apply Hs.
   - (* step update property *)
     intros l s im s' om Hproto msg.
     destruct l as [i li].
@@ -1700,7 +1698,7 @@ Proof.
     {
       intro j.
       apply (input_valid_transition_preloaded_project_any j) in Hproto.
-      destruct Hproto as [|(lj & Hlj & _)]; [by left | right; congruence].
+      by destruct Hproto as [|(lj & Hlj & _)]; [left | right; congruence].
     }
     apply input_valid_transition_preloaded_project_active in Hproto;simpl in Hproto.
     apply (oracle_step_update (stepwise_props i)) with (msg:=msg) in Hproto.
@@ -1735,12 +1733,12 @@ Lemma oracle_component_selected_previously
 Proof.
   apply valid_state_has_trace in Hs as (is & tr & Htr).
   eapply VLSM_incl_finite_valid_trace_init_to in Htr as Hpre_tr
-  ; [|apply constraint_preloaded_free_incl].
+  ; [| by apply constraint_preloaded_free_incl].
   apply (VLSM_projection_finite_valid_trace_init_to
           (preloaded_component_projection IM i))
      in Hpre_tr.
   eapply prove_all_have_message_from_stepwise in Horacle
-  ; [| apply stepwise_props |eapply finite_valid_trace_from_to_last_pstate, Hpre_tr].
+  ; [| by apply stepwise_props | by eapply finite_valid_trace_from_to_last_pstate, Hpre_tr].
   specialize (Horacle _ _ Hpre_tr); clear Hpre_tr.
   apply Exists_exists in Horacle as (item & Hitem & Hout).
   apply elem_of_map_option in Hitem as (itemX & HitemX & HitemX_pr).
@@ -1748,16 +1746,16 @@ Proof.
   exists (finite_trace_last is pre), itemX.
   rewrite cons_middle in Htr_pr.
   eapply (input_valid_transition_to X) in Htr_pr as Ht
-  ; [cbn in Ht | apply valid_trace_forget_last in Htr; apply Htr].
+  ; [cbn in Ht | by apply valid_trace_forget_last in Htr; apply Htr].
   unfold pre_VLSM_projection_transition_item_project,
          composite_project_label in HitemX_pr; cbn in HitemX_pr.
   rewrite app_assoc in Htr_pr.
-  case_decide as Hi; [|congruence]; apply Some_inj in HitemX_pr
+  case_decide as Hi; [| by congruence]; apply Some_inj in HitemX_pr
   ; subst i item tr; cbn in *.
   apply proj1, finite_valid_trace_from_to_app_split, proj2 in Htr.
   rewrite finite_trace_last_is_last in Htr.
   destruct itemX, l; cbn in *.
-  by split_and!; [|exists suf|..].
+  by split_and!; [| exists suf |..].
 Qed.
 
 End sec_stepwise_props.
@@ -1778,7 +1776,7 @@ Proof.
   intros s m.
   apply (Decision_iff (P:=List.Exists (fun i => has_been_sent (IM i) (s i) m) (enum index))).
   - by rewrite Exists_finite.
-  - typeclasses eauto.
+  - by typeclasses eauto.
 Qed.
 
 Lemma composite_has_been_sent_stepwise_props
@@ -1831,7 +1829,7 @@ Proof.
   intros s m.
   apply (Decision_iff (P:=List.Exists (fun i => has_been_received (IM i) (s i) m) (enum index))).
   - by rewrite Exists_finite.
-  - typeclasses eauto.
+  - by typeclasses eauto.
 Qed.
 
 Lemma composite_has_been_received_stepwise_props
@@ -1903,7 +1901,7 @@ Proof.
   intros s m.
   apply (Decision_iff (P:=List.Exists (fun i => has_been_directly_observed (IM i) (s i) m) (enum index))).
   - by rewrite Exists_finite.
-  - typeclasses eauto.
+  - by typeclasses eauto.
 Qed.
 
 Lemma composite_has_been_directly_observed_stepwise_props
@@ -1924,8 +1922,8 @@ Definition composite_HasBeenDirectlyObservedCapability_from_stepwise
   : HasBeenDirectlyObservedCapability X.
 Proof.
   exists composite_has_been_directly_observed.
-  - apply composite_has_been_directly_observed_dec.
-  - apply (composite_has_been_directly_observed_stepwise_props constraint).
+  - by apply composite_has_been_directly_observed_dec.
+  - by apply (composite_has_been_directly_observed_stepwise_props constraint).
 Defined.
 
 Context
@@ -2028,16 +2026,16 @@ Proof.
   intro m.
   rewrite emitted_messages_are_valid_iff.
   intros [[i [[mi Hmi] _]] | [(s, om) [(i, l) [s' Ht]]]]
-  ; [contradict Hmi; apply no_initial_messages_in_IM |].
+  ; [by contradict Hmi; apply no_initial_messages_in_IM |].
   apply (VLSM_incl_input_valid_transition (constraint_preloaded_free_incl IM _)) in Ht.
   apply pre_loaded_with_all_messages_projection_input_valid_transition_eq
     with (j := i) in Ht; [| done]; cbn in Ht.
   specialize (can_emit_signed i m).
   spec can_emit_signed; [by eexists _,_,_ |].
   unfold channel_authenticated_message in can_emit_signed.
-  destruct (sender m) as [v|] eqn: Hsender; [|inversion can_emit_signed].
+  destruct (sender m) as [v|] eqn: Hsender; [| by inversion can_emit_signed].
   apply Some_inj in can_emit_signed.
-  exists v; subst; unfold can_emit; eauto.
+  by exists v; subst; unfold can_emit; eauto.
 Qed.
 
 Lemma composite_no_initial_valid_messages_have_sender
@@ -2050,7 +2048,7 @@ Proof.
   intros m Hm.
   cut (exists v, sender m = Some v /\
    can_emit (pre_loaded_with_all_messages_vlsm (IM (A v))) m).
-  - intros (v & -> & _); congruence.
+  - by intros (v & -> & _); congruence.
   - by eapply composite_no_initial_valid_messages_emitted_by_sender.
 Qed.
 
@@ -2080,7 +2078,7 @@ Lemma has_been_sent_iff_by_sender
       [m v] (Hsender : sender m = Some v):
   composite_has_been_sent s m <-> has_been_sent (IM (A v)) (s (A v)) m.
 Proof.
-  split;[| by exists (A v)].
+  split; [| by exists (A v)].
   intros [i Hi].
   erewrite Hsender_safety; [done | done |].
   assert
@@ -2093,7 +2091,7 @@ Proof.
   eapply can_emit_from_valid_trace.
   - by eapply valid_trace_forget_last.
   - eapply proper_sent; [| done | done].
-    revert Htr_pr; apply valid_trace_last_pstate.
+    by revert Htr_pr; apply valid_trace_last_pstate.
 Qed.
 
 Lemma no_additional_equivocations_constraint_dec
@@ -2101,7 +2099,7 @@ Lemma no_additional_equivocations_constraint_dec
 Proof.
   intros l (s, om).
   destruct om; [| by left].
-  apply no_additional_equivocations_dec.
+  by apply no_additional_equivocations_dec.
 Qed.
 
 (**
@@ -2142,7 +2140,7 @@ Proof.
   intros [j [m [Hsender [Hnbs Hrcv]]]].
   revert Hrcv.
   apply has_been_received_stepwise_from_trace.
-  apply Hs.
+  by apply Hs.
 Qed.
 
 Context
@@ -2241,10 +2239,10 @@ Proof.
   ; destruct l as [i li]; cbn in *; subst output.
   exists destination; split; [done |].
   eapply VLSM_incl_input_valid_transition in Ht; cbn in Ht;
-    [|apply constraint_preloaded_free_incl].
+    [| by apply constraint_preloaded_free_incl].
   eapply (VLSM_projection_input_valid_transition (preloaded_component_projection IM i))
     in Ht; [by eexists _,_ |].
-  apply (composite_project_label_eq IM).
+  by apply (composite_project_label_eq IM).
 Qed.
 
 Lemma messages_sent_from_component_of_valid_state_are_valid
@@ -2389,7 +2387,7 @@ Proof.
     + by eapply preloaded_messages_sent_from_component_of_valid_state_are_valid.
   - eapply valid_state_project_preloaded_to_preloaded.
     eapply VLSM_incl_valid_state; [| done].
-    apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
+    by apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
 Qed.
 
 End sec_composite.
@@ -2420,7 +2418,7 @@ Lemma composite_has_been_directly_observed_free_iff
   : composite_has_been_directly_observed IM s m <-> has_been_directly_observed (free_composite_vlsm IM) s m.
 Proof.
   unfold has_been_directly_observed; cbn; unfold has_been_directly_observed_from_sent_received; cbn.
-  apply composite_has_been_directly_observed_sent_received_iff.
+  by apply composite_has_been_directly_observed_sent_received_iff.
 Qed.
 
 Lemma composite_has_been_directly_observed_from_component
@@ -2467,9 +2465,9 @@ Proof.
     subst composite_item.
     by destruct item.
   - apply composite_has_been_directly_observed_free_iff, proper_directly_observed; [done |].
-    apply has_been_directly_observed_consistency; [typeclasses eauto | done |].
+    apply has_been_directly_observed_consistency; [by typeclasses eauto | done |].
     apply proper_directly_observed in Hobs ; [| done].
-    apply has_been_directly_observed_consistency in Hobs; [| typeclasses eauto | done].
+    apply has_been_directly_observed_consistency in Hobs; [| by typeclasses eauto | done].
     destruct Hobs as [is [tr [Htr Hobs]]].
     apply (VLSM_full_projection_finite_valid_trace_init_to (lift_to_composite_preloaded_vlsm_full_projection IM i)) in Htr as Hpre_tr.
     eexists. eexists. exists Hpre_tr.
@@ -2515,7 +2513,7 @@ Lemma composite_computable_messages_oracle
   : computable_messages_oracle Free composite_oracle_set
       (composite_message_selector IM (message_selectors := indexed_message_selector)).
 Proof.
-  constructor; intros
+  by constructor; intros
   ; setoid_rewrite elem_of_composite_oracle_set
   ; apply composite_stepwise_props
      with (message_selectors := indexed_message_selector)
@@ -2670,7 +2668,7 @@ Lemma input_valid_transition_received_not_resent l s m s' om'
   (Ht : input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s,Some m) (s', om'))
   : om' <> Some m.
 Proof.
-  destruct om' as [m'|]; [|congruence].
+  destruct om' as [m'|]; [| by congruence].
   intro Heq. inversion Heq. subst m'. clear Heq.
   destruct (Hno_resend _ _ _ _ _ Ht) as [_ Hnbr_m].
   elim Hnbr_m. clear Hnbr_m.
@@ -2692,7 +2690,7 @@ Lemma lift_preloaded_trace_to_seeded
   : finite_valid_trace (pre_loaded_vlsm X P) is tr.
 Proof.
   unfold trace_received_not_sent_before_or_after_invariant in Htrm.
-  split; [|apply Htr].
+  split; [| by apply Htr].
   induction Htr using finite_valid_trace_rev_ind; intros.
   - rapply @finite_valid_trace_from_empty.
     by apply initial_state_is_valid.
@@ -2703,9 +2701,9 @@ Proof.
       unfold trace_has_message in Hsend.
       rewrite Exists_app, Exists_cons, Exists_nil in Hsend.
       simpl in Hsend.
-      cut (oom <> Some m);[tauto|clear Hsend].
+      cut (oom <> Some m); [by itauto |].
       intros ->.
-      cut (has_been_received X sf m);[apply (Hno_resend _ _ _ _ _ Hx)|].
+      cut (has_been_received X sf m); [by apply (Hno_resend _ _ _ _ _ Hx) |].
       apply (has_been_received_step_update Hx);right.
       erewrite oracle_partial_trace_update.
       - by left.
@@ -2716,7 +2714,7 @@ Proof.
     apply (extend_right_finite_trace_from _ IHHtr).
     repeat split;try apply Hx;
     [by apply finite_valid_trace_last_pstate |].
-    destruct iom as [m|];[|apply option_valid_message_None].
+    destruct iom as [m |]; [| by apply option_valid_message_None].
     (*
       If m was sent during tr, it is valid because it was
       produced in a valid (by IHHtr) trace.
@@ -2748,10 +2746,7 @@ Proof.
   apply valid_state_has_trace in Hs as Htr.
   destruct Htr as [is [tr Htr]].
   specialize (lift_preloaded_trace_to_seeded P tr) as Hlift.
-  spec Hlift.
-  { revert Hequiv_s.
-    by apply state_received_not_sent_invariant_trace_iff with is.
-  }
+  spec Hlift; [by revert Hequiv_s; apply state_received_not_sent_invariant_trace_iff with is |].
   specialize (Hlift _ (valid_trace_forget_last Htr)).
   apply proj1 in Hlift.
   apply finite_valid_trace_last_pstate in Hlift.
@@ -2845,7 +2840,7 @@ Proof.
   eapply composite_received_valid; [done |].
   specialize (proper_received _ s Hspre m) as Hproper.
   apply proj2 in Hproper. apply Hproper.
-  apply has_been_received_consistency; [typeclasses eauto | done |].
+  apply has_been_received_consistency; [by typeclasses eauto | done |].
   by exists is, tr, Htr.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -704,7 +704,7 @@ Proof.
   - intro m.
     unfold trace_has_message.
     rewrite Exists_nil.
-  - by itauto.
+    by itauto.
   - intro m. specialize (IHHtr m).
     unfold trace_has_message.
     rewrite Exists_cons.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -85,15 +85,15 @@ Definition fixed_equivocation_vlsm_composition : VLSM message
 Lemma fixed_equivocation_vlsm_composition_incl_free
   : VLSM_incl fixed_equivocation_vlsm_composition Free.
 Proof.
-  apply constraint_free_incl.
+  by apply constraint_free_incl.
 Qed.
 
 Lemma fixed_equivocation_vlsm_composition_incl_preloaded_free
   : VLSM_incl fixed_equivocation_vlsm_composition (pre_loaded_with_all_messages_vlsm Free).
 Proof.
   apply VLSM_incl_trans with (machine Free).
-  - apply fixed_equivocation_vlsm_composition_incl_free.
-  - apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  - by apply fixed_equivocation_vlsm_composition_incl_free.
+  - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
 (** ** A (seemingly) stronger definition for fixed-set equivocation
@@ -120,15 +120,15 @@ Proof.
   - rewrite Exists_exists. apply exist_proper. intro i.
     rewrite elem_of_list_filter. apply and_iff_compat_r.
     split; [intros [Hi Hl]; done | split; [done |]].
-    apply elem_of_enum.
-  - apply Exists_dec. intro i. apply has_been_sent_dec.
+    by apply elem_of_enum.
+  - by apply Exists_dec; intro i; apply has_been_sent_dec.
 Qed.
 
 Lemma sent_by_non_equivocating_are_sent s m
   (Hsent : sent_by_non_equivocating s m)
   : composite_has_been_sent IM s m.
 Proof.
-  destruct Hsent as [i [Hi Hsent]]. by exists i.
+  by destruct Hsent as [i [Hi Hsent]]; exists i.
 Qed.
 
 Lemma sent_by_non_equivocating_are_directly_observed s m
@@ -172,7 +172,7 @@ Lemma Equivocators_Strong_Fixed_incl base_s
       (equivocators_composition_for_directly_observed base_s).
 Proof.
   apply pre_loaded_vlsm_incl.
-  apply sent_by_non_equivocating_are_directly_observed.
+  by apply sent_by_non_equivocating_are_directly_observed.
 Qed.
 
 (**
@@ -183,9 +183,9 @@ Lemma strong_fixed_equivocation_subsumption s m
   : strong_fixed_equivocation s m -> fixed_equivocation s m.
 Proof.
   intros [Hobs | Hemit]; [left|right].
-  - revert Hobs. apply sent_by_non_equivocating_are_directly_observed.
+  - by apply sent_by_non_equivocating_are_directly_observed.
   - revert Hemit. apply VLSM_incl_can_emit.
-    apply Equivocators_Strong_Fixed_incl.
+    by apply Equivocators_Strong_Fixed_incl.
 Qed.
 
 Lemma strong_fixed_equivocation_constraint_subsumption
@@ -203,7 +203,7 @@ Proof.
   apply constraint_subsumption_incl.
   apply preloaded_constraint_subsumption_stronger.
   apply strong_constraint_subsumption_strongest.
-  apply strong_fixed_equivocation_constraint_subsumption.
+  by apply strong_fixed_equivocation_constraint_subsumption.
 Qed.
 
 End sec_strong_fixed_equivocation.
@@ -253,7 +253,7 @@ Lemma fixed_equivocation_constraint_index_incl_subsumption
     (fixed_equivocation_constraint IM indices2).
 Proof.
   intros l (s, [m |]); [| done].
-  apply fixed_equivocation_index_incl_subsumption.
+  by apply fixed_equivocation_index_incl_subsumption.
 Qed.
 
 Lemma fixed_equivocation_vlsm_composition_index_incl
@@ -264,7 +264,7 @@ Proof.
   apply constraint_subsumption_incl.
   apply preloaded_constraint_subsumption_stronger.
   apply strong_constraint_subsumption_strongest.
-  apply fixed_equivocation_constraint_index_incl_subsumption.
+  by apply fixed_equivocation_constraint_index_incl_subsumption.
 Qed.
 
 End sec_fixed_equivocation_index_incl.
@@ -301,8 +301,8 @@ Definition Fixed_incl_Free : VLSM_incl Fixed Free := constraint_free_incl _ _.
 
 Lemma Fixed_incl_Preloaded : VLSM_incl Fixed (pre_loaded_with_all_messages_vlsm Free).
 Proof.
-  eapply VLSM_incl_trans; [apply Fixed_incl_Free|].
-  apply (vlsm_incl_pre_loaded_with_all_messages_vlsm Free).
+  eapply VLSM_incl_trans; [by apply Fixed_incl_Free |].
+  by apply (vlsm_incl_pre_loaded_with_all_messages_vlsm Free).
 Qed.
 
 Definition preloaded_Fixed_incl_Preloaded : VLSM_incl (pre_loaded_with_all_messages_vlsm Fixed) (pre_loaded_with_all_messages_vlsm Free)
@@ -312,8 +312,8 @@ Definition StrongFixed_incl_Free : VLSM_incl StrongFixed Free := constraint_free
 
 Lemma StrongFixed_incl_Preloaded : VLSM_incl StrongFixed (pre_loaded_with_all_messages_vlsm Free).
 Proof.
-  eapply VLSM_incl_trans; [apply StrongFixed_incl_Free|].
-  apply (vlsm_incl_pre_loaded_with_all_messages_vlsm Free).
+  eapply VLSM_incl_trans; [by apply StrongFixed_incl_Free |].
+  by apply (vlsm_incl_pre_loaded_with_all_messages_vlsm Free).
 Qed.
 
 Lemma in_futures_preserves_sent_by_non_equivocating s base_s
@@ -324,9 +324,9 @@ Lemma in_futures_preserves_sent_by_non_equivocating s base_s
 Proof.
   intros m (i & Hi & Hsent).
   exists i; split; [done |].
-  eapply in_futures_preserving_oracle_from_stepwise
-  ; [apply has_been_sent_stepwise_from_trace | | done].
-  by apply (VLSM_projection_in_futures (preloaded_component_projection IM i)).
+  eapply in_futures_preserving_oracle_from_stepwise; [| | done].
+  - by apply has_been_sent_stepwise_from_trace.
+  - by apply (VLSM_projection_in_futures (preloaded_component_projection IM i)).
 Qed.
 
 Lemma in_futures_preserves_can_emit_by_equivocators_composition_for_sent s base_s
@@ -400,7 +400,7 @@ Proof.
   - right.
     clear -Hemit Hobs_s_protocol. revert Hemit.
     apply VLSM_incl_can_emit; simpl.
-    apply basic_VLSM_incl; intros s0 **; [done | | apply Hv | apply H].
+    apply basic_VLSM_incl; intros s0 **; [done | | by apply Hv | by apply H].
     destruct HmX as [Him | Hobs].
     + by apply initial_message_is_valid; left.
     + apply Hobs_s_protocol in Hobs as [Hsent | Hemit].
@@ -424,10 +424,10 @@ Proof.
   repeat split.
   - done.
   - apply proj1 in Ht.
-    destruct iom as [im|]; [|apply option_valid_message_None].
+    destruct iom as [im |]; [| by apply option_valid_message_None].
     apply strong_fixed_equivocation_eqv_valid_message.
-    apply (fixed_input_has_strong_fixed_equivocation_helper _ _ Ht).
-  - apply Ht.
+    by apply (fixed_input_has_strong_fixed_equivocation_helper _ _ Ht).
+  - by apply Ht.
   - apply proj2 in Ht. simpl in Ht.
     simpl. unfold sub_IM at 2. simpl. unfold composite_state_sub_projection at 1. simpl.
     destruct (vtransition _ _ _) as (si', om').
@@ -458,7 +458,7 @@ Proof.
     apply (VLSM_projection_in_futures
       (preloaded_component_projection IM (projT1 l))) in Hfuture.
     apply in_futures_preserving_oracle_from_stepwise with (field_selector output) (sf (projT1 l))
-    ; [apply has_been_sent_stepwise_from_trace | done |].
+    ; [by apply has_been_sent_stepwise_from_trace | done |].
     apply (VLSM_incl_input_valid_transition Fixed_incl_Preloaded) in Ht.
     specialize (VLSM_projection_input_valid_transition
       (preloaded_component_projection IM (projT1 l)) l (projT2 l)) as Hproject.
@@ -522,7 +522,7 @@ Proof.
       cbn; unfold pre_VLSM_projection_transition_item_project;
       cbn; unfold composite_label_sub_projection_option.
       case_decide as Hl.
-      * eapply finite_valid_trace_from_to_app; [apply Htr_pr |].
+      * eapply finite_valid_trace_from_to_app; [by apply Htr_pr |].
         apply finite_valid_trace_from_to_singleton.
         apply valid_trace_last_pstate in Htr_pr.
         by apply fixed_input_valid_transition_sub_projection_helper.
@@ -556,7 +556,7 @@ Lemma fixed_finite_valid_trace_sub_projection is f tr
               (finite_trace_sub_projection IM equivocators tr).
 Proof.
   apply fixed_finite_valid_trace_sub_projection_helper with (base_s := f) in Htr as Htr_pr.
-  - split; [apply Htr_pr|].
+  - split; [by apply Htr_pr |].
     apply proj2 in Htr.
     by specialize (composite_initial_state_sub_projection IM equivocators is Htr).
   - apply in_futures_refl. apply valid_trace_last_pstate in Htr.
@@ -608,8 +608,7 @@ Lemma fixed_input_has_strong_fixed_equivocation
 Proof.
   apply fixed_input_has_strong_fixed_equivocation_helper with (base_s := s) in Ht
   ; [done |].
-  apply fixed_directly_observed_has_strong_fixed_equivocation.
-  apply Ht.
+  by apply fixed_directly_observed_has_strong_fixed_equivocation, Ht.
 Qed.
 
 (**
@@ -628,7 +627,7 @@ Proof.
       by eapply (input_valid_transition_in_futures PreFree).
     + by apply fixed_directly_observed_has_strong_fixed_equivocation.
   - apply input_valid_transition_in_futures in Ht.
-    revert Ht. apply fixed_valid_state_sub_projection.
+    by apply fixed_valid_state_sub_projection.
   - apply in_futures_refl. apply input_valid_transition_destination in Ht.
     by apply (VLSM_incl_valid_state Fixed_incl_Preloaded).
   - done.
@@ -693,7 +692,7 @@ Lemma Equivocators_Fixed_Strong_eq base_s
 Proof.
   apply VLSM_eq_incl_iff. split.
   - by apply Equivocators_Fixed_Strong_incl.
-  - apply Equivocators_Strong_Fixed_incl.
+  - by apply Equivocators_Strong_Fixed_incl.
 Qed.
 
 (**
@@ -719,8 +718,8 @@ Qed.
 Lemma Fixed_eq_StrongFixed : VLSM_eq Fixed StrongFixed.
 Proof.
   apply VLSM_eq_incl_iff. split.
-  - apply Fixed_incl_StrongFixed.
-  - apply StrongFixed_incl_Fixed.
+  - by apply Fixed_incl_StrongFixed.
+  - by apply StrongFixed_incl_Fixed.
 Qed.
 
 End sec_Fixed_eq_StrongFixed.
@@ -777,7 +776,7 @@ Lemma restrict_observed_to_non_equivocating_incl s eqv_is
       (lift_sub_state_to IM equivocators s eqv_is)).
 Proof.
   apply pre_loaded_vlsm_incl.
-  apply lift_sub_state_to_sent_by_non_equivocating_iff.
+  by apply lift_sub_state_to_sent_by_non_equivocating_iff.
 Qed.
 
 Lemma restrict_observed_to_non_equivocating_incl_rev s eqv_is
@@ -787,7 +786,7 @@ Lemma restrict_observed_to_non_equivocating_incl_rev s eqv_is
     (equivocators_composition_for_sent IM equivocators s).
 Proof.
   apply pre_loaded_vlsm_incl.
-  apply lift_sub_state_to_sent_by_non_equivocating_iff.
+  by apply lift_sub_state_to_sent_by_non_equivocating_iff.
 Qed.
 
 (**
@@ -799,12 +798,12 @@ Lemma lift_sub_state_to_strong_fixed_equivocation s eqv_is m
     strong_fixed_equivocation IM equivocators (lift_sub_state_to IM equivocators s eqv_is) m.
 Proof.
   split; intros [Hs | Hs]; [left|right|left|right]; revert Hs.
-  - apply lift_sub_state_to_sent_by_non_equivocating_iff.
+  - by apply lift_sub_state_to_sent_by_non_equivocating_iff.
   - apply VLSM_incl_can_emit.
-    apply restrict_observed_to_non_equivocating_incl.
-  - apply lift_sub_state_to_sent_by_non_equivocating_iff.
+    by apply restrict_observed_to_non_equivocating_incl.
+  - by apply lift_sub_state_to_sent_by_non_equivocating_iff.
   - apply VLSM_incl_can_emit.
-    apply restrict_observed_to_non_equivocating_incl_rev.
+    by apply restrict_observed_to_non_equivocating_incl_rev.
 Qed.
 
 (**
@@ -840,7 +839,7 @@ Proof.
   - intros [i liX].
     unfold remove_equivocating_state_project;
     unfold remove_equivocating_label_project; cbn.
-    case_decide as Hi; [|congruence].
+    case_decide as Hi; [| by congruence].
     intros _ s om s' om';
     destruct (vtransition _ _ _) as (si', _om') eqn: Hti;
     inversion_clear 1.
@@ -873,8 +872,7 @@ Proof.
   intros eqv_is Heqv_is.
   apply (VLSM_incl_valid_state (StrongFixed_incl_Fixed IM equivocators)).
   apply (VLSM_projection_valid_state (remove_equivocating_transitions_fixed_projection _ Heqv_is)).
-  revert Hbase_s.
-  apply (VLSM_incl_valid_state (Fixed_incl_StrongFixed IM equivocators)).
+  by apply (VLSM_incl_valid_state (Fixed_incl_StrongFixed IM equivocators)).
 Qed.
 
 Lemma lift_sub_state_to_sent_are_directly_observed s
@@ -883,7 +881,7 @@ Lemma lift_sub_state_to_sent_are_directly_observed s
 Proof.
   intros m Hsent.
   apply (lift_sub_state_to_sent_by_non_equivocating_iff base_s s m) in Hsent.
-  revert Hsent. apply sent_by_non_equivocating_are_directly_observed.
+  by eapply sent_by_non_equivocating_are_directly_observed.
 Qed.
 
 Lemma strong_fixed_equivocation_lift_sub_state_to s
@@ -983,7 +981,7 @@ Proof.
     left.
     destruct Hsent as [i Hsent].
     exists i.
-    rewrite elem_of_nil. itauto.
+    by rewrite elem_of_nil; itauto.
 Qed.
 
 Lemma strong_fixed_equivocation_constraint_no_equivocators
@@ -995,8 +993,8 @@ Proof.
   destruct som as (s, [m |]); [| done].
   simpl.
   specialize (strong_fixed_equivocation_no_equivocators s m).
-  unfold composite_no_equivocations, composite_no_equivocations_except_from, sent_except_from. simpl.
-  itauto.
+  unfold composite_no_equivocations, composite_no_equivocations_except_from, sent_except_from.
+  by cbn; itauto.
 Qed.
 
 Lemma strong_fixed_equivocation_vlsm_composition_no_equivocators
@@ -1022,8 +1020,8 @@ Lemma fixed_equivocation_vlsm_composition_no_equivocators
       (composite_vlsm IM (composite_no_equivocations IM)).
 Proof.
   eapply VLSM_eq_trans.
-  - apply Fixed_eq_StrongFixed.
-  - apply strong_fixed_equivocation_vlsm_composition_no_equivocators.
+  - by apply Fixed_eq_StrongFixed.
+  - by apply strong_fixed_equivocation_vlsm_composition_no_equivocators.
 Qed.
 
 End sec_fixed_equivocation_no_equivocators.
@@ -1060,13 +1058,13 @@ Lemma lift_strong_fixed_non_equivocating
 Proof.
   apply induced_sub_projection_lift.
   intros s1 s2 Heq l om.
-  destruct om as [m|]; [|itauto].
+  destruct om as [m |]; [| by itauto].
   cut
     (forall m, sent_by_non_equivocating IM equivocators s1 m ->
       sent_by_non_equivocating IM equivocators s2 m).
   {
     intros Hsent_impl [[j [Hj Hsent]] | Hemit].
-    - left. apply Hsent_impl. by exists j.
+    - by left; apply Hsent_impl; exists j.
     - right. revert Hemit.
       by apply VLSM_incl_can_emit, pre_loaded_vlsm_incl.
   }
@@ -1075,7 +1073,7 @@ Proof.
   exists i. split; [done |].
   replace (s2 i) with (s1 i); [done |].
   assert (Hi' : i ∈ non_equivocators)
-    by (apply set_diff_intro; [apply elem_of_enum | done]).
+    by (apply set_diff_intro; [apply elem_of_enum |]; done).
   by eapply f_equal_dep with (x := dexist i Hi') in Heq.
 Qed.
 
@@ -1098,7 +1096,7 @@ Proof.
   revert Htr.
   apply VLSM_incl_finite_valid_trace.
   apply induced_sub_projection_constraint_subsumption_incl.
-  apply fixed_strong_equivocation_subsumption.
+  by apply fixed_strong_equivocation_subsumption.
 Qed.
 
 Lemma fixed_non_equivocating_projection_friendliness
@@ -1107,7 +1105,7 @@ Lemma fixed_non_equivocating_projection_friendliness
         (fixed_equivocation_constraint IM equivocators)).
 Proof.
   apply induced_sub_projection_friendliness.
-  apply lift_fixed_non_equivocating.
+  by apply lift_fixed_non_equivocating.
 Qed.
 
 (**
@@ -1123,7 +1121,7 @@ Lemma fixed_non_equivocating_traces_char is tr
     finite_trace_sub_projection IM non_equivocators etr = tr.
 Proof.
   apply (projection_friendly_trace_char (induced_sub_projection_is_projection _ _ _)).
-  apply fixed_non_equivocating_projection_friendliness.
+  by apply fixed_non_equivocating_projection_friendliness.
 Qed.
 
 End sec_fixed_non_equivocator_lifting.

--- a/theories/VLSM/Core/Equivocation/FullNode.v
+++ b/theories/VLSM/Core/Equivocation/FullNode.v
@@ -122,7 +122,7 @@ Proof.
   apply node_generated_without_further_equivocation_weaken; [done | | done].
   revert Hs.
   apply VLSM_incl_valid_state.
-  apply preloaded_constraint_free_incl.
+  by apply preloaded_constraint_free_incl.
 Qed.
 
 End sec_full_node_constraint.

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -109,7 +109,7 @@ Proof.
   intros s Hs; exists (elements(equivocating_validators s));
     [by apply NoDup_elements | | done].
   by intros v Hv; apply elem_of_elements, elem_of_filter; split; [done |];
-  apply Hcomprehensive.
+    apply Hcomprehensive.
 Qed.
 
 End sec_basic_limited_message_equivocation.
@@ -155,9 +155,9 @@ Lemma tracewise_not_heavy_LimitedEquivocationProp_iff :
   forall s, not_heavy s <-> LimitedEquivocationProp IM is_equivocating s.
 Proof.
   intros; split.
-  - apply not_heavy_impl_LimitedEquivocationProp,
+  - by apply not_heavy_impl_LimitedEquivocationProp,
       tracewise_basic_equivocation_state_validators_comprehensive_prop.
-  - apply LimitedEquivocationProp_impl_not_heavy.
+  - by apply LimitedEquivocationProp_impl_not_heavy.
 Qed.
 
 End sec_tracewise_limited_message_equivocation.
@@ -210,9 +210,10 @@ Proof.
     - by intros i Hi; apply elem_of_remove_dups, Hincl; unfold tracewise_equivocating_validators; apply Hi.
   }
   assert (StrongFixedinclPreFree : VLSM_incl StrongFixed PreFree).
-  { apply VLSM_incl_trans with (machine Free).
-    - apply (constraint_free_incl IM (strong_fixed_equivocation_constraint IM equivocators)).
-    - apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  {
+    apply VLSM_incl_trans with (machine Free).
+    - by apply (constraint_free_incl IM (strong_fixed_equivocation_constraint IM equivocators)).
+    - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
   apply valid_state_has_trace in Hs as [is [tr Htr]].
   apply (VLSM_incl_finite_valid_trace_init_to StrongFixedinclPreFree) in Htr as Hpre_tr.
@@ -254,8 +255,8 @@ Proof.
     as Heq.
   apply VLSM_eq_proj1 in Heq.
   apply VLSM_incl_trans with (machine StrongFixed).
-  - apply Heq.
-  - apply StrongFixed_incl_Limited.
+  - by apply Heq.
+  - by apply StrongFixed_incl_Limited.
 Qed.
 
 End sec_fixed_limited_message_equivocation.
@@ -334,10 +335,10 @@ Proof.
   - by eapply valid_trace_forget_last, strong_witness_has_fixed_equivocation.
   - replace (sum_weights _) with (equivocation_fault s); [done |].
     apply set_eq_nodup_sum_weight_eq.
-    + apply NoDup_elements.
-    + apply NoDup_remove_dups.
+    + by apply NoDup_elements.
+    + by apply NoDup_remove_dups.
     + apply ListSetExtras.set_eq_extract_forall.
-      intro i. rewrite elem_of_remove_dups. itauto.
+      by intro i; rewrite elem_of_remove_dups; itauto.
 Qed.
 
 (**
@@ -359,8 +360,8 @@ Proof.
   eapply traces_exhibiting_limited_equivocation_are_valid_rev; [done.. | |].
   - apply valid_trace_add_default_last.
     eapply VLSM_incl_finite_valid_trace; [| done].
-    apply constraint_free_incl.
-  - apply tracewise_not_heavy_LimitedEquivocationProp_iff,
+    by apply constraint_free_incl.
+  - by apply tracewise_not_heavy_LimitedEquivocationProp_iff,
       full_node_limited_equivocation_valid_state_weight,
       finite_valid_trace_last_pstate with (X := Limited), Htr.
 Qed.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -46,7 +46,7 @@ Lemma messages_with_valid_dependences_can_be_emitted s dm
   (Hemitted: can_emit (pre_loaded_with_all_messages_vlsm (IM dm_i)) dm)
   : can_emit (equivocators_composition_for_sent IM equivocators s) dm.
 Proof.
-  eapply sub_valid_preloaded_lifts_can_be_emitted, message_dependencies_are_sufficient
+  by eapply sub_valid_preloaded_lifts_can_be_emitted, message_dependencies_are_sufficient
   ; itauto eauto.
 Qed.
 
@@ -59,7 +59,7 @@ Proof.
   apply Hdeps.
   transitivity dm; [done |].
   apply msg_dep_happens_before_iff_one.
-  itauto.
+  by itauto.
 Qed.
 
 Lemma dependencies_are_valid s m
@@ -80,8 +80,8 @@ Proof.
   ; [| done | done].
   intros dm0 Hdm0.
   apply Hind with dm; [done | | done].
-  - clear -Heqv Hdm; revert dm m Hdm Heqv.
-    apply msg_dep_rel_reflects_dependencies_with_non_equivocating_senders_were_sent.
+  clear -Heqv Hdm; revert dm m Hdm Heqv.
+  by apply msg_dep_rel_reflects_dependencies_with_non_equivocating_senders_were_sent.
 Qed.
 
 Lemma msg_dep_strong_fixed_equivocation_subsumption s m
@@ -93,7 +93,7 @@ Proof.
   cut (forall dm, msg_dep_rel message_dependencies dm m -> valid_message_prop (equivocators_composition_for_sent IM equivocators s) dm)
   ; [| by apply dependencies_are_valid].
   intro Hdeps; right.
-  apply messages_with_valid_dependences_can_be_emitted with i; itauto.
+  by apply messages_with_valid_dependences_can_be_emitted with i; itauto.
 Qed.
 
 Lemma msg_dep_strong_fixed_equivocation_constraint_subsumption
@@ -125,22 +125,22 @@ Proof.
   - intros [sub_i li] lY HlX_pr sX om sX' om' [_ HtX]; revert HtX.
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
     unfold sub_label_element_project in HlX_pr; cbn in HlX_pr.
-    case_decide as Heqij; [|congruence].
+    case_decide as Heqij; [| by congruence].
     subst i; cbv in HlX_pr; apply Some_inj in HlX_pr; subst li.
     cbn; unfold sub_IM, sub_state_element_project; cbn.
     rewrite (sub_IM_state_pi sX Hj Hi).
     destruct (vtransition _ _ _) as (sj', _om'); inversion_clear 1.
-    f_equal; symmetry. apply sub_IM_state_update_eq.
+    by f_equal; symmetry; apply sub_IM_state_update_eq.
   - intros [sub_i li] HlX_pr sX om sX' om' [_ HtX].
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
     unfold sub_label_element_project in HlX_pr; cbn in HlX_pr.
-    case_decide as Heqij; [congruence|].
+    case_decide as Heqij; [by congruence |].
     cbn in HtX; destruct (vtransition _ _ _) as (si', _om').
     inversion_clear HtX.
     unfold sub_state_element_project.
     by state_update_simpl.
   - by intros sX HsX; apply (HsX (dexist j Hj)).
-  - intro; intros; apply any_message_is_valid_in_preloaded.
+  - by intro; intros; apply any_message_is_valid_in_preloaded.
 Qed.
 
 Lemma equivocators_composition_can_emit_sender s m
@@ -174,11 +174,11 @@ Proof.
   eapply message_dependencies_are_necessary in Hproduce as Hobs.
   eapply has_been_directly_observed_sent_received_iff
     in Hobs as [Hreceived | Hsent]; [.. | done]; cycle 1.
-  + left; exists i; split; [done |].
-    eapply in_futures_preserving_oracle_from_stepwise
-    ; [apply has_been_sent_stepwise_from_trace | done | done].
-  + by eapply in_futures_valid_fst.
-  + apply in_futures_valid_fst in Hfutures as Hdestination.
+  - left; exists i; split; [done |].
+    by eapply in_futures_preserving_oracle_from_stepwise
+    ; [apply has_been_sent_stepwise_from_trace | |].
+  - by eapply in_futures_valid_fst.
+  - apply in_futures_valid_fst in Hfutures as Hdestination.
     specialize (received_component_received_previously IM Hdestination Hreceived)
       as (s_item_dm & [] & Ht & Hfutures_dm & <- & Hinput);
       destruct l as [i li]; cbn in Hinput; subst input; cbn in *.
@@ -186,9 +186,9 @@ Proof.
       ; destruct Ht as [(_ & _ & _ & Hc) _].
       eapply in_futures_preserves_strong_fixed_equivocation; [| apply Hc].
       eapply VLSM_incl_in_futures.
-      * apply constraint_preloaded_free_incl
+      + by apply constraint_preloaded_free_incl
          with (constraint := strong_fixed_equivocation_constraint IM equivocators).
-      * by do 2 (eapply in_futures_trans; [done |]).
+      + by do 2 (eapply in_futures_trans; [done |]).
 Qed.
 
 Lemma msg_dep_rel_reflects_strong_fixed_equivocation
@@ -207,7 +207,7 @@ Proof.
       ; [| by left | by right].
       destruct_dec_sig sub_j j Hj Heqsub_j; subst.
       clear -Him no_initial_messages_in_IM; contradict Him.
-      apply no_initial_messages_in_IM.
+      by apply no_initial_messages_in_IM.
     }
     destruct Hemit as ((sX, iom) & (sub_i, li) & sX' & HtX).
     eapply (preloaded_composite_directly_observed_valid _ _ _ sX').
@@ -319,7 +319,7 @@ Proof.
   destruct (sender m) as [v |]; [| congruence].
   eexists; split; [done |].
   replace (A v) with i; [done |].
-  congruence.
+  by congruence.
 Qed.
 
 Context
@@ -336,7 +336,7 @@ Lemma fixed_full_node_equivocation_incl
       (composite_vlsm IM full_node_fixed_set_equivocation_constraint).
 Proof.
   eapply VLSM_incl_trans.
-  - apply Fixed_incl_StrongFixed.
+  - by apply Fixed_incl_StrongFixed.
   - eapply VLSM_incl_trans.
     + by eapply strong_msg_dep_fixed_equivocation_incl.
     + apply constraint_subsumption_incl
@@ -355,7 +355,7 @@ Lemma full_node_fixed_equivocation_constraint_subsumption
 Proof.
   intros l [s [m |]] (_ & Hm & Hv & Hc); [| itauto]
   ; destruct Hc as [Hsent | Heqv]; [left | right].
-  - revert Hsent; apply sent_by_non_equivocating_are_directly_observed.
+  - by revert Hsent; apply sent_by_non_equivocating_are_directly_observed.
   - destruct l as [i li], Heqv as (j & Hsender & HAj).
     apply Hfull in Hv.
     eapply VLSM_incl_can_emit.
@@ -368,9 +368,8 @@ Proof.
     }
     eapply VLSM_full_projection_can_emit.
     {
-      apply @preloaded_sub_element_full_projection
-        with (Hj := HAj) (P := fun dm => dm ∈ message_dependencies m).
-      itauto.
+      by apply @preloaded_sub_element_full_projection
+        with (Hj := HAj) (P := fun dm => dm ∈ message_dependencies m); itauto.
     }
     eapply message_dependencies_are_sufficient.
     cut (exists k, can_emit (pre_loaded_with_all_messages_vlsm (IM k)) m).
@@ -385,7 +384,7 @@ Proof.
             (vlsm_incl_pre_loaded_with_all_messages_vlsm (composite_vlsm IM _))).
     apply emitted_messages_are_valid_iff in Hm as [[k [[im Him] Heqm]] | Hemit]
     ; [| done].
-    clear Heqm; contradict Him; apply no_initial_messages_in_IM.
+    by clear Heqm; contradict Him; apply no_initial_messages_in_IM.
 Qed.
 
 Lemma full_node_fixed_equivocation_incl

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -78,7 +78,7 @@ Lemma coeqv_limited_equivocation_state_annotation_nodup s
     NoDup (state_annotation s).
 Proof.
   induction 1 using valid_state_prop_ind.
-  - destruct s, Hs as [_ ->]; cbn in *; constructor.
+  - by destruct s, Hs as [_ ->]; cbn in *; constructor.
   - destruct Ht as [_ Ht]; cbn in Ht.
     unfold annotated_transition in Ht
     ; destruct (vtransition _ _ _); inversion Ht.
@@ -90,8 +90,7 @@ Lemma coeqv_limited_equivocation_state_not_heavy s
     (sum_weights (state_annotation s) <= proj1_sig threshold)%R.
 Proof.
   induction 1 using valid_state_prop_ind.
-  - destruct s, Hs as [_ ->], threshold; cbn in *.
-    by apply Rge_le.
+  - by destruct s, Hs as [_ ->], threshold; cbn in *; apply Rge_le.
   - destruct Ht as [(_ & _ & _ & Hc) Ht]
     ; cbn in Ht; unfold annotated_transition in Ht; destruct (vtransition _ _ _)
     ; inversion_clear Ht.
@@ -248,7 +247,7 @@ Lemma annotated_free_input_valid_projection
 Proof.
   intro Hvalid.
   eapply (VLSM_projection_input_valid (preloaded_component_projection IM i))
-  ; [apply (composite_project_label_eq IM) |].
+  ; [by apply (composite_project_label_eq IM) |].
   by apply (VLSM_incl_input_valid (vlsm_incl_pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM))),
         (VLSM_full_projection_input_valid (forget_annotations_projection (free_composite_vlsm IM) _ _ _)).
 Qed.
@@ -276,7 +275,7 @@ Lemma msg_dep_full_node_valid_iff l (s : @state _ (annotated_type (free_composit
     vvalid (full_node_limited_equivocation_vlsm IM sender) l (s, om).
 Proof.
   cbn; unfold annotated_valid, coeqv_limited_equivocation_constraint; destruct l as [i li].
-  rewrite full_node_msg_dep_composite_transition_message_equivocators; itauto.
+  by rewrite full_node_msg_dep_composite_transition_message_equivocators; itauto.
 Qed.
 
 Lemma msg_dep_full_node_transition_iff l (s : @state _ (annotated_type (free_composite_vlsm IM) (set validator))) om
@@ -286,7 +285,7 @@ Lemma msg_dep_full_node_transition_iff l (s : @state _ (annotated_type (free_com
 Proof.
   cbn; unfold annotated_transition;
     destruct (vtransition _ _ _) as (s', om'), l as (i, li).
- rewrite full_node_msg_dep_composite_transition_message_equivocators; itauto.
+  by rewrite full_node_msg_dep_composite_transition_message_equivocators; itauto.
 Qed.
 
 Lemma msg_dep_full_node_limited_equivocation_vlsm_incl :
@@ -327,8 +326,8 @@ Lemma full_node_msg_dep_limited_equivocation_vlsm_eq :
     (msg_dep_limited_equivocation_vlsm IM full_message_dependencies sender).
 Proof.
   apply VLSM_eq_incl_iff; split.
-  - apply full_node_msg_dep_limited_equivocation_vlsm_incl.
-  - apply msg_dep_full_node_limited_equivocation_vlsm_incl.
+  - by apply full_node_msg_dep_limited_equivocation_vlsm_incl.
+  - by apply msg_dep_full_node_limited_equivocation_vlsm_incl.
 Qed.
 
 End sec_full_node_msg_dep_limited_equivocation_equivalence.
@@ -400,7 +399,7 @@ Proof.
     unfold msg_dep_message_equivocators, coeqv_message_equivocators,
            msg_dep_coequivocating_senders, not_directly_observed_happens_before_dependencies
     ; rewrite decide_False, elem_of_app, !elem_of_map_option by done.
-    right; exists dm; rewrite elem_of_list_filter
+    by right; exists dm; rewrite elem_of_list_filter
     ; setoid_rewrite full_message_dependencies_happens_before
     ; itauto.
   }
@@ -423,7 +422,7 @@ Lemma message_equivocators_can_emit (s : vstate Limited) im
       im.
 Proof.
   eapply VLSM_full_projection_can_emit.
-  - apply equivocators_composition_for_directly_observed_index_incl_full_projection
+  - by apply equivocators_composition_for_directly_observed_index_incl_full_projection
      with (Hincl := set_union_subseteq_right (state_annotation s) (msg_dep_message_equivocators
                       IM full_message_dependencies sender (original_state s) im)).
   - specialize (equivocating_messages_are_equivocator_emitted _ _ HLemit Hnobserved)
@@ -466,14 +465,14 @@ Proof.
   split.
   - rewrite set_eq_nodup_sum_weight_eq
        with (lv2 := state_annotation (finite_trace_last is tr)).
-    + apply coeqv_limited_equivocation_state_not_heavy,
+    + by apply coeqv_limited_equivocation_state_not_heavy,
             finite_valid_trace_last_pstate, Htr.
-    + apply NoDup_remove_dups.
-    + apply coeqv_limited_equivocation_state_annotation_nodup,
+    + by apply NoDup_remove_dups.
+    + by apply coeqv_limited_equivocation_state_annotation_nodup,
             finite_valid_trace_last_pstate, Htr.
     + apply set_eq_extract_forall.
       setoid_rewrite elem_of_remove_dups.
-      itauto.
+      by itauto.
   - split; [| apply Htr].
     apply valid_trace_add_default_last in Htr.
     induction Htr using finite_valid_trace_init_to_rev_ind
@@ -481,7 +480,7 @@ Proof.
     setoid_rewrite map_app.
     apply finite_valid_trace_from_app_iff; split.
     + revert IHHtr.
-      eapply VLSM_incl_finite_valid_trace_from,
+      by eapply VLSM_incl_finite_valid_trace_from,
              fixed_equivocation_vlsm_composition_index_incl,
              coeqv_limited_equivocation_transition_state_annotation_incl,
              Ht.
@@ -550,7 +549,7 @@ Proof.
           as [[j [[mj Hmj] Heqim]] | Hemit]
         ; [clear Heqim; contradict Hmj; apply no_initial_messages_in_IM |].
         eapply VLSM_full_projection_can_emit; [| done].
-        apply forget_annotations_projection.
+        by apply forget_annotations_projection.
 Qed.
 
 Corollary msg_dep_fixed_limited_equivocation is tr
@@ -599,7 +598,7 @@ Proof.
   replace (finite_trace_last _ _) with s
        by (apply valid_trace_get_last in Htr1; congruence).
   unfold coeqv_message_equivocators.
-  case_decide as Hnobserved; [apply list_subseteq_nil |].
+  case_decide as Hnobserved; [by apply list_subseteq_nil |].
   destruct Ht as [(Hs & Him & Hv & [Hobs | Hemitted]) Ht]
   ; [done | intros eqv Heqv].
   unfold msg_dep_coequivocating_senders,
@@ -636,7 +635,7 @@ Proof.
     + eapply msg_dep_rel_reflects_strong_fixed_equivocation
       ; [done | done |].
       apply VLSM_incl_valid_state; [| done].
-      apply Fixed_incl_StrongFixed.
+      by apply Fixed_incl_StrongFixed.
 Qed.
 
 Lemma msg_dep_limited_fixed_equivocation
@@ -647,7 +646,7 @@ Lemma msg_dep_limited_fixed_equivocation
       (msg_dep_annotate_trace_with_equivocators IM full_message_dependencies sender is tr).
 Proof.
   intros (equivocators & Hlimited & Htr).
-  split; [| split; [apply Htr | done]].
+  split; [| by split; [apply Htr |]].
   apply valid_trace_add_default_last in Htr.
   match goal with
   |- finite_valid_trace_from Limited ?is ?tr =>
@@ -662,13 +661,13 @@ Proof.
   - rewrite @msg_dep_annotate_trace_with_equivocators_app; cbn.
     unfold annotate_trace_item; rewrite !finite_trace_last_is_last; cbn.
     split; cycle 1.
-    + eapply fixed_transition_preserves_annotation_equivocators
-      ; [done | done | apply IHHtr1].
+    + by eapply fixed_transition_preserves_annotation_equivocators
+      ; [| | apply IHHtr1].
     + apply finite_valid_trace_from_app_iff.
-      split; [apply IHHtr1 |].
+      split; [by apply IHHtr1 |].
       apply finite_valid_trace_singleton.
       repeat split.
-      * apply finite_valid_trace_last_pstate, IHHtr1.
+      * by apply finite_valid_trace_last_pstate, IHHtr1.
       * clear -Heqiom IHHtr2.
         destruct IHHtr2 as [IHHtr2 _].
         unfold empty_initial_message_or_final_output in Heqiom.
@@ -679,26 +678,26 @@ Proof.
         rewrite @msg_dep_annotate_trace_with_equivocators_app.
         apply Exists_app; right.
         destruct iom_item.
-        apply Exists_exists; eexists; split; [left | done].
+        by apply Exists_exists; eexists; split; [left |].
       * destruct l as [i li]; cbn.
         rewrite msg_dep_annotate_trace_with_equivocators_last_original_state; cbn.
         replace (finite_trace_last _ _) with s
              by (apply valid_trace_get_last in Htr1; congruence).
-        apply Ht.
+        by apply Ht.
       * apply Rle_trans with (sum_weights (remove_dups equivocators))
         ; [| done].
         apply sum_weights_subseteq.
         -- destruct iom as [im|]; cycle 1.
            ++ eapply coeqv_limited_equivocation_state_annotation_nodup.
-              apply finite_valid_trace_last_pstate, IHHtr1.
+              by apply finite_valid_trace_last_pstate, IHHtr1.
            ++ apply set_union_nodup_left.
               eapply coeqv_limited_equivocation_state_annotation_nodup.
-              apply finite_valid_trace_last_pstate, IHHtr1.
-        -- apply NoDup_remove_dups.
+              by apply finite_valid_trace_last_pstate, IHHtr1.
+        -- by apply NoDup_remove_dups.
         -- transitivity equivocators.
-           ++ eapply fixed_transition_preserves_annotation_equivocators
-              ; [done | done | apply IHHtr1].
-           ++ intro; apply elem_of_remove_dups.
+           ++ by eapply fixed_transition_preserves_annotation_equivocators
+              ; [| | apply IHHtr1].
+           ++ by intro; apply elem_of_remove_dups.
       * destruct l as [i li]; cbn; unfold annotated_transition; cbn.
         rewrite !msg_dep_annotate_trace_with_equivocators_last_original_state; cbn.
         replace (finite_trace_last _ _) with s

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -131,8 +131,8 @@ Proof.
     split; [| done].
     rapply extend_right_finite_trace_from; [done |].
     apply finite_valid_trace_last_pstate in IHtr as Hs.
-    cut (option_valid_message_prop X iom);[firstorder|].
-    destruct iom as [m|];[|apply option_valid_message_None].
+    cut (option_valid_message_prop X iom); [by firstorder |].
+    destruct iom as [m |]; [| by apply option_valid_message_None].
     destruct Hx as [Hv _].
     apply Henforced in Hv.
     destruct Hv as [Hbsm | []].
@@ -144,7 +144,7 @@ Lemma preloaded_incl_no_equivocations
 Proof.
   specialize no_equivocations_preloaded_traces.
   clear -X. destruct X as [T [S M]].
-  apply VLSM_incl_finite_traces_characterization.
+  by apply VLSM_incl_finite_traces_characterization.
 Qed.
 
 Lemma preloaded_eq_no_equivocations
@@ -313,7 +313,7 @@ Proof.
   apply VLSM_eq_incl_iff.
   specialize (constraint_subsumption_incl IM) as Hincl.
   unfold no_equivocations_additional_constraint_with_pre_loaded.
-  split;apply Hincl;intros l [s [m|]] Hpv; apply Hpv.
+  by split; apply Hincl; intros l [s [m |]] Hpv; apply Hpv.
 Qed.
 
 End sec_seeded_composite_vlsm_no_equivocation.

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -43,10 +43,9 @@ Definition item_equivocating_in_trace
 #[local] Instance item_equivocating_in_trace_dec : RelDecision item_equivocating_in_trace.
 Proof.
   intros item tr.
-  destruct item. destruct input as [m|]
-  ; [|right; itauto].
+  destruct item. destruct input as [m |]; [| by right; itauto].
   unfold item_equivocating_in_trace, trace_has_message, field_selector; cbn.
-  typeclasses eauto.
+  by typeclasses eauto.
 Qed.
 
 (**
@@ -82,8 +81,8 @@ Proof.
   apply elem_of_list_filter, proj2, elem_of_one_element_decompositions in Hitem.
   subst tr _item.
   spec Hinput_none item.
-  spec Hinput_none. { apply elem_of_app. right. apply elem_of_app. left. left. }
-  congruence.
+  spec Hinput_none; [| by congruence].
+  by apply elem_of_app; right; apply elem_of_app; do 2 left.
 Qed.
 
 Lemma elem_of_equivocating_senders_in_trace
@@ -126,7 +125,7 @@ Proof.
   intros v. rewrite !elem_of_equivocating_senders_in_trace.
   intros [m [Hm Heqv]].
   exists m. split; [done |].
-  revert Heqv. apply equivocation_in_trace_prefix.
+  by apply equivocation_in_trace_prefix.
 Qed.
 
 (**
@@ -207,7 +206,7 @@ Proof.
     intros.
     erewrite <- oracle_initial_trace_update
       with (vlsm := free_composite_vlsm IM); cycle 1.
-    - apply composite_has_been_sent_stepwise_props.
+    - by apply composite_has_been_sent_stepwise_props.
     - done.
     - by eapply has_been_sent_iff_by_sender.
   }
@@ -246,8 +245,7 @@ Lemma transition_receiving_no_sender_reflects_is_equivocating_tracewise
   : is_equivocating_tracewise_no_has_been_sent s' v -> is_equivocating_tracewise_no_has_been_sent s v.
 Proof.
   intro Hs'.
-  by destruct (transition_is_equivocating_tracewise_char _ _ _ _ _ Ht v Hs')
-  ; [|congruence].
+  by destruct (transition_is_equivocating_tracewise_char _ _ _ _ _ Ht v Hs'); [| congruence].
 Qed.
 
 Lemma is_equivocating_statewise_implies_is_equivocating_tracewise s v
@@ -279,9 +277,8 @@ Proof.
   rewrite Htr in Htrv.
   intro Hbs_m. elim Hnbs_m. clear Hnbs_m.
   revert Hbs_m.
-  apply in_futures_preserving_oracle_from_stepwise with (field_selector output)
-  ; [apply has_been_sent_stepwise_from_trace|].
-  by eexists.
+  apply in_futures_preserving_oracle_from_stepwise with (field_selector output); [| by eexists].
+  by apply has_been_sent_stepwise_from_trace.
 Qed.
 
 Lemma initial_state_not_is_equivocating_tracewise
@@ -292,9 +289,9 @@ Lemma initial_state_not_is_equivocating_tracewise
 Proof.
   intros Heqv.
   specialize (Heqv s []).
-  spec Heqv. { split; [| done]. constructor. by apply initial_state_is_valid. }
+  spec Heqv; [by split; [| done]; constructor; apply initial_state_is_valid |].
   destruct Heqv as [m [_ [prefix [suf [item [Heq _]]]]]].
-  destruct prefix; inversion Heq.
+  by destruct prefix; inversion Heq.
 Qed.
 
 Context
@@ -317,7 +314,7 @@ Proof.
   unfold equivocating_validators.
   simpl.
   rewrite elem_of_filter, elem_of_list_to_set.
-  itauto (apply elem_of_enum).
+  by itauto (apply elem_of_enum).
 Qed.
 
 Lemma equivocating_validators_empty_in_initial_state
@@ -359,8 +356,7 @@ Lemma composite_transition_no_sender_equivocators_weight
   : (equivocation_fault s' <= equivocation_fault s)%R.
 Proof.
   specialize (input_valid_transition_receiving_no_sender_reflects_equivocating_validators _ _ _ _ _ Ht Hno_sender) as Heqv.
-  revert Heqv.
-  apply incl_equivocating_validators_equivocation_fault.
+  by apply incl_equivocating_validators_equivocation_fault.
 Qed.
 
 End sec_tracewise_equivocation.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -65,9 +65,9 @@ Lemma equivocating_senders_in_trace_witnessing_equivocation_prop
   (s := finite_trace_last is tr)
   : set_eq (elements (equivocating_validators s)) (equivocating_senders_in_trace IM sender tr).
 Proof.
-  split; intros v Hv; [apply elem_of_elements, Htr in Hv | apply elem_of_elements, Htr].
-  - by apply elem_of_equivocating_senders_in_trace.
-  - by eapply elem_of_equivocating_senders_in_trace.
+  split; intros v Hv.
+  - by apply elem_of_elements, Htr in Hv; apply elem_of_equivocating_senders_in_trace.
+  - by eapply elem_of_elements, Htr, elem_of_equivocating_senders_in_trace.
 Qed.
 
 (**
@@ -99,7 +99,7 @@ Proof.
   rewrite <- elem_of_elements.
   replace (elements (equivocating_validators s)) with (@nil validator).
   simpl.
-  split; [inversion 1|].
+  split; [by inversion 1|].
   intros [m [_ Hmsg]].
   - by elim (no_equivocation_in_empty_trace PreFree m).
   - by symmetry; apply elements_empty_iff, equivocating_validators_empty_in_initial_state.
@@ -182,7 +182,7 @@ Proof.
   destruct (transition_is_equivocating_tracewise_char IM A sender  _ _ _ _ _ Ht _ Hv)
     as [| Hom];
     [by contradict Hnv; apply equivocating_validators_is_equivocating_tracewise_iff |].
-  destruct om as [m|]; simpl in Hom; [|congruence].
+  destruct om as [m|]; simpl in Hom; [| by congruence].
   exists m; split_and!; [done.. |].
   intros is tr [Htr Hinit] Hwitness.
   specialize (extend_right_finite_trace_from_to _ Htr Ht) as Htr'.
@@ -250,10 +250,10 @@ Proof.
   ; [| by split].
   remember (finite_trace_last is tr) as s.
   destruct (option_bind _ _ sender om) as [v|] eqn:Heq_v.
-  - destruct om as [m|]; [|inversion Heq_v]. simpl in Heq_v.
-    destruct (decide (set_eq (elements (equivocating_validators s)) (elements (equivocating_validators s'))))
-    ; [apply set_eq_fin_set in s0; left;split; [done |]|].
-    + by apply
+  - destruct om as [m|]; [| by inversion Heq_v]. simpl in Heq_v.
+    destruct (decide (set_eq (elements (equivocating_validators s)) (elements (equivocating_validators s')))).
+    + apply set_eq_fin_set in s0; left; split; [done |].
+      by apply
         (input_valid_transition_reflects_trace_witnessing_equivocation_prop
           _ _ _ (conj Htr Hinit) _ Hwitness);
       subst; intros ? ?; apply s0.
@@ -282,8 +282,7 @@ Proof.
         [by right | left].
         apply elem_of_singleton.
         by apply Honly_v in Hv';
-        destruct Hv' as [|[_m [Heq_m [Heq_v' _]]]]; [by subst |];
-        congruence.
+          destruct Hv' as [|[_m [Heq_m [Heq_v' _]]]]; [by subst |]; congruence.
       * by apply elem_of_union in Hv' as [Heq_v' | Hs'0]
         ; [by apply elem_of_singleton in Heq_v'; subst v' | by apply Hincl].
   - left; split.
@@ -322,10 +321,11 @@ Proof.
   - by apply app_eq_nil in Heqtr as []; subst.
   - remember {| input := iom |} as item.
     spec IHHtr.
-    { intros pre suf Heq.
+    {
+      intros pre suf Heq.
       specialize (Hwitness pre (suf ++ [item])).
       apply Hwitness.
-      subst. apply app_assoc.
+      by subst; apply app_assoc.
     }
     destruct_list_last suffix suffix' _item Heqsuffix.
     + rewrite app_nil_r in Heqtr. subst. subst ps.
@@ -338,7 +338,7 @@ Proof.
       specialize (Hwitness (tr ++ [item]) []).
       spec Hwitness. { apply app_nil_r. }
       replace sf with (destination item) by (subst; done).
-      apply (equivocating_validators_witness_monotonicity _ _ _ Htr _ Hwitness).
+      by apply (equivocating_validators_witness_monotonicity _ _ _ Htr _ Hwitness).
 Qed.
 
 (**
@@ -365,7 +365,7 @@ Proof.
     subst.
     intro v. rewrite finite_trace_last_is_last.
     specialize (Hprefix tr'' []).
-    spec Hprefix; [apply app_nil_r|].
+    spec Hprefix; [by apply app_nil_r |].
     apply valid_trace_get_last in Htr'' as Hlst'.
     split.
     + intros Hv. apply Heq in Hv.
@@ -399,7 +399,7 @@ Proof.
         by eexists tr', _, [].
   - rewrite app_assoc in Heq_tr''_item. apply app_inj_tail in Heq_tr''_item.
     destruct Heq_tr''_item as [Heq_tr'' Heq_item].
-    apply (Hprefix _ _ Heq_tr'').
+    by apply (Hprefix _ _ Heq_tr'').
 Qed.
 
 Lemma strong_trace_witnessing_equivocation_prop_extend_neq
@@ -422,7 +422,7 @@ Proof.
     subst prefix suffix.
     intro v'. rewrite finite_trace_last_is_last. simpl.
     specialize (Hprefix tr []).
-    spec Hprefix; [apply app_nil_r|].
+    spec Hprefix; [by apply app_nil_r |].
     apply valid_trace_get_last in Htr as Hlst'.
     split.
     + intros Hv'. apply Hneq in Hv'.
@@ -445,11 +445,10 @@ Proof.
         apply Hprefix.
         by exists m.
       * left. simpl in Heqv.
-        destruct Heqv as [Heq_om Heqv].
-        congruence.
+        by destruct Heqv as [Heq_om Heqv]; congruence.
   - rewrite app_assoc in Heq_tr''_item. apply app_inj_tail in Heq_tr''_item.
     destruct Heq_tr''_item as [Heq_tr'' Heq_item].
-    apply (Hprefix _ _ Heq_tr'').
+    by apply (Hprefix _ _ Heq_tr'').
 Qed.
 
 (**
@@ -506,13 +505,13 @@ Proof.
     + by apply finite_valid_trace_init_add_last.
     + intros prefix suffix Heq_tr.
       apply app_eq_nil in Heq_tr. destruct Heq_tr. subst.
-      apply initial_state_witnessing_equivocation_prop. apply Htr.
+      by apply initial_state_witnessing_equivocation_prop, Htr.
   - rewrite finite_trace_last_is_last.
     intros ? Hn Htr'_item Hwitness.
     apply finite_valid_trace_init_add_last
       with (sf := destination item)
       in Htr'_item
-    ; [|apply finite_trace_last_is_last].
+    ; [| by apply finite_trace_last_is_last].
     destruct item as [l om s' om']. simpl in *.
     destruct
       (equivocating_validators_witness_last_char _ _ _ _ _ _ Htr'_item Hwitness)
@@ -526,10 +525,7 @@ Proof.
       destruct Htr'_item as [Htr'_item Hinit].
       apply finite_valid_trace_from_to_app_split in Htr'_item.
       destruct Htr'_item as [Htr' Hitem].
-      spec IHn.
-      { split; [| done].
-        by apply finite_valid_trace_from_to_forget_last in Htr'.
-      }
+      spec IHn; [by split; [| done]; apply finite_valid_trace_from_to_forget_last in Htr' |].
       spec IHn Hwitness'.
       destruct IHn as [is' [tr'' [[Htr'' Hinit'] Hprefix]]].
       specialize
@@ -537,7 +533,7 @@ Proof.
         as Htr''_item.
       eexists is', _.
       split; [done |].
-      apply (strong_trace_witnessing_equivocation_prop_extend_eq _ is tr' (conj Htr' Hinit))
+      by apply (strong_trace_witnessing_equivocation_prop_extend_eq _ is tr' (conj Htr' Hinit))
       ; [by split | done..].
     + subst. destruct Hneq as [Hneq Hwneq].
       match type of Hnv with
@@ -564,8 +560,7 @@ Proof.
       simpl in *.
       rewrite Htr''_lst in IHm.
       specialize (IHm eq_refl eq_refl).
-      spec IHm.
-      { by apply finite_valid_trace_init_to_forget_last in Htr''. }
+      spec IHm; [by apply finite_valid_trace_init_to_forget_last in Htr'' |].
       spec IHm Hwitness'.
       destruct IHm as [is'' [tr''' [[Htr''' Hinit'] Hprefix]]].
       apply proj1, finite_valid_trace_from_to_app_split, proj2 in Htr'_item as Hitem.
@@ -577,7 +572,7 @@ Proof.
       eexists is'', _.
       split; [done |].
       specialize (Hprefix tr''' []) as Hwitness'''.
-      spec Hwitness'''; [apply app_nil_r|].
+      spec Hwitness'''; [by apply app_nil_r |].
       specialize (Hwneq _ _ (conj Htr''' Hinit') Hwitness''').
       remember {| input := Some msg |} as item.
       specialize
@@ -678,31 +673,31 @@ Lemma equivocators_can_emit_free m
     (equivocators_composition_for_directly_observed IM (elements(equivocating_validators sf)) s)
     m.
 Proof.
-    apply emitted_messages_are_valid_iff in Hmsg
-      as [(_v & [_im Him] & Heqim) | Hiom]
-    ; [by elim (no_initial_messages_in_IM _v _im) |].
-    apply (VLSM_incl_can_emit (vlsm_incl_pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)))
-      in Hiom.
-    apply can_emit_composite_project in Hiom as [_v Hiom].
-    specialize (Hsender_safety _ _ Hsender _ Hiom) as Heq_v. simpl in Heq_v.
-    subst _v.
-    eapply message_dependencies_are_sufficient in Hiom.
-    unfold pre_loaded_free_equivocating_vlsm_composition, free_equivocating_vlsm_composition.
-      specialize
-        (@lift_to_composite_generalized_preloaded_vlsm_full_projection
-          message (sub_index (elements(equivocating_validators sf))) _ (sub_IM IM (elements(equivocating_validators sf)))
-          (λ msg : message, msg ∈ message_dependencies m)
-          (composite_has_been_directly_observed IM s))
-        as Hproj.
-      spec Hproj.
-      { intros dm Hdm.
-        destruct l as (i, li). simpl in Hv.
-        apply (Hfull _ _ _ _ Hv) in Hdm.
-        by exists i.
-      }
-      apply elem_of_elements in Hequivocating_v.
-      spec Hproj (@dexist _ _ (fun v => sub_index_prop_dec (elements(equivocating_validators sf)) v) v Hequivocating_v).
-      by apply (VLSM_full_projection_can_emit Hproj).
+  apply emitted_messages_are_valid_iff in Hmsg
+    as [(_v & [_im Him] & Heqim) | Hiom]
+  ; [by elim (no_initial_messages_in_IM _v _im) |].
+  apply (VLSM_incl_can_emit (vlsm_incl_pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)))
+    in Hiom.
+  apply can_emit_composite_project in Hiom as [_v Hiom].
+  specialize (Hsender_safety _ _ Hsender _ Hiom) as Heq_v. simpl in Heq_v.
+  subst _v.
+  eapply message_dependencies_are_sufficient in Hiom.
+  unfold pre_loaded_free_equivocating_vlsm_composition, free_equivocating_vlsm_composition.
+  specialize
+    (@lift_to_composite_generalized_preloaded_vlsm_full_projection
+      message (sub_index (elements(equivocating_validators sf))) _ (sub_IM IM (elements(equivocating_validators sf)))
+      (λ msg : message, msg ∈ message_dependencies m)
+      (composite_has_been_directly_observed IM s))
+    as Hproj.
+  spec Hproj.
+  { intros dm Hdm.
+    destruct l as (i, li). simpl in Hv.
+    apply (Hfull _ _ _ _ Hv) in Hdm.
+    by exists i.
+  }
+  apply elem_of_elements in Hequivocating_v.
+  spec Hproj (@dexist _ _ (fun v => sub_index_prop_dec (elements(equivocating_validators sf)) v) v Hequivocating_v).
+  by apply (VLSM_full_projection_can_emit Hproj).
 Qed.
 
 (** *** Main result of the section
@@ -723,14 +718,14 @@ Lemma strong_witness_has_fixed_equivocation is s tr
   (Heqv: strong_trace_witnessing_equivocation_prop (Cm := Ci) IM id sender is tr)
   : finite_valid_trace_init_to (fixed_equivocation_vlsm_composition IM (elements(equivocating_validators s))) is s tr.
 Proof.
-  split; [|apply Htr].
+  split; [| by apply Htr].
   induction Htr using finite_valid_trace_init_to_rev_ind.
   - eapply (finite_valid_trace_from_to_empty (fixed_equivocation_vlsm_composition IM (elements(equivocating_validators si)))).
     by apply initial_state_is_valid.
   - spec IHHtr.
     { intros prefix. intros.
       apply (Heqv prefix (suffix ++  [{| l := l; input := iom; destination := sf; output := oom |}])).
-      subst. apply app_assoc.
+      by subst; apply app_assoc.
     }
     apply (VLSM_incl_finite_valid_trace_init_to (vlsm_incl_pre_loaded_with_all_messages_vlsm Free))
       in Htr as Hpre_tr.
@@ -744,7 +739,7 @@ Proof.
       remember {| destination := sf |} as item.
       replace sf with (destination item) by (subst; done).
       eapply equivocating_validators_witness_monotonicity; [done |].
-      apply Heqv with (suffix := []), app_nil_r.
+      by apply Heqv with (suffix := []), app_nil_r.
     }
     clear IHHtr.
     apply (extend_right_finite_trace_from_to _ Htr_sf).
@@ -754,14 +749,10 @@ Proof.
       (Heqv
         (tr ++ [{| l := l; input := iom; destination := sf; output := oom |}])
         []).
-    spec Heqv; [apply app_nil_r|].
-    destruct iom as [im|].
-    2:{
-      repeat split
-      ; [done | apply option_valid_message_None | done..].
-    }
+    spec Heqv; [by apply app_nil_r |].
+    destruct iom as [im|]; [| by repeat split; [| apply option_valid_message_None | ..]].
     apply Free_has_sender in Hiom as _Hsender.
-    destruct (sender im) as [v|] eqn:Hsender; [|congruence].
+    destruct (sender im) as [v|] eqn:Hsender; [| by congruence].
     clear _Hsender.
     spec Heqv v.
     rewrite finite_trace_last_is_last in Heqv.
@@ -794,8 +785,7 @@ Proof.
     apply emitted_messages_are_valid.
     specialize
       (EquivPreloadedBase_Fixed_weak_full_projection IM _ _ Hs') as Hproj.
-    spec Hproj.
-    { intros.  apply no_initial_messages_in_IM. }
+    spec Hproj; [by intros; apply no_initial_messages_in_IM |].
     apply (VLSM_weak_full_projection_can_emit Hproj).
     by apply (VLSM_incl_can_emit (Equivocators_Fixed_Strong_incl IM _  _ Hs')).
 Qed.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -525,7 +525,11 @@ Proof.
       destruct Htr'_item as [Htr'_item Hinit].
       apply finite_valid_trace_from_to_app_split in Htr'_item.
       destruct Htr'_item as [Htr' Hitem].
-      spec IHn; [by split; [| done]; apply finite_valid_trace_from_to_forget_last in Htr' |].
+      spec IHn.
+      {
+        split; [| done].
+        by apply finite_valid_trace_from_to_forget_last in Htr'.
+      }
       spec IHn Hwitness'.
       destruct IHn as [is' [tr'' [[Htr'' Hinit'] Hprefix]]].
       specialize
@@ -750,7 +754,7 @@ Proof.
         (tr ++ [{| l := l; input := iom; destination := sf; output := oom |}])
         []).
     spec Heqv; [by apply app_nil_r |].
-    destruct iom as [im|]; [| by repeat split; [| apply option_valid_message_None | ..]].
+    destruct iom as [im |]; [| by repeat split; auto using option_valid_message_None].
     apply Free_has_sender in Hiom as _Hsender.
     destruct (sender im) as [v|] eqn:Hsender; [| by congruence].
     clear _Hsender.

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -62,7 +62,7 @@ Proof.
   exists itemX. split; [done |].
   revert Hm.
   unfold pre_VLSM_projection_transition_item_project in Hpr.
-  destruct (label_project (l itemX)); [|congruence].
+  destruct (label_project (l itemX)); [| by congruence].
   inversion Hpr.
   by apply Hselector.
 Qed.
@@ -170,8 +170,7 @@ Proof.
   apply (VLSM_weak_full_projection_valid_state Hsimul) in Hs as HsY.
   apply (prove_all_have_message_from_stepwise _ _ _ _ HstepwiseY _ HsY m).
   apply (selected_messages_consistency_prop_from_stepwise _ _ _ _ HstepwiseY HoracleY_dec _ HsY).
-  revert Hm.
-  apply VLSM_weak_full_projection_selected_message_exists_in_some_preloaded_traces.
+  by eapply VLSM_weak_full_projection_selected_message_exists_in_some_preloaded_traces.
 Qed.
 
 End sec_selectors.
@@ -184,10 +183,10 @@ Lemma VLSM_weak_full_projection_has_been_sent
 Proof.
   apply VLSM_weak_full_projection_oracle with (field_selector output) (field_selector output).
   - by intros [] [] Hin Hout; cbn in *; subst.
-  - apply (has_been_sent_stepwise_from_trace X).
-  - apply (has_been_sent_stepwise_from_trace Y).
-  - apply has_been_sent_dec.
-  - apply has_been_sent_dec.
+  - by apply (has_been_sent_stepwise_from_trace X).
+  - by apply (has_been_sent_stepwise_from_trace Y).
+  - by apply has_been_sent_dec.
+  - by apply has_been_sent_dec.
 Qed.
 
 Lemma VLSM_weak_full_projection_has_been_received
@@ -198,10 +197,10 @@ Lemma VLSM_weak_full_projection_has_been_received
 Proof.
   apply VLSM_weak_full_projection_oracle with (field_selector input) (field_selector input).
   - by intros [] [] Hin Hout; cbn in *; subst.
-  - apply (has_been_received_stepwise_from_trace X).
-  - apply (has_been_received_stepwise_from_trace Y).
-  - apply has_been_received_dec.
-  - apply has_been_received_dec.
+  - by apply (has_been_received_stepwise_from_trace X).
+  - by apply (has_been_received_stepwise_from_trace Y).
+  - by apply has_been_received_dec.
+  - by apply has_been_received_dec.
 Qed.
 
 Lemma VLSM_weak_full_projection_has_been_directly_observed
@@ -214,10 +213,10 @@ Lemma VLSM_weak_full_projection_has_been_directly_observed
 Proof.
   apply VLSM_weak_full_projection_oracle with item_sends_or_receives item_sends_or_receives.
   - by intros [] [] **; cbn in *; subst.
-  - apply has_been_directly_observed_stepwise_props.
-  - apply has_been_directly_observed_stepwise_props.
-  - apply has_been_directly_observed_dec.
-  - apply has_been_directly_observed_dec.
+  - by apply has_been_directly_observed_stepwise_props.
+  - by apply has_been_directly_observed_stepwise_props.
+  - by apply has_been_directly_observed_dec.
+  - by apply has_been_directly_observed_dec.
 Qed.
 
 End sec_weak_full_projection_oracle.
@@ -424,14 +423,14 @@ Context
 Lemma can_emit_projection
   : can_emit PreFree m -> can_emit (pre_loaded_with_all_messages_vlsm (IM j)) m.
 Proof.
-  destruct (sender m) as [v|] eqn:Hsender; simpl in Hj; [|congruence].
+  destruct (sender m) as [v|] eqn:Hsender; simpl in Hj; [| by congruence].
   apply Some_inj in Hj.
   specialize (Hsender_safety _ _ Hsender).
   intros [(s0,om0) [(i, li) [s1 Hemitted]]].
   specialize (preloaded_component_projection IM i) as Hproj.
   specialize (VLSM_projection_input_valid_transition Hproj (existT i li) li)
     as Htransition.
-  spec Htransition; [apply (composite_project_label_eq IM)|].
+  spec Htransition; [by apply (composite_project_label_eq IM) |].
   apply Htransition in Hemitted. clear Htransition.
   remember (s0 i) as s0i. clear s0 Heqs0i.
   remember (s1 i) as s1i. clear s1 Heqs1i.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -64,7 +64,7 @@ Proof.
   intros i _.
   spec Hs i.
   destruct Hs as [Hs _].
-  congruence.
+  by congruence.
 Qed.
 
 Section sec_equivocating_indices_BasicEquivocation.
@@ -81,7 +81,7 @@ Program Instance equivocating_indices_BasicEquivocation : BasicEquivocation (com
   }.
 Next Obligation.
   intro. intros.
-  typeclasses eauto.
+  by typeclasses eauto.
 Qed.
 
 Lemma equivocating_indices_equivocating_validators
@@ -127,7 +127,7 @@ Proof.
   intros i Hi.
   apply elem_of_list_filter.
   apply elem_of_list_filter in Hi.
-  split; [|apply Hi].
+  split; [| by apply Hi].
   destruct Hi as [Hi _].
   intro Hsi. elim Hi. clear Hi. unfold is_singleton_state in *.
   simpl in *.
@@ -159,7 +159,7 @@ Lemma equivocators_plan_cannot_decrease_state_size
 Proof.
   intro eqv. subst s'.
   induction plan using rev_ind.
-  - simpl. lia.
+  - by cbn; lia.
   - rewrite (composite_apply_plan_app equivocator_IM s plan).
     destruct (composite_apply_plan equivocator_IM s plan) as [junk s1].
     destruct x as [l im].
@@ -171,8 +171,7 @@ Proof.
       destruct (composite_transition equivocator_IM l som) eqn:Htrans
     end.
     apply equivocators_transition_cannot_decrease_state_size with (eqv:=eqv) in Htrans.
-    clear -IHplan Htrans.
-    simpl in * |- *. lia.
+    by cbn in *; lia.
 Qed.
 
 Lemma equivocators_pre_trace_cannot_decrease_state_size
@@ -195,7 +194,7 @@ Proof.
   unfold is_equivocating_state, is_singleton_state.
   intros eqv Hseqv.
   apply equivocators_pre_trace_cannot_decrease_state_size  with (eqv := eqv) in Htr.
-  cbv in *; lia.
+  by cbv in *; lia.
 Qed.
 
 Context
@@ -215,9 +214,9 @@ Lemma equivocators_no_equivocations_vlsm_incl_equivocators_free
   : VLSM_incl equivocators_no_equivocations_vlsm equivocators_free_vlsm.
 Proof.
   apply basic_VLSM_incl.
-  - cbv; intros s Hn n; specialize (Hn n); split_and!; itauto.
+  - by cbv; intros s Hn n; specialize (Hn n); split_and!; itauto.
   - by intro; intros; apply initial_message_is_valid.
-  - split; [| done]. apply Hv.
+  - by split; [apply Hv |].
   - by destruct 1.
 Qed.
 
@@ -226,15 +225,13 @@ Lemma equivocators_no_equivocations_vlsm_incl_PreFree
 Proof.
   apply VLSM_incl_trans with (machine equivocators_free_vlsm).
   apply equivocators_no_equivocations_vlsm_incl_equivocators_free.
-  apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
 Lemma preloaded_equivocators_no_equivocations_vlsm_incl_PreFree
   : VLSM_incl (pre_loaded_with_all_messages_vlsm equivocators_no_equivocations_vlsm) (pre_loaded_with_all_messages_vlsm equivocators_free_vlsm).
 Proof.
-  apply basic_VLSM_incl_preloaded.
-  1,3: by intro.
-  by intros l s om [Hv _].
+  by apply basic_VLSM_incl_preloaded; [intro | inversion 1 | intro].
 Qed.
 
 Lemma equivocators_initial_state_size
@@ -286,9 +283,9 @@ Proof.
   apply @Decision_iff with (P := (Forall (fun eqv => existing_descriptor (IM eqv) (eqv_descriptors eqv) (s eqv)) (enum index))).
   - rewrite Forall_forall. apply forall_proper. intros.
     split; [| done].
-    intro Henum. apply Henum, elem_of_enum.
+    by intro Henum; apply Henum, elem_of_enum.
   - apply Forall_dec. intro eqv.
-    apply existing_descriptor_dec.
+    by apply existing_descriptor_dec.
 Qed.
 
 Lemma not_equivocating_equivocator_descriptors_proper
@@ -297,7 +294,7 @@ Lemma not_equivocating_equivocator_descriptors_proper
   (Hne : not_equivocating_equivocator_descriptors eqv_descriptors s)
   : proper_equivocator_descriptors eqv_descriptors s.
 Proof.
-  intro eqv. apply existing_descriptor_proper. apply Hne.
+  by intro eqv; apply existing_descriptor_proper, Hne.
 Qed.
 
 Definition zero_descriptor
@@ -316,7 +313,8 @@ Lemma zero_descriptor_proper
   (s : vstate equivocators_free_vlsm)
   : proper_equivocator_descriptors zero_descriptor s.
 Proof.
-  apply not_equivocating_equivocator_descriptors_proper. apply zero_descriptor_not_equivocating.
+  apply not_equivocating_equivocator_descriptors_proper.
+  by apply zero_descriptor_not_equivocating.
 Qed.
 
 Lemma proper_equivocator_descriptors_state_update_eqv
@@ -394,7 +392,7 @@ Lemma equivocator_descriptors_update_neq
   (Hneq : j <> i)
   : equivocator_descriptors_update s i si j = s j.
 Proof.
-  unfold equivocator_descriptors_update. by case_decide.
+  by unfold equivocator_descriptors_update; case_decide.
 Qed.
 
 (**
@@ -432,8 +430,8 @@ Lemma equivocator_descriptors_update_id
 Proof.
   apply functional_extensionality_dep_good.
   intro j.
-  destruct (decide (j = i)).
-  - subst. apply equivocator_descriptors_update_eq.
+  destruct (decide (j = i)); subst.
+  - by apply equivocator_descriptors_update_eq.
   - by apply equivocator_descriptors_update_neq.
 Qed.
 
@@ -446,8 +444,8 @@ Lemma equivocator_descriptors_update_twice
 Proof.
   apply functional_extensionality_dep_good.
   intro j.
-  destruct (decide (j = i)).
-  - subst. rewrite equivocator_descriptors_update_eq. symmetry. apply equivocator_descriptors_update_eq.
+  destruct (decide (j = i)); subst.
+  - by rewrite equivocator_descriptors_update_eq, equivocator_descriptors_update_eq.
   - by rewrite !equivocator_descriptors_update_neq.
 Qed.
 
@@ -486,8 +484,7 @@ Proof.
   destruct (eqv_descriptors eqv) as [sn | i]; [done |].
   destruct Heqv as [es_eqv_i Hes_eqv_i].
   simpl. rewrite Hes_eqv_i. simpl.
-  revert Hes_eqv_i Hes.
-  apply equivocator_vlsm_initial_state_preservation_rev.
+  by eapply equivocator_vlsm_initial_state_preservation_rev.
 Qed.
 
 Lemma equivocators_initial_message

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -82,7 +82,7 @@ Proof.
   unfold eq_rect_r, eq_rect in Hpr; simpl in Hpr.
   match type of Hpr with
     (match ?exp with _ => _ end = _)
-    => destruct exp as [(oitemx, deqv')|] eqn:Hitem_pr;[|congruence]
+    => destruct exp as [(oitemx, deqv')|] eqn: Hitem_pr; [| by congruence]
   end.
   simpl in Ht.
   destruct item. simpl in *. destruct l as (i, li). simpl in *.
@@ -99,15 +99,14 @@ Proof.
     rewrite! elem_of_list_filter in *.
     specialize (Hdescriptors eqv).
     state_update_simpl.
-    cut (is_equivocating_state (IM eqv) si' \/  is_newmachine_descriptor (IM eqv) (descriptors eqv)).
-      by itauto.
-    apply
+    cut (is_equivocating_state (IM eqv) si' \/  is_newmachine_descriptor (IM eqv) (descriptors eqv));
+      [by itauto |].
+    by apply
       (equivocator_transition_item_project_preserves_equivocating_indices (IM eqv) {|
       l := li;
       input := input;
       destination := si';
-      output := output |} _ Hdescriptors _ _ Hitem_pr _ Hv Htei).
-    itauto.
+      output := output |} _ Hdescriptors _ _ Hitem_pr _ Hv Htei); itauto.
   - destruct Heqv as [Heqv | Heqv]
     ; apply elem_of_list_filter in Heqv as [Heqv Hin].
     + left.
@@ -135,7 +134,7 @@ Proof.
   intros i Hi.
   unfold equivocators_transition_item_project in Hpr.
   destruct (decide (i = projT1 (l item))).
-  -  subst i. rewrite Hi in Hpr.
+  - subst i. rewrite Hi in Hpr.
     specialize
       (equivocators_vlsm_transition_item_project_zero_descriptor (IM (projT1 (l item)))
         (composite_transition_item_projection equivocator_IM item)
@@ -167,7 +166,7 @@ Proof.
     (equivocator_vlsm_transition_item_project (IM (projT1 (l item)))
       (composite_transition_item_projection equivocator_IM item)
       (descriptors (projT1 (l item))))
-    eqn: Hpr'; [|congruence].
+    eqn: Hpr'; [| by congruence].
   by destruct p, o; inversion Hpr; state_update_simpl.
 Qed.
 
@@ -195,7 +194,7 @@ Lemma equivocators_transition_item_project_proper
   : is_Some (equivocators_transition_item_project eqv_descriptors item).
 Proof.
   apply equivocators_transition_item_project_proper_descriptor.
-  apply Hproper.
+  by Hproper.
 Qed.
 
 (**
@@ -265,12 +264,8 @@ Proof.
       (s (projT1 (l item)))
       Hs
     ) as Hproject.
-  spec Hproject.
-  { clear -Hv.
-    by rewrite (sigT_eta (l item)) in Hv.
-  }
-  spec Hproject.
-  { by apply composite_transition_project_active in Ht. }
+  spec Hproject; [by rewrite (sigT_eta (l item)) in Hv |].
+  spec Hproject; [by apply composite_transition_project_active in Ht |].
   destruct Hproject as [Heqv' [eqv [Heqv Hproject]]].
   exists (equivocator_descriptors_update (zero_descriptor IM) (projT1 (l item)) eqv).
   split.
@@ -289,8 +284,7 @@ Proof.
   }
   unfold equivocators_transition_item_project.
   state_update_simpl.
-  rewrite Hproject.
-  do 2 f_equal. apply equivocator_descriptors_update_twice.
+  by rewrite Hproject, equivocator_descriptors_update_twice.
 Qed.
 
 Lemma equivocators_transition_item_project_proper_descriptor_characterization
@@ -437,12 +431,13 @@ Proof.
       (composite_transition_item_projection equivocator_IM item)
       (eqv_descriptors (projT1 (l item))))
     as [([itemi|], descriptori)|] eqn:Hpr_itemi
-  ; [|congruence|congruence].
+  ; [| by congruence..].
   inversion Hpr_item. subst. clear Hpr_item. simpl.
   repeat split.
   apply equivocator_transition_item_project_inv_characterization in Hpr_itemi
     as [[Hex Hl]].
-  rewrite Hl. by exists Hex.
+  rewrite Hl.
+  by exists Hex.
 Qed.
 
 Definition equivocators_trace_project_folder
@@ -482,7 +477,7 @@ Proof.
   revert trX' eqv_descriptors.
   induction tr; intros.
   - simpl. split; intro Htr.
-    + inversion Htr. subst. by exists [].
+    + by inversion Htr; subst; exists [].
     + by destruct Htr as [trX [[= <-] ?]]; subst.
   - simpl.
     remember (fold_right equivocators_trace_project_folder (Some (itrX, ieqv_descriptors)) tr)
@@ -491,17 +486,17 @@ Proof.
       as pr_tr.
     split.
     + intro Htr.
-      destruct pr_itrX_tr as [(tr1,e1)|] ; [|inversion Htr].
+      destruct pr_itrX_tr as [(tr1,e1)|] ; [| by inversion Htr].
       specialize (IHtr tr1 e1). apply proj1 in IHtr. specialize (IHtr eq_refl).
       destruct IHtr as [trX [Hpr_tr Htr1]].
       rewrite Hpr_tr in *. rewrite Htr1 in *.
       simpl in Htr. simpl.
       destruct (equivocators_transition_item_project e1 a)
-        as [(oitem, eqv_descriptors'')|] eqn:Ha; [|congruence].
+        as [(oitem, eqv_descriptors'')|] eqn: Ha; [| by congruence].
       by destruct oitem; inversion Htr; eexists _.
     + intros [trX [Htr HtrX']].
       subst trX'.
-      destruct pr_tr as [(tr1, e1)|]; [|inversion Htr].
+      destruct pr_tr as [(tr1, e1)|]; [| by inversion Htr].
       specialize (IHtr (tr1 ++ itrX) e1). apply proj2 in IHtr.
       rewrite IHtr by (eexists _; done).
       simpl in *.
@@ -561,8 +556,8 @@ Proof.
   end.
   destruct r_sufX as [(sufX, eqv_descriptors')|]
   ; [
-    | rewrite equivocators_trace_project_fold_None; split;
-      [intro contra; congruence| intros [preX [sufX [eqv_descriptors' [contra _]]]]; congruence]
+    | by rewrite equivocators_trace_project_fold_None; split;
+      [intro contra; congruence | intros [preX [sufX [eqv_descriptors' [contra _]]]]; congruence]
     ].
   specialize (equivocators_trace_project_folder_additive_iff pre sufX eqv_descriptors' ieqv_descriptors trX)
     as Hadd.
@@ -570,7 +565,7 @@ Proof.
   split.
   - by intros (preX & HpreX & HtrX); exists preX, sufX, eqv_descriptors'.
   - intros [preX [_sufX [_eqv_descriptors' [Heq [Hpre HtrX]]]]].
-    exists preX. by inversion Heq; subst.
+    by exists preX; inversion Heq; subst.
 Qed.
 
 (**
@@ -597,16 +592,16 @@ Proof.
   generalize dependent sufX. generalize dependent eqv_descriptors.
   induction tr using rev_ind; intros eqv_descriptors sufX.
   - cbn; inversion 1 as [[Hnil Heq]]; clear -Hnil.
-    destruct preX; inversion Hnil.
+    by destruct preX; inversion Hnil.
   - intro Hsome.
     apply equivocators_trace_project_app_iff in Hsome
       as (trX' & xX & eqv_descriptors' & Hpr_x & Hpr_tr & Heq).
     simpl in Hpr_x.
     destruct (equivocators_transition_item_project eqv_descriptors x)
       as [(ox, descriptorx)|] eqn:Hpr_x_item
-    ; [|congruence].
+    ; [| by congruence].
     destruct xX as [|xX _empty].
-    + destruct ox; [congruence|].
+    + destruct ox; [by congruence |].
       inversion Hpr_x. subst. clear Hpr_x.
       rewrite app_nil_r in  Heq. subst trX'.
       specialize (IHtr eqv_descriptors' sufX Hpr_tr).
@@ -616,9 +611,9 @@ Proof.
       repeat split; [| done | done].
       apply equivocators_trace_project_app_iff.
       exists sufX, [], eqv_descriptors'. rewrite app_nil_r.
-      repeat split; [|assumption].
+      repeat split; [| done].
       by simpl; rewrite Hpr_x_item.
-    + destruct ox; [|congruence].
+    + destruct ox; [| by congruence].
       inversion Hpr_x. subst. clear Hpr_x.
       destruct_list_last sufX sufX' _xX Heq_sufX.
       * subst. rewrite app_nil_r in Heq. apply app_inj_tail in Heq.
@@ -634,7 +629,7 @@ Proof.
         repeat split; [| done | done].
         apply equivocators_trace_project_app_iff.
         exists sufX', [xX], eqv_descriptors'.
-        repeat split; [|assumption].
+        repeat split; [| done].
         by simpl; rewrite Hpr_x_item.
 Qed.
 
@@ -655,7 +650,8 @@ Proof.
   intro Hpr_tr.
   destruct sufX as [|itemX sufX].
   - rewrite app_nil_r in Hpr_tr.
-    exists tr, [], eqv_descriptors. by rewrite app_nil_r.
+    exists tr, [], eqv_descriptors.
+    by rewrite app_nil_r.
   - change (itemX :: sufX) with ([itemX] ++ sufX) in Hpr_tr.
     apply equivocators_trace_project_app_inv_item in Hpr_tr.
     destruct Hpr_tr as [pre [suf [item [item_descriptors [pre_descriptors [Hpr_suf [Hpr_item [Hpr_pre Heqtr]]]]]]]].
@@ -663,7 +659,7 @@ Proof.
     subst. repeat split; [| done].
     apply equivocators_trace_project_app_iff.
     exists [itemX], sufX, item_descriptors.
-    repeat split; [assumption|].
+    repeat split; [done |].
     by simpl; rewrite Hpr_item.
 Qed.
 
@@ -688,7 +684,7 @@ Proof.
   simpl in Hproject_x.
   destruct
     (equivocators_transition_item_project descriptors x)
-    as [(oitemx, _descriptors')|] eqn:Hpr_x ; [|congruence].
+    as [(oitemx, _descriptors')|] eqn: Hpr_x ; [| by congruence].
   assert (_descriptors' = descriptors') as -> by (destruct oitemx; congruence).
   clear Hproject_x trX sufX.
 
@@ -703,7 +699,7 @@ Proof.
   destruct Hpr_x_char as [_ [_ [[= <- <-] [_ Hchar2]]]].
   specialize (Hchar2 s Hv Ht) as [Hdescriptors' _].
   specialize (IHHtr _ Hdescriptors' _ Hproject_tr).
-  revert IHHtr Hx_preserves. apply transitivity.
+  by etransitivity.
 Qed.
 
 (**
@@ -753,13 +749,12 @@ Proof.
     destruct l as (i, li). simpl in *.
     destruct (decide (i = eqv)).
     + subst. spec His_tr eqv. spec Htr_x eqv.
-      destruct (descriptors eqv) eqn:Hvin_desc_eqv.
-      * simpl in Hex_new. by rewrite Hex_new in Hex_new'.
-      * destruct (final_descriptors' eqv) eqn:Hfin_desc_eqv'.
-        -- simpl in Hex_new, Hex_new'. rewrite Hex_new'. simpl.  lia.
-        -- destruct (idescriptors eqv); simpl in *; lia.
-    + rewrite Heq_final_descriptors' in Hex_new'.
-      by state_update_simpl.
+      destruct (descriptors eqv) eqn:Hvin_desc_eqv;
+        [by simpl in Hex_new; rewrite Hex_new in Hex_new' |].
+      destruct (final_descriptors' eqv) eqn:Hfin_desc_eqv'.
+      * by simpl in Hex_new, Hex_new'; rewrite Hex_new'; simpl;  lia.
+      * by destruct (idescriptors eqv); simpl in *; lia.
+    + by rewrite Heq_final_descriptors' in Hex_new'; state_update_simpl.
 Qed.
 
 Lemma equivocators_trace_project_preserves_equivocating_indices_final
@@ -821,7 +816,7 @@ Proof.
     match type of Hproject_tr with
     | fold_right _ ?i _ = _ => destruct i as [(projectx,final_descriptors')|] eqn:Hproject_x
     end
-    ; [|rewrite equivocators_trace_project_fold_None in Hproject_tr; inversion Hproject_tr].
+    ; [| by rewrite equivocators_trace_project_fold_None in Hproject_tr; inversion Hproject_tr].
     apply equivocators_trace_project_folder_additive_iff in Hproject_tr.
     destruct Hproject_tr as [trX0 [HtrX0 HtrX]].
     specialize (IHtr _ _ HtrX0).
@@ -834,7 +829,7 @@ Proof.
       simpl in *.
       destruct (equivocators_transition_item_project final_descriptors x)
         as [(ox, final')|] eqn:Hpr_item_x
-      ; [|congruence].
+      ; [| by congruence].
       unfold equivocators_transition_item_project in Hpr_item_x.
       destruct (decide (i = projT1 (l x))).
       - subst i.
@@ -854,7 +849,7 @@ Proof.
         split; [done |].
         simpl. destruct x. simpl in *. destruct l as (i, li). simpl in *.
         unfold pre_VLSM_projection_transition_item_project, composite_project_label. simpl.
-        destruct (decide (i = i)); [|congruence].
+        destruct (decide (i = i)); [| by congruence].
         f_equal.
         replace e with (@eq_refl _ i) by (apply Eqdep_dec.UIP_dec; done). clear e.
         destruct item'.
@@ -883,7 +878,7 @@ Proof.
     destruct IHtr as [Heqv_initial Hpr_trXi'].
     split; [done |].
     subst.
-    apply map_option_app.
+    by apply map_option_app.
 Qed.
 
 (**
@@ -908,7 +903,7 @@ Proof.
   simpl in Hproject_x.
   destruct
     (equivocators_transition_item_project descriptors x)
-    as [(oitemx, _descriptors')|] eqn:Hpr_x ; [|congruence].
+    as [(oitemx, _descriptors')|] eqn: Hpr_x; [| by congruence].
   assert (_descriptors' = descriptors') as -> by (destruct oitemx; congruence).
   clear Hproject_x trX sufX.
   destruct Hx as [(_ & _  & Hv & _) Ht].
@@ -978,7 +973,7 @@ Proof.
     (preloaded_equivocators_valid_trace_from_project
       (zero_descriptor IM) is tr
     ) as Hproject.
-  simpl in Hproject. spec Hproject.  { apply zero_descriptor_proper. }
+  simpl in Hproject. spec Hproject; [by apply zero_descriptor_proper |].
   spec Hproject Htr.
   destruct Hproject as [trX [initial_descriptors [Hproject _]]].
   exists trX.
@@ -1011,10 +1006,10 @@ Proof.
   end.
   simpl in Heqproject_x.
   destruct project_x as [(x', x_descriptors)|]
-  ; [|rewrite equivocators_trace_project_fold_None in Hproject; congruence].
+  ; [| by rewrite equivocators_trace_project_fold_None in Hproject; congruence].
   destruct (equivocators_transition_item_project final_descriptors x) as [(oitem', ditem')|]
     eqn:Hproject_x
-  ; [|congruence].
+  ; [| by congruence].
   apply (equivocators_trace_project_folder_additive_iff tr x' x_descriptors initial_descriptors trX)
   in Hproject.
   destruct Hproject as [trX' [Hproject_x' HeqtrX]].
@@ -1028,7 +1023,7 @@ Proof.
   match type of Hproject_x with
   | context [equivocator_vlsm_transition_item_project ?X ?i ?c] => remember (equivocator_vlsm_transition_item_project X i c)  as projecti
   end.
-  destruct projecti as [(oitem'', ditem'')|]; [|congruence].
+  destruct projecti as [(oitem'', ditem'')|]; [| by congruence].
   unfold equivocator_vlsm_transition_item_project in Heqprojecti.
   unfold final_state in *. clear final_state.
   rewrite finite_trace_last_is_last. simpl.
@@ -1058,7 +1053,7 @@ Proof.
     inversion Ht. subst om'. clear Ht.
     replace (s i) with si' in * by (subst; state_update_simpl; done).
     destruct (equivocator_state_project si' j) as [si'j|] eqn:Hj; [| done].
-    destruct li as [ndi | idi li | idi li]
+    by destruct li as [ndi | idi li | idi li]
     ; destruct (decide _)
     ; inversion Heqprojecti; subst; clear Heqprojecti
     ; inversion Hproject_x; subst; clear Hproject_x
@@ -1125,14 +1120,15 @@ Proof.
   end.
   remember (equivocator_descriptors_update (zero_descriptor IM) i eqv_final) as final_descriptors.
   assert (Hfinal_descriptors : not_equivocating_equivocator_descriptors IM final_descriptors final).
-  { intro eqv. subst final_descriptors.
+  {
+    intro eqv. subst final_descriptors.
     destruct (decide (i = eqv)); subst; state_update_simpl; [done |].
-    apply zero_descriptor_proper.
+    by apply zero_descriptor_proper.
   }
   exists final_descriptors.
   subst final.
-  assert (Hfinal_descriptors_proper : proper_equivocator_descriptors final_descriptors (finite_trace_last is tr)).
-  { by apply not_equivocating_equivocator_descriptors_proper. }
+  assert (Hfinal_descriptors_proper : proper_equivocator_descriptors final_descriptors (finite_trace_last is tr))
+    by (apply not_equivocating_equivocator_descriptors_proper; done).
   destruct (preloaded_equivocators_valid_trace_from_project  _ _ _ Hfinal_descriptors_proper Htr)
     as [trX [initial_descriptors [Hproject_tr _]]].
   exists initial_descriptors, trX. split; [done |]. split; [done |].
@@ -1140,8 +1136,7 @@ Proof.
     (equivocators_trace_project_finite_trace_projection_list_commute i final_descriptors initial_descriptors
       eqv_init tr trX trXi Hproject_tr)
     as Hcommute.
-  assert (Hfinali : final_descriptors i = eqv_final).
-  { by subst; state_update_simpl. }
+  assert (Hfinali : final_descriptors i = eqv_final) by (subst; state_update_simpl; done).
   rewrite Hfinali in Hcommute.
   spec Hcommute Hprojecti.
   destruct Hcommute as [Hiniti Hcommute].
@@ -1179,7 +1174,7 @@ Proof.
   rewrite !Exists_app. right. left. constructor.
   apply equivocators_transition_item_project_inv_characterization in Hpr_item.
   destruct Hpr_item as [_ [_ [Heqoutput _]]].
-  simpl in *. congruence.
+  by simpl in *; congruence.
 Qed.
 
 (**
@@ -1212,9 +1207,11 @@ Proof.
     exists [].
     repeat (split; [done |]).
     cut (vinitial_state_prop (free_composite_vlsm IM) (equivocators_state_project final_descriptors is)).
-    { intro Hinit. split; [| done]. constructor. by apply initial_state_is_valid. }
-    apply (equivocators_initial_state_project IM); [| done].
-    apply Htr.
+    {
+      intro Hinit; split; [| done].
+      by constructor; apply initial_state_is_valid.
+    }
+    by apply (equivocators_initial_state_project IM); [apply Htr |].
   - destruct Htr as [Htr Hinit].
     apply finite_valid_trace_from_to_app_split in Htr.
     destruct Htr as [Htr Hx].
@@ -1294,11 +1291,11 @@ Proof.
   unfold partial_trace_project,equivocators_partial_trace_project.
   split.
   - intros Hpr_tr.
-    case_decide; [|congruence].
+    case_decide; [| by congruence].
     destruct (equivocators_trace_project final_descriptors trX)
       as [(_trY, initial_descriptors)|] eqn:Htr_project
-    ; [|congruence].
-    inversion Hpr_tr. subst _trY. clear Hpr_tr. eauto.
+    ; [| by congruence].
+    by inversion Hpr_tr; subst _trY; clear Hpr_tr; eauto.
   - intros [Hnot_equiv [initial_descriptors [Hpr_tr Hpr_s]]].
     by rewrite decide_True, Hpr_tr; subst.
 Qed.
@@ -1457,10 +1454,11 @@ Proof.
   specialize
     (preloaded_equivocators_valid_trace_from_project (zero_descriptor IM) sX trX)
     as Hproject.
-  simpl in Hproject. spec Hproject.  { apply zero_descriptor_proper. }
+  simpl in Hproject; spec Hproject; [by apply zero_descriptor_proper |].
   spec Hproject Hpre_tr.
   destruct Hproject as [_trX [initial_descriptors [_Htr_pr [_ Hlst]]]].
-  rewrite Htr_pr in _Htr_pr. by inversion _Htr_pr; subst.
+  rewrite Htr_pr in _Htr_pr.
+  by inversion _Htr_pr; subst.
 Qed.
 
 Lemma PreFreeE_PreFree_vlsm_partial_projection
@@ -1521,12 +1519,12 @@ Proof.
   simpl in *.
   destruct (equivocators_transition_item_project IM final_descriptors item)
     as [(ox, final')|] eqn:Hpr_item_x
-  ; [|congruence].
+  ; [| by congruence].
   unfold equivocators_transition_item_project in Hpr_item_x.
   unfold composite_transition_item_projection in Hpr_item_x.
   remember (equivocator_vlsm_transition_item_project (IM (projT1 (l item))) (composite_transition_item_projection_from_eq (equivocator_IM IM) item (projT1 (l item)) eq_refl) (final_descriptors (projT1 (l item))))
     as pr_item_x.
-  destruct pr_item_x as [(oitem', descriptor')|]; [|congruence].
+  destruct pr_item_x as [(oitem', descriptor')|]; [| by congruence].
 
   unfold composite_transition_item_projection_from_eq in Heqpr_item_x.
   unfold eq_rect_r in Heqpr_item_x.
@@ -1560,23 +1558,19 @@ Proof.
       ; simpl
       ; destruct (decide ((proj1_sig i) = projT1 (l item))).
       * rewrite equivocator_descriptors_update_eq_rew with (Heq := e).
-        assert (e1 : i = (dexist (projT1 (l item)) Hl)).
-        { by apply dsig_eq. }
+        assert (e1 : i = (dexist (projT1 (l item)) Hl)) by (apply dsig_eq; done).
         subst i.
         rewrite equivocator_descriptors_update_eq_rew with (Heq := eq_refl).
         simpl in e. replace e with (eq_refl (projT1 (l item))); [done |].
         by apply Eqdep_dec.UIP_dec.
-      * rewrite! equivocator_descriptors_update_neq; [done | done |].
-        by intros ->.
+      * by rewrite! equivocator_descriptors_update_neq; [| | intros ->].
       * rewrite equivocator_descriptors_update_eq_rew with (Heq := e).
-        assert (e1 : i = (dexist (projT1 (l item)) Hl)).
-        { by apply dsig_eq. }
+        assert (e1 : i = (dexist (projT1 (l item)) Hl)) by (apply dsig_eq; done).
         subst i.
         rewrite equivocator_descriptors_update_eq_rew with (Heq := eq_refl).
         simpl in e. replace e with (eq_refl (projT1 (l item))); [done |].
         by apply Eqdep_dec.UIP_dec.
-      * rewrite! equivocator_descriptors_update_neq; [done | done |].
-        by intros ->.
+      * by rewrite! equivocator_descriptors_update_neq; [| | intros ->].
     + destruct oitem' as [item'|]
       ; inversion Hpr_sub_item; subst; clear Hpr_sub_item
       ; inversion Hpr_item_x; subst; clear Hpr_item_x
@@ -1641,7 +1635,7 @@ Proof.
     match type of Hproject_tr with
     | fold_right _ ?i _ = _ => destruct i as [(projectx,final_descriptors')|] eqn:Hproject_x
     end
-    ; [|rewrite equivocators_trace_project_fold_None in Hproject_tr; inversion Hproject_tr].
+    ; [| by rewrite equivocators_trace_project_fold_None in Hproject_tr; inversion Hproject_tr].
     apply equivocators_trace_project_folder_additive_iff in Hproject_tr.
     destruct Hproject_tr as [trX0 [HtrX0 HtrX]].
     specialize (IHtr _ _ HtrX0).
@@ -1660,7 +1654,7 @@ Proof.
     destruct IHtr as [Heqv_initial Hpr_trXi'].
     split; [done |].
     subst.
-    apply finite_trace_sub_projection_app.
+    by apply finite_trace_sub_projection_app.
 Qed.
 
 Section sec_seeded_equivocators_valid_trace_project.
@@ -1689,7 +1683,7 @@ Qed.
 Lemma seeded_no_equivocation_incl_preloaded
   : VLSM_incl SeededXE SubPreFreeE.
 Proof.
-  apply seeded_no_equivocation_incl_preloaded.
+  by apply seeded_no_equivocation_incl_preloaded.
 Qed.
 
 Lemma seeded_equivocators_valid_trace_project
@@ -1714,8 +1708,9 @@ Proof.
     by apply finite_valid_trace_from_add_last.
   }
   assert (Hpre_tr_to : finite_valid_trace_init_to SubPreFreeE is final_state tr).
-  { revert Htr_to. apply VLSM_incl_finite_valid_trace_init_to.
-    apply seeded_no_equivocation_incl_preloaded.
+  {
+    revert Htr_to; apply VLSM_incl_finite_valid_trace_init_to.
+    by apply seeded_no_equivocation_incl_preloaded.
   }
   pose proof (pre_equivocators_valid_trace_project _ _ _ _
     Hpre_tr_to final_descriptors Hproper) as Hex.
@@ -1740,9 +1735,9 @@ Proof.
       by exists (exist _ _ H).
     }
     apply equivocators_initial_state_project; [| done].
-    apply Htr.
+    by apply Htr.
   - specialize (H (length tr')) as H'.
-    spec H'. { rewrite app_length. simpl. lia. }
+    spec H'; [by rewrite app_length; cbn; lia |].
     destruct Htr as [Htr Hinit].
     apply finite_valid_trace_from_app_iff in Htr.
     destruct Htr as [Htr Hlst].
@@ -1781,13 +1776,12 @@ Proof.
     destruct Hx as [Hvx Htx].
     destruct item. simpl in *. subst.
     apply finite_valid_trace_singleton.
-    assert (Htr_to : finite_valid_trace_init_to SeededXE is (finite_trace_last is tr') tr').
-    { split; [| done].
-      by apply finite_valid_trace_from_add_last.
-    }
+    assert (Htr_to : finite_valid_trace_init_to SeededXE is (finite_trace_last is tr') tr')
+      by (split; [apply finite_valid_trace_from_add_last |]; done).
     assert (Hpre_tr_to : finite_valid_trace_init_to SubPreFreeE is (finite_trace_last is tr') tr').
-    { revert Htr_to. apply VLSM_incl_finite_valid_trace_init_to.
-      apply seeded_no_equivocation_incl_preloaded.
+    {
+      revert Htr_to; apply VLSM_incl_finite_valid_trace_init_to.
+      by apply seeded_no_equivocation_incl_preloaded.
     }
     pose proof (pre_equivocators_valid_trace_project sub_IM _ _ _
      Hpre_tr_to final_descriptors' Hproper') as Hpr_tr'.
@@ -1800,22 +1794,20 @@ Proof.
     rewrite <- Heq_final_stateX' in Htx, Hvx.
     repeat split; [done | | done | done].
 
-    destruct input as [input|]
-    ; [| apply option_valid_message_None].
+    destruct input as [input |]; [| by apply option_valid_message_None].
     apply proj1 in Hc. simpl in Hc.
     apply or_comm in Hc.
     destruct Hc as [Hinit_input | Hno_equiv]
     ; [by apply initial_message_is_valid, seeded_equivocators_initial_message; right |].
-    assert
-      (Hs_free : valid_state_prop SubPreFreeE (finite_trace_last is tr')).
-    { by apply proj1, finite_valid_trace_from_to_last_pstate in Hpre_tr_to. }
+    assert (Hs_free : valid_state_prop SubPreFreeE (finite_trace_last is tr'))
+      by (apply proj1, finite_valid_trace_from_to_last_pstate in Hpre_tr_to; done).
     apply (composite_proper_sent sub_equivocator_IM _ Hs_free) in Hno_equiv.
     specialize (Hno_equiv is tr' Hpre_tr_to).
     apply finite_valid_trace_init_to_forget_last in Hpre_tr_to as Hpre_tr.
     destruct (equivocators_trace_project_output_reflecting_inv _ _ _ (proj1 Hpre_tr) _ Hno_equiv)
       as [final_descriptors_m [initial_descriptors_m [trXm [Hfinal_descriptors_m [Hproject_trXm Hex]]]]].
     specialize (H (length tr')).
-    spec H. { rewrite app_length. simpl. lia. }
+    spec H; [by rewrite app_length; cbn; lia |].
     specialize (H tr' (conj Htr Hinit) eq_refl).
     assert (Hfinal_descriptors_m_proper : proper_equivocator_descriptors sub_IM final_descriptors_m (finite_trace_last is tr'))
       by (apply not_equivocating_equivocator_descriptors_proper; done).
@@ -1827,25 +1819,23 @@ Proof.
     simpl in *. rewrite Hproject_trXm in Hproject_trXm'.
     inversion Hproject_trXm'. subst trXm' initial_descriptors_m'. clear Hproject_trXm'.
     apply option_valid_message_Some.
-    apply (valid_trace_output_is_valid _ _ _ (proj1 H) _ Hex).
+    by apply (valid_trace_output_is_valid _ _ _ (proj1 H) _ Hex).
 Qed.
 
 Lemma SeededXE_incl_PreFreeE
   : VLSM_incl SeededXE SubPreFreeE.
 Proof.
   apply basic_VLSM_strong_incl.
-  - intros s Hn n; itauto.
-  - cbv; itauto.
+  - by intros s Hn n; itauto.
+  - by cbv; itauto.
   - by destruct 1.
-  - cbv; itauto.
+  - by cbv; itauto.
 Qed.
 
 Lemma PreSeededXE_incl_PreFreeE
   : VLSM_incl (pre_loaded_with_all_messages_vlsm SeededXE) SubPreFreeE.
 Proof.
-  apply basic_VLSM_incl_preloaded.
-  1, 3: by intro; intros.
-  by destruct 1.
+  by apply basic_VLSM_incl_preloaded; [intro | inversion 1 | intro].
 Qed.
 
 Lemma SeededXE_SeededX_vlsm_partial_projection
@@ -1856,11 +1846,12 @@ Proof.
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
     assert
       (HPreFree_pre_tr : finite_valid_trace_from SubPreFreeE s_pre (pre ++ tr)).
-    { revert Hpre_tr. apply VLSM_incl_finite_valid_trace_from.
-      apply SeededXE_incl_PreFreeE.
+    {
+      revert Hpre_tr; apply VLSM_incl_finite_valid_trace_from.
+      by apply SeededXE_incl_PreFreeE.
     }
     clear Hpre_tr. revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
-    apply equivocators_partial_trace_project_extends_left.
+    by apply equivocators_partial_trace_project_extends_left.
   - intros s tr sX trX Hpr_tr Htr.
     destruct (destruct_equivocators_partial_trace_project sub_IM  Hpr_tr)
       as [Hnot_equiv [initial_descriptors [Htr_project Hs_project]]].
@@ -1908,11 +1899,12 @@ Proof.
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
     assert
       (HPreFree_pre_tr : finite_valid_trace_from PreFreeE s_pre (pre ++ tr)).
-    { revert Hpre_tr. apply VLSM_incl_finite_valid_trace_from.
-      apply equivocators_no_equivocations_vlsm_incl_PreFree.
+    {
+      revert Hpre_tr; apply VLSM_incl_finite_valid_trace_from.
+      by apply equivocators_no_equivocations_vlsm_incl_PreFree.
     }
     clear Hpre_tr.  revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
-    apply equivocators_partial_trace_project_extends_left.
+    by apply equivocators_partial_trace_project_extends_left.
   - intros s tr sX trX Hpr_tr Htr.
     destruct (destruct_equivocators_partial_trace_project IM Hpr_tr)
       as [Hnot_equiv [initial_descriptors [Htr_project Hs_project]]].
@@ -1962,11 +1954,12 @@ Proof.
         (free_sub_free_equivocator_descriptors final_descriptors)
         )
       as Hproject.
-   spec Hproject.
-   { clear -Hproper. intro sub_i.
+    spec Hproject.
+    {
+      clear -Hproper. intro sub_i.
       destruct_dec_sig sub_i i Hi Heqsub_i. subst.
       rewrite <- (VLSM_full_projection_finite_trace_last Hproj).
-      apply Hproper.
+      by apply Hproper.
     }
     destruct Hproject  as [_trX [_initial_descriptors [_ [_Htr_project [_ HtrX]]]]].
 
@@ -2067,8 +2060,8 @@ Proof.
     (preloaded_equivocators_valid_trace_from_project _
       _ _ _ Hproper HPreFree_tr
     ) as [trX [initial_descriptors [Htr_project [Hinitial_desciptors Hfinal_project]]]].
-  eexists. eexists. eexists. eexists. split; [done |]. split; [apply Hinitial_desciptors|].
-  split; [apply Htr_project|]. split; [apply Hfinal_project|].
+  eexists. eexists. eexists. eexists. split; [done |]. split; [by apply Hinitial_desciptors |].
+  split; [by apply Htr_project |]. split; [by apply Hfinal_project |].
   apply valid_trace_add_default_last.
   apply Hsim; [| done].
   by rewrite Htr_project.
@@ -2082,7 +2075,7 @@ Proof.
   destruct l as [i [sn| ji li| ji li]]; cbn in Hv, Ht.
   - inversion_clear Ht. unfold equivocators_total_state_project.
     by state_update_simpl.
-  - simpl in Hl. destruct ji as [|ji]; [inversion Hl|]. clear Hl.
+  - simpl in Hl. destruct ji as [| ji]; [by inversion Hl |]. clear Hl.
     destruct (equivocator_state_project _ _) as [si|]; [| done].
     destruct (vtransition _ _ _) as (si', _om').
     inversion_clear Ht.  unfold equivocators_total_state_project.
@@ -2099,11 +2092,12 @@ Proof.
   constructor; [constructor|].
   - intros * Htr. apply PreFreeE_Free_vlsm_projection_type.
     apply VLSM_incl_finite_valid_trace_from; [| done].
-    apply equivocators_no_equivocations_vlsm_incl_PreFree.
+    by apply equivocators_no_equivocations_vlsm_incl_PreFree.
   - intros * Htr.
     assert (Hpre_tr : finite_valid_trace PreFreeE sX trX).
-    { apply VLSM_incl_finite_valid_trace; [| done].
-      apply equivocators_no_equivocations_vlsm_incl_PreFree.
+    {
+      apply VLSM_incl_finite_valid_trace; [| done].
+      by apply equivocators_no_equivocations_vlsm_incl_PreFree.
     }
     specialize
      (VLSM_partial_projection_finite_valid_trace (equivocators_no_equivocations_vlsm_X_vlsm_partial_projection (zero_descriptor IM))
@@ -2117,7 +2111,7 @@ Proof.
     remember (pre_VLSM_projection_finite_trace_project _ _ _ _ _) as tr.
     replace tr with (equivocators_total_trace_project IM trX); [done |].
     subst. symmetry.
-    eapply (equivocators_total_VLSM_projection_finite_trace_project IM), Hpre_tr.
+    by eapply (equivocators_total_VLSM_projection_finite_trace_project IM), Hpre_tr.
 Qed.
 
 Lemma preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection
@@ -2138,7 +2132,7 @@ Proof.
     remember (pre_VLSM_projection_finite_trace_project _ _ _ _ _) as tr.
     replace tr with (equivocators_total_trace_project IM trX); [done |].
     subst. symmetry.
-    eapply equivocators_total_VLSM_projection_finite_trace_project, Htr.
+    by eapply equivocators_total_VLSM_projection_finite_trace_project, Htr.
 Qed.
 
 End sec_equivocators_composition_vlsm_projection.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -194,7 +194,7 @@ Lemma equivocators_transition_item_project_proper
   : is_Some (equivocators_transition_item_project eqv_descriptors item).
 Proof.
   apply equivocators_transition_item_project_proper_descriptor.
-  by Hproper.
+  by apply Hproper.
 Qed.
 
 (**

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -70,13 +70,13 @@ Proof.
   intros i Hi. apply Hs.
   apply elem_of_list_filter, proj1 in Hi.
   apply elem_of_list_filter.
-  split; [|apply elem_of_enum].
+  split; [| by apply elem_of_enum].
   cbn in Ht.
   destruct l as (eqv, leqv).
   destruct (equivocator_transition _ _ _) as (si', _om') eqn:Hti.
   inversion Ht. subst. clear Ht.
   destruct (decide (i = eqv)); subst; state_update_simpl; [| done].
-  apply (zero_descriptor_transition_reflects_equivocating_state (IM eqv) _ _ _ _ _ Hti _ Hzero Hi).
+  by apply (zero_descriptor_transition_reflects_equivocating_state (IM eqv) _ _ _ _ _ Hti _ Hzero Hi).
 Qed.
 
 (** If a future state has fixed equivocation, then so must the current state. *)
@@ -91,7 +91,7 @@ Proof.
   apply transitivity.
   destruct Ht as [_ Ht].
   revert Ht.
-  rapply @equivocators_transition_preserves_equivocating_indices.
+  by rapply @equivocators_transition_preserves_equivocating_indices.
 Qed.
 
 (**
@@ -134,7 +134,7 @@ Proof.
     destruct Hin as [His Hin].
     unfold is_equivocating_state in His.
     contradict His.
-    apply Hinit.
+    by apply Hinit.
   }
   clear Hinit.
   induction Htr; [done |].
@@ -155,17 +155,15 @@ Lemma equivocators_fixed_equivocations_vlsm_incl_PreFree
   : VLSM_incl equivocators_fixed_equivocations_vlsm (pre_loaded_with_all_messages_vlsm (free_composite_vlsm equivocator_IM)).
 Proof.
   apply VLSM_incl_trans with (machine (free_composite_vlsm equivocator_IM)).
-  - apply equivocators_fixed_equivocations_vlsm_incl_free.
-  - apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  - by apply equivocators_fixed_equivocations_vlsm_incl_free.
+  - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
 (** Inclusion of preloaded machine into the preloaded free composition. *)
 Lemma preloaded_equivocators_fixed_equivocations_vlsm_incl_free
   : VLSM_incl (pre_loaded_with_all_messages_vlsm equivocators_fixed_equivocations_vlsm) (pre_loaded_with_all_messages_vlsm (free_composite_vlsm equivocator_IM)).
 Proof.
-  apply basic_VLSM_incl_preloaded.
-  1, 3: by intro; intros.
-  by destruct 1.
+  by apply basic_VLSM_incl_preloaded; [intro | inversion 1 | intro].
 Qed.
 
 (**
@@ -176,7 +174,7 @@ Lemma equivocators_fixed_equivocations_vlsm_incl_no_equivocations
   : VLSM_incl equivocators_fixed_equivocations_vlsm (equivocators_no_equivocations_vlsm IM).
 Proof.
   apply constraint_subsumption_incl.
-  intros l (s,om) Hv. apply Hv.
+  by intros l [s om] Hv; apply Hv.
 Qed.
 
 End sec_equivocators_fixed_equivocations_vlsm.
@@ -232,7 +230,7 @@ Proof.
   unfold node_generated_without_further_equivocation_alt in Hm.
   right.
   eapply can_emit_composite_free_lift with (j := dexist i Hi); [| done].
-  itauto.
+  by eauto.
 Qed.
 
 (**
@@ -314,7 +312,7 @@ Proof.
   destruct (eqv_descriptors i); [done |].
   destruct Heqv_descriptors as [s_i_n Heqv_descriptors].
   apply equivocator_state_project_Some_rev in Heqv_descriptors.
-  f_equal; lia.
+  by f_equal; lia.
 Qed.
 
 (**
@@ -438,11 +436,9 @@ Proof.
       apply valid_state_prop_iff. left.
       by exists (exist _ _ His).
     }
-    subst.
-    apply fixed_equivocators_initial_state_project; [|apply Hproper].
-    apply Htr.
+    by subst; apply fixed_equivocators_initial_state_project; [apply Htr | apply Hproper].
   - specialize (IHlen (length tr')) as IH'.
-    spec IH'. { rewrite app_length. simpl. lia. }
+    spec IH'; [by rewrite app_length; cbn; lia |].
     destruct Htr as [Htr Hinit].
     apply finite_valid_trace_from_app_iff in Htr.
     destruct Htr as [Htr Hlst].
@@ -478,15 +474,17 @@ Proof.
       as (trX' & initial_descriptors & _ & Htr_project & Hstate_project & HtrX').
     assert
       (Htr' : finite_valid_trace FreeE is tr').
-    {  split; [| done].
-      revert Htr.  apply VLSM_incl_finite_valid_trace_from.
-      apply equivocators_fixed_equivocations_vlsm_incl_free.
+    {
+      split; [| done].
+      revert Htr; apply VLSM_incl_finite_valid_trace_from.
+      by apply equivocators_fixed_equivocations_vlsm_incl_free.
     }
     assert
       (Htr'pre : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) is tr').
-    { split; [| done].
+    {
+      split; [| done].
       specialize (vlsm_incl_pre_loaded_with_all_messages_vlsm FreeE) as Hincl.
-      apply (VLSM_incl_finite_valid_trace_from Hincl). apply Htr'.
+      by apply (VLSM_incl_finite_valid_trace_from Hincl), Htr'.
     }
     specialize
       (equivocators_trace_project_preserves_proper_fixed_equivocator_descriptors _ _ (proj1 Htr'pre) _ _ _ Htr_project Hproper')
@@ -513,8 +511,8 @@ Proof.
       |- finite_valid_trace_from _ ?l _ => remember l as lst
       end.
       destruct item.
-      assert (Hplst : valid_state_prop X' lst).
-      { by apply finite_valid_trace_last_pstate in HtrX'; subst. }
+      assert (Hplst : valid_state_prop X' lst)
+        by (apply finite_valid_trace_last_pstate in HtrX'; subst; done).
       apply (extend_right_finite_trace_from X'); [by constructor |].
       simpl in Hl. subst.
       simpl in Hc.
@@ -522,7 +520,7 @@ Proof.
       simpl in Htx,Hvx,Hstate_project.
       rewrite Hstate_project in Hvx, Htx.
       destruct input as [input|]
-      ; [|repeat split; [done | apply option_valid_message_None | done | apply HconstraintNone | done]].
+      ; [| by repeat split; [done | apply option_valid_message_None | done | apply HconstraintNone | done]].
       simpl in Hno_equiv.
       apply or_comm in Hno_equiv.
       destruct Hno_equiv as [Hinit_input | Hno_equiv]
@@ -551,8 +549,8 @@ Proof.
         as (trXm' & initial_descriptors_m' & Hproper_initial_m & Hproject_trXm' & Hpr_fin_tr' & HtrXm).
       simpl in *. rewrite Hproject_trXm in Hproject_trXm'.
       inversion Hproject_trXm'. subst trXm' initial_descriptors_m'. clear Hproject_trXm'.
-      repeat split. 1, 3, 5: done.
-      * eapply valid_trace_output_is_valid; [apply HtrXm | done].
+      repeat split; [done | | done | | done].
+      * by eapply valid_trace_output_is_valid; [apply HtrXm |].
       * rewrite <- Hstate_project.
         apply Hconstraint_hbs; [done | apply Hproper' |].
         assert (Hlst'pre : valid_state_prop (pre_loaded_with_all_messages_vlsm FreeE) (finite_trace_last is tr'))
@@ -561,7 +559,8 @@ Proof.
         apply has_been_sent_consistency; [typeclasses eauto | done | ].
         by exists is, tr', (valid_trace_add_default_last Htr'pre).
     + exists trX'. exists initial_descriptors. subst foldx. split; [done |].
-      split; [apply Htr_project|]. split; [| done].
+      split; [by apply Htr_project |].
+      split; [| done].
       subst tr. clear -Hstate_project Hx.
       unfold final_state.
       by rewrite <- Hstate_project, <- Hx, finite_trace_last_is_last.
@@ -614,7 +613,7 @@ Proof.
   assert (Htr_Pre : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) is tr).
   { revert Htr. apply VLSM_incl_finite_valid_trace.
     apply VLSM_incl_trans with (machine FreeE);
-    [|apply vlsm_incl_pre_loaded_with_all_messages_vlsm].
+    [| by apply vlsm_incl_pre_loaded_with_all_messages_vlsm].
     apply equivocators_fixed_equivocations_vlsm_incl_free.
   }
 
@@ -627,7 +626,7 @@ Proof.
   }
   rewrite (has_been_directly_observed_sent_received_iff Free) by done.
   right. apply proper_sent; [done |].
-  apply has_been_sent_consistency; [typeclasses eauto | done |].
+  apply has_been_sent_consistency; [by typeclasses eauto | done |].
   exists (equivocators_state_project IM initial_descriptors is), trX,
     (valid_trace_add_default_last HtrX_Pre).
 
@@ -670,7 +669,7 @@ Proof.
   simpl in *.
   destruct (equivocators_transition_item_project IM eqv_descriptors'' item)
     as [(o, odescriptor)|] eqn:Hpr
-  ; [|congruence].
+  ; [| by congruence].
   destruct item. simpl in *.
   apply first_transition_valid in Hpre_item_free. simpl in Hpre_item_free.
   destruct Hpre_item_free as [[_ [_ [Hv _]]] Ht].
@@ -730,18 +729,20 @@ Proof.
   destruct (free_equivocators_valid_trace_project descriptors is tr Hproper Htr)
     as [trX [initial_descriptors [Hinitial_descriptors [Htr_project [Hfinal_state HtrXFree]]]]].
   assert (HtrXPre : finite_valid_trace (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)) (equivocators_state_project IM initial_descriptors is) trX).
-  { revert HtrXFree. apply VLSM_incl_finite_valid_trace.
-    apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  {
+    revert HtrXFree; apply VLSM_incl_finite_valid_trace.
+    by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
   assert (Hlst_trX : valid_state_prop (pre_loaded_with_all_messages_vlsm Free) lst_trX).
-  { subst lst_trX. subst s. simpl. simpl in Hfinal_state. rewrite Hfinal_state.
-    apply finite_valid_trace_last_pstate. apply HtrXPre.
+  {
+    subst lst_trX s; cbn in Hfinal_state |- *; rewrite Hfinal_state.
+    by apply finite_valid_trace_last_pstate, HtrXPre.
   }
   assert (Htr_free : finite_valid_trace  (pre_loaded_with_all_messages_vlsm FreeE) is tr).
   { revert Htr.  apply VLSM_incl_finite_valid_trace.
     apply VLSM_incl_trans with (machine FreeE)
-    ; [apply equivocators_fixed_equivocations_vlsm_incl_free|].
-    apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+    ; [by apply equivocators_fixed_equivocations_vlsm_incl_free |].
+    by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
   subst tr.
   destruct Htr as [Htr His].
@@ -753,10 +754,11 @@ Proof.
   destruct (composite_has_been_directly_observed_dec IM lst_trX m) as [|Heqv]
   ; [by left | right].
   assert (Hsuf_free : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE) (finite_trace_last is pre) ([item] ++ suf)).
-  { revert Hsuf. apply VLSM_incl_finite_valid_trace_from.
+  {
+    revert Hsuf; apply VLSM_incl_finite_valid_trace_from.
     apply VLSM_incl_trans with (machine FreeE)
-    ; [apply equivocators_fixed_equivocations_vlsm_incl_free|].
-    apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+    ; [by apply equivocators_fixed_equivocations_vlsm_incl_free |].
+    by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
   assert (Hs_free : valid_state_prop  (pre_loaded_with_all_messages_vlsm FreeE) s).
   { apply finite_valid_trace_last_pstate in Hsuf_free. subst s.
@@ -769,11 +771,13 @@ Proof.
   clear Ht.
   destruct Hc as [Hc | Hinit]; [|done ].
   assert (Hpre_free : finite_valid_trace FreeE is pre).
-  { split; [| done]. revert Hpre. apply VLSM_incl_finite_valid_trace_from.
-    apply equivocators_fixed_equivocations_vlsm_incl_free.
+  {
+    split; [| done].
+    revert Hpre; apply VLSM_incl_finite_valid_trace_from.
+    by apply equivocators_fixed_equivocations_vlsm_incl_free.
   }
-  assert (Hpre_lst_free : valid_state_prop FreeE (finite_trace_last is pre)).
-  { apply (finite_valid_trace_last_pstate FreeE). apply Hpre_free. }
+  assert (Hpre_lst_free : valid_state_prop FreeE (finite_trace_last is pre))
+    by (apply (finite_valid_trace_last_pstate FreeE), Hpre_free; done).
   specialize (specialized_proper_sent_rev FreeE _ Hpre_lst_free m) as Hproper_sent.
   apply Hproper_sent in Hc. clear Hproper_sent.
   specialize (Hc  is pre (valid_trace_add_default_last Hpre_free)).
@@ -812,7 +816,7 @@ Proof.
     destruct Htr_s0 as [_ Hfuture].
     rewrite finite_trace_last_is_last in Hfuture.
     eexists.
-    apply valid_trace_add_last;[apply Hfuture|].
+    apply valid_trace_add_last; [by apply Hfuture |].
     by rewrite finite_trace_last_is_last.
   }
   eapply (in_futures_reflects_fixed_equivocation) in Hfutures; [| done].
@@ -826,7 +830,7 @@ Proof.
   contradict Heqv.
   apply composite_has_been_directly_observed_free_iff.
   eapply in_futures_preserving_oracle_from_stepwise; cycle 2
-  ; [|apply has_been_directly_observed_stepwise_props|].
+  ; [| by apply has_been_directly_observed_stepwise_props |].
   - by eapply not_equivocating_sent_message_has_been_directly_observed_in_projection; cycle 1.
   - subst lst_trX. subst s. simpl. simpl in Hfinal_state.
     rewrite Hfinal_state. subst trX.
@@ -836,7 +840,7 @@ Proof.
     apply finite_valid_trace_from_app_iff in HtrXPre.
     simpl in *. rewrite Hpre_final_state.
     apply valid_trace_add_default_last.
-    apply HtrXPre.
+    by apply HtrXPre.
 Qed.
 
 (**
@@ -885,8 +889,8 @@ Proof.
   {
     revert Hsuf. apply VLSM_incl_finite_valid_trace_from.
     apply VLSM_incl_trans with (machine FreeE).
-    - apply equivocators_fixed_equivocations_vlsm_incl_free.
-    - apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+    - by apply equivocators_fixed_equivocations_vlsm_incl_free.
+    - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
   specialize
     (equivocators_trace_project_preserves_proper_fixed_equivocator_descriptors _ _ Hsufpre
@@ -940,15 +944,15 @@ Proof.
   left.
   assert (HtrX_free : finite_valid_trace (pre_loaded_with_all_messages_vlsm Free) (equivocators_state_project IM initial_descriptors is) trX).
   {
-    revert HtrX. clear. apply VLSM_incl_finite_valid_trace.
-    apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+    revert HtrX; apply VLSM_incl_finite_valid_trace.
+    by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
   specialize (finite_valid_trace_last_pstate _ _ _ (proj1 HtrX_free)) as Hfree_lst.
   subst sX s.
   simpl in *.
   rewrite Hlast_state.
   apply (composite_proper_sent IM); [done |].
-  apply has_been_sent_consistency; [typeclasses eauto | done |].
+  apply has_been_sent_consistency; [by typeclasses eauto | done |].
   exists (equivocators_state_project IM initial_descriptors is), trX, (valid_trace_add_default_last HtrX_free).
   clear HtrX HtrX_free Hfree_lst.
   by eapply equivocator_vlsm_trace_project_reflect_non_equivocating.
@@ -980,7 +984,7 @@ Proof.
   - by intro; intros.
   - intro; intros.
     apply initial_message_is_valid; cbn.
-    destruct HmX; auto.
+    by destruct HmX; auto.
   - intros l s om [Hs [_ [Hv Hc]]].
     split; [done |].
     destruct Hc as [Hc _].
@@ -997,7 +1001,7 @@ Proof.
     apply (preloaded_valid_state_projection (equivocator_IM (sub_IM IM equivocating)) subi).
     revert Hs.
     apply VLSM_incl_valid_state.
-    apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
+    by apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
   - by destruct 1.
 Qed.
 
@@ -1018,7 +1022,7 @@ Proof.
   apply basic_VLSM_incl; intros ? *; [done | | | by destruct 1].
   - intros.
     apply initial_message_is_valid; cbn.
-    destruct HmX; auto.
+    by destruct HmX; auto.
   - intros (Hs & _ & Hv & Hc & _) _ _.
     split; [done |].
     split; [| done].
@@ -1034,7 +1038,7 @@ Proof.
     apply (preloaded_valid_state_projection (equivocator_IM (sub_IM IM equivocating)) subi).
     revert Hs.
     apply VLSM_incl_valid_state.
-    apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
+    by apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
 Qed.
 
 (**
@@ -1070,14 +1074,15 @@ Proof.
   apply valid_state_has_trace in Hs.
   destruct Hs as [is [tr Htr]].
   assert (Htr'pre : finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm FreeE) is s tr).
-  { revert Htr. apply VLSM_incl_finite_valid_trace_init_to.
+  {
+    revert Htr; apply VLSM_incl_finite_valid_trace_init_to.
     apply VLSM_incl_trans with (machine FreeE).
-    - apply
+    - by apply
       (constraint_free_incl (equivocator_IM IM) (equivocators_fixed_equivocations_constraint IM equivocating)).
-    - apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+    - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
-  assert (Hplst : valid_state_prop (pre_loaded_with_all_messages_vlsm FreeE) s).
-  { by apply valid_trace_last_pstate in Htr'pre. }
+  assert (Hplst : valid_state_prop (pre_loaded_with_all_messages_vlsm FreeE) s)
+    by (apply valid_trace_last_pstate in Htr'pre; done).
   apply proper_sent in Hm; [| done]. clear Hplst.
   specialize (Hm is tr Htr'pre).
   (*
@@ -1125,8 +1130,8 @@ Proof.
       (composite_transition_item_projection (equivocator_IM IM) item)
       (item_descriptors (projT1 (l item)))
     ) as [(o, deqv')|]
-    ; [|congruence].
-  destruct o as [item'|]; [|congruence].
+    ; [| by congruence].
+  destruct o as [item'|]; [| by congruence].
   inversion Hpr_item. subst output_itemX pre_descriptors. clear Hpr_item deqv'.
   simpl in Houtput_select.
 
@@ -1139,10 +1144,7 @@ Proof.
       _ n item
     ) as Hitem_equivocating.
   clear Hdescriptors n.
-  spec Hitem_equivocating.
-  { subst.
-    rewrite !elem_of_app.
-    right. left. left. }
+  spec Hitem_equivocating; [by subst; rewrite !elem_of_app; right; left; left |].
   spec Hitem_equivocating Houtput_select.
 
   (*
@@ -1179,7 +1181,7 @@ Proof.
     intros e.
     destruct e.
     apply not_equivocating_equivocator_descriptors_proper in Hfinal_descriptors_m.
-    apply Hfinal_descriptors_m.
+    by apply Hfinal_descriptors_m.
   }
   destruct Hsub_project
     as [trX' [initial_descriptors' [_ [Hpr_tr' [_ HtrX]]]]].
@@ -1239,7 +1241,7 @@ Theorem fixed_equivocators_valid_trace_project
     finite_valid_trace X isX trX.
 Proof.
   apply _equivocators_valid_trace_project; [done | done | done |]; intros.
-  apply fixed_equivocation_constraint_has_constraint_has_been_sent_prop.
+  by apply fixed_equivocation_constraint_has_constraint_has_been_sent_prop.
 Qed.
 
 Lemma fixed_equivocators_vlsm_partial_projection
@@ -1250,8 +1252,9 @@ Proof.
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
     assert
       (HPreFree_pre_tr : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE) s_pre (pre ++ tr)).
-    { revert Hpre_tr. apply VLSM_incl_finite_valid_trace_from.
-      apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
+    {
+      revert Hpre_tr; apply VLSM_incl_finite_valid_trace_from.
+      by apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
     }
     clear Hpre_tr.  revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
     apply equivocators_partial_trace_project_extends_left.
@@ -1274,10 +1277,11 @@ Proof.
   constructor; [constructor|]; intros sX trX HtrX.
   - apply PreFreeE_Free_vlsm_projection_type.
     apply VLSM_incl_finite_valid_trace_from; [| done].
-    apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
+    by apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
   - assert (Hpre_tr : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) sX trX).
-    { apply VLSM_incl_finite_valid_trace; [| done].
-      apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
+    {
+      apply VLSM_incl_finite_valid_trace; [| done].
+      by apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
     }
     specialize
      (VLSM_partial_projection_finite_valid_trace (fixed_equivocators_vlsm_partial_projection (zero_descriptor IM))
@@ -1291,7 +1295,7 @@ Proof.
     remember (pre_VLSM_projection_finite_trace_project _ _ _ _ _) as tr.
     replace tr with (equivocators_total_trace_project IM trX); [done |].
     subst. symmetry.
-    apply (equivocators_total_VLSM_projection_finite_trace_project IM (proj1 Hpre_tr)).
+    by apply (equivocators_total_VLSM_projection_finite_trace_project IM (proj1 Hpre_tr)).
 Qed.
 
 End sec_from_equivocators_to_nodes.
@@ -1328,7 +1332,7 @@ Lemma strong_constraint_subsumption_all_fixed
     (equivocators_fixed_equivocations_constraint IM (enum index))
     (equivocators_no_equivocations_constraint IM).
 Proof.
-  intros l (s, om) Hv. apply Hv.
+  by intros l [s om] Hv; apply Hv.
 Qed.
 
 Lemma equivocators_fixed_equivocations_all_eq : VLSM_eq XE NE.
@@ -1338,14 +1342,14 @@ Proof.
   - apply constraint_subsumption_incl.
     apply preloaded_constraint_subsumption_stronger.
     apply strong_constraint_subsumption_strongest.
-    apply strong_constraint_subsumption_all_fixed.
+    by apply strong_constraint_subsumption_all_fixed.
   - apply
       (constraint_subsumption_incl (equivocator_IM IM)
         (equivocators_no_equivocations_constraint IM)
         (equivocators_fixed_equivocations_constraint IM (enum index))).
     apply preloaded_constraint_subsumption_stronger.
     apply strong_constraint_subsumption_strongest.
-    apply strong_constraint_subsumption_fixed_all.
+    by apply strong_constraint_subsumption_fixed_all.
 Qed.
 
 End sec_all_equivocating.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -1144,7 +1144,7 @@ Proof.
       _ n item
     ) as Hitem_equivocating.
   clear Hdescriptors n.
-  spec Hitem_equivocating; [by subst; rewrite !elem_of_app; right; left; left |].
+  spec Hitem_equivocating; [by rewrite Heqtr, !elem_of_app, elem_of_cons; auto |].
   spec Hitem_equivocating Houtput_select.
 
   (*

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -441,20 +441,20 @@ Proof.
         ).
   - clear isX sX trX HtrX. intro; intros.
     specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM []) as HinclE.
-    destruct iom as [im |]; [| by exists [], eqv_state_s; split; [constructor |]; eauto].
-    destruct HcX as [Hsent | Hemitted]; [| done].
-    exists []. exists eqv_state_s.
-    split; [by constructor |].
-    split; [done |].
-    split; [done |].
-    apply (VLSM_eq_valid_state HeqXE) in Hstate_valid.
-    apply (VLSM_incl_valid_state HinclE) in Hstate_valid.
-    left.
-    revert Hsent. subst.
-    by specialize
-      (VLSM_projection_has_been_sent_reflect
-        (preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection IM)
-        eqv_state_s Hstate_valid im) as Hsent.
+    destruct iom as [im |]; [| by exists [], eqv_state_s; split; constructor].
+    + destruct HcX as [Hsent | Hemitted]; [| done].
+      exists []. exists eqv_state_s.
+      split; [by constructor |].
+      split; [done |].
+      split; [done |].
+      apply (VLSM_eq_valid_state HeqXE) in Hstate_valid.
+      apply (VLSM_incl_valid_state HinclE) in Hstate_valid.
+      left.
+      revert Hsent. subst.
+      by specialize
+        (VLSM_projection_has_been_sent_reflect
+          (preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection IM)
+          eqv_state_s Hstate_valid im) as Hsent.
 Qed.
 
 End sec_no_equivocation.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -199,7 +199,7 @@ Proof.
   destruct iom as [im|]; swap 1 2; [|destruct HcX as [Hsent | Hemitted]].
   - exists [], eqv_state_s.
     by split; [constructor | eauto].
-  - exists []. eqv_state_s.
+  - exists []. exists eqv_state_s.
     split; [by constructor |].
     split; [done |].
     split; [done |].

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -126,7 +126,7 @@ Proof.
           (preloaded_equivocator_zero_projection (IM i))).
       apply (VLSM_incl_valid_state HinclE) in Heqv_state_s.
       revert Heqv_state_s.
-      apply (VLSM_projection_valid_state (preloaded_component_projection (equivocator_IM IM) i)).
+      by apply (VLSM_projection_valid_state (preloaded_component_projection (equivocator_IM IM) i)).
   - destruct (composite_transition _ _ _) as (s', om') eqn:Ht'.
     apply
       (equivocating_transition_preserves_fixed_equivocation
@@ -197,9 +197,9 @@ Proof.
   specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM equivocating) as HinclE.
   intro; intros.
   destruct iom as [im|]; swap 1 2; [|destruct HcX as [Hsent | Hemitted]].
-  - exists []. exists eqv_state_s.
-    split; [constructor|]; eauto.
-  - exists []. exists eqv_state_s.
+  - exists [], eqv_state_s.
+    by split; [constructor | eauto].
+  - exists []. eqv_state_s.
     split; [by constructor |].
     split; [done |].
     split; [done |].
@@ -287,13 +287,13 @@ Proof.
       constraint for which we employ Lemma [fixed_equivocation_replay_has_message].
     *)
     repeat split.
-    + apply
+    + by apply
       (equivocators_total_trace_project_replayed_trace_from
         IM equivocating eqv_state_s im_eis im_etr).
     + subst s.
-      apply
-      (equivocators_total_state_project_replayed_trace_from
-        IM equivocating eqv_state_s im_eis im_etr).
+      by apply
+        (equivocators_total_state_project_replayed_trace_from
+          IM equivocating eqv_state_s im_eis im_etr).
     + apply (VLSM_eq_valid_state HeqXE) in Hstate_valid.
       apply (VLSM_incl_valid_state HinclE) in Hstate_valid as Hstate_pre.
       specialize
@@ -309,7 +309,7 @@ Proof.
       simpl. intro Hrew. rewrite Hrew. clear Hrew.
       apply fixed_equivocation_replay_has_message; [done |].
       clear -Him_etr Him_output.
-      destruct_list_last im_etr im_ert' item Heqim_etr; [inversion Him_output|].
+      destruct_list_last im_etr im_ert' item Heqim_etr; [by inversion Him_output |].
       apply proj1 in Him_etr.
       replace (im_ert' ++ [item]) with (im_ert' ++ [item] ++ []) in Him_etr
         by (rewrite app_assoc; apply app_nil_r).
@@ -373,7 +373,7 @@ Proof.
         (zero_descriptor_transition_preserves_fixed_equivocation
           IM equivocating _ _ _ _ _ Het Hes li
         ).
-  - apply fixed_equivocation_has_replayable_message_prop.
+  - by apply fixed_equivocation_has_replayable_message_prop.
 Qed.
 
 End sec_fixed_equivocating.
@@ -441,11 +441,7 @@ Proof.
         ).
   - clear isX sX trX HtrX. intro; intros.
     specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM []) as HinclE.
-    destruct iom as [im|].
-    2: {
-      exists []. exists eqv_state_s.
-      split; [constructor |]; eauto.
-    }
+    destruct iom as [im |]; [| by exists [], eqv_state_s; split; [constructor |]; eauto].
     destruct HcX as [Hsent | Hemitted]; [| done].
     exists []. exists eqv_state_s.
     split; [by constructor |].

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -442,19 +442,19 @@ Proof.
   - clear isX sX trX HtrX. intro; intros.
     specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM []) as HinclE.
     destruct iom as [im |]; [| by exists [], eqv_state_s; split; constructor].
-    + destruct HcX as [Hsent | Hemitted]; [| done].
-      exists []. exists eqv_state_s.
-      split; [by constructor |].
-      split; [done |].
-      split; [done |].
-      apply (VLSM_eq_valid_state HeqXE) in Hstate_valid.
-      apply (VLSM_incl_valid_state HinclE) in Hstate_valid.
-      left.
-      revert Hsent. subst.
-      by specialize
-        (VLSM_projection_has_been_sent_reflect
-          (preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection IM)
-          eqv_state_s Hstate_valid im) as Hsent.
+    destruct HcX as [Hsent | Hemitted]; [| done].
+    exists []. exists eqv_state_s.
+    split; [by constructor |].
+    split; [done |].
+    split; [done |].
+    apply (VLSM_eq_valid_state HeqXE) in Hstate_valid.
+    apply (VLSM_incl_valid_state HinclE) in Hstate_valid.
+    left.
+    revert Hsent. subst.
+    by specialize
+      (VLSM_projection_has_been_sent_reflect
+        (preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection IM)
+        eqv_state_s Hstate_valid im) as Hsent.
 Qed.
 
 End sec_no_equivocation.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
@@ -60,8 +60,8 @@ Proof.
   unfold state_has_fixed_equivocation in Hfixed.
   unfold equivocation_fault.
   apply sum_weights_subseteq.
-  - apply NoDup_elements.
-  - apply NoDup_remove_dups.
+  - by apply NoDup_elements.
+  - by apply NoDup_remove_dups.
   - intros i Hi.
     rewrite equivocating_indices_equivocating_validators in Hi.
     apply elem_of_elements, elem_of_list_to_set in Hi.
@@ -101,7 +101,7 @@ Lemma limited_equivocators_finite_valid_trace_init_to_rev
 Proof.
   destruct HtrX as (equivocating & Hlimited & HtrX).
   eapply VLSM_incl_finite_valid_trace, valid_trace_add_default_last in HtrX
-  ; [|eapply VLSM_eq_proj1,Fixed_eq_StrongFixed].
+  ; [| by eapply VLSM_eq_proj1,Fixed_eq_StrongFixed].
   specialize
     (fixed_equivocators_finite_valid_trace_init_to_rev IM _
       no_initial_messages_in_IM _ _ _ HtrX)

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
@@ -98,17 +98,14 @@ Proof.
   specialize equivocators_limited_equivocations_vlsm_incl_free as Hincl1.
   specialize (vlsm_incl_pre_loaded_with_all_messages_vlsm FreeE)
     as Hincl2.
-  revert Hincl1 Hincl2.
-  apply VLSM_incl_trans.
+  by eapply VLSM_incl_trans.
 Qed.
 
 (** Inclusion of preloaded machine in the preloaded free composition. *)
 Lemma preloaded_equivocators_limited_equivocations_vlsm_incl_free
   : VLSM_incl (pre_loaded_with_all_messages_vlsm equivocators_limited_equivocations_vlsm) PreFreeE.
 Proof.
-  apply basic_VLSM_incl_preloaded; intros ? *.
-  1, 3: itauto.
-  by destruct 1.
+  by apply basic_VLSM_incl_preloaded; intros ? *; [intro | inversion 1 | intro].
 Qed.
 
 (**
@@ -163,8 +160,8 @@ Proof.
   split; [| apply Htr].
   cut
     (forall equivocating, elements(equivocating_validators s) ⊆ equivocating ->
-      finite_valid_trace_from_to (equivocators_fixed_equivocations_vlsm IM equivocating) is s tr).
-  { by intros H'; apply H'. }
+      finite_valid_trace_from_to (equivocators_fixed_equivocations_vlsm IM equivocating) is s tr);
+    [by intros H'; apply H' |].
   induction Htr using finite_valid_trace_init_to_rev_ind; intros equivocating Hincl.
   - apply (finite_valid_trace_from_to_empty (equivocators_fixed_equivocations_vlsm IM equivocating)).
     by apply initial_state_is_valid.
@@ -188,7 +185,7 @@ Proof.
       apply valid_trace_last_pstate in IHHtr.
       destruct Ht as [[_ [_ [Hv [[Hno_equiv _] Hno_heavy]]]] Ht].
       repeat split; [done | | done | done | | done].
-      + destruct iom as [m|]; [|apply option_valid_message_None].
+      + destruct iom as [m |]; [| by apply option_valid_message_None].
         destruct Hno_equiv as [Hsent | Hfalse]; [| done].
         simpl in Hsent.
         by eapply composite_sent_valid.
@@ -232,14 +229,14 @@ Proof.
   - by eapply not_equivocating_equivocator_descriptors_proper_fixed.
   - destruct Hpr as [trX [initial_descriptors [Hinitial_descriptors [Hpr [Hlst_pr Hpr_fixed]]]]].
     exists trX, initial_descriptors.
-    repeat split; [apply Hinitial_descriptors | done | done |].
+    repeat split; [by apply Hinitial_descriptors | done | done |].
     exists (elements (equivocating_validators (finite_trace_last is tr))).
     split; [| done].
     apply valid_trace_add_default_last, valid_trace_last_pstate, valid_state_limited_equivocation in Htr.
     transitivity (equivocation_fault (finite_trace_last is tr)); [| done].
     apply sum_weights_subseteq.
-    + apply NoDup_remove_dups.
-    + apply NoDup_elements.
+    + by apply NoDup_remove_dups.
+    + by apply NoDup_elements.
     + by intros i Hi; apply elem_of_remove_dups.
 Qed.
 
@@ -327,7 +324,7 @@ Proof.
       final_descriptors is tr Hproper Htr)
       as [trX [initial_descriptors [Hinitial_descriptors [Hpr [Hlst_pr Hpr_limited]]]]].
   exists trX, initial_descriptors.
-  repeat split. 1-3: done.
+  repeat split; [done.. | |].
   - by eapply traces_exhibiting_limited_equivocation_are_valid.
   - by destruct Hpr_limited as [equivs Hpr_limited]; apply Hpr_limited.
 Qed.
@@ -345,11 +342,12 @@ Proof.
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
     assert
       (HPreFree_pre_tr : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE) s_pre (pre ++ tr)).
-    { revert Hpre_tr. apply VLSM_incl_finite_valid_trace_from.
-      apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
+    {
+      revert Hpre_tr; apply VLSM_incl_finite_valid_trace_from.
+      by apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
     }
     clear Hpre_tr.  revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
-    apply equivocators_partial_trace_project_extends_left.
+    by apply equivocators_partial_trace_project_extends_left.
   - intros s tr sX trX Hpr_tr Htr.
     destruct (destruct_equivocators_partial_trace_project IM Hpr_tr)
       as [Hnot_equiv [initial_descriptors [Htr_project Hs_project]]].
@@ -372,10 +370,11 @@ Proof.
   constructor; [constructor|]; intros ? *.
   - intros HtrX. apply PreFreeE_Free_vlsm_projection_type.
     revert HtrX. apply VLSM_incl_finite_valid_trace_from.
-    apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
+    by apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
   - intro HtrX. assert (Hpre_tr : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) sX trX).
-    { revert HtrX. apply VLSM_incl_finite_valid_trace.
-      apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
+    {
+      revert HtrX; apply VLSM_incl_finite_valid_trace.
+      by apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
     }
     specialize
      (VLSM_partial_projection_finite_valid_trace (limited_equivocators_vlsm_partial_projection (zero_descriptor IM))
@@ -389,7 +388,7 @@ Proof.
     remember (pre_VLSM_projection_finite_trace_project _ _ _ _ _) as tr.
     replace tr with (equivocators_total_trace_project IM trX); [done |].
     subst. symmetry.
-    apply (equivocators_total_VLSM_projection_finite_trace_project IM (proj1 Hpre_tr)).
+    by apply (equivocators_total_VLSM_projection_finite_trace_project IM (proj1 Hpre_tr)).
 Qed.
 
 End sec_equivocators_projection_constrained_limited.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -56,8 +56,8 @@ Lemma SeededXE_Free_full_projection
 Proof.
   apply basic_VLSM_full_projection; intros ? *.
   - split; [| done].
-    apply lift_sub_valid. apply Hv.
-  - intros [_ Ht]. revert Ht. apply lift_sub_transition.
+    by apply lift_sub_valid, Hv.
+  - by intros [_ Ht]; revert Ht; apply lift_sub_transition.
   - by intros; apply (lift_sub_state_initial equivocator_IM).
   - intros; destruct HmX as [Hinit|Hseeded]; [| by apply Hseed].
     apply initial_message_is_valid.
@@ -114,7 +114,7 @@ Proof.
   intro i.
   unfold lift_equivocators_sub_state_to.
   destruct (decide _); [|lia].
-  rewrite equivocator_state_append_size. lia.
+  by rewrite equivocator_state_append_size; lia.
 Qed.
 
 (** The plan item corresponding to an initial state equivocation. *)
@@ -174,13 +174,13 @@ Proof.
     unfold lift_equivocators_sub_state_to.
     case_decide; [| done].
     rewrite decide_True; [done |].
-    apply elem_of_enum.
+    by apply elem_of_enum.
   }
   induction l using rev_ind; intros.
   - case_decide; [| done].
     by rewrite decide_False; [| inversion 1].
-  - spec IHl; [apply incl_app_inv in Hincl; apply Hincl |].
-    spec IHl; [apply NoDup_app in Hnodup; apply Hnodup |].
+  - spec IHl; [by apply incl_app_inv in Hincl; apply Hincl |].
+    spec IHl; [by apply NoDup_app in Hnodup; apply Hnodup |].
     subst tr_full_replay_is.
     rewrite map_app, (composite_apply_plan_app equivocator_IM); simpl in *
     ; destruct (composite_apply_plan _ _ _) as (aitems, afinal); simpl in *.
@@ -190,7 +190,7 @@ Proof.
     + rewrite decide_False in IHl.
       * rewrite IHl, decide_True.
         -- rewrite (sub_IM_state_pi is _Hix Hix); symmetry.
-           apply equivocator_state_append_singleton_is_extend, (His (dexist i Hix)).
+           by apply equivocator_state_append_singleton_is_extend, (His (dexist i Hix)).
         -- rewrite elem_of_app, elem_of_list_singleton; right.
            by apply dsig_eq.
       * intro Heqv.
@@ -231,7 +231,7 @@ Proof.
   split.
   - apply equivocators_trace_project_app_iff.
     exists [],[],eqv_descriptors.
-    repeat split; [|apply IHl].
+    repeat split; [| by apply IHl].
     specialize (Heqv_descriptors (` x)).
     unfold existing_descriptor in Heqv_descriptors.
     destruct (eqv_descriptors (` x)) eqn:Heqv_x; [done |].
@@ -270,7 +270,7 @@ Proof.
   simpl in *.
   rewrite finite_trace_last_is_last. simpl.
   intros i j Hj.
-  destruct (decide (`x = i)); subst; equivocator_state_update_simpl; [| auto].
+  destruct (decide (`x = i)); subst; equivocator_state_update_simpl; [| by auto].
   specialize (IHl (` x) j Hj).
   destruct_equivocator_state_project (full_replay_state (` x)) j s_x_j Hltj; [|lia].
   rewrite equivocator_state_extend_project_1; [done |].
@@ -325,7 +325,7 @@ Proof.
   unfold replayed_trace_from.
   destruct_list_last tr tr' lst Htr.
   - simpl. rewrite app_nil_r.
-    apply equivocator_state_project_replayed_initial_state_from_left.
+    by apply equivocator_state_project_replayed_initial_state_from_left.
   - unfold pre_VLSM_full_projection_finite_trace_project.
     rewrite map_app, app_assoc. simpl.
     rewrite finite_trace_last_is_last.
@@ -361,7 +361,7 @@ Proof.
   apply functional_extensionality_dep.
   intro i.
   apply equivocator_state_descriptor_project_replayed_trace_from_left.
-  apply zero_descriptor_not_equivocating.
+  by apply zero_descriptor_not_equivocating.
 Qed.
 
 Lemma equivocators_trace_project_replayed_trace_from_left full_replay_state is tr
@@ -411,7 +411,7 @@ Proof.
   unfold equivocators_total_trace_project.
   rewrite equivocators_trace_project_replayed_trace_from_left
   ; [done |].
-  apply zero_descriptor_not_equivocating.
+  by apply zero_descriptor_not_equivocating.
 Qed.
 
 Lemma lift_equivocators_sub_valid
@@ -505,23 +505,21 @@ Proof.
   intro l.
   induction l using rev_ind; intros Hincl.
   - by constructor.
-  - spec IHl.  { intros i Hi. by apply Hincl, in_app_iff; left. }
+  - spec IHl; [by intros i Hi; apply Hincl, in_app_iff; left |].
     rewrite map_app.
     apply finite_valid_plan_from_app_iff.
     split; [done |].
     apply finite_valid_trace_singleton. simpl.
     repeat split.
-    + revert IHl. apply apply_plan_last_valid.
-    + apply option_valid_message_None.
-    + apply His.
+    + by apply apply_plan_last_valid.
+    + by apply option_valid_message_None.
+    + by apply His.
     + apply Hconstraint_none.
-      * clear -x. by destruct_dec_sig x i Hi Hx; subst.
+      * by destruct_dec_sig x i Hi Hx; subst.
       * apply finite_valid_trace_last_pstate in IHl.
         remember (finite_trace_last _ _) as lst.
-        replace ((apply_plan _ _ _).2) with lst
-        ; [done |].
-        subst.
-        apply apply_plan_last.
+        replace ((apply_plan _ _ _).2) with lst; [done |].
+        by subst; apply apply_plan_last.
 Qed.
 
 Lemma lift_initial_message
@@ -538,10 +536,10 @@ Lemma lift_equivocators_sub_weak_projection
 Proof.
   apply basic_VLSM_weak_full_projection; intros ? *.
   - split.
-    + apply lift_equivocators_sub_valid. apply Hv.
+    + by apply lift_equivocators_sub_valid, Hv.
     + by apply Hsubsumption.
-  - intros Ht. apply lift_equivocators_sub_transition; apply Ht.
-  - intro. rewrite <- replayed_initial_state_from_lift; [| done].
+  - by intros Ht; apply lift_equivocators_sub_transition; apply Ht.
+  - intro; rewrite <- replayed_initial_state_from_lift; [| done].
     by apply finite_valid_trace_last_pstate, replayed_initial_state_from_valid.
   - by intros; apply lift_initial_message.
 Qed.
@@ -584,7 +582,7 @@ Lemma PreFreeSubE_PreFreeE_weak_full_projection
 Proof.
   apply basic_VLSM_weak_full_projection; intros ? *.
   - by split; [apply lift_equivocators_sub_valid; apply Hv |].
-  - intro Ht. apply lift_equivocators_sub_transition; apply Ht.
+  - by intro Ht; apply lift_equivocators_sub_transition; apply Ht.
   - intros.
     rewrite <- replayed_initial_state_from_lift; [| done].
     apply finite_valid_trace_last_pstate.
@@ -592,7 +590,7 @@ Proof.
     apply (VLSM_eq_finite_valid_trace_from Heq).
     apply replayed_initial_state_from_valid; [done | | done].
     by apply (VLSM_eq_valid_state Heq).
-  - intros. apply any_message_is_valid_in_preloaded.
+  - by intros; apply any_message_is_valid_in_preloaded.
 Qed.
 
 Section sec_seeded_no_equiv.
@@ -668,7 +666,7 @@ Proof.
       seed)
       as Hvalid.
   spec Hvalid; [done |].
-  spec Hvalid; [apply sent_are_valid|].
+  spec Hvalid; [by apply sent_are_valid |].
   specialize (Hvalid _ Hfull_replay_state).
   apply Hvalid; [| done].
   by intros; apply SeededNoEquiv_subsumption.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -122,8 +122,7 @@ Proof.
       constructor.
       by apply initial_state_is_valid.
     }
-    apply functional_extensionality_dep_good.
-    by subst.
+    by apply functional_extensionality_dep_good; subst.
   - destruct IHHtrX1 as [eqv_state_is [Hstate_start_project [eqv_state_s [Hstate_final_project [eqv_state_tr [Hstate_project [Hstate_trace _ ]]]]]]].
     destruct IHHtrX2 as [eqv_msg_is [Hmsg_start_project [eqv_msg_s [_ [eqv_msg_tr [Hmsg_project [Hmsg_trace Hfinal_msg ]]]]]]].
     exists eqv_state_is. split; [done |].
@@ -203,15 +202,15 @@ Proof.
         cbn. unfold equivocators_transition_item_project.
         by cbn; rewrite !equivocator_state_project_zero, decide_True
         ; cbn; repeat f_equal.
-      - apply Hstate_trace.
+      - by apply Hstate_trace.
       - by rewrite! finite_trace_last_output_is_last.
     }
     clear Happ_extend.
     apply valid_trace_last_pstate in Happ.
     repeat split; [done |..| done].
-    + destruct iom as [im|]; [|apply option_valid_message_None].
+    + destruct iom as [im |]; [| by apply option_valid_message_None].
       destruct Hbs_iom as [Hbs_iom | Hseeded].
-      * apply (preloaded_composite_sent_valid (equivocator_IM IM) _ _ _ Happ _ Hbs_iom).
+      * by apply (preloaded_composite_sent_valid (equivocator_IM IM) _ _ _ Happ _ Hbs_iom).
       * by apply initial_message_is_valid.
     + by subst el; cbn; rewrite equivocator_state_project_zero, Hes_pr_eqv.
     + by apply Hsubsumption.
@@ -279,8 +278,7 @@ Proof.
   apply (VLSM_full_projection_finite_valid_trace Hproj) in Htr.
   revert Htr.
   apply VLSM_incl_finite_valid_trace.
-  apply basic_VLSM_incl_preloaded_with.
-  1, 3-5: intro; intros; done.
+  apply basic_VLSM_incl_preloaded_with; [done | | by intro..].
   intros l s om (Hv & Hc & _).
   split; [done |].
   split; [| done].
@@ -317,11 +315,7 @@ Proof.
     by elim (no_initial_messages_in_IM i mi).
   - clear isX sX trX HtrX.
     intro; intros.
-    destruct iom as [im|].
-    2: {
-      exists [], eqv_state_s.
-      by split; [constructor |].
-    }
+    destruct iom as [im |]; [| by exists [], eqv_state_s; split; [constructor |]].
     specialize (NoEquivocation.seeded_no_equivocation_incl_preloaded (equivocator_IM IM) (free_constraint _) seed)
       as HinclE.
     apply valid_trace_forget_last in Hmsg_trace.
@@ -354,7 +348,7 @@ Proof.
 
     apply Exists_app. right.
     destruct_list_last eqv_msg_tr eqv_msg_tr' itemX Heqv_msg_tr
-    ; [inversion Hfinal_msg|].
+    ; [by inversion Hfinal_msg |].
     rewrite finite_trace_last_output_is_last in Hfinal_msg.
     apply Exists_app. right.
     unfold VLSM_full_projection_finite_trace_project, pre_VLSM_full_projection_finite_trace_project.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -315,7 +315,7 @@ Proof.
     by elim (no_initial_messages_in_IM i mi).
   - clear isX sX trX HtrX.
     intro; intros.
-    destruct iom as [im |]; [| by exists [], eqv_state_s; split; [constructor |]].
+    destruct iom as [im |]; [| by exists [], eqv_state_s; split; constructor].
     specialize (NoEquivocation.seeded_no_equivocation_incl_preloaded (equivocator_IM IM) (free_constraint _) seed)
       as HinclE.
     apply valid_trace_forget_last in Hmsg_trace.

--- a/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
@@ -46,14 +46,14 @@ Lemma equivocator_state_append_transition l s om s' om' base_s
       (equivocator_state_append base_s s, om) = (equivocator_state_append base_s s', om').
 Proof.
   destruct l; cbn; intros Hv Ht
-  ; [inversion_clear Ht; f_equal; apply equivocator_state_append_extend_commute|..]
+  ; [by inversion_clear Ht; f_equal; apply equivocator_state_append_extend_commute | ..]
   ; (destruct (equivocator_state_project s n) as [sn|] eqn:Hn; [| done])
   ;  rewrite (equivocator_state_append_project_2 _ base_s s _ n eq_refl)
   ;  rewrite Hn
   ;  destruct (vtransition _ _ _) as (sn', _om') eqn:Hti
   ;  inversion_clear Ht; f_equal.
-  - apply equivocator_state_append_update_commute.
-  - apply equivocator_state_append_extend_commute.
+  - by apply equivocator_state_append_update_commute.
+  - by apply equivocator_state_append_extend_commute.
 Qed.
 
 Lemma equivocator_state_append_initial_state_in_futures
@@ -73,9 +73,10 @@ Proof.
   apply (finite_valid_trace_from_to_singleton (pre_loaded_vlsm (equivocator_vlsm X) seed)).
   repeat split.
   - done.
-  - apply option_valid_message_None.
-  - apply H.
-  - cbn. f_equal. symmetry. apply equivocator_state_append_singleton_is_extend. apply H.
+  - by apply option_valid_message_None.
+  - by apply H.
+  - cbn. f_equal. symmetry.
+    by apply equivocator_state_append_singleton_is_extend, H.
 Qed.
 
 Lemma equivocator_state_append_transition_initial_state
@@ -99,8 +100,8 @@ Lemma equivocator_state_append_preloaded_with_weak_projection
         (equivocator_state_append_label base_s) (equivocator_state_append base_s).
 Proof.
   apply basic_VLSM_weak_full_projection; intro; intros.
-  - apply equivocator_state_append_valid. apply Hv.
-  - apply equivocator_state_append_transition; apply H.
+  - by apply equivocator_state_append_valid, Hv.
+  - by apply equivocator_state_append_transition; apply H.
   - by apply equivocator_state_append_transition_initial_state.
   - by apply initial_message_is_valid.
 Qed.

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -110,7 +110,7 @@ Definition is_equivocating_state
   : Decision (is_equivocating_state s).
 Proof.
   apply Decision_not.
-  by is_singleton_state_dec.
+  by apply is_singleton_state_dec.
 Qed.
 
 (**
@@ -322,7 +322,7 @@ Proof.
   destruct (decide _).
   - by rewrite fin_to_nat_to_fin in e; lia.
   - apply equivocator_state_eq.
-    by !rewrite !fin_to_nat_to_fin.
+    by rewrite !fin_to_nat_to_fin.
 Qed.
 
 Lemma equivocator_state_extend_project_2 es s i (Hi : i = equivocator_state_n es)

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -97,7 +97,7 @@ Lemma is_singleton_state_dec
   (s : equivocator_state)
   : Decision (is_singleton_state s).
 Proof.
-  apply Nat.eq_dec.
+  by apply Nat.eq_dec.
 Qed.
 
 Definition is_equivocating_state
@@ -110,7 +110,7 @@ Definition is_equivocating_state
   : Decision (is_equivocating_state s).
 Proof.
   apply Decision_not.
-  apply is_singleton_state_dec.
+  by is_singleton_state_dec.
 Qed.
 
 (**
@@ -154,8 +154,7 @@ Lemma equivocator_state_project_None_rev s i
   : equivocator_state_project s i = None -> ~i < equivocator_state_n s.
 Proof.
   unfold equivocator_state_project.
-  case_decide; [congruence|].
-  intro. lia.
+  by case_decide; [congruence | intro; lia].
 Qed.
 
 #[local] Ltac destruct_equivocator_state_project' es i si Hi Hpr :=
@@ -203,7 +202,7 @@ Qed.
 
 (** The original state index is present in any equivocator state. *)
 Lemma Hzero (s : equivocator_state) : 0 < equivocator_state_n s.
-Proof. pose proof (equivocator_state_last_n s). lia. Qed.
+Proof. by pose proof (equivocator_state_last_n s); lia. Qed.
 
 Definition equivocator_state_zero (es : equivocator_state) : state :=
   equivocator_state_s es (nat_to_fin (Hzero es)).
@@ -262,9 +261,10 @@ Proof.
     f_equal.
     inversion Hpr.
     rewrite decide_False.
-    + apply equivocator_state_eq. by rewrite !fin_to_nat_to_fin.
+    + apply equivocator_state_eq.
+      by rewrite !fin_to_nat_to_fin.
     + intro Hcontra.
-      rewrite !fin_to_nat_to_fin in Hcontra. congruence.
+      by rewrite !fin_to_nat_to_fin in Hcontra; congruence.
   - rewrite Heq in Hj.
     by rewrite (equivocator_state_project_None _ _ Hj).
 Qed.
@@ -297,7 +297,7 @@ Program Definition equivocator_state_extend
       if decide (S (equivocator_state_last bs) = j) then s else equivocator_state_s bs (@of_nat_lt j (S (equivocator_state_last bs)) _)
     ).
 Next Obligation.
-  intros. specialize (fin_to_nat_lt j).  lia.
+  by intros; specialize (fin_to_nat_lt j);  lia.
 Qed.
 
 Lemma equivocator_state_extend_size bs s
@@ -320,9 +320,9 @@ Proof.
   cbn.
   specialize (equivocator_state_last_n es) as Hes_size.
   destruct (decide _).
-  - rewrite fin_to_nat_to_fin in e. lia.
+  - by rewrite fin_to_nat_to_fin in e; lia.
   - apply equivocator_state_eq.
-    by rewrite !fin_to_nat_to_fin.
+    by !rewrite !fin_to_nat_to_fin.
 Qed.
 
 Lemma equivocator_state_extend_project_2 es s i (Hi : i = equivocator_state_n es)
@@ -337,8 +337,7 @@ Proof.
   destruct (decide _); [done |].
   elim n.
   rewrite fin_to_nat_to_fin.
-  specialize (equivocator_state_last_n es) as Hes_size.
-  lia.
+  by specialize (equivocator_state_last_n es) as Hes_size; lia.
 Qed.
 
 Lemma equivocator_state_extend_project_3 es s i (Hi : equivocator_state_n es < i)
@@ -379,22 +378,21 @@ Program Definition equivocator_state_append
         equivocator_state_s es2 (@of_nat_lt k (equivocator_state_n es2) _)
       end).
 Next Obligation.
-  intros.
-  specialize (equivocator_state_last_n es2) as Hlst_es2.
-  lia.
+  by intros; specialize (equivocator_state_last_n es2) as Hlst_es2; lia.
 Qed.
 
 Lemma equivocator_state_append_size es1 es2
   : equivocator_state_n (equivocator_state_append es1 es2) =
     equivocator_state_n es1 + equivocator_state_n es2.
 Proof.
-  destruct es1, es2. unfold equivocator_state_n.
-  simpl. lia.
+  by destruct es1, es2; unfold equivocator_state_n; cbn; lia.
 Qed.
 
 Lemma equivocator_state_append_lst es1 es2
   : equivocator_state_last (equivocator_state_append es1 es2) = equivocator_state_last es2 + equivocator_state_n es1.
-Proof. destruct es1, es2. cbn. unfold equivocator_state_n. simpl. lia. Qed.
+Proof.
+  by destruct es1, es2; unfold equivocator_state_n; cbn; lia.
+Qed.
 
 Lemma equivocator_state_append_project_1 s s' i (Hi : i < equivocator_state_n s)
   : equivocator_state_project (equivocator_state_append s s') i = equivocator_state_project s i.
@@ -402,8 +400,7 @@ Proof.
   specialize (equivocator_state_projection_irrel s) as Hpi.
   rewrite (equivocator_state_project_Some _ _ Hi).
   specialize (equivocator_state_append_size s s') as Hsize.
-  assert (Hi' : i < equivocator_state_n (equivocator_state_append s s'))
-    by lia.
+  assert (Hi' : i < equivocator_state_n (equivocator_state_append s s')) by lia.
   rewrite (equivocator_state_project_Some _ _ Hi').
   f_equal.
   destruct s as (n1, bs1).
@@ -412,8 +409,7 @@ Proof.
   simpl in *.
   rewrite to_nat_of_nat.
   unfold equivocator_state_n. simpl.
-  case_decide; [|lia].
-  by apply Hpi.
+  by case_decide; [apply Hpi | lia].
 Qed.
 
 Lemma equivocator_state_append_project_2 s s' i k (Hi : i = k + equivocator_state_n s)
@@ -433,8 +429,7 @@ Proof.
   subst.
   destruct s, s'. simpl in *. unfold equivocator_state_n in *. simpl in *.
   rewrite to_nat_of_nat.
-  case_decide; [lia|].
-  apply Hpi. lia.
+  by case_decide; [| apply Hpi]; lia.
 Qed.
 
 Lemma equivocator_state_append_project_3 s s' i (Hi : ~i < equivocator_state_n s + equivocator_state_n s')
@@ -442,8 +437,7 @@ Lemma equivocator_state_append_project_3 s s' i (Hi : ~i < equivocator_state_n s
 Proof.
   apply equivocator_state_project_None.
   unfold equivocator_state_n, equivocator_state_append, equivocator_state_last in *.
-  simpl in *.
-  lia.
+  by cbn in *; lia.
 Qed.
 
 #[local] Ltac destruct_equivocator_state_append_project' es es' i Hi k Hk Hpr :=
@@ -475,7 +469,7 @@ Proof.
   symmetry.
   unfold is_singleton_state in Hsingleton.
   destruct_equivocator_state_append_project es1 es2 i Hi k Hk.
-  - apply equivocator_state_extend_project_3. lia.
+  - by apply equivocator_state_extend_project_3; lia.
   - rewrite equivocator_state_extend_project_2 by lia.
     rewrite <- equivocator_state_project_zero.
     by f_equal; lia.
@@ -802,10 +796,10 @@ Definition existing_descriptor
 #[local] Instance  existing_descriptor_dec : RelDecision existing_descriptor.
 Proof.
   intros d s. destruct d; simpl.
-  - right. itauto.
+  - by right; itauto.
   - destruct_equivocator_state_project s n _sn Hn.
     + by left.
-    + right. intros [si Hi]. congruence.
+    + by right; intros [si Hi]; congruence.
 Qed.
 
 Definition existing_equivocator_label
@@ -831,8 +825,7 @@ Lemma existing_equivocator_label_forget_proper
   (Hs : proper_existing_equivocator_label l s)
   : existing_equivocator_label l.
 Proof.
-  destruct l; [| done..].
-  inversion Hs.
+  by destruct l; [inversion Hs | ..].
 Qed.
 
 Lemma existing_descriptor_proper
@@ -868,8 +861,8 @@ Proof.
   ; cbn in Hv, Ht;  destruct_equivocator_state_project s ei sei Hei; [| done | | done]
   ; destruct (vtransition _ _ _) as (si', om')
   ; inversion Ht; subst; equivocator_state_update_simpl.
-  - exists l. f_equal. lia.
-  - lia.
+  - by exists l; f_equal; lia.
+  - by lia.
 Qed.
 
 (**
@@ -904,7 +897,7 @@ Proof.
   ; [inversion Ht; rewrite Hex_size; lia|..]
   ; cbn in Ht
   ; destruct (equivocator_state_project _ _)
-  ; [|inversion Ht; lia| |inversion Ht; lia]
+  ; [| by inversion Ht; lia | | by inversion Ht; lia]
   ; destruct (vtransition _ _ _) as (si', om')
   ; inversion Ht; subst; clear Ht.
   - by equivocator_state_update_simpl.
@@ -919,7 +912,7 @@ Lemma equivocator_transition_preserves_equivocating_state
   : is_equivocating_state X s -> is_equivocating_state X s'.
 Proof.
   intros Hs Hs'. elim Hs. clear Hs. revert Ht Hs' .
-  apply equivocator_transition_reflects_singleton_state.
+  by apply equivocator_transition_reflects_singleton_state.
 Qed.
 
 Lemma zero_descriptor_transition_reflects_equivocating_state
@@ -972,7 +965,7 @@ Proof.
       vtransition equivocator_vlsm l (s, om) = (s', om')
     *)
     destruct l as [sn|i l|i l]
-    ; [ inversion_clear Ht; split; [apply option_valid_message_None|]
+    ; [ inversion_clear Ht; split; [by apply option_valid_message_None |]
       ; intros
       ; destruct_equivocator_state_extend_project s sn i Hi
       ; [ by apply IHHbs1 in H
@@ -1042,7 +1035,7 @@ Lemma equivocator_state_project_valid_message
   :
   option_valid_message_prop X om.
 Proof.
-  destruct om as [m|]; [|apply option_valid_message_None].
+  destruct om as [m |]; [| by apply option_valid_message_None].
   specialize (vlsm_is_pre_loaded_with_False_initial_message equivocator_vlsm) as Hinit.
   apply (VLSM_incl_valid_message (VLSM_eq_proj1 (vlsm_is_pre_loaded_with_False equivocator_vlsm))) in Hom
   ; [| done].
@@ -1088,7 +1081,7 @@ Lemma new_machine_label_equivocator_transition_size
   : equivocator_state_n s' = S (equivocator_state_n s).
 Proof.
   inversion_clear Ht.
-  apply equivocator_state_extend_size.
+  by apply equivocator_state_extend_size.
 Qed.
 
 Lemma existing_true_label_equivocator_transition_size
@@ -1102,7 +1095,7 @@ Proof.
   rewrite Hv in Ht.
   destruct (vtransition _ _ _).
   inversion Ht. subst.
-  apply equivocator_state_extend_size.
+  by apply equivocator_state_extend_size.
 Qed.
 
 Lemma existing_false_label_equivocator_transition_size
@@ -1126,8 +1119,8 @@ Lemma new_machine_label_equivocator_state_project_last
     equivocator_state_descriptor_project s (NewMachine sn).
 Proof.
   inversion_clear Ht. simpl.
-  destruct_equivocator_state_extend_project s sn (equivocator_state_n s) Hi
-  ; [lia | done | lia].
+  by destruct_equivocator_state_extend_project s sn (equivocator_state_n s) Hi;
+    [lia | | lia].
 Qed.
 
 Lemma new_machine_label_equivocator_state_project_not_last
@@ -1139,7 +1132,7 @@ Lemma new_machine_label_equivocator_state_project_not_last
     equivocator_state_descriptor_project s (Existing ni).
 Proof.
   subst. inversion_clear Ht. simpl.
-  destruct_equivocator_state_extend_project s sn ni Hi; [done | lia..].
+  by destruct_equivocator_state_extend_project s sn ni Hi; [| lia..].
 Qed.
 
 Lemma existing_true_label_equivocator_state_project_not_last
@@ -1157,7 +1150,7 @@ Proof.
   destruct (vtransition _ _ _) as (si', _om') eqn:Hti.
   inversion Ht; subst s' _om'. clear Ht.
   simpl.
-  destruct_equivocator_state_extend_project s si' ni Hni'; [done | lia..].
+  by destruct_equivocator_state_extend_project s si' ni Hni'; [| lia..].
 Qed.
 
 Lemma existing_true_label_equivocator_state_project_last

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -108,12 +108,12 @@ Proof.
   - assert (si = si') by congruence; subst si'.
     inversion_clear HitemX.
     inversion_clear HitemX'.
-    repeat split.
+    by repeat split.
   - assert (si = si') by congruence; subst si'.
     subst.
     inversion_clear HitemX.
     inversion_clear HitemX'.
-    repeat split.
+    by repeat split.
 Qed.
 
 (**
@@ -129,7 +129,7 @@ Lemma equivocator_transition_item_project_inv_none
     equivocator_state_project (destination item) i = None.
 Proof.
   destruct item.
-  destruct descriptor as [s|i]; cbn in *; [congruence|].
+  destruct descriptor as [s | i]; cbn in *; [by congruence |].
   exists i. split; [done |].
   destruct_equivocator_state_project destination i si Hi; [| done].
   by destruct l; case_decide.
@@ -145,7 +145,8 @@ Proof.
   ; [by eexists |].
   apply equivocator_transition_item_project_inv_none in contra.
   destruct contra as [id [Heqd Hd]].
-  subst. simpl in *. destruct Hproper as [x Hproper]. congruence.
+  subst. simpl in *. destruct Hproper as [x Hproper].
+  by congruence.
 Qed.
 
 (**
@@ -163,7 +164,7 @@ Lemma equivocator_transition_item_project_inv_messages
     proper_descriptor X idescriptor (destination item) /\
     input item = input itemX /\ output item = output itemX.
 Proof.
-  destruct idescriptor as [s|j]; cbn in Hitem; [congruence|].
+  destruct idescriptor as [s | j]; cbn in Hitem; [by congruence |].
   exists j. split; [done |].
   destruct item.
   simpl in Hitem |- *.
@@ -218,7 +219,7 @@ Lemma exists_equivocator_transition_item_project
 Proof.
   destruct item. simpl in *.
   destruct l as [sn| i l| i l]
-  ; [inversion Hs| ..]
+  ; [by inversion Hs | ..]
   ; cbn in Hv, Ht
   ; destruct (equivocator_state_project _ _) as [si|] eqn:Hpr; [| done | | done]
   ; split; [done | | done |]
@@ -308,7 +309,7 @@ Proof.
     ; eexists _, _; split; try done.
     + split; [done |].
       intros.
-      split; [apply Hv|].
+      split; [by apply Hv |].
       specialize (new_machine_label_equivocator_transition_size X Ht) as Ht_size.
       specialize (equivocator_state_last_n X destination) as Hlst_size.
       split; [lia|].
@@ -323,8 +324,7 @@ Proof.
       cut (proper_descriptor X (Existing n) s).
       { intros [_sn Hpr']. split_and!; [by eexists _sn | lia |].
         apply equivocator_state_project_Some_rev in Hpr'.
-        rewrite <- (new_machine_label_equivocator_state_project_not_last X Ht)
-          by assumption.
+        rewrite <- (new_machine_label_equivocator_state_project_not_last X Ht) by done.
         by simpl; rewrite Hpr.
       }
       simpl.
@@ -362,9 +362,8 @@ Proof.
       specialize (existing_false_label_equivocator_transition_size X Ht _ Hpri) as Ht_size.
       specialize (equivocator_state_last_n X destination) as Hlst_size.
       destruct_equivocator_state_project s n _sn Hn; [by eexists |].
-      apply equivocator_state_project_Some_rev in Hpr.
-      lia.
-    + split; [simpl; repeat split|].
+      by apply equivocator_state_project_Some_rev in Hpr; lia.
+    + split; [by simpl; repeat split |].
       intros.
       cbn in Hv.
       simpl.
@@ -402,8 +401,7 @@ Proof.
       specialize (existing_true_label_equivocator_transition_size X Ht _ Hpri) as Ht_size.
       specialize (equivocator_state_last_n X destination) as Hlst_size.
       destruct_equivocator_state_project s n _sn Hn; [by eexists |].
-      apply equivocator_state_project_Some_rev in Hpr.
-      lia.
+      by apply equivocator_state_project_Some_rev in Hpr; lia.
 Qed.
 
 Lemma equivocator_transition_item_project_preserves_equivocating_indices
@@ -441,11 +439,11 @@ Proof.
     unfold equivocator_vlsm_transition_item_project in Hproject.
     destruct descriptor as [|deqvi]; [done |].
     destruct (equivocator_state_project destination deqvi); [| done].
-    case_decide; [congruence|].
-    inversion Hproject. subst. inversion Heqv.
+    case_decide; [by congruence |].
+    by inversion Hproject; subst; inversion Heqv.
   - specialize (existing_true_label_equivocator_transition_size X Ht _ Hsj) as Ht_size.
     left. unfold is_equivocating_state, is_singleton_state. rewrite Ht_size.
-    cbv; lia.
+    by cbv; lia.
 Qed.
 
 Lemma equivocator_transition_item_project_inv_characterization
@@ -464,7 +462,8 @@ Proof.
   apply equivocator_transition_item_project_proper_characterization in Hproper.
   destruct Hproper as [oitem [odescriptor [Hpr' H]]].
   rewrite Hpr' in Hitem.
-  inversion Hitem. subst. apply H.
+  inversion Hitem. subst.
+  by apply H.
 Qed.
 
 (**
@@ -525,7 +524,7 @@ Proof.
   simpl in Hproject.
   destruct (equivocator_vlsm_trace_project bsuffix dlast) as [(suffix, dmiddle)|]
     eqn:Hsuffix
-  ; [|congruence].
+  ; [| by congruence].
   exists dmiddle.
   destruct (equivocator_vlsm_transition_item_project bprefix dmiddle) as [[[prefix|] i]|]
     eqn:Hprefix
@@ -562,7 +561,7 @@ Proof.
       simpl in Ha.
       destruct (equivocator_vlsm_transition_item_project a da)
         as [(oitem', i)|]
-      ; [|congruence].
+      ; [| by congruence].
       by destruct oitem' as [item'|]; inversion Ha; subst.
     + by subst; rewrite app_assoc.
 Qed.
@@ -585,7 +584,7 @@ Proof.
   - simpl in Hprefix.
     destruct (equivocator_vlsm_trace_project bprefix dmiddle) as [(prefix', dstart')|]
       eqn:Hprefix'
-    ; [|congruence].
+    ; [| by congruence].
     specialize (IHbprefix prefix' dstart' eq_refl).
     simpl. rewrite IHbprefix.
     by destruct (equivocator_vlsm_transition_item_project a dstart') as [[[item' |] i] |]
@@ -611,7 +610,7 @@ Lemma equivocator_valid_transition_project_inv2
     item' = {| l := lx; input := iom; destination := sx; output := oom |} /\
     vvalid X lx (s'x, iom) /\ vtransition X lx (s'x, iom) = (sx, oom).
 Proof.
-  destruct di as [sn| i]; [simpl in Hitem; congruence|].
+  destruct di as [sn | i]; [by simpl in Hitem; congruence |].
   eexists _; split; [done |].
   simpl in Hitem.
   destruct (equivocator_state_project s i) as [si|] eqn:Heqsi; [| done].
@@ -632,8 +631,7 @@ Proof.
     replace (equivocator_state_n s') with  (equivocator_state_last s)
     ; [by rewrite Heqsi |].
     specialize (existing_true_label_equivocator_transition_size X Ht _ Heqs'j) as Ht_size.
-    specialize (equivocator_state_last_n X s) as Hs_lst.
-    lia.
+    by specialize (equivocator_state_last_n X s) as Hs_lst; lia.
 Qed.
 
 Lemma equivocator_valid_transition_project_inv3
@@ -663,10 +661,9 @@ Proof.
   subst item. simpl in Hitem.
   destruct (equivocator_state_project s i) as [si|] eqn:Heqsi; [| done].
   destruct l as [sn|id lx|id lx]; destruct (decide _); inversion Hitem; subst.
-  - inversion Ht; subst. split_and!.
-    1-2, 4: done. 1, 3: apply Hv.
-    by rewrite equivocator_state_extend_lst,
-               equivocator_state_extend_project_2 in Heqsi.
+  - inversion Ht; subst.
+    split_and!; [done | done | apply Hv | done | | apply Hv].
+    by rewrite equivocator_state_extend_lst, equivocator_state_extend_project_2 in Heqsi.
   - eexists; split; [done |].
     specialize (new_machine_label_equivocator_state_project_not_last X Ht i) as Hn.
     simpl in Hn. rewrite Heqsi in Hn.
@@ -675,8 +672,7 @@ Proof.
     apply equivocator_state_project_Some_rev in Heqsi.
     spec Hn; [lia|].
     simpl in Hn.
-    destruct_equivocator_state_project s' i s'i Hi; [|lia].
-    by subst.
+    by destruct_equivocator_state_project s' i s'i Hi; [subst | lia].
   - eexists; split; [done |].
     cbn in Hv.
     destruct (equivocator_state_project s' id) as [s'id|] eqn:Hpr; [| done].
@@ -725,9 +721,8 @@ Proof.
     eexists; split; [done |].
     rewrite Hi'.
     exists None.
-    rewrite decide_False; [done |].
-    rewrite equivocator_state_extend_lst.
-    lia.
+    rewrite decide_False ; [done |].
+    by rewrite equivocator_state_extend_lst; lia.
   - cbn in Hv. destruct (equivocator_state_project s' j) as [s'j|] eqn:Heqs'j
     ; [| done].
     specialize (existing_false_label_equivocator_transition_size X Ht _ Heqs'j) as Ht_size.
@@ -742,7 +737,7 @@ Proof.
     destruct_equivocator_state_project s i' si Hlti; [|lia].
     eexists; split; [done |].
     rewrite decide_False; [by eexists _|].
-    specialize (equivocator_state_last_n X s). lia.
+    by specialize (equivocator_state_last_n X s); lia.
 Qed.
 
 Lemma equivocator_valid_transition_project_inv5_new_machine
@@ -791,7 +786,7 @@ Proof.
     apply equivocator_state_project_Some_rev in Heqs'i as Hlti.
     destruct_equivocator_state_project s _i si Hi; [|lia].
     simpl in Heqsi'. subst si.
-    rewrite decide_True; eauto.
+    by rewrite decide_True; eauto.
   - specialize (existing_true_label_equivocator_transition_size X Ht _ Heqs'i) as Ht_size.
     specialize (existing_true_label_equivocator_state_project_last X Ht _ Heqs'i) as Ht_pr.
     cbn in Ht. rewrite Heqs'i in Ht.
@@ -833,8 +828,11 @@ Lemma preloaded_with_equivocator_vlsm_trace_project_valid
     end.
 Proof.
   induction Hbtr; intros.
-  - exists []. eexists; split; [done |]. eexists; split; [done |].
-    constructor. revert Hj. by apply preloaded_with_equivocator_state_project_valid_state.
+  - exists [].
+    eexists; split; [done |].
+    eexists; split; [done |].
+    constructor. revert Hj.
+    by apply preloaded_with_equivocator_state_project_valid_state.
   - remember {| l := l; input := iom; |} as item.
     destruct Ht as [[Hs' [Hiom Hv]] Ht].
     specialize (IHHbtr Hj) as [tlX [di' [Htl_pr Hdi]]].
@@ -846,8 +844,7 @@ Proof.
     destruct Hdi as [si [Heqsi HltX]].
     specialize (equivocator_transition_item_project_proper_characterization item (Existing i))
       as Hchar.
-    spec Hchar.
-    {  subst item.  simpl. rewrite Heqsi. by eexists. }
+    spec Hchar; [by subst item; cbn; rewrite Heqsi; eexists |].
     destruct Hchar as [oitem [descriptor' [Hitem_pr [Hchar1 Hchar2]]]].
     rewrite Hitem_pr.
     subst item.
@@ -982,7 +979,7 @@ Proof.
   destruct (equivocator_vlsm_transition_item_project x dj)
     as [(_x, _dmiddle)|]
     eqn:Hx'
-  ; [|congruence].
+  ; [| by congruence].
   destruct _x as [itemx|]; inversion Hx; subst lx _dmiddle; clear Hx.
   - subst. destruct x. unfold equivocator_vlsm_transition_item_project in Hx'.
     simpl.
@@ -1062,10 +1059,10 @@ Proof.
     as [trX' [di' [HtrX' Hdi]]].
   rewrite HtrX in HtrX'.
   inversion HtrX'. subst di' trX'.  clear HtrX'.
-  destruct di as [sn|n]; repeat split; [apply Hdi..|].
+  destruct di as [sn | n]; repeat split; [by apply Hdi.. |].
   destruct Hdi as [isi [Hisi HtrX']].
   exists isi. repeat split; [done.. |].
-  apply (equivocator_vlsm_initial_state_preservation_rev X _ _ _ Hisi).
+  by apply (equivocator_vlsm_initial_state_preservation_rev X _ _ _ Hisi).
 Qed.
 
 Definition equivocator_label_zero_project (l : equivocator_label X) : option (vlabel X) :=
@@ -1091,7 +1088,7 @@ Proof.
     + rewrite equivocator_state_project_zero in H0.
       by destruct (vtransition _ _ _); inversion_clear H0.
     + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _)|]; inversion_clear H0.
-  - apply H.
+  - by apply H.
   - by apply equivocator_state_project_valid_message.
 Qed.
 
@@ -1110,7 +1107,7 @@ Proof.
     + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _)|]; inversion_clear H0.
     + by rewrite equivocator_state_project_zero in H0; destruct (vtransition _ _ _); inversion_clear H0.
     + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _)|]; inversion_clear H0.
-  - apply H.
+  - by apply H.
 Qed.
 
 End sec_equivocator_vlsm_projections.

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -40,10 +40,10 @@ Lemma equivocator_vlsm_trace_project_output_reflecting
 Proof.
   revert trX i HtrX Hjbs.
   induction tr; intros.
-  - inversion HtrX. subst. inversion Hjbs.
+  - by inversion HtrX; subst; inversion Hjbs.
   - simpl in HtrX.
     destruct (equivocator_vlsm_trace_project _ tr j) as [(trX', i')|]
-      eqn:Htr; [|congruence].
+      eqn: Htr; [| by congruence].
     specialize (IHtr trX').
     destruct (equivocator_vlsm_transition_item_project _ a i') as [[[item'|] i'']|]
       eqn:Hitem'
@@ -112,7 +112,7 @@ Lemma preloaded_equivocator_vlsm_trace_project_valid_item
           equivocator_vlsm_trace_project _ btr dfinal = Some (tr, dfirst).
 Proof.
   specialize (preloaded_equivocator_vlsm_valid_trace_project_inv2 X bs bf btr) as Hinv2.
-  spec Hinv2. { intro contra. subst. inversion Hitem. }
+  spec Hinv2; [by intro contra; subst; inversion Hitem |].
   spec Hinv2 Hbtr.
   apply elem_of_list_split in Hitem.
   destruct Hitem as [bprefix [bsuffix Heq]].
@@ -137,7 +137,7 @@ Proof.
   specialize
     (equivocator_vlsm_trace_project_app_inv _ [bitem] bsuffix (Existing i) (Existing idl) dsuffix [itemx] suffix)
     as Hsuffix'.
-  spec Hsuffix'.  { by simpl; rewrite Hitemx. }
+  spec Hsuffix'; [by cbn; rewrite Hitemx |].
   subst dsuffix.
   spec Hsuffix' Hsuffix.
   subst bitem.
@@ -159,14 +159,14 @@ Proof.
   specialize (Hinv2 _ _ _ Htr) as [bfi [Hdfinal Hdinitial]].
   split.
   - apply elem_of_app. right. left.
-  - eexists _. eexists _. repeat split; [..|apply Htr].
+  - eexists _, _. repeat split; [.. | by apply Htr].
     + clear -Hdinitial.
       destruct dfirst as [sn | j].
       * by destruct Hdinitial.
-      * destruct Hdinitial as [bsj [Hdinitial _]]. by exists bsj.
+      * by destruct Hdinitial as [bsj [Hdinitial _]]; exists bsj.
     + remember (bprefix ++ _) as btr.
       specialize (equivocator_vlsm_trace_project_inv X btr) as Hinv.
-      spec Hinv. { by destruct bprefix; subst. }
+      spec Hinv; [by destruct bprefix; subst |].
       spec Hinv i.
       spec Hinv; [by subst; eexists |].
       specialize (Hinv bs) as [lst_i Hlst_i].
@@ -197,12 +197,9 @@ Proof.
   destruct (equivocator_label_descriptor (l item)) as [sn | i] eqn:Hsndl.
   - destruct item. destruct l; inversion Hsndl.
     subst. simpl in *.
-    specialize
-      (preloaded_equivocator_vlsm_trace_project_valid_item_new_machine
-         _ _ Htr _ Hin _ eq_refl)
-      as Hitem.
-    simpl in Hitem.
-    destruct Hitem as [_ [Hcontra _]]. congruence.
+    by destruct (preloaded_equivocator_vlsm_trace_project_valid_item_new_machine
+      _ _ Htr _ Hin _ eq_refl)
+      as  [_ [Hcontra _]]; cbn in *; congruence.
   - apply valid_trace_add_default_last in Htr.
     specialize
     (preloaded_equivocator_vlsm_trace_project_valid_item
@@ -215,7 +212,7 @@ Proof.
   apply equivocator_transition_item_project_inv_messages in Hitemx.
   destruct Hitemx as [_ [_ [_ [_ Hitemx]]]].
   simpl in *.
-  congruence.
+  by congruence.
 Qed.
 
 Section sec_oracle_lifting.
@@ -272,7 +269,7 @@ Proof.
     + intros (i & _ & Hi); exists i.
       by destruct (equivocator_state_project s i); [eexists |].
   - apply Exists_dec; intro i.
-    destruct (equivocator_state_project s i); [apply Hdec | typeclasses eauto].
+    by destruct (equivocator_state_project s i); [apply Hdec | typeclasses eauto].
 Qed.
 
 Lemma equivocator_oracle_stepwise_props
@@ -308,9 +305,10 @@ Proof.
       specialize
         (oracle_step_update l sidesc im sidesc' om').
       spec oracle_step_update.
-      { repeat split
-        ; [..| eexists _; apply (pre_loaded_with_all_messages_message_valid_initial_state_message X) | done | done].
-        apply (preloaded_equivocator_state_project_valid_state X _ Hs _ _ Hidesc).
+      {
+        repeat split; [| | done..].
+        - by apply (preloaded_equivocator_state_project_valid_state X _ Hs _ _ Hidesc).
+        - by eexists _; apply (pre_loaded_with_all_messages_message_valid_initial_state_message X).
       }
       specialize (existing_false_label_equivocator_state_project_not_same X Ht _ Hidesc)
         as Hnot_same.
@@ -327,13 +325,13 @@ Proof.
            simpl in Hsame. subst s'i.
            apply oracle_step_update in Hbri.
            destruct Hbri as [H | Hbri]; [| by right; eexists _,_].
-           left. revert H. apply Hselector_io.
+           by left; revert H; apply Hselector_io.
         -- right. exists i, s'i. split; [| done].
            spec Hnot_same i.
            spec Hnot_same; [lia|]. spec Hnot_same n.
            simpl in Hnot_same. rewrite Hs'i in Hnot_same.
            destruct_equivocator_state_project s i si Hlti'; [|lia].
-           simpl in Hnot_same. congruence.
+           by cbn in Hnot_same; congruence.
       * apply proj2 in oracle_step_update.
         apply equivocator_state_project_Some_rev in Hidesc as Hltidesc.
         intros [Heq_im | [ins [sins [Hsins Hbri]]]].
@@ -352,22 +350,22 @@ Proof.
               specialize (oracle_step_update (or_intror Hbri)).
               exists ins, sidesc'. split; [| done].
               simpl in Hsame.
-              destruct_equivocator_state_project s' ins _sidesc' Hins; [|lia].
-              by subst.
+              by destruct_equivocator_state_project s' ins _sidesc' Hins; [subst |lia].
            ++ exists ins, sins. split; [| done].
               spec Hnot_same ins. spec Hnot_same; [lia|]. spec Hnot_same n.
               simpl in Hnot_same. rewrite Hsins in Hnot_same.
               destruct_equivocator_state_project s' ins _sins Hins; [|lia].
-              simpl in Hnot_same. congruence.
+              cbn in Hnot_same; congruence.
     + cbn in Hv.
       destruct (equivocator_state_project s idesc) as [sidesc|] eqn:Hidesc; [| done].
       destruct (vtransition X l (sidesc, im)) as (sidesc', om') eqn:Htx.
       specialize
         (oracle_step_update l sidesc im sidesc' om').
       spec oracle_step_update.
-      { repeat split
-        ; [..| eexists _; apply (pre_loaded_with_all_messages_message_valid_initial_state_message X) | done | done].
-        apply (preloaded_equivocator_state_project_valid_state X _ Hs _ _ Hidesc).
+      {
+        repeat split; [| | done..].
+        - by apply (preloaded_equivocator_state_project_valid_state X _ Hs _ _ Hidesc).
+        - by eexists _; apply (pre_loaded_with_all_messages_message_valid_initial_state_message X).
       }
       specialize (existing_true_label_equivocator_state_project_not_last X Ht _ Hidesc)
         as Hnot_last.
@@ -384,14 +382,13 @@ Proof.
            simpl in Hlast. subst s'i.
            apply oracle_step_update in Hbri.
            destruct Hbri as [H | Hbri]; [| by right; eexists _,_].
-           left. revert H. apply Hselector_io.
+           by left; revert H; apply Hselector_io.
         -- right. exists i, s'i. split; [| done].
            spec Hnot_last i.
            spec Hnot_last; [lia|].
            simpl in Hnot_last. rewrite Hs'i in Hnot_last.
            destruct_equivocator_state_project s i si Hlti'; [|lia].
-           simpl in Hnot_last.
-           congruence.
+           by cbn in Hnot_last; congruence.
       * apply proj2 in oracle_step_update.
         intros [Heq_im | [ins [sins [Hsins Hbri]]]].
         -- unfold equivocator_selector in Heq_im. simpl in Heq_im.
@@ -406,7 +403,7 @@ Proof.
            simpl in Hnot_last. rewrite Hsins in Hnot_last.
            exists ins, sins. split; [| done].
            destruct_equivocator_state_project s' ins _sins Hltins'; [|lia].
-           simpl in Hnot_last. congruence.
+           by cbn in Hnot_last; congruence.
 Qed.
 
 End sec_oracle_lifting.
@@ -434,12 +431,10 @@ Lemma equivocator_has_been_received_stepwise_props
 Proof.
   eapply oracle_stepwise_props_change_selector.
   - apply equivocator_oracle_stepwise_props
-    ; [|apply has_been_received_stepwise_from_trace].
-    cbv; itauto.
-  - intros s item; destruct item, l; cbn.
-    2,3:itauto.
-    intros [(_ & _ & _ & Him) _]; simpl in Him; subst.
-    itauto congruence.
+    ; [| by apply has_been_received_stepwise_from_trace].
+    by cbv; itauto.
+  - intros s item; destruct item, l; cbn; [| by itauto..].
+    by intros [(_ & _ & _ & Him) _]; simpl in Him; subst; itauto congruence.
 Qed.
 
 (** Finally we define the [HasBeenReceivedCapability] for the [equivocator_vlsm]. *)
@@ -474,12 +469,10 @@ Lemma equivocator_has_been_sent_stepwise_props
 Proof.
   eapply oracle_stepwise_props_change_selector.
   - apply equivocator_oracle_stepwise_props
-    ; [|apply has_been_sent_stepwise_from_trace].
-    cbv; itauto.
-  - intros s item; destruct item, l; cbn.
-    2,3:itauto.
-    intros [_ Ht]; inversion_clear Ht.
-    itauto congruence.
+    ; [| by apply has_been_sent_stepwise_from_trace].
+    by cbv; itauto.
+  - intros s item; destruct item, l; cbn; [| by itauto..].
+    by intros [_ Ht]; inversion_clear Ht; itauto congruence.
 Qed.
 
 (** Finally we define the [HasBeenSentCapability] for the [equivocator_vlsm]. *)

--- a/theories/VLSM/Core/FinSetMessageDependencies.v
+++ b/theories/VLSM/Core/FinSetMessageDependencies.v
@@ -26,9 +26,9 @@ Class FinSetFullMessageDependencies
   : FullMessageDependencies (elements ∘ message_dependencies) (elements ∘ full_message_dependencies).
 Proof.
   constructor.
-  - setoid_rewrite elem_of_elements; apply fin_set_full_message_dependencies_happens_before.
-  - setoid_rewrite elem_of_elements; apply fin_set_full_message_dependencies_irreflexive.
-  - intro; apply NoDup_elements.
+  - by setoid_rewrite elem_of_elements; apply fin_set_full_message_dependencies_happens_before.
+  - by setoid_rewrite elem_of_elements; apply fin_set_full_message_dependencies_irreflexive.
+  - by intro; apply NoDup_elements.
 Qed.
 
 Definition fin_set_msg_dep_happens_before

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -106,7 +106,7 @@ Definition message_dependencies_full_node_condition_prop : Prop :=
 Lemma msg_dep_happens_before_iff_one x z
   : msg_dep_happens_before x z <->
     msg_dep_rel x z \/ exists y, msg_dep_happens_before x y /\ msg_dep_rel y z.
-Proof. apply tc_r_iff. Qed.
+Proof. by apply tc_r_iff. Qed.
 
 (**
   If the [msg_dep_rel]ation reflects a predicate <<P>>, then
@@ -137,7 +137,7 @@ Proof.
   - rewrite emitted_messages_are_valid_iff; left; right.
     apply Hreflects with m; [done |].
     destruct Hinit as [Hinit | Hp]; [| done].
-    contradict Hinit; apply no_initial_messages_in_X.
+    by contradict Hinit; apply no_initial_messages_in_X.
   - apply (directly_observed_valid (pre_loaded_vlsm X P) s).
     + by exists (Some m); apply can_produce_valid.
     + destruct X.
@@ -165,7 +165,7 @@ Lemma msg_dep_has_been_sent
 Proof.
   revert m Hsent; induction Hs using valid_state_prop_ind; intro m.
   - intro Hbs; contradict Hbs; eapply oracle_no_inits; [| done].
-    apply has_been_sent_stepwise_from_trace.
+    by apply has_been_sent_stepwise_from_trace.
   - rewrite has_been_sent_step_update by done; intros [-> | Hrcv] dm Hdm.
     + by eapply message_dependencies_are_necessary; [eexists _, _ |].
     + by eapply has_been_directly_observed_step_update; [done |]; right; eapply IHHs.
@@ -196,7 +196,7 @@ Lemma full_node_has_been_received
 Proof.
   revert m Hreceived; induction Hs using valid_state_prop_ind; intro m.
   - intro Hbr; contradict Hbr; eapply oracle_no_inits; [| done].
-    apply has_been_received_stepwise_from_trace.
+    by apply has_been_received_stepwise_from_trace.
   - rewrite has_been_received_step_update by done; intros [-> | Hrcv] dm Hdm
     ; rewrite has_been_directly_observed_step_update by done; right.
     + by eapply Hfull; [apply Ht|].
@@ -247,10 +247,10 @@ Lemma msg_dep_full_node_input_valid_happens_before_has_been_directly_observed
     has_been_directly_observed X s dm.
 Proof.
   intro dm; rewrite msg_dep_happens_before_iff_one; intros [Hdm | (dm' & Hdm' & Hdm)].
-  - eapply Hfull; [apply Hvalid | done].
+  - by eapply Hfull; [apply Hvalid |].
   - eapply msg_dep_happens_before_reflect; [| done |].
-    + apply msg_dep_full_node_reflects_has_been_directly_observed; [apply Hfull | apply Hvalid].
-    + eapply Hfull; [apply Hvalid | done].
+    + by apply msg_dep_full_node_reflects_has_been_directly_observed; [apply Hfull | apply Hvalid].
+    + by eapply Hfull; [apply Hvalid |].
 Qed.
 
 End sec_message_dependencies.
@@ -532,7 +532,8 @@ Proof.
   intros dm m Hdm.
   rewrite !emitted_messages_are_valid_iff.
   intros [[i [[im Him] _]] | Hemit]
-  ; [contradict Him; apply no_initial_messages_in_IM | right].
+  ; [by contradict Him; apply no_initial_messages_in_IM |].
+  right.
   pose proof (vlsm_is_pre_loaded_with_False X) as XeqXFalse.
   apply (VLSM_eq_can_emit XeqXFalse).
   cut (valid_message_prop (pre_loaded_vlsm X (fun _ => False)) dm).
@@ -540,17 +541,16 @@ Proof.
     clear -no_initial_messages_in_IM.
     rewrite emitted_messages_are_valid_iff.
     intros [[[i [[im Him] _]] | Hpreloaded] | Hemit]; try itauto.
-    contradict Him; apply no_initial_messages_in_IM.
+    by contradict Him; apply no_initial_messages_in_IM.
   }
   eapply msg_dep_reflects_validity.
-  - apply composite_message_dependencies.
+  - by apply composite_message_dependencies.
   - intros _ [i [[im Him] _]].
-    contradict Him; apply no_initial_messages_in_IM.
-  - itauto.
+    by contradict Him; apply no_initial_messages_in_IM.
+  - by itauto.
   - done.
   - apply emitted_messages_are_valid_iff.
-    apply (VLSM_eq_can_emit XeqXFalse) in Hemit.
-    auto.
+    by apply (VLSM_eq_can_emit XeqXFalse) in Hemit; auto.
 Qed.
 
 Lemma msg_dep_reflects_happens_before_free_validity
@@ -635,7 +635,7 @@ Lemma composite_HasBeenObserved_iff : forall s m,
   exists i, HasBeenObserved (IM i) message_dependencies (s i) m.
 Proof.
   split; [| by intros []; eapply composite_HasBeenObserved_lift].
-  intros [[i Hobsi] |m' [i Hobsi] Hmm'];
+  by intros [[i Hobsi] | m' [i Hobsi] Hmm'];
     exists i; [by constructor 1 | by econstructor 2].
 Qed.
 
@@ -918,10 +918,10 @@ Lemma msg_dep_reflects_sub_free_validity
     valid_message_prop (pre_loaded_vlsm X P) dm.
 Proof.
   eapply msg_dep_reflects_validity; [| | done].
-  - typeclasses eauto.
+  - by typeclasses eauto.
   - intros m [sub_i [[im Him] Heqm]].
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
-    contradict Him; apply no_initial_messages_in_IM.
+    by contradict Him; apply no_initial_messages_in_IM.
 Qed.
 
 End sec_sub_composite_message_dependencies.
@@ -977,7 +977,7 @@ Proof.
   intros m Hm.
   contradict Hm.
   rewrite <- full_message_dependencies_happens_before.
-  apply full_message_dependencies_irreflexive.
+  by apply full_message_dependencies_irreflexive.
 Qed.
 
 #[export] Instance msg_dep_happens_before_strict : StrictOrder (msg_dep_happens_before message_dependencies) := {}.
@@ -995,13 +995,13 @@ Qed.
 Lemma msg_dep_happens_before_wf : well_founded (msg_dep_happens_before message_dependencies).
 Proof.
   apply tc_wf_projected with (<) (fun m => length (full_message_dependencies m));
-    [typeclasses eauto | | apply Wf_nat.lt_wf ].
+    [by typeclasses eauto | | by apply Wf_nat.lt_wf ].
   intros; unfold lt.
   change (S _) with (length (x :: full_message_dependencies x)).
   apply NoDup_subseteq_length.
   - constructor.
-    + apply full_message_dependencies_irreflexive.
-    + apply full_message_dependencies_nodups.
+    + by apply full_message_dependencies_irreflexive.
+    + by apply full_message_dependencies_nodups.
   - intros z Hz; inversion Hz; subst;
       [| by eapply msg_dep_rel_full_message_dependecies_subset].
     by apply full_message_dependencies_happens_before; constructor.
@@ -1071,7 +1071,7 @@ Lemma emittable_from_dependencies_prop_iff m
 Proof.
   unfold emittable_from_dependencies_prop; split.
   - by inversion 1; rewrite Hsender.
-  - destruct (sender m) eqn: Hsender; [by split with v | inversion 1].
+  - by destruct (sender m) eqn: Hsender; [exists v | inversion 1].
 Qed.
 
 (**
@@ -1104,7 +1104,7 @@ Lemma free_valid_from_valid_dependencies
 Proof.
   eapply emitted_messages_are_valid, free_valid_preloaded_lifts_can_be_emitted; [| done].
   by intros; apply Hdeps, full_message_dependencies_happens_before, msg_dep_happens_before_iff_one;
-  left.
+    left.
 Qed.
 
 (**
@@ -1119,7 +1119,8 @@ Proof.
   intros m Hm.
   specialize (Hm m) as Hemit; spec Hemit; [left |].
   inversion Hemit as [v _ Hemit']; clear Hemit.
-  apply free_valid_from_valid_dependencies with (A v); [done | clear v Hemit'].
+  apply free_valid_from_valid_dependencies with (A v); [done |].
+  clear v Hemit'.
   eapply FullMessageDependencies_ind; [done |].
   intros dm Hdm Hdeps.
   specialize (Hm dm); spec Hm; [by right |].

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -137,8 +137,8 @@ Lemma _apply_plan_cons
      (aitems ++ a'items, a'final).
 Proof.
   replace (ai :: a') with ([ai] ++ a').
-  apply _apply_plan_app.
-  itauto.
+  - by apply _apply_plan_app.
+  - by itauto.
 Qed.
 
 (** We can forget information from a trace to obtain a plan. *)
@@ -215,7 +215,7 @@ Proof.
   simpl in *.
   destruct (apply_plan afinal b) as (bitems, bfinal).
   rewrite Happ. simpl. clear Happ. subst afinal.
-  apply finite_valid_trace_from_app_iff.
+  by apply finite_valid_trace_from_app_iff.
 Qed.
 
 Lemma finite_valid_plan_empty
@@ -301,9 +301,9 @@ Proof.
     ( apply finite_valid_plan_from_app_iff in H
     ; destruct H as [Ha Hx]; apply IHa in Ha as Ha').
   - by inversion H.
-  - constructor.
+  - by constructor.
   - by destruct prefa; simpl in Heqa.
-  - destruct H as [Hs _]. by constructor.
+  - by destruct H as [Hs _]; constructor.
   - by destruct Ha' as [Hs _].
   - destruct Ha' as [_ [Hmsgs _]].
     apply Forall_app. split; [done |].
@@ -313,7 +313,7 @@ Proof.
     destruct x.
     destruct ( vtransition X label_a0 (lst, input_a0)) as (dest, out).
     simpl. simpl in Hx. inversion Hx. subst.
-    apply Ht.
+    by apply Ht.
   - assert (Hsuffa : suffa = [] \/ suffa <> []) by
       (destruct suffa; try (left; congruence); right; congruence).
     destruct Hsuffa.
@@ -326,7 +326,7 @@ Proof.
       destruct ai.
       destruct ( vtransition X label_a0 (lst, input_a0)) as (dest, out).
       simpl. simpl in Hx. inversion Hx. subst.
-      apply Ht.
+      by apply Ht.
     + apply exists_last in H. destruct H as [suffa' [x' Heq]]. subst.
       repeat rewrite app_assoc in Heqa.
       apply app_inj_tail in Heqa. rewrite <- app_assoc in Heqa. destruct Heqa; subst.
@@ -382,7 +382,8 @@ Proof.
     | context[let (_, _) := let (_, _) := ?t in _ in _] =>
       destruct t as [dest output] eqn : eq_trans
     end.
-    inversion H; subst. by setoid_rewrite eq_trans.
+    inversion H; subst.
+    by setoid_rewrite eq_trans.
   - match type of H with
     | input_valid_transition _ _ _ ?t =>
       destruct t as [dest output] eqn : eq_trans

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -129,7 +129,7 @@ Proof.
   destruct item. subst i. destruct l as (i, li).
   simpl. unfold pre_VLSM_projection_transition_item_project, composite_project_label.
   simpl.
-  destruct (decide _); [|congruence].
+  destruct (decide _); [| by congruence].
   f_equal. unfold composite_transition_item_projection, composite_transition_item_projection_from_eq.
   simpl.
   f_equal.
@@ -270,11 +270,11 @@ Proof.
   apply elem_of_map_option in Hitemj as [itemX [HitemX HitemX_pr]].
   exists itemX. split; [done |].
   unfold pre_VLSM_projection_transition_item_project in HitemX_pr.
-  destruct (composite_project_label _ _ _) as [lY|] eqn:Hly; [|congruence].
+  destruct (composite_project_label _ _ _) as [lY |] eqn: Hly; [| by congruence].
   inversion HitemX_pr. subst. clear HitemX_pr.
   repeat split.
   unfold composite_project_label in Hly.
-  case_decide; [|congruence].
+  case_decide; [| by congruence].
   exists H.
   by inversion Hly.
 Qed.
@@ -339,7 +339,7 @@ Proof.
   destruct (id Hv) as [sX [Hsi [Hps [Hopm _]]]]; subst.
   repeat split; [| | done].
   - by eapply (VLSM_projection_valid_state (component_projection _ constraint j)).
-  - apply any_message_is_valid_in_preloaded.
+  - by apply any_message_is_valid_in_preloaded.
 Qed.
 
 Lemma projection_valid_implies_composition_valid_message
@@ -428,10 +428,9 @@ Lemma proj_pre_loaded_with_all_messages_valid_state_message_preservation
   : valid_state_message_prop PreLoaded s om.
 Proof.
   induction Hps.
-  - apply (valid_initial_state_message PreLoaded); [done |].
-    by destruct om.
-  - apply (valid_generated_state_message PreLoaded) with s _om _s om l. 1-2, 4: done.
-    simpl. eapply (projection_valid_implies_valid IM). exact Hv.
+  - by apply (valid_initial_state_message PreLoaded); [| destruct om].
+  - apply (valid_generated_state_message PreLoaded) with s _om _s om l; [done.. | | done].
+    by cbn; eapply (projection_valid_implies_valid IM), Hv.
 Qed.
 
 (** We can now finally prove the main result for this section. *)
@@ -442,8 +441,8 @@ Proof.
   apply (basic_VLSM_incl (machine Xj) (machine PreLoaded)); intro; intros.
   - done.
   - by apply initial_message_is_valid.
-  - unfold vvalid; cbn. eapply (projection_valid_implies_valid IM), Hv.
-  - apply H.
+  - by unfold vvalid; cbn; eapply (projection_valid_implies_valid IM), Hv.
+  - by apply H.
 Qed.
 
 Lemma component_projection_to_preloaded :
@@ -451,8 +450,8 @@ Lemma component_projection_to_preloaded :
     (composite_project_label IM j) (fun s => s j).
 Proof.
   eapply VLSM_projection_incl_trans.
-  - apply component_projection.
-  - apply proj_pre_loaded_with_all_messages_incl.
+  - by apply component_projection.
+  - by apply proj_pre_loaded_with_all_messages_incl.
 Qed.
 
 (**
@@ -493,12 +492,12 @@ Proof.
   eapply VLSM_eq_trans;
     [| apply VLSM_eq_sym, pre_composite_vlsm_induced_projection_validator_iff].
   apply pre_loaded_with_all_messages_validator_proj_eq.
-  - apply component_transition_projection_None.
-  - apply component_label_projection_lift.
-  - apply component_state_projection_lift.
-  - intro s; apply (composite_initial_state_prop_lift IM).
-  - apply component_transition_projection_Some.
-  - apply component_projection_to_preloaded.
+  - by apply component_transition_projection_None.
+  - by apply component_label_projection_lift.
+  - by apply component_state_projection_lift.
+  - by intro s; apply (composite_initial_state_prop_lift IM).
+  - by apply component_transition_projection_Some.
+  - by apply component_projection_to_preloaded.
   - intros li si omi Hiv.
     apply Hvalidator in Hiv as (sX & <- & HivX).
     exists (existT j li), sX; split; [| done..].
@@ -555,7 +554,7 @@ Proof.
   - by apply initial_state_is_valid, (composite_initial_state_prop_lift IM j).
   - destruct Ht as [Hvj Ht].
     specialize (Hfr _ _ _ Hvj _ IHHp).
-    spec Hfr; [apply state_update_eq |].
+    spec Hfr; [by apply state_update_eq |].
     exists om'.
     destruct Hvj as [_ [_ Hvj]].
     apply (projection_valid_implies_composition_valid_message IM) in Hvj as Hom.
@@ -568,7 +567,7 @@ Proof.
     state_update_simpl.
     replace (vtransition (IM j) _ _) with (s', om').
     f_equal.
-    apply state_update_twice.
+    by applystate_update_twice.
 Qed.
 
 (**
@@ -582,15 +581,14 @@ Lemma projection_friendliness_lift_to_composite_vlsm_full_projection
   : VLSM_full_projection Xj X (lift_to_composite_label IM j) (lift_to_composite_state' IM j).
 Proof.
   apply basic_VLSM_full_projection; intro; intros.
-  - apply (Hfr _ _ _ Hv); [| apply state_update_eq].
-    apply (projection_friendliness_sufficient_condition_valid_state Hfr).
-    apply Hv.
+  - apply (Hfr _ _ _ Hv); [| by apply state_update_eq].
+    by apply (projection_friendliness_sufficient_condition_valid_state Hfr), Hv.
   - unfold lift_to_composite_label, vtransition. simpl.
     unfold lift_to_composite_state' at 1.
     state_update_simpl.
     replace (vtransition (IM j) _ _) with (s', om')
       by (symmetry; apply H).
-    f_equal. unfold lift_to_composite_state'. apply state_update_twice.
+    by rewrite state_update_twice.
   - by apply (composite_initial_state_prop_lift IM j).
   - by destruct Hv as [Hs [Homj [sX [Heqs [HsX [Hom Hv]]]]]].
 Qed.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -567,7 +567,7 @@ Proof.
     state_update_simpl.
     replace (vtransition (IM j) _ _) with (s', om').
     f_equal.
-    by applystate_update_twice.
+    by apply state_update_twice.
 Qed.
 
 (**

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1561,7 +1561,7 @@ Proof.
   intros m Hm.
   eapply VLSM_incl_can_emit.
   - apply (pre_loaded_vlsm_incl_relaxed _ (fun m => Q m \/ P m)).
-  - by itauto.
+    by itauto.
   - eapply VLSM_full_projection_can_emit; [| done].
     apply preloaded_sub_element_full_projection.
     by itauto.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -40,7 +40,7 @@ Lemma sub_IM_state_pi
 Proof.
   unfold dexist.
   replace (bool_decide_pack _ e1) with (bool_decide_pack _ e2); [done |].
-  apply proof_irrel.
+  by apply proof_irrel.
 Qed.
 
 Lemma sub_IM_state_update_eq
@@ -52,8 +52,8 @@ Lemma sub_IM_state_update_eq
 Proof.
   cut (forall be1 be2, be1 = be2 ->
       state_update sub_IM s (exist _ i be1) si (exist _ i be2) = si).
-  { intro Heq. apply Heq. apply proof_irrel. }
-  by intros; subst; state_update_simpl.
+  - by intro Heq; apply Heq, proof_irrel.
+  - by intros; subst; state_update_simpl.
 Qed.
 
 Lemma sub_IM_state_update_neq
@@ -89,7 +89,7 @@ Lemma composite_initial_state_sub_projection
   (Hs : composite_initial_state_prop IM s)
   : composite_initial_state_prop sub_IM (composite_state_sub_projection s).
 Proof.
-  intros (i, Hi). apply Hs.
+  by intros [i Hi]; apply Hs.
 Qed.
 
 Definition composite_label_sub_projection
@@ -126,7 +126,7 @@ Lemma lift_sub_state_to_eq
   : lift_sub_state_to s0 s i = s (dexist i Hi).
 Proof.
   unfold lift_sub_state_to.
-  by case_decide; [apply sub_IM_state_pi|].
+  by case_decide; [apply sub_IM_state_pi |].
 Qed.
 
 Lemma lift_sub_state_to_neq
@@ -238,8 +238,8 @@ Lemma composite_trace_sub_projection_lift
     = tr.
 Proof.
   apply (induced_validator_trace_lift (free_composite_vlsm IM)).
-  - apply composite_label_sub_projection_option_lift.
-  - apply composite_state_sub_projection_lift.
+  - by apply composite_label_sub_projection_option_lift.
+  - by apply composite_state_sub_projection_lift.
 Qed.
 
 Lemma induced_sub_projection_transition_consistency_Some
@@ -289,10 +289,10 @@ Lemma induced_sub_projection_is_projection
     composite_state_sub_projection.
 Proof.
   apply projection_induced_validator_is_projection.
-  - apply composite_label_sub_projection_option_lift.
-  - apply composite_state_sub_projection_lift.
-  - apply induced_sub_projection_transition_consistency_Some.
-  - apply induced_sub_projection_transition_consistency_None.
+  - by apply composite_label_sub_projection_option_lift.
+  - by apply composite_state_sub_projection_lift.
+  - by apply induced_sub_projection_transition_consistency_Some.
+  - by apply induced_sub_projection_transition_consistency_None.
 Qed.
 
 Lemma induced_sub_projection_valid_projection l s om
@@ -305,7 +305,7 @@ Proof.
   destruct lX as [i _li].
   unfold composite_label_sub_projection_option in HlX.
   simpl in HlX.
-  case_decide; [|congruence].
+  case_decide; [| by congruence].
   unfold composite_label_sub_projection in HlX.
   simpl in HlX.
   apply Some_inj in HlX.
@@ -313,7 +313,7 @@ Proof.
   exists i.
   split; [done |].
   exists _li, (sX i).
-  repeat split; [|apply any_message_is_valid_in_preloaded| apply Hv].
+  repeat split; [| by apply any_message_is_valid_in_preloaded | by apply Hv].
   apply (VLSM_projection_valid_state (preloaded_component_projection IM i)).
   apply (VLSM_incl_valid_state (vlsm_incl_pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM))).
   by apply (VLSM_incl_valid_state (constraint_free_incl IM constraint)).
@@ -331,7 +331,7 @@ Proof.
   destruct_dec_sig sub_k k Hk Heqsub_k; subst.
   unfold composite_state_sub_projection; cbn.
   destruct (decide (i = k)); subst; state_update_simpl; [done |].
-  apply lift_sub_state_to_eq.
+  by apply lift_sub_state_to_eq.
 Qed.
 
 End sec_induced_sub_projection.
@@ -348,10 +348,10 @@ Lemma induced_sub_projection_constraint_subsumption_incl
   : VLSM_incl (pre_induced_sub_projection constraint1) (pre_induced_sub_projection constraint2).
 Proof.
   apply projection_induced_validator_incl.
-  - apply composite_label_sub_projection_option_lift.
-  - apply composite_state_sub_projection_lift.
-  - apply induced_sub_projection_transition_consistency_Some.
-  - apply induced_sub_projection_transition_consistency_Some.
+  - by apply composite_label_sub_projection_option_lift.
+  - by apply composite_state_sub_projection_lift.
+  - by apply induced_sub_projection_transition_consistency_Some.
+  - by apply induced_sub_projection_transition_consistency_Some.
   - by apply constraint_subsumption_incl.
 Qed.
 
@@ -378,15 +378,14 @@ Context
 Program Definition sub_index_list_annotate : list sub_index :=
   list_annotate _ sub_index_list _.
 Next Obligation.
-  apply Forall_forall.
-  itauto.
+  by apply Forall_forall.
 Qed.
 
 #[export] Instance stdpp_finite_sub_index
   : finite.Finite sub_index.
 Proof.
   exists (remove_dups sub_index_list_annotate).
-  - apply NoDup_remove_dups.
+  - by apply NoDup_remove_dups.
   - intro sub_x.
     apply elem_of_remove_dups, elem_of_list_annotate.
     by destruct_dec_sig sub_x x Hx Heqsub_x; subst.
@@ -402,8 +401,8 @@ Definition finite_trace_sub_projection_app
 Lemma X_incl_Pre : VLSM_incl X Pre.
 Proof.
   apply VLSM_incl_trans with (machine (free_composite_vlsm IM)).
-  - apply (constraint_free_incl IM constraint).
-  - apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  - by apply (constraint_free_incl IM constraint).
+  - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
 Lemma finite_trace_sub_projection_last_state
@@ -568,7 +567,7 @@ Proof.
     as Hvj.
   rewrite <- (finite_trace_sub_projection_last_state s tr Htr) in Htj, Hvj.
   repeat split; [done | | done | | done].
-  - destruct iom as [m|]; [|apply (option_valid_message_None Xj)].
+  - destruct iom as [m |]; [| by apply (option_valid_message_None Xj)].
     apply (option_valid_message_Some Xj).
     clear -Hmsg m Hlx IHtr tr.
     remember {| input := Some m |} as x.
@@ -591,9 +590,9 @@ Proof.
       as [itemX HitemX].
     exists itemX.
     split.
-    + apply elem_of_map_option. by exists item.
+    + by apply elem_of_map_option; exists item.
     + unfold pre_VLSM_projection_transition_item_project in HitemX.
-      destruct (composite_label_sub_projection_option _); [|congruence].
+      destruct (composite_label_sub_projection_option _); [| by congruence].
       by inversion HitemX.
   - clear -Hmsg Sub_Free Hlst His IHtr.
     destruct iom as [m|]; [| done].
@@ -603,21 +602,21 @@ Proof.
     { unfold from_sub_projection at 1, pre_VLSM_projection_in_projection, composite_label_sub_projection_option.
       by subst; case_decide.
     }
-     specialize (Hmsg tr x []). rewrite Heqx in Hmsg.
+    specialize (Hmsg tr x []). rewrite Heqx in Hmsg.
     specialize (Hmsg m eq_refl eq_refl).
     spec Hmsg; [by subst |].
     destruct Hmsg as [Hseed | [item [Hitem [Hout Hsub_item]]]]; [by right |].
     left.
     remember (finite_trace_last (composite_state_sub_projection _) _) as lst.
-    assert (Hlst_pre : valid_state_prop (pre_loaded_with_all_messages_vlsm Sub_Free) lst).
-    { revert Hlst. apply VLSM_incl_valid_state.  apply Xj_incl_Pre_Sub_Free.  }
+    assert (Hlst_pre : valid_state_prop (pre_loaded_with_all_messages_vlsm Sub_Free) lst)
+      by (revert Hlst; apply VLSM_incl_valid_state, Xj_incl_Pre_Sub_Free; done).
     apply composite_proper_sent; [done |].
-    apply has_been_sent_consistency; [typeclasses eauto | done |].
+    apply has_been_sent_consistency; [by typeclasses eauto | done |].
     exists (composite_state_sub_projection s), (finite_trace_sub_projection tr).
     split.
     + split; [| done].
-       apply (VLSM_incl_finite_valid_trace_from_to Xj_incl_Pre_Sub_Free).
-       apply valid_trace_add_last; auto.
+      apply (VLSM_incl_finite_valid_trace_from_to Xj_incl_Pre_Sub_Free).
+      by apply valid_trace_add_last; auto.
     + apply Exists_exists.
       assert
         (Hsome: is_Some
@@ -631,10 +630,9 @@ Proof.
       [|contradict Hsome; apply is_Some_None].
       cbn.
       split.
-      * apply elem_of_map_option. by exists item.
+      * by apply elem_of_map_option; exists item.
       * unfold pre_VLSM_projection_transition_item_project in Hproj.
-        destruct (composite_label_sub_projection_option _); [|congruence].
-        by inversion Hproj.
+        by destruct (composite_label_sub_projection_option _); [inversion Hproj | congruence].
 Qed.
 
 Lemma valid_state_sub_projection
@@ -693,7 +691,7 @@ Proof.
   intros i.
   unfold lift_sub_state, lift_sub_state_to.
   case_decide as Hi.
-  - apply (Hs (dexist i Hi)).
+  - by apply (Hs (dexist i Hi)).
   - by destruct (vs0 _).
 Qed.
 
@@ -707,8 +705,8 @@ Proof.
   intros i.
   unfold lift_sub_state_to.
   case_decide as Hi.
-  - apply (Hs (dexist i Hi)).
-  - apply Hs0.
+  - by apply (Hs (dexist i Hi)).
+  - by apply Hs0.
 Qed.
 
 Lemma lift_sub_message_initial
@@ -734,7 +732,7 @@ Proof.
   subst. simpl.
   unfold sub_IM in li. simpl in li.
   case_decide as _Hi; [| done].
-  rewrite (sub_IM_state_pi s _Hi Hi); auto.
+  by rewrite (sub_IM_state_pi s _Hi Hi); auto.
 Qed.
 
 Lemma lift_sub_transition l s om s' om'
@@ -826,12 +824,12 @@ Proof.
   destruct lX as (i, liX).
   unfold remove_equivocating_label_project in Hl.
   simpl in Hl.
-  destruct (decide _); [congruence|].
+  destruct (decide _); [by congruence |].
   inversion Hl. subst lY. clear Hl.
   split; [| done].
   cbn in Hv |- *.
   unfold remove_equivocating_state_project.
-  rewrite lift_sub_state_to_neq; [apply Hv | done].
+  by rewrite lift_sub_state_to_neq; [apply Hv |].
 Qed.
 
 Lemma remove_equivocating_strong_projection_transition_preservation_Some eqv_is
@@ -841,7 +839,7 @@ Proof.
   destruct lX as (i, liX).
   unfold remove_equivocating_label_project in Hl.
   simpl in Hl.
-  destruct (decide _); [congruence|].
+  destruct (decide _); [by congruence |].
   inversion Hl. subst lY. clear Hl.
   cbn in Ht |- *.
   unfold remove_equivocating_state_project.
@@ -859,7 +857,7 @@ Proof.
   destruct lX as (i, liX).
   unfold remove_equivocating_label_project in Hl.
   simpl in Hl.
-  case_decide; [|congruence]. clear Hl.
+  case_decide; [| by congruence]. clear Hl.
   cbn in Ht.
   destruct (vtransition _ _ _) as (si', _om').
   inversion_clear Ht.
@@ -876,7 +874,7 @@ Proof.
   intros s Hs i.
   unfold remove_equivocating_state_project, lift_sub_state_to.
   destruct (decide _); [| done].
-  exact (Heqv_is (dexist i s0)).
+  by apply (Heqv_is (dexist i s0)).
 Qed.
 
 (**
@@ -891,9 +889,9 @@ Lemma remove_equivocating_transitions_preloaded_projection eqv_is
   : VLSM_projection PreFree PreFree remove_equivocating_label_project (remove_equivocating_state_project eqv_is).
 Proof.
   apply basic_VLSM_projection_preloaded.
-  - apply remove_equivocating_strong_projection_valid_preservation.
-  - apply remove_equivocating_strong_projection_transition_preservation_Some.
-  - apply remove_equivocating_strong_projection_transition_consistency_None.
+  - by apply remove_equivocating_strong_projection_valid_preservation.
+  - by apply remove_equivocating_strong_projection_transition_preservation_Some.
+  - by apply remove_equivocating_strong_projection_transition_consistency_None.
   - by apply remove_equivocating_strong_full_projection_initial_state_preservation.
 Qed.
 
@@ -948,11 +946,11 @@ Lemma PreSubFree_PreFree_weak_full_projection
 Proof.
   apply basic_VLSM_weak_full_projection.
   - split; [| done].
-    apply lift_sub_to_valid, Hv.
+    by apply lift_sub_to_valid, Hv.
   - intros l s om s' om' Hv.
-    apply lift_sub_to_transition, Hv.
-  - apply preloaded_lift_sub_state_to_initial_state.
-  - intro; intros; apply any_message_is_valid_in_preloaded.
+    by apply lift_sub_to_transition, Hv.
+  - by apply preloaded_lift_sub_state_to_initial_state.
+  - by intro; intros; apply any_message_is_valid_in_preloaded.
 Qed.
 
 (**
@@ -975,13 +973,13 @@ Proof.
   apply basic_VLSM_full_projection.
   - intros l s om (_ & _ & (i, li) & sX & [Heql [=] (HsX & Hom & Hv & Hc)]) _ _.
     unfold composite_label_sub_projection_option in Heql; cbn in Heql.
-    case_decide as Hi; [| congruence].
+    case_decide as Hi; [| by congruence].
     apply Some_inj in Heql; subst l; cbn.
     unfold constrained_composite_valid, lift_sub_state; cbn;
     rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi); subst.
     split; [done |].
     eapply Hconstraint_consistency; [| done].
-    symmetry; apply composite_state_sub_projection_lift_to.
+    by symmetry; apply composite_state_sub_projection_lift_to.
   - intros l s om s' om' [_ Ht]; revert Ht; cbn
     ; destruct (vtransition _ _ _) as [si' _om']
     ; inversion_clear 1.
@@ -1093,7 +1091,7 @@ Proof.
   unfold sub_IM in li; simpl in li.
   destruct (decide (sub_index_prop indices1 i)) as [H_i|]
   ; [| done].
-  rewrite (sub_IM_state_pi s H_i Hi); auto.
+  by rewrite (sub_IM_state_pi s H_i Hi).
 Qed.
 
 Lemma lift_sub_incl_transition l s om s' om'
@@ -1118,8 +1116,7 @@ Lemma lift_sub_incl_full_projection
   : VLSM_full_projection (free_composite_vlsm sub_IM1) (free_composite_vlsm sub_IM2) lift_sub_incl_label lift_sub_incl_state.
 Proof.
   apply basic_VLSM_strong_full_projection; intro; intros.
-  - split; [| done].
-    apply lift_sub_incl_valid. apply H.
+  - by split; [apply lift_sub_incl_valid, H |].
   - by apply lift_sub_incl_transition.
   - by apply lift_sub_incl_state_initial.
   - by apply lift_sub_incl_message_initial.
@@ -1131,8 +1128,7 @@ Lemma lift_sub_incl_preloaded_full_projection
   : VLSM_full_projection (pre_loaded_vlsm (free_composite_vlsm sub_IM1) P) (pre_loaded_vlsm (free_composite_vlsm sub_IM2) Q) lift_sub_incl_label lift_sub_incl_state.
 Proof.
   apply basic_VLSM_full_projection_preloaded_with; [done |..]; intro; intros.
-  - split; [| done].
-    apply lift_sub_incl_valid. apply H.
+  - by split; [apply lift_sub_incl_valid, H |].
   - by apply lift_sub_incl_transition.
   - by apply lift_sub_incl_state_initial.
   - by apply lift_sub_incl_message_initial.
@@ -1188,7 +1184,7 @@ Proof.
     unfold composite_project_label; cbn.
     by rewrite decide_True_pi with eq_refl.
   }
-  rewrite (Hsender_safety i); [done |]. eexists _; eauto.
+  by rewrite (Hsender_safety i); [| eexists _; eauto].
 Qed.
 
 (** *** Sender and sender-safety specialized for the subcomposition *)
@@ -1220,12 +1216,12 @@ Proof.
   unfold channel_authenticated_message in *.
   simpl in Hemit.
   unfold sub_IM_sender.
-  destruct (sender m) as [v|]; [|simpl in Hemit; congruence].
+  destruct (sender m) as [v |]; [| by simpl in Hemit; congruence].
   apply Some_inj in Hemit. subst.
   case_decide; [| done].
   simpl.
   f_equal.
-  apply dsig_eq; itauto.
+  by apply dsig_eq.
 Qed.
 
 Lemma sub_IM_preserves_no_initial_messages
@@ -1235,7 +1231,7 @@ Proof.
   intros Hno_init sub_i m.
   destruct_dec_sig sub_i i Hi Heqsub_i.
   subst.
-  apply Hno_init.
+  by apply Hno_init.
 Qed.
 
 Lemma sub_IM_sender_safety
@@ -1250,8 +1246,8 @@ Proof.
   apply (Hsender_safety m v); [| done].
   clear -Hsender.
   unfold sub_IM_sender in Hsender.
-  destruct (sender m) as [_v|] eqn:Hsender_v; [|congruence].
-  case_decide; [|congruence].
+  destruct (sender m) as [_v |] eqn: Hsender_v; [| by congruence].
+  case_decide; [| by congruence].
   by inversion Hsender; itauto.
 Qed.
 
@@ -1276,11 +1272,11 @@ Proof.
     by apply dsig_eq.
   }
   erewrite has_been_sent_iff_by_sender
-  ; [| apply sub_IM_sender_safety | done | done].
+  ; [| by apply sub_IM_sender_safety | done | done].
   unfold sub_IM_A, sub_IM, SubProjectionTraces.sub_IM; cbn.
   rewrite (sub_IM_state_pi s (proj2_dsig (dexist v Hv)) Hv).
   apply has_been_sent_irrelevance.
-  revert Hs; apply preloaded_valid_state_projection with (j := dexist (A v) Hv).
+  by revert Hs; apply preloaded_valid_state_projection with (j := dexist (A v) Hv).
 Qed.
 
 (** ** No-equivocation results for sub-composition
@@ -1337,7 +1333,7 @@ Proof.
   cbn. unfold sub_IM at 6. simpl.
   unfold lift_sub_state at 1. rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi).
   destruct (vtransition _ _ _) as (si', _om').
-  split; inversion 1; subst; clear H; f_equal; extensionality sub_j
+  by split; inversion 1; subst; clear H; f_equal; extensionality sub_j
   ; destruct_dec_sig sub_j j Hj Heqsub_j
   ; subst sub_j
   ; unfold composite_state_sub_projection
@@ -1367,13 +1363,13 @@ Proof.
   - by elim (no_initial_messages_in_IM i im).
   - apply (VLSM_incl_can_emit (constraint_preloaded_free_incl _ _)) in Hemitted.
     specialize (can_emit_projection IM A sender Hsender_safety (A v) m) as Hemit.
-    spec Hemit; [rewrite Hsender; itauto|].
+    spec Hemit; [by rewrite Hsender; itauto |].
     apply Hemit in Hemitted; clear Hemit.
     cbn in Hc; rewrite Hsender in Hc; cbn in Hc; case_decide.
-    + left. subst. eexists; exact Hc.
+    + by left; subst; eexists; exact Hc.
     + right. exists (A v).
       unfold channel_authenticated_message.
-      rewrite Hsender; itauto.
+      by rewrite Hsender; itauto.
 Qed.
 
 End sec_sub_composition_sender.
@@ -1400,7 +1396,7 @@ Context
 Program Definition free_sub_free_index (i : index) : sub_index (enum index) :=
   dexist i _.
 Next Obligation.
-  intros. apply elem_of_enum.
+  by intros; apply elem_of_enum.
 Qed.
 
 Definition free_sub_free_label (l : composite_label IM) : composite_label sub_IM :=
@@ -1427,7 +1423,7 @@ Lemma preloaded_sub_composition_all_full_projection
   : VLSM_full_projection (pre_loaded_vlsm X seed) (pre_loaded_vlsm SubX seed) free_sub_free_label (composite_state_sub_projection IM (enum index)).
 Proof.
   apply basic_VLSM_strong_full_projection.
-  - intros [i li] *; auto.
+  - by intros [i li] *; auto.
   - intros [i li] *; cbn.
     unfold sub_IM, SubProjectionTraces.sub_IM at 2; cbn
     ; unfold composite_state_sub_projection at 1; cbn
@@ -1446,7 +1442,7 @@ Lemma sub_composition_all_full_projection
   : VLSM_full_projection X SubX free_sub_free_label (composite_state_sub_projection IM (enum index)).
 Proof.
   apply basic_VLSM_strong_full_projection.
-  - intros [i li] *; auto.
+  - by intros [i li] *; auto.
   - intros [i li] *
     ; cbn; unfold vtransition
     ; cbn; unfold sub_IM, SubProjectionTraces.sub_IM at 2
@@ -1524,7 +1520,7 @@ Lemma sub_element_state_neq s i Hi
 Proof.
   intros Hij.
   unfold sub_element_state; cbn.
-  case_decide; congruence.
+  by case_decide; congruence.
 Qed.
 
 #[local] Hint Rewrite @sub_element_state_eq : state_update.
@@ -1565,10 +1561,10 @@ Proof.
   intros m Hm.
   eapply VLSM_incl_can_emit.
   - apply (pre_loaded_vlsm_incl_relaxed _ (fun m => Q m \/ P m)).
-    itauto.
+  - by itauto.
   - eapply VLSM_full_projection_can_emit; [| done].
     apply preloaded_sub_element_full_projection.
-    itauto.
+    by itauto.
 Qed.
 
 (** *** A subcomposition can be projected to one component
@@ -1603,7 +1599,7 @@ Proof.
   intros (sub_i,li) HlX s om s' om' HtX.
   destruct_dec_sig sub_i i Hi Heqsub_i; subst.
   unfold sub_label_element_project in HlX; cbn in HlX, HtX.
-  case_decide as Hij; [congruence|].
+  case_decide as Hij; [by congruence |].
   destruct (vtransition _ _ _) as (si', _om').
   inversion_clear HtX.
   unfold sub_state_element_project.
@@ -1668,8 +1664,8 @@ Lemma induced_sub_element_projection_is_projection constraint
     sub_label_element_project sub_state_element_project.
 Proof.
   apply @projection_induced_validator_is_projection.
-  - intro; apply sub_element_label_project.
-  - intro; apply sub_element_state_project.
+  - by intro; apply sub_element_label_project.
+  - by intro; apply sub_element_state_project.
   - intros ? **; eapply sub_transition_element_project_Some; cycle 2.
     2-3: setoid_rewrite <- (induced_sub_projection_transition_is_composite _ _ constraint).
     all: done.
@@ -1703,7 +1699,7 @@ Lemma lift_sub_free_preloaded_with_full_projection
 Proof.
   apply (basic_VLSM_full_projection_preloaded_with SubFree Free seed seed); intro; intros.
   - done.
-  - split; [| done]. apply lift_sub_valid, H.
+  - by split; [apply lift_sub_valid, H |].
   - by rapply lift_sub_transition.
   - by apply (lift_sub_state_initial IM).
   - by apply (lift_sub_message_initial IM indices).
@@ -1748,12 +1744,10 @@ Proof.
   ; [by rewrite composite_project_label_eq |].
   cut (input_valid
         (pre_loaded_with_all_messages_vlsm (free_composite_vlsm (sub_IM IM indices)))
-        (existT (dexist i Hi) li) (sub_s, Some im)).
-  {
-    apply (VLSM_full_projection_input_valid lift_sub_preloaded_free_full_projection).
-  }
+        (existT (dexist i Hi) li) (sub_s, Some im));
+    [by apply (VLSM_full_projection_input_valid lift_sub_preloaded_free_full_projection) |].
   eapply VLSM_incl_input_valid; [| done].
-  apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
+  by apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
 Qed.
 
 Lemma can_emit_sub_projection
@@ -1768,8 +1762,7 @@ Lemma can_emit_sub_projection
 Proof.
   intro Hemit.
   apply can_emit_projection with validator A sender; [done | done|].
-  revert Hemit.
-  apply (VLSM_full_projection_can_emit lift_sub_preloaded_free_full_projection).
+  by eapply (VLSM_full_projection_can_emit lift_sub_preloaded_free_full_projection).
 Qed.
 
 (**
@@ -1819,7 +1812,7 @@ Lemma sub_no_indices_no_can_emit (P : message -> Prop)
   : forall m, ~ can_emit (pre_loaded_vlsm (free_composite_vlsm sub_IM) P) m.
 Proof.
   apply pre_loaded_empty_composition_no_emit, elem_of_empty_nil.
-  intro sub_i; destruct_dec_sig sub_i i Hi Heqsub_i; subst; inversion Hi.
+  by intro sub_i; destruct_dec_sig sub_i i Hi Heqsub_i; subst; inversion Hi.
 Qed.
 
 End sec_empty_sub_composition.

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -44,9 +44,8 @@ Lemma transition_monotone_in_futures
 Proof.
   destruct Hfutures as [tr Htr].
   induction Htr; [done |].
-  apply input_valid_transition_forget_input,
-    valid_transition_next, transition_monotonicity in Ht.
-  by lia.
+  by apply input_valid_transition_forget_input,
+    valid_transition_next, transition_monotonicity in Ht; lia.
 Qed.
 
 Lemma transition_monotone_empty_trace
@@ -58,9 +57,8 @@ Proof.
   induction Htr using finite_valid_trace_from_to_ind; [done | subst].
   assert (state_size s <= state_size s')
     by (apply transition_monotone_in_futures; [| eexists]; done).
-  apply input_valid_transition_forget_input,
-    valid_transition_next, transition_monotonicity in Ht.
-  by lia.
+  by apply input_valid_transition_forget_input,
+    valid_transition_next, transition_monotonicity in Ht; lia.
 Qed.
 
 (**
@@ -295,7 +293,7 @@ Proof.
   apply composite_tv_state_destructor_state_update in Hdestruct as Heqs'; [| done].
   intros j Hinit; destruct (decide (i = j)); subst; [| by state_update_simpl].
   apply composite_tv_state_destructor_initial in Hinit; [| done].
-  rewrite Hinit in Hdestruct; inversion Hdestruct.
+  by rewrite Hinit in Hdestruct; inversion Hdestruct.
 Qed.
 
 Lemma composite_tv_state_destructor_size :
@@ -419,7 +417,7 @@ Lemma composite_tv_state_destructor_preserves_not_in_indices_initial  :
 Proof.
   intros s' Hs' * Heq indices Hinits' j Hj.
   by erewrite composite_tv_state_destructor_reflects_initiality;
-    [apply Hinits' | done | eapply elem_of_list_lookup_2 | apply Hinits'].
+    [apply Hinits' | | eapply elem_of_list_lookup_2 | apply Hinits'].
 Qed.
 
 (**

--- a/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
+++ b/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
@@ -246,7 +246,7 @@ Proof.
       spec Hchannel_i; [by eexists _, _, _ |].
       specialize (Hchannel j m_j) as Hchannel_j.
       spec Hchannel_j; [by eexists _, _, _ |].
-      congruence.
+      by congruence.
     + apply Some_inj in H_output as <-.
       apply tc_r_iff in Hbefore as [Hdm | (m' & Hbefore & Hdm)].
       * by eapply composite_observed_before_send_subsumes_msg_dep_rel;
@@ -257,7 +257,7 @@ Proof.
         eexists s_j, _; constructor; [done.. |]; cbn.
         destruct Hobs as [[| Houtput] |]; subst; [by constructor | | by do 2 econstructor].
         apply Some_inj in Houtput; subst m_j.
-        contradict Hdm; apply tc_reflect_irreflexive; typeclasses eauto.
+        by contradict Hdm; apply tc_reflect_irreflexive; typeclasses eauto.
 Qed.
 
 (**
@@ -540,7 +540,7 @@ Proof.
       [| done..].
     rewrite find_largest_nat_with_property_bounded_None in Hsent_not_obs, Hnot_send.
     rewrite composite_tv_state_destructor_initial in Hinitial;
-      [| typeclasses eauto | done].
+      [| by typeclasses eauto | done].
     destruct composite_state_destructor as [| [item s]] eqn: Hdestruct;
       [done | clear Hinitial]; cbn in *.
     specialize (Hnot_send 0); spec Hnot_send; [lia |].

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -165,7 +165,7 @@ Lemma trace_has_message_observed_iff m tr
   (Hobserved : trace_has_message item_sends_or_receives m tr)
   : trace_has_message (field_selector input) m tr \/ trace_has_message (field_selector output) m tr.
 Proof.
-  unfold trace_has_message in *. rewrite !Exists_exists in *. firstorder.
+  by unfold trace_has_message in *; rewrite !Exists_exists in *; firstorder.
 Qed.
 
 (** Defines a message received but not sent by within the trace. *)
@@ -328,8 +328,8 @@ Proof.
   destruct H as [H |<-].
   - unfold finite_trace_nth.
     rewrite map_app, app_comm_cons.
-    rewrite nth_error_app2;simpl length;rewrite map_length;[|solve[auto with arith]].
-    destruct n;[exfalso;lia|].
+    rewrite nth_error_app2; simpl length; rewrite map_length; [| by auto with arith].
+    destruct n; [by exfalso; lia |].
     by rewrite (Nat.sub_succ_l (length t1) n); [|lia].
   - by rewrite finite_trace_nth_app1, finite_trace_nth_last,
       Nat.sub_diag, finite_trace_nth_first.
@@ -355,9 +355,8 @@ Proof.
   rewrite list_prefix_map.
   generalize (List.map destination tr); intro l; clear tr.
   destruct n.
-  - simpl. intros [= <-]. by destruct l.
-  - simpl. intro H. symmetry. revert H s.
-    apply list_prefix_nth_last.
+  - by simpl; intros [= <-]; destruct l.
+  - by cbn; intros H; symmetry; apply list_prefix_nth_last.
 Qed.
 
 Lemma finite_trace_last_suffix
@@ -519,7 +518,7 @@ Lemma initial_message_is_valid
   valid_message_prop m.
 Proof.
   exists (proj1_sig (vs0 X)).
-  apply valid_initial_state_message; [| done]. apply proj2_sig.
+  by apply valid_initial_state_message; [apply proj2_sig |].
 Qed.
 
 (**
@@ -534,8 +533,7 @@ Lemma option_valid_message_None
   : option_valid_message_prop None.
 Proof.
   exists (proj1_sig (vs0 X)).
-  apply valid_initial_state_message; [| done].
-  apply proj2_sig.
+  by apply valid_initial_state_message; [apply proj2_sig |].
 Qed.
 
 Lemma option_valid_message_Some
@@ -543,7 +541,7 @@ Lemma option_valid_message_Some
   (Hpm : valid_message_prop m)
   : option_valid_message_prop (Some m).
 Proof.
-  destruct Hpm as [s Hpm]. by exists s.
+  by destruct Hpm as [s Hpm]; exists s.
 Qed.
 
 Lemma option_initial_message_is_valid
@@ -553,7 +551,7 @@ Lemma option_initial_message_is_valid
 Proof.
   destruct om.
   - by apply option_valid_message_Some, initial_message_is_valid.
-  - apply option_valid_message_None.
+  - by apply option_valid_message_None.
 Qed.
 
 (** *** Input validity and input valid transitions
@@ -645,7 +643,7 @@ Lemma input_valid_transition_origin
       (Ht : input_valid_transition l (s, om) (s',om'))
   : valid_state_prop s.
 Proof.
-  destruct Ht as [[[_om Hp] _] _]. by exists _om.
+  by destruct Ht as [[[_om Hp] _] _]; exists _om.
 Qed.
 
 Lemma input_valid_transition_destination
@@ -740,7 +738,7 @@ Lemma input_valid_transition_deterministic :
     input_valid_transition lbl (s, iom) (s2, oom2) ->
       s1 = s2 /\ oom1 = oom2.
 Proof.
-  do 2 inversion 1; itauto congruence.
+  by do 2 inversion 1; itauto congruence.
 Qed.
 
 (**
@@ -792,11 +790,10 @@ Proof.
   split.
   - intros Hm; inversion Hm; subst.
     + by right.
-    + left. exists (s1, om0), l0.
-      repeat split; try red; eauto.
+    + by left; exists (s1, om0), l0; firstorder.
   - intros [Hem | Him].
     + by apply option_can_produce_valid.
-    + constructor; apply Him.
+    + by constructor; apply Him.
 Qed.
 
 Definition can_produce_valid_iff
@@ -820,8 +817,8 @@ Lemma can_emit_iff
   : can_emit m <-> exists s, can_produce s m.
 Proof.
   split.
-  - intros [som [l [s Ht]]]. by exists s, som, l.
-  - intros [s [som [l Ht]]]. by exists som, l, s.
+  - by intros [som [l [s Ht]]]; exists s, som, l.
+  - by intros [s [som [l Ht]]]; exists som, l, s.
 Qed.
 
 (** If a VLSM [can_emit] a message <<m>>, then <<m>> is valid. *)
@@ -873,11 +870,10 @@ Proof.
   - intro Hps'. destruct Hps' as [om' Hs].
     inversion Hs; subst.
     + by left; exists (exist _ _ Hs0).
-    + right. exists l0. exists (s, om). exists om'.
-      repeat split; try red; eauto.
+    + by right; exists l0, (s, om), om'; firstorder.
   - intros [[[s His] Heq] | [l [[s om] [om' [[[_om Hps] [[_s Hpm] Hv]] Ht]]]]]; subst.
-    + exists None. by apply valid_initial_state_message.
-    + exists om'. by apply valid_generated_state_message with s _om _s om l.
+    + by exists None; apply valid_initial_state_message.
+    + by exists om'; apply valid_generated_state_message with s _om _s om l.
 Qed.
 
 (**
@@ -903,7 +899,7 @@ Proof.
   destruct Hs as [om Hs].
   induction Hs.
   - by apply IHinit.
-  - apply (IHgen s' l0 om om' s); firstorder.
+  - by apply (IHgen s' l0 om om' s); firstorder.
 Qed.
 
 (** Valid message characterization. *)
@@ -918,8 +914,7 @@ Proof.
   - intros [s' Hpm'].
     inversion Hpm'; subst.
     + by left; exists (exist _ m' Hom).
-    + right. exists l0. exists (s, om). exists s'.
-      firstorder.
+    + by right; exists l0, (s, om), s'; firstorder.
   - intros [[[s His] Heq] | [l [[s om] [s' [[[_om Hps] [[_s Hpm] Hv]] Ht]]]]]; subst.
     + by apply initial_message_is_valid.
     + by exists s'; apply valid_generated_state_message with s _om _s om l.
@@ -1016,7 +1011,7 @@ Lemma finite_valid_trace_first_pstate
   (Htr : finite_valid_trace_from s tr)
   : valid_state_prop s.
 Proof.
-  by inversion Htr; subst; [|apply Ht].
+  by inversion Htr; subst; [| apply Ht].
 Qed.
 
 Lemma finite_valid_trace_tail
@@ -1122,7 +1117,7 @@ Lemma valid_trace_observed_is_valid
   (Hobserved : trace_has_message item_sends_or_receives m tr)
   : valid_message_prop m.
 Proof.
-  apply trace_has_message_observed_iff in Hobserved as [Hm |Hm]
+  by apply trace_has_message_observed_iff in Hobserved as [Hm |Hm]
   ; revert Htr m Hm; [apply valid_trace_input_is_valid | apply valid_trace_output_is_valid].
 Qed.
 
@@ -1175,7 +1170,7 @@ Proof.
   revert s.
   induction ls;intro s.
   - rewrite finite_trace_last_nil. simpl.
-    itauto (eauto using finite_valid_trace_first_pstate, finite_valid_trace_from_empty).
+    by itauto (eauto using finite_valid_trace_first_pstate, finite_valid_trace_from_empty).
   - rewrite finite_trace_last_cons. simpl.
     specialize (IHls (destination a)).
     split.
@@ -1203,11 +1198,11 @@ Lemma finite_valid_trace_from_rev_ind
     P s tr.
 Proof.
   induction tr using rev_ind; intro Htr.
-  - inversion Htr. apply Hempty. congruence.
+  - by inversion Htr; apply Hempty; congruence.
   - apply finite_valid_trace_from_app_iff in Htr.
     destruct Htr as [Htr Hx].
     destruct x; apply (Hextend _ _ Htr (IHtr Htr)).
-    inversion Hx; congruence.
+    by inversion Hx; congruence.
 Qed.
 
 Lemma finite_valid_trace_rev_ind
@@ -1227,8 +1222,8 @@ Lemma finite_valid_trace_rev_ind
 Proof.
   intros si tr [Htr Hinit].
   induction Htr using finite_valid_trace_from_rev_ind.
-  - apply Hempty;auto.
-  - apply Hextend;[split|..];auto.
+  - by apply Hempty.
+  - by apply Hextend; auto.
 Qed.
 
 (**
@@ -1313,7 +1308,7 @@ Proof.
   destruct Hm as (item & Hitem & Houtput).
   exists (destination item).
   unfold can_produce; rewrite <- Houtput.
-  eapply can_produce_from_valid_trace; [apply Htr | done].
+  by eapply can_produce_from_valid_trace; [apply Htr |].
 Qed.
 
 (* end hide *)
@@ -1358,14 +1353,14 @@ Qed.
 Lemma finite_valid_trace_from_to_forget_last
       s f tr : finite_valid_trace_from_to s f tr -> finite_valid_trace_from s tr.
 Proof.
-  induction 1;constructor;auto.
+  by induction 1; constructor; auto.
 Qed.
 
 Lemma finite_valid_trace_from_to_last
       s f tr : finite_valid_trace_from_to s f tr -> finite_trace_last s tr = f.
 Proof.
   induction 1.
-  - apply finite_trace_last_nil.
+  - by apply finite_trace_last_nil.
   - by rewrite finite_trace_last_cons.
 Qed.
 
@@ -1422,7 +1417,7 @@ Proof.
   - rewrite finite_trace_last_cons.
     inversion 1; subst; simpl in *.
     apply IHls in Htl as [].
-    auto using finite_valid_trace_from_to_extend.
+    by auto using finite_valid_trace_from_to_extend.
 Qed.
 
 Definition finite_valid_trace_init_to si sf tr : Prop
@@ -1468,7 +1463,7 @@ Proof.
   induction Ht12.
   - by apply finite_valid_trace_from_to_singleton.
   - rewrite <- app_comm_cons.
-    apply finite_valid_trace_from_to_extend; auto.
+    by apply finite_valid_trace_from_to_extend; auto.
 Qed.
 
 Lemma finite_valid_trace_from_to_rev_ind
@@ -1490,7 +1485,7 @@ Proof.
   revert sf Htr.
   induction tr using rev_ind;
   intros sf Htr.
-  - inversion Htr; subst. by apply Hempty.
+  - by inversion Htr; subst; apply Hempty.
   - apply finite_valid_trace_from_to_app_split in Htr.
     destruct Htr as [Htr Hstep].
     inversion Hstep;subst.
@@ -1587,9 +1582,9 @@ Proof.
   unfold empty_initial_message_or_final_output.
   destruct_list_last tl tl' item Heqtl.
   - inversion Htl; [done |].
-    destruct tl0; simpl in *; congruence.
+    by destruct tl0; simpl in *; congruence.
   - rewrite <- Heqtl in Htl.
-    inversion Htl; [destruct tl'; simpl in *; congruence|].
+    inversion Htl; [by destruct tl'; simpl in *; congruence |].
     revert Heqtl; subst; intro Heqtl.
     by apply app_inj_tail, proj2 in Heqtl; subst.
 Qed.
@@ -1615,8 +1610,7 @@ Proof.
   - destruct IHHp1 as [is [tl Hs]].
     destruct IHHp2 as [om_is [om_tl Hom]].
     eexists; eexists.
-    apply
-      (finite_valid_trace_init_to_emit_extend _ _ _ _ Hs _ _ _ _ Hom _ Hv _ _ Ht).
+    by apply (finite_valid_trace_init_to_emit_extend _ _ _ _ Hs _ _ _ _ Hom _ Hv _ _ Ht).
 Qed.
 
 Lemma finite_valid_trace_init_to_emit_forget_emit
@@ -1628,12 +1622,12 @@ Proof.
   split; [| done].
   clear Hinit.
   induction Htl.
-  - constructor. by apply initial_state_is_valid.
+  - by constructor; apply initial_state_is_valid.
   - apply finite_valid_trace_from_to_app with s; [done |].
     apply finite_valid_trace_from_to_singleton.
     apply finite_valid_trace_init_to_emit_valid_state_message in Htl1.
     apply finite_valid_trace_init_to_emit_valid_state_message in Htl2.
-    repeat split; try red; eauto.
+    by firstorder.
 Qed.
 
 Lemma finite_valid_trace_init_to_add_emit
@@ -1646,7 +1640,7 @@ Proof.
   destruct Ht as [[_ [[_s Hiom] Hv]] Ht].
   destruct (finite_valid_trace_init_to_emit_valid_state_message_rev _ _ Hiom)
     as [iom_s [iom_tr Hiom_tr]].
-  apply (finite_valid_trace_init_to_emit_extend _ _ _ _ IHHtl _ _ _ _ Hiom_tr _ Hv _ _ Ht).
+  by apply (finite_valid_trace_init_to_emit_extend _ _ _ _ IHHtl _ _ _ _ Hiom_tr _ Hv _ _ Ht).
 Qed.
 
 (**
@@ -1680,14 +1674,15 @@ Proof.
   induction Htr.
   - by apply Hempty.
   - assert (Hivt : input_valid_transition l0 (s, iom) (s', oom)).
-    { apply finite_valid_trace_init_to_emit_valid_state_message in Htr1.
+    {
+      apply finite_valid_trace_init_to_emit_valid_state_message in Htr1.
       apply finite_valid_trace_init_to_emit_valid_state_message in Htr2.
-      repeat split; try red; eauto.
+      by firstorder.
     }
     apply finite_valid_trace_init_to_emit_output in Htr2 as Houtput.
     apply finite_valid_trace_init_to_emit_forget_emit in Htr1.
     apply finite_valid_trace_init_to_emit_forget_emit in Htr2.
-    apply (Hextend _ _ _ IHHtr1 Htr1 _ _ _ _ Houtput IHHtr2 Htr2 _ _ _ Hivt).
+    by apply (Hextend _ _ _ IHHtr1 Htr1 _ _ _ _ Houtput IHHtr2 Htr2 _ _ _ Hivt).
 Qed.
 
 (** *** Infinite protocol traces
@@ -1724,10 +1719,10 @@ Lemma infinite_valid_trace_consecutive_valid_transition
 Proof.
   generalize dependent is. generalize dependent tr.
   induction tr1.
-  - intros tr Heq is Htr. simpl in Heq; subst. by inversion Htr; inversion Htl; subst.
+  - by cbn; intros tr -> is Htr; inversion Htr; inversion Htl; subst.
   - specialize (IHtr1 (stream_app (tr1 ++ [te1; te2]) tr2) eq_refl).
-    intros tr Heq is Htr; subst. inversion Htr; subst.
-    apply (IHtr1 s Htl).
+    intros tr Heq is Htr; subst; inversion Htr; subst.
+    by apply (IHtr1 s Htl).
 Qed.
 
 Lemma infinite_valid_trace_from_app_iff
@@ -1742,14 +1737,15 @@ Proof.
   intros. generalize dependent ls'. generalize dependent s.
   induction ls; intros; split.
   - by destruct 1.
-  - simpl; intros Hls'; split; [| done]. constructor. inversion Hls'.
-    apply (input_valid_transition_origin Ht).
+  - simpl; intros Hls'; split; [| done].
+    constructor; inversion Hls'.
+    by apply (input_valid_transition_origin Ht).
   - simpl. intros [Htr Htr'].
     destruct a. apply infinite_valid_trace_from_extend.
-    + apply IHls. inversion Htr. split. apply Htl.
+    + apply IHls. inversion Htr. split; [by apply Htl |].
       unfold s' in Htr'.
       by rewrite finite_trace_last_cons in Htr'.
-    + inversion Htr. apply Ht.
+    + by inversion Htr; apply Ht.
   - inversion 1; subst.
     apply (IHls s1 ls') in Htl as []; split.
     + by constructor.
@@ -1878,11 +1874,11 @@ Proof.
   apply finite_valid_trace_init_to_emit_output in Htr as Houtput.
   unfold empty_initial_message_or_final_output in Houtput.
   destruct_list_last tr tr' item Heqtr.
-  - left. split; [| done]. inversion Htr; [done |].
-    destruct tl; simpl in *; congruence.
-  - right. apply finite_valid_trace_init_to_emit_forget_emit in Htr.
-    eexists _,_.
-    by rewrite finite_trace_last_output_is_last.
+  - left; split; [| done].
+    inversion Htr; [done |].
+    by destruct tl; simpl in *; congruence.
+  - apply finite_valid_trace_init_to_emit_forget_emit in Htr.
+    by right; eexists _,_; rewrite finite_trace_last_output_is_last.
 Qed.
 
 (**
@@ -1919,7 +1915,7 @@ Proof.
   destruct Hs1 as [s0 [ts Hts]].
   exists s0, ts.
   destruct Hts as [Hts Hinit].
-  repeat split; [| done | revert Hts; apply finite_valid_trace_from_to_last].
+  repeat split; [| done | by revert Hts; apply finite_valid_trace_from_to_last].
   revert Ht.
   by apply extend_right_finite_trace_from_to.
 Qed.
@@ -1955,7 +1951,7 @@ Proof.
   apply finite_valid_trace_from_to_last in Htrs as Hlast.
   rewrite <- Hlast in Htr.
   apply finite_valid_trace_from_to_forget_last in Htrs.
-  repeat (split || done || apply finite_valid_trace_from_app_iff).
+  by firstorder using finite_valid_trace_from_app_iff.
 Qed.
 
 (**
@@ -2010,7 +2006,7 @@ Proof.
   unfold in_futures in Hin.
   destruct Hin as [tr Htr].
   induction Htr; [done |].
-  apply Ht in Ht0. by transitivity s.
+  by apply Ht in Ht0; transitivity s.
 Qed.
 
 Instance eq_equiv : @Equivalence state eq := _.
@@ -2027,7 +2023,7 @@ Proof.
   apply (StrictOrder_PreOrder eq_equiv) in Hpre.
   - specialize (in_futures_preserving (relation_disjunction R eq) Hpre) as Hpreserve.
     spec Hpreserve.
-    + intro; intros. left. apply (Ht s3 s4 l0 om1 om2 Hvalid_transition).
+    + by intro; intros; left; eapply Ht.
     + by destruct (Hpreserve s1 s2).
   - by intros x1 x2 -> y1 y2 ->.
 Qed.
@@ -2063,8 +2059,7 @@ Lemma input_valid_transition_in_futures {l s im s' om}
   : in_futures s s'.
 Proof.
   apply finite_valid_trace_singleton in Ht.
-  apply finite_valid_trace_from_add_last with (f := s') in Ht; [| done].
-  by eexists.
+  by apply finite_valid_trace_from_add_last with (f := s') in Ht; [eexists |].
 Qed.
 
 Lemma elem_of_trace_in_futures_left is s tr
@@ -2114,11 +2109,9 @@ Proof.
   apply finite_valid_trace_from_to_last in Hsuffix_tr.
   split.
   - rewrite finite_trace_nth_app1;[|lia].
-    rewrite finite_trace_nth_last.
-    congruence.
+    by rewrite finite_trace_nth_last; congruence.
   - rewrite finite_trace_nth_app2;[|lia].
-    rewrite Nat.add_comm, Nat.add_sub, finite_trace_nth_last.
-    congruence.
+    by rewrite Nat.add_comm, Nat.add_sub, finite_trace_nth_last; congruence.
 Qed.
 
 Definition trace_segment
@@ -2142,7 +2135,7 @@ Proof.
   destruct tr as [s tr | s tr]; simpl in *; destruct Htr as [Htr Hinit].
   - by apply finite_valid_trace_from_segment with s.
   - inversion Hfirst; subst; clear Hfirst.
-    apply (infinite_valid_trace_from_segment s tr Htr n1 n2 Hle).
+    by apply (infinite_valid_trace_from_segment s tr Htr n1 n2 Hle).
 Qed.
 
 Inductive Trace_messages : Type :=
@@ -2259,7 +2252,7 @@ Proof.
   specialize (trace_prefix_valid (exist _ tr Htr)); simpl; intro Hpref.
   remember (trace_prefix_fn tr n) as pref_tr.
   destruct pref_tr as [s l | s l]; cycle 1.
-  - destruct tr as [s' l' | s' l']; inversion Heqpref_tr.
+  - by destruct tr as [s' l' | s' l']; inversion Heqpref_tr.
   - destruct l as [| item l].
     + by destruct tr as [s' l' | s' l']
       ; destruct Htr as [Htr Hinit]
@@ -2334,16 +2327,16 @@ Proof.
   simpl in *.
   inversion Hle; subst; clear Hle.
   - rewrite Hs1 in Hs2. inversion Hs2; subst; clear Hs2.
-    exists []. constructor. by apply valid_trace_nth with tr n2.
+    by exists []; constructor; apply valid_trace_nth with tr n2.
   - exists (trace_segment tr n1 (S m)).
     apply finite_valid_trace_from_add_last; [by apply valid_trace_segment; [| lia |] |].
     destruct tr as [s tr | s tr]; simpl.
     + simpl in Hs1, Hs2.
       unfold list_segment.
       rewrite finite_trace_last_suffix.
-      by apply finite_trace_last_prefix.
-      apply finite_trace_nth_length in Hs2.
-      rewrite list_prefix_length; lia.
+      * by apply finite_trace_last_prefix.
+      * apply finite_trace_nth_length in Hs2.
+        by rewrite list_prefix_length; lia.
     + unfold stream_segment.
       rewrite unlock_finite_trace_last.
       rewrite list_suffix_map, stream_prefix_map.
@@ -2353,8 +2346,7 @@ Proof.
         unfold Str_nth in Hs2. simpl in Hs2.
         by inversion Hs2; subst.
       * specialize (stream_prefix_length (Streams.map destination tr) (S m)); intro Hpref_len.
-        rewrite Hpref_len.
-        lia.
+        by rewrite Hpref_len; lia.
 Qed.
 (* end hide *)
 
@@ -2557,8 +2549,7 @@ Lemma pre_loaded_with_all_messages_message_valid_initial_state_message
   (om : option message)
   : valid_state_message_prop pre_loaded_with_all_messages_vlsm (proj1_sig (vs0 X)) om.
 Proof.
-  apply valid_initial_state_message;[apply proj2_sig|].
-  by destruct om.
+  by apply valid_initial_state_message; [apply proj2_sig | destruct om].
 Qed.
 
 Lemma pre_loaded_with_all_messages_valid_state_message_preservation
@@ -2568,8 +2559,7 @@ Lemma pre_loaded_with_all_messages_valid_state_message_preservation
   : valid_state_message_prop pre_loaded_with_all_messages_vlsm s om.
 Proof.
   induction Hps.
-  - apply (valid_initial_state_message pre_loaded_with_all_messages_vlsm); [done |].
-    by destruct om.
+  - by apply (valid_initial_state_message pre_loaded_with_all_messages_vlsm); [| destruct om].
   - by apply (valid_generated_state_message pre_loaded_with_all_messages_vlsm) with s _om _s om l0.
 Qed.
 
@@ -2582,7 +2572,7 @@ Proof.
   destruct Hps as [om Hprs].
   exists om.
   apply pre_loaded_with_all_messages_valid_state_message_preservation.
-  itauto.
+  by itauto.
 Qed.
 (* end hide *)
 
@@ -2590,7 +2580,7 @@ Lemma any_message_is_valid_in_preloaded (om: option message):
   option_valid_message_prop pre_loaded_with_all_messages_vlsm om.
 Proof.
   eexists.
-  apply pre_loaded_with_all_messages_message_valid_initial_state_message.
+  by apply pre_loaded_with_all_messages_message_valid_initial_state_message.
 Qed.
 
 Inductive preloaded_valid_state_prop : state -> Prop :=
@@ -2641,11 +2631,9 @@ Lemma preloaded_weaken_input_valid_transition
 Proof.
   unfold input_valid_transition.
   intros [[[_om valid_s] [_ Hvalid]] Htrans].
-  split;[clear Htrans | done].
-  split.
+  repeat split; [| | done..].
   - by exists _om; apply preloaded_weaken_valid_state_message_prop.
-  - clear _om valid_s.
-    split; [| done]. apply any_message_is_valid_in_preloaded.
+  - by apply any_message_is_valid_in_preloaded.
 Qed.
 
 Lemma preloaded_weaken_valid_trace_from s tr
@@ -2655,11 +2643,11 @@ Proof.
   intros H. induction H using finite_valid_trace_from_rev_ind.
   - apply (finite_valid_trace_from_empty pre_loaded_with_all_messages_vlsm).
     destruct H as [om H]. exists om.
-    revert H. apply preloaded_weaken_valid_state_message_prop.
+    by revert H; apply preloaded_weaken_valid_state_message_prop.
   - apply (finite_valid_trace_from_app_iff pre_loaded_with_all_messages_vlsm).
     split; [done |].
     apply (finite_valid_trace_singleton pre_loaded_with_all_messages_vlsm).
-    revert Hx. apply preloaded_weaken_input_valid_transition.
+    by revert Hx; apply preloaded_weaken_input_valid_transition.
 Qed.
 
 Lemma pre_traces_with_valid_inputs_are_valid is s tr
@@ -2672,7 +2660,7 @@ Lemma pre_traces_with_valid_inputs_are_valid is s tr
 Proof.
   revert s Htr Hobs.
   induction tr using rev_ind; intros; split
-  ; [|apply Htr | | apply Htr]
+  ; [| by apply Htr | | by apply Htr]
   ; destruct Htr as [Htr Hinit].
   - inversion Htr; subst.
     by apply (finite_valid_trace_from_to_empty X), initial_state_is_valid.
@@ -2680,10 +2668,7 @@ Proof.
     apply finite_valid_trace_from_to_app_split in Htr.
     destruct Htr as [Htr Hx].
     specialize (IHtr _ (conj Htr Hinit)).
-    spec IHtr.
-    {
-      by intros; apply Hobs, trace_has_message_prefix.
-    }
+    spec IHtr; [by intros; apply Hobs, trace_has_message_prefix |].
     destruct IHtr as [IHtr _];
     apply finite_valid_trace_from_to_forget_last in IHtr.
     apply finite_valid_trace_from_add_last; [| done].
@@ -2695,7 +2680,7 @@ Proof.
     destruct iom as [m |]; [| apply option_valid_message_None].
     apply option_valid_message_Some, Hobs.
     red; rewrite Exists_app, Exists_cons.
-    subst; cbn; itauto.
+    by subst; cbn; itauto.
 Qed.
 
 End sec_pre_loaded_with_all_messages_vlsm.
@@ -2723,14 +2708,14 @@ Proof.
     exists (trs ++ [lstitem]). exists lstitem.
     by rewrite last_error_is_last; subst.
   - intros [is [tr [item [Htr [Hitem [Hs Hm]]]]]].
-    destruct_list_last tr tr' item' Heq; [inversion Hitem|].
+    destruct_list_last tr tr' item' Heq; [by inversion Hitem |].
     clear Heq.
     rewrite last_error_is_last in Hitem. inversion Hitem. clear Hitem. subst item'.
     destruct Htr as [Htr _].
     apply finite_valid_trace_from_app_iff in Htr.
     destruct Htr as [_ Htr].
     inversion Htr. clear Htr. subst. simpl in Hm. subst.
-    eexists _, l0. apply Ht.
+    by eexists _, l0; apply Ht.
 Qed.
 
 (** *** Properties of provably-equal VLSMs
@@ -2875,13 +2860,13 @@ Proof.
     inversion Hitem; inversion Htl; subst.
     destruct Ht as [(_ & _ & Hv) Ht].
     exfalso; clear His'; eapply @not_ValidTransitionNext_initial;
-      [| done | esplit; done].
-    typeclasses eauto.
+      [| done | by esplit].
+    by typeclasses eauto.
   - destruct_list_last tr' tr'' item Heqtr'; subst tr'.
     + inversion Htr'; subst; clear Htr'.
       destruct Ht as [(_ & _ & Hv) Ht].
-      exfalso; eapply @not_ValidTransitionNext_initial; [| done | esplit; done].
-      typeclasses eauto.
+      exfalso; eapply @not_ValidTransitionNext_initial; [| done | by esplit].
+      by typeclasses eauto.
     + apply finite_valid_trace_from_to_app_split in Htr' as [Htr' Hitem].
       inversion Hitem; inversion Htl; subst; clear Hitem Htl.
       apply input_valid_transition_forget_input in Ht, Ht0.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -21,9 +21,9 @@ Lemma same_VLSM_full_projection
   : VLSM_full_projection X1 X2 (same_VLSM_label_rew Heq) (same_VLSM_state_rew Heq).
 Proof.
   apply basic_VLSM_strong_full_projection; intro.
-  - apply same_VLSM_valid_preservation.
-  - apply same_VLSM_transition_preservation.
-  - apply same_VLSM_initial_state_preservation.
+  - by apply same_VLSM_valid_preservation.
+  - by apply same_VLSM_transition_preservation.
+  - by apply same_VLSM_initial_state_preservation.
   - by apply same_VLSM_initial_message_preservation.
 Qed.
 

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -54,8 +54,8 @@ Definition pre_VLSM_full_projection_infinite_trace_project
 Lemma pre_VLSM_full_projection_infinite_trace_project_infinitely_often
   : forall s, InfinitelyOften (is_Some ∘ (Some ∘ label_project ∘ l)) s.
 Proof.
-  cofix H. intros (a, s). constructor; simpl; [|apply H].
-  apply Streams.Here. by eexists.
+  cofix H. intros (a, s). constructor; simpl; [| by apply H].
+  by apply Streams.Here; eexists.
 Qed.
 
 Lemma pre_VLSM_full_projection_infinite_trace_project_EqSt
@@ -63,7 +63,7 @@ Lemma pre_VLSM_full_projection_infinite_trace_project_EqSt
   Streams.EqSt (pre_VLSM_full_projection_infinite_trace_project s) (pre_VLSM_projection_infinite_trace_project _ _ (Some ∘ label_project) state_project s Hinf).
 Proof.
   intros.
-  apply stream_map_option_EqSt.
+  by apply stream_map_option_EqSt.
 Qed.
 
 Lemma pre_VLSM_full_projection_finite_trace_last
@@ -139,8 +139,8 @@ Lemma weak_projection_valid_preservation_from_full
   : weak_full_projection_valid_preservation ->
     weak_projection_valid_preservation X Y (Some ∘ label_project) state_project.
 Proof.
-  intros Hvalid lX lY Hl.
-  inversion_clear Hl. apply Hvalid.
+  intros Hvalid lX lY Hl; inversion_clear Hl.
+  by apply Hvalid.
 Qed.
 
 Definition strong_full_projection_valid_preservation : Prop :=
@@ -152,7 +152,8 @@ Lemma strong_projection_valid_preservation_from_full
     strong_projection_valid_preservation X Y (Some ∘ label_project) state_project.
 Proof.
   intros Hvalid lX lY Hl.
-  inversion_clear Hl. apply Hvalid.
+  inversion_clear Hl.
+  by apply Hvalid.
 Qed.
 
 Lemma strong_full_projection_valid_preservation_weaken
@@ -160,7 +161,7 @@ Lemma strong_full_projection_valid_preservation_weaken
     weak_full_projection_valid_preservation.
 Proof.
   intros Hstrong l s om Hpv Hs Hom.
-  apply Hstrong. apply Hpv.
+  by apply Hstrong, Hpv.
 Qed.
 
 Definition weak_full_projection_transition_preservation : Prop :=
@@ -172,13 +173,13 @@ Lemma weak_projection_transition_preservation_Some_from_full
   : weak_full_projection_transition_preservation ->
     weak_projection_transition_preservation_Some X Y (Some ∘ label_project) state_project.
 Proof.
-  intros Htransition lX lY Hl.
-  inversion_clear Hl. apply Htransition.
+  intros Htransition lX lY Hl; inversion_clear Hl.
+  by apply Htransition.
 Qed.
 
 Lemma weak_projection_transition_consistency_None_from_full
   : weak_projection_transition_consistency_None _ _ (Some ∘ label_project) state_project.
-Proof. inversion 1. Qed.
+Proof. by inversion 1. Qed.
 
 Definition strong_full_projection_transition_preservation : Prop :=
   forall l s om s' om',
@@ -190,7 +191,8 @@ Lemma strong_projection_transition_preservation_Some_from_full
     strong_projection_transition_preservation_Some X Y (Some ∘ label_project) state_project.
 Proof.
   intros Htransition lX lY Hl.
-  inversion_clear Hl. apply Htransition.
+  inversion_clear Hl.
+  by apply Htransition.
 Qed.
 
 Lemma strong_projection_transition_consistency_None_from_full
@@ -202,7 +204,7 @@ Lemma strong_full_projection_transition_preservation_weaken
     weak_full_projection_transition_preservation.
 Proof.
   intros Hstrong l s om s' om' Ht.
-  apply Hstrong. apply Ht.
+  by apply Hstrong, Ht.
 Qed.
 
 Definition weak_full_projection_initial_message_preservation : Prop :=
@@ -220,7 +222,8 @@ Lemma strong_full_projection_initial_message_preservation_weaken
   : strong_full_projection_initial_message_preservation ->
     weak_full_projection_initial_message_preservation.
 Proof.
-  intros Hstrong l s m Hv HsY Him. apply Hstrong in Him.
+  intros Hstrong l s m Hv HsY Him.
+  apply Hstrong in Him.
   by apply initial_message_is_valid.
 Qed.
 
@@ -276,7 +279,7 @@ Lemma VLSM_full_projection_projection_type
 Proof.
   split; intros.
   destruct_list_last trX trX' lstX Heq; [done |].
-  apply (pre_VLSM_full_projection_finite_trace_last _).
+  by apply pre_VLSM_full_projection_finite_trace_last.
 Qed.
 
 Section sec_weak_projection_properties.
@@ -311,8 +314,8 @@ Lemma VLSM_weak_full_projection_is_projection
   : VLSM_weak_projection X Y (Some ∘ label_project) state_project.
 Proof.
   split.
-  - apply VLSM_full_projection_projection_type.
-  - apply VLSM_weak_full_projection_finite_valid_trace_from.
+  - by apply VLSM_full_projection_projection_type.
+  - by apply VLSM_weak_full_projection_finite_valid_trace_from.
 Qed.
 
 Definition VLSM_weak_full_projection_valid_state
@@ -376,8 +379,8 @@ Lemma VLSM_weak_full_projection_can_emit
   : can_emit X m -> can_emit Y m.
 Proof.
   repeat rewrite can_emit_iff.
-  intros [s Hsm]. exists (state_project s). revert Hsm.
-  apply VLSM_weak_full_projection_can_produce.
+  intros [s Hsm]. exists (state_project s).
+  by apply VLSM_weak_full_projection_can_produce.
 Qed.
 
 Lemma VLSM_weak_full_projection_valid_message
@@ -387,8 +390,9 @@ Lemma VLSM_weak_full_projection_valid_message
 Proof.
   intros Hm.
   apply emitted_messages_are_valid_iff in Hm as [Hinit | Hemit].
-  - apply Hinitial_valid_message in Hinit. by apply initial_message_is_valid.
-  - apply emitted_messages_are_valid. revert Hemit. apply VLSM_weak_full_projection_can_emit.
+  - apply Hinitial_valid_message in Hinit.
+    by apply initial_message_is_valid.
+  - by apply emitted_messages_are_valid, VLSM_weak_full_projection_can_emit.
 Qed.
 
 End sec_weak_projection_properties.
@@ -424,8 +428,8 @@ Lemma VLSM_full_projection_is_projection
   : VLSM_projection X Y (Some ∘ label_project) state_project.
 Proof.
   split.
-  - apply VLSM_full_projection_projection_type.
-  - apply VLSM_full_projection_finite_valid_trace.
+  - by apply VLSM_full_projection_projection_type.
+  - by apply VLSM_full_projection_finite_valid_trace.
 Qed.
 
 Definition VLSM_full_projection_finite_valid_trace_from
@@ -452,7 +456,7 @@ Definition VLSM_full_projection_initial_state
 Lemma VLSM_full_projection_weaken
   : VLSM_weak_full_projection X Y label_project state_project.
 Proof.
-  constructor. apply VLSM_full_projection_finite_valid_trace_from.
+  by constructor; apply VLSM_full_projection_finite_valid_trace_from.
 Qed.
 
 Definition VLSM_full_projection_valid_state
@@ -519,8 +523,8 @@ Lemma VLSM_full_projection_infinite_valid_trace
     infinite_valid_trace Y (state_project s) (VLSM_full_projection_infinite_trace_project Hsimul ls).
 Proof.
   intros [Htr His]. split.
-  - revert Htr. apply VLSM_full_projection_infinite_valid_trace_from.
-  - revert His. apply VLSM_full_projection_initial_state.
+  - by apply VLSM_full_projection_infinite_valid_trace_from.
+  - by apply VLSM_full_projection_initial_state.
 Qed.
 
 Lemma VLSM_full_projection_valid_trace
@@ -529,8 +533,8 @@ Lemma VLSM_full_projection_valid_trace
     valid_trace_prop Y (VLSM_full_projection_trace_project t).
 Proof.
   intros [s tr | s tr]; simpl.
-  - apply VLSM_full_projection_finite_valid_trace.
-  - apply VLSM_full_projection_infinite_valid_trace.
+  - by apply VLSM_full_projection_finite_valid_trace.
+  - by apply VLSM_full_projection_infinite_valid_trace.
 Qed.
 
 (**
@@ -547,10 +551,10 @@ Proof.
   intros s om Hsom.
   apply option_can_produce_valid_iff.
   apply option_can_produce_valid_iff in Hsom as [Hgen | [His Him]].
-  - left. revert Hgen. apply VLSM_full_projection_can_produce.
-  - right. split.
-    + revert His. apply VLSM_full_projection_initial_state.
-    + destruct om as [m|]; [| done]. by apply Hmessage.
+  - by left; apply VLSM_full_projection_can_produce.
+  - right; split.
+    + by apply VLSM_full_projection_initial_state.
+    + by destruct om as [m|]; [apply Hmessage |].
 Qed.
 
 End sec_full_projection_properties.
@@ -614,7 +618,7 @@ Proof.
   revert tr l input Heqtr'.
   generalize (Some m) as om.
   induction Htr using finite_valid_trace_init_to_rev_strong_ind
-  ; intros; [destruct tr; simpl in *; congruence|].
+  ; intros; [by destruct tr; simpl in *; congruence |].
   apply app_inj_tail in Heqtr' as [Heqtr Heqitem].
   subst tr0.
   inversion Heqitem. subst l0 input oom. clear Heqitem.
@@ -634,7 +638,7 @@ Proof.
   destruct Hs as [_om Hs].
   assert (Hom : option_valid_message_prop Y iom).
   {
-    destruct iom as [im|]; [|apply option_valid_message_None].
+    destruct iom as [im |]; [| by apply option_valid_message_None].
     unfold empty_initial_message_or_final_output in Heqiom.
     destruct_list_last iom_tr iom_tr' iom_item Heqiom_tr.
     - by apply (Hmessage _ _ _ (proj1 Ht)); [eexists |].
@@ -656,9 +660,9 @@ Proof.
   specialize (basic_VLSM_weak_projection X Y (Some ∘ label_project) state_project) as Hproj.
   spec Hproj; [by apply weak_projection_valid_preservation_from_full|].
   spec Hproj; [by apply weak_projection_transition_preservation_Some_from_full|].
-  spec Hproj; [apply weak_projection_transition_consistency_None_from_full|].
+  spec Hproj; [by apply weak_projection_transition_consistency_None_from_full |].
   spec Hproj; [done |].
-  spec Hproj; [apply weak_projection_valid_message_preservation_from_full|].
+  spec Hproj; [by apply weak_projection_valid_message_preservation_from_full |].
   constructor. intro; intros.
   by apply (VLSM_weak_projection_finite_valid_trace_from Hproj) in H.
 Qed.
@@ -672,8 +676,8 @@ Lemma basic_VLSM_weak_full_projection_strengthen
 Proof.
   constructor. intros sX trX [HtrX HsX].
   split.
-  - revert HtrX. apply (VLSM_weak_full_projection_finite_valid_trace_from Hweak).
-  - revert HsX. apply Hstate.
+  - by apply (VLSM_weak_full_projection_finite_valid_trace_from Hweak).
+  - by apply Hstate.
 Qed.
 
 Lemma basic_VLSM_full_projection
@@ -718,9 +722,9 @@ Lemma basic_VLSM_full_projection_preloaded
 Proof.
   constructor.
   intros sX trX HtrX.
-  split; [|apply Hstate; apply HtrX].
+  split; [| by apply Hstate; apply HtrX].
   induction HtrX using finite_valid_trace_rev_ind.
-  - constructor. by apply initial_state_is_valid, Hstate.
+  - by constructor; apply initial_state_is_valid, Hstate.
   - setoid_rewrite map_app. apply finite_valid_trace_from_app_iff.
     split; [done |].
     simpl. apply (finite_valid_trace_singleton (pre_loaded_with_all_messages_vlsm Y)).
@@ -730,7 +734,7 @@ Proof.
     rewrite (pre_VLSM_full_projection_finite_trace_last _ _ label_project state_project) in Hv, Ht.
     repeat split; [.. | done | done].
     + by apply finite_valid_trace_last_pstate in IHHtrX.
-    + apply any_message_is_valid_in_preloaded.
+    + by apply any_message_is_valid_in_preloaded.
 Qed.
 
 Lemma basic_VLSM_full_projection_preloaded_with
@@ -749,9 +753,9 @@ Proof.
   constructor.
   intros sX trX HtrX.
   apply valid_trace_add_default_last in HtrX.
-  split; [|apply Hstate; apply HtrX].
+  split; [| by apply Hstate; apply HtrX].
   induction HtrX using finite_valid_trace_init_to_rev_strong_ind.
-  - constructor. by apply initial_state_is_valid, Hstate.
+  - by constructor; apply initial_state_is_valid, Hstate.
   - setoid_rewrite map_app. apply finite_valid_trace_from_app_iff.
     split; [done |].
     simpl. apply (finite_valid_trace_singleton (pre_loaded_vlsm Y Q)).
@@ -763,7 +767,7 @@ Proof.
     simpl.
     repeat split; [.. | done | done].
     + by apply finite_valid_trace_last_pstate in IHHtrX1.
-    + destruct iom as [m|]; [|apply option_valid_message_None].
+    + destruct iom as [m |]; [| by apply option_valid_message_None].
       unfold empty_initial_message_or_final_output in Heqiom.
       destruct_list_last iom_tr iom_tr' iom_lst Heqiom_tr
       ; [apply option_initial_message_is_valid; destruct Heqiom as [Him | Hp]|].
@@ -771,5 +775,6 @@ Proof.
       * by right; auto.
       * apply
           (valid_trace_output_is_valid (pre_loaded_vlsm Y Q) _ _ IHHtrX2 m).
-        setoid_rewrite map_app. apply Exists_app. by right; left.
+        setoid_rewrite map_app.
+        by apply Exists_app; right; left.
 Qed.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -30,7 +30,7 @@ Lemma VLSM_eq_incl_l
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_eq X Y -> VLSM_incl X Y.
 Proof.
-  intros Heq t Hxt. by apply Heq.
+  by intros Heq t Hxt; apply Heq.
 Qed.
 
 Lemma VLSM_eq_incl_r
@@ -38,14 +38,14 @@ Lemma VLSM_eq_incl_r
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_eq X Y -> VLSM_incl Y X.
 Proof.
-  intros Heq t Hyt. by apply Heq.
+  by intros Heq t Hyt; apply Heq.
 Qed.
 
 Lemma VLSM_eq_incl_iff
   (MX MY : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_eq X Y <-> VLSM_incl X Y /\ VLSM_incl Y X.
-Proof. firstorder. Qed.
+Proof. by firstorder. Qed.
 
 End sec_VLSM_equality.
 
@@ -58,7 +58,7 @@ Lemma VLSM_eq_refl
   (X := mk_vlsm MX)
   : VLSM_eq X X.
 Proof.
-  firstorder.
+  by firstorder.
 Qed.
 
 Lemma VLSM_eq_sym
@@ -68,7 +68,7 @@ Lemma VLSM_eq_sym
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_eq X Y -> VLSM_eq Y X.
 Proof.
-  firstorder.
+  by firstorder.
 Qed.
 
 Lemma VLSM_eq_trans
@@ -78,7 +78,7 @@ Lemma VLSM_eq_trans
   (X := mk_vlsm MX) (Y := mk_vlsm MY) (Z := mk_vlsm MZ)
   : VLSM_eq X Y -> VLSM_eq Y Z -> VLSM_eq X Z.
 Proof.
-  firstorder.
+  by firstorder.
 Qed.
 
 Section sec_VLSM_eq_properties.
@@ -97,14 +97,12 @@ Context
 
 Lemma VLSM_eq_proj1 : VLSM_incl X Y.
 Proof.
-  apply VLSM_eq_incl_iff in Hincl.
-  apply Hincl.
+  by apply VLSM_eq_incl_iff in Hincl; apply Hincl.
 Qed.
 
 Lemma VLSM_eq_proj2 : VLSM_incl Y X.
 Proof.
-  apply VLSM_eq_incl_iff in Hincl.
-  apply Hincl.
+  by apply VLSM_eq_incl_iff in Hincl; apply Hincl.
 Qed.
 
 Lemma VLSM_eq_finite_valid_trace
@@ -113,8 +111,8 @@ Lemma VLSM_eq_finite_valid_trace
   : finite_valid_trace X s tr <-> finite_valid_trace Y s tr.
 Proof.
   split.
-  - apply (VLSM_incl_finite_valid_trace VLSM_eq_proj1).
-  - apply (VLSM_incl_finite_valid_trace VLSM_eq_proj2).
+  - by apply (VLSM_incl_finite_valid_trace VLSM_eq_proj1).
+  - by apply (VLSM_incl_finite_valid_trace VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_finite_valid_trace_init_to
@@ -124,8 +122,8 @@ Lemma VLSM_eq_finite_valid_trace_init_to
     finite_valid_trace_init_to Y s f tr.
 Proof.
   split.
-  - apply (VLSM_incl_finite_valid_trace_init_to VLSM_eq_proj1).
-  - apply (VLSM_incl_finite_valid_trace_init_to VLSM_eq_proj2).
+  - by apply (VLSM_incl_finite_valid_trace_init_to VLSM_eq_proj1).
+  - by apply (VLSM_incl_finite_valid_trace_init_to VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_valid_state
@@ -133,8 +131,8 @@ Lemma VLSM_eq_valid_state
   : valid_state_prop X s <-> valid_state_prop Y s.
 Proof.
   split.
-  - apply (VLSM_incl_valid_state VLSM_eq_proj1).
-  - apply (VLSM_incl_valid_state VLSM_eq_proj2).
+  - by apply (VLSM_incl_valid_state VLSM_eq_proj1).
+  - by apply (VLSM_incl_valid_state VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_initial_state
@@ -142,8 +140,8 @@ Lemma VLSM_eq_initial_state
   : vinitial_state_prop X is <-> vinitial_state_prop Y is.
 Proof.
   split.
-  - apply (VLSM_incl_initial_state VLSM_eq_proj1).
-  - apply (VLSM_incl_initial_state VLSM_eq_proj2).
+  - by apply (VLSM_incl_initial_state VLSM_eq_proj1).
+  - by apply (VLSM_incl_initial_state VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_finite_valid_trace_from
@@ -153,8 +151,8 @@ Lemma VLSM_eq_finite_valid_trace_from
     finite_valid_trace_from Y s tr.
 Proof.
   split.
-  - apply (VLSM_incl_finite_valid_trace_from VLSM_eq_proj1).
-  - apply (VLSM_incl_finite_valid_trace_from VLSM_eq_proj2).
+  - by apply (VLSM_incl_finite_valid_trace_from VLSM_eq_proj1).
+  - by apply (VLSM_incl_finite_valid_trace_from VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_finite_valid_trace_from_to
@@ -163,8 +161,8 @@ Lemma VLSM_eq_finite_valid_trace_from_to
   : finite_valid_trace_from_to X s f tr <-> finite_valid_trace_from_to Y s f tr.
 Proof.
   split.
-  - apply (VLSM_incl_finite_valid_trace_from_to VLSM_eq_proj1).
-  - apply (VLSM_incl_finite_valid_trace_from_to VLSM_eq_proj2).
+  - by apply (VLSM_incl_finite_valid_trace_from_to VLSM_eq_proj1).
+  - by apply (VLSM_incl_finite_valid_trace_from_to VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_in_futures
@@ -172,8 +170,8 @@ Lemma VLSM_eq_in_futures
   : in_futures X s1 s2 <-> in_futures Y s1 s2.
 Proof.
   split.
-  - apply (VLSM_incl_in_futures VLSM_eq_proj1).
-  - apply (VLSM_incl_in_futures VLSM_eq_proj2).
+  - by apply (VLSM_incl_in_futures VLSM_eq_proj1).
+  - by apply (VLSM_incl_in_futures VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_input_valid_transition
@@ -182,8 +180,8 @@ Lemma VLSM_eq_input_valid_transition
   input_valid_transition Y l (s,im) (s',om).
 Proof.
   split.
-  - apply (VLSM_incl_input_valid_transition VLSM_eq_proj1).
-  - apply (VLSM_incl_input_valid_transition VLSM_eq_proj2).
+  - by apply (VLSM_incl_input_valid_transition VLSM_eq_proj1).
+  - by apply (VLSM_incl_input_valid_transition VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_input_valid
@@ -191,8 +189,8 @@ Lemma VLSM_eq_input_valid
   input_valid X l (s,im) <-> input_valid Y l (s,im).
 Proof.
   split.
-  - apply (VLSM_incl_input_valid VLSM_eq_proj1).
-  - apply (VLSM_incl_input_valid VLSM_eq_proj2).
+  - by apply (VLSM_incl_input_valid VLSM_eq_proj1).
+  - by apply (VLSM_incl_input_valid VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_can_produce
@@ -201,8 +199,8 @@ Lemma VLSM_eq_can_produce
   : option_can_produce X s om <-> option_can_produce Y s om.
 Proof.
   split.
-  - apply (VLSM_incl_can_produce VLSM_eq_proj1).
-  - apply (VLSM_incl_can_produce VLSM_eq_proj2).
+  - by apply (VLSM_incl_can_produce VLSM_eq_proj1).
+  - by apply (VLSM_incl_can_produce VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_can_emit
@@ -210,8 +208,8 @@ Lemma VLSM_eq_can_emit
   : can_emit X m <-> can_emit Y m.
 Proof.
   split.
-  - apply (VLSM_incl_can_emit VLSM_eq_proj1).
-  - apply (VLSM_incl_can_emit VLSM_eq_proj2).
+  - by apply (VLSM_incl_can_emit VLSM_eq_proj1).
+  - by apply (VLSM_incl_can_emit VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_infinite_valid_trace_from
@@ -220,8 +218,8 @@ Lemma VLSM_eq_infinite_valid_trace_from
     infinite_valid_trace_from Y s ls.
 Proof.
   split.
-  - apply (VLSM_incl_infinite_valid_trace_from VLSM_eq_proj1).
-  - apply (VLSM_incl_infinite_valid_trace_from VLSM_eq_proj2).
+  - by apply (VLSM_incl_infinite_valid_trace_from VLSM_eq_proj1).
+  - by apply (VLSM_incl_infinite_valid_trace_from VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_infinite_valid_trace
@@ -229,16 +227,16 @@ Lemma VLSM_eq_infinite_valid_trace
   : infinite_valid_trace X s ls <-> infinite_valid_trace Y s ls.
 Proof.
   split.
-  - apply (VLSM_incl_infinite_valid_trace VLSM_eq_proj1).
-  - apply (VLSM_incl_infinite_valid_trace VLSM_eq_proj2).
+  - by apply (VLSM_incl_infinite_valid_trace VLSM_eq_proj1).
+  - by apply (VLSM_incl_infinite_valid_trace VLSM_eq_proj2).
 Qed.
 
 Lemma VLSM_eq_valid_trace
   : forall t, valid_trace_prop X t <-> valid_trace_prop Y t.
 Proof.
   split.
-  - apply (VLSM_incl_valid_trace VLSM_eq_proj1).
-  - apply (VLSM_incl_valid_trace VLSM_eq_proj2).
+  - by apply (VLSM_incl_valid_trace VLSM_eq_proj1).
+  - by apply (VLSM_incl_valid_trace VLSM_eq_proj2).
 Qed.
 
 End sec_VLSM_eq_properties.
@@ -258,8 +256,8 @@ Lemma pre_loaded_vlsm_with_valid_eq
   : VLSM_eq (pre_loaded_vlsm X (fun m => P m \/ Q m)) (pre_loaded_vlsm X P).
 Proof.
   apply VLSM_eq_incl_iff; split; cbn.
-  - apply pre_loaded_vlsm_incl_relaxed; itauto.
-  - apply pre_loaded_vlsm_incl; itauto.
+  - by apply pre_loaded_vlsm_incl_relaxed; itauto.
+  - by apply pre_loaded_vlsm_incl; itauto.
 Qed.
 
 Lemma pre_loaded_vlsm_idem
@@ -267,16 +265,16 @@ Lemma pre_loaded_vlsm_idem
   : VLSM_eq (pre_loaded_vlsm (pre_loaded_vlsm X P) P) (pre_loaded_vlsm X P).
 Proof.
   apply VLSM_eq_incl_iff; split; cbn.
-  - apply pre_loaded_vlsm_idem_l.
-  - apply pre_loaded_vlsm_idem_r.
+  - by apply pre_loaded_vlsm_idem_l.
+  - by apply pre_loaded_vlsm_idem_r.
 Qed.
 
 Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True
   : VLSM_eq (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun m => True)).
 Proof.
   apply VLSM_eq_incl_iff; split; cbn.
-  - apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_l.
-  - apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_r.
+  - by apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_l.
+  - by apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_r.
 Qed.
 
 Lemma pre_loaded_with_all_messages_eq_validating_pre_loaded_vlsm
@@ -300,8 +298,8 @@ Lemma vlsm_is_pre_loaded_with_False
   : VLSM_eq X (pre_loaded_vlsm X (fun m => False)).
 Proof.
   destruct X as (T, M). intro Hpp.
-  apply VLSM_eq_incl_iff. simpl.
-  split; apply basic_VLSM_strong_incl; cbv; itauto.
+  apply VLSM_eq_incl_iff.
+  by cbn; split; apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
 Lemma vlsm_is_pre_loaded_with_False_initial_message
@@ -320,8 +318,8 @@ Lemma pre_loaded_with_all_messages_vlsm_idem
   : VLSM_eq (pre_loaded_with_all_messages_vlsm (pre_loaded_with_all_messages_vlsm X)) (pre_loaded_with_all_messages_vlsm X).
 Proof.
   apply VLSM_eq_incl_iff; split; cbn.
-  - apply pre_loaded_with_all_messages_vlsm_idem_l.
-  - apply pre_loaded_with_all_messages_vlsm_idem_r.
+  - by apply pre_loaded_with_all_messages_vlsm_idem_l.
+  - by apply pre_loaded_with_all_messages_vlsm_idem_r.
 Qed.
 
 Lemma vlsm_is_pre_loaded_with_False_valid_state_message s om
@@ -330,7 +328,7 @@ Proof.
   pose proof vlsm_is_pre_loaded_with_False as Heq.
   apply VLSM_eq_incl_iff in Heq.
   destruct X as (T, M); simpl in *.
-  split; (apply VLSM_incl_valid_state_message; [|cbv;tauto]); apply Heq.
+  by split; (apply VLSM_incl_valid_state_message; [| cbv; tauto]); apply Heq.
 Qed.
 
 End sec_VLSM_incl_preloaded_properties.

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -29,7 +29,7 @@ Lemma VLSM_incl_refl
   (X := mk_vlsm MX)
   : VLSM_incl X X.
 Proof.
-  firstorder.
+  by firstorder.
 Qed.
 
 Lemma VLSM_incl_trans
@@ -37,7 +37,7 @@ Lemma VLSM_incl_trans
   (X := mk_vlsm MX) (Y := mk_vlsm MY) (Z := mk_vlsm MZ)
   : VLSM_incl X Y -> VLSM_incl Y Z -> VLSM_incl X Z.
 Proof.
-  firstorder.
+  by firstorder.
 Qed.
 
 Lemma VLSM_incl_finite_traces_characterization
@@ -49,14 +49,15 @@ Lemma VLSM_incl_finite_traces_characterization
     finite_valid_trace X s tr -> finite_valid_trace Y s tr.
 Proof.
   split; intros Hincl.
-  - intros. by apply (Hincl (Finite s tr)).
+  - by intros; apply (Hincl (Finite s tr)).
   - intros tr Htr.
     destruct tr as [is tr | is tr]; simpl in *.
-    + revert Htr. apply Hincl.
+    + by apply Hincl.
     + destruct Htr as [HtrX HisX].
       assert (His_tr: finite_valid_trace X is []).
-      { split; [| done]. constructor.
-        by apply initial_state_is_valid.
+      {
+        split; [| done].
+        by constructor; apply initial_state_is_valid.
       }
       apply Hincl in His_tr.
       destruct His_tr as [_ HisY].
@@ -64,7 +65,7 @@ Proof.
       apply infinite_valid_trace_from_prefix_rev.
       intros.
       pose proof (infinite_valid_trace_from_prefix _ _ _ HtrX n) as HfinX.
-      apply (Hincl _ _ (conj HfinX HisX)).
+      by apply Hincl.
 Qed.
 
 (**
@@ -77,16 +78,19 @@ Lemma VLSM_incl_full_projection_iff
   : VLSM_incl X Y <-> VLSM_full_projection X Y id id.
 Proof.
   assert (Hid : forall tr, tr = pre_VLSM_full_projection_finite_trace_project _ _ id id tr).
-  { induction tr; [done |]. destruct a. by cbn; f_equal. }
+  {
+    induction tr; [done |].
+    by destruct a; cbn; f_equal.
+  }
   split.
   - constructor; intros.
     apply (proj1 (VLSM_incl_finite_traces_characterization (machine X) (machine Y)) H) in H0.
     replace (pre_VLSM_full_projection_finite_trace_project _ _ _ _ trX) with trX; [done |].
-    apply Hid.
+    by apply Hid.
   - intro Hproject. apply VLSM_incl_finite_traces_characterization.
     intros. apply (VLSM_full_projection_finite_valid_trace Hproject) in H.
     replace (VLSM_full_projection_finite_trace_project Hproject _) with tr in H; [done |].
-    apply Hid.
+    by apply Hid.
 Qed.
 
 Definition VLSM_incl_is_full_projection
@@ -188,14 +192,14 @@ Lemma VLSM_incl_valid_state
   (Hs : valid_state_prop X s)
   : valid_state_prop Y s.
 Proof.
-  revert Hs. apply (VLSM_full_projection_valid_state (VLSM_incl_is_full_projection Hincl)).
+  by apply (VLSM_full_projection_valid_state (VLSM_incl_is_full_projection Hincl)).
 Qed.
 
 Lemma VLSM_incl_initial_state
   (is : vstate X)
   : vinitial_state_prop X is -> vinitial_state_prop Y is.
 Proof.
-  apply (VLSM_full_projection_initial_state (VLSM_incl_is_full_projection Hincl)).
+  by apply (VLSM_full_projection_initial_state (VLSM_incl_is_full_projection Hincl)).
 Qed.
 
 Lemma VLSM_incl_finite_valid_trace_from
@@ -224,7 +228,7 @@ Lemma VLSM_incl_in_futures
   (s1 s2 : vstate X)
   : in_futures X s1 s2 -> in_futures Y s1 s2.
 Proof.
-  apply (VLSM_full_projection_in_futures (VLSM_incl_is_full_projection Hincl)).
+  by apply (VLSM_full_projection_in_futures (VLSM_incl_is_full_projection Hincl)).
 Qed.
 
 Lemma VLSM_incl_input_valid_transition
@@ -232,8 +236,7 @@ Lemma VLSM_incl_input_valid_transition
   input_valid_transition X l (s,im) (s',om) ->
   input_valid_transition Y l (s,im) (s',om).
 Proof.
-  apply
-    (VLSM_full_projection_input_valid_transition (VLSM_incl_is_full_projection Hincl)).
+  by apply (VLSM_full_projection_input_valid_transition (VLSM_incl_is_full_projection Hincl)).
 Qed.
 
 Lemma VLSM_incl_input_valid
@@ -241,8 +244,7 @@ Lemma VLSM_incl_input_valid
   input_valid X l (s,im) ->
   input_valid Y l (s,im).
 Proof.
-  apply
-    (VLSM_full_projection_input_valid (VLSM_incl_is_full_projection Hincl)).
+  by apply (VLSM_full_projection_input_valid (VLSM_incl_is_full_projection Hincl)).
 Qed.
 
 (**
@@ -265,14 +267,14 @@ Lemma VLSM_incl_can_produce
   (om : option message)
   : option_can_produce X s om -> option_can_produce Y s om.
 Proof.
-  apply (VLSM_full_projection_can_produce (VLSM_incl_is_full_projection Hincl)).
+  by apply (VLSM_full_projection_can_produce (VLSM_incl_is_full_projection Hincl)).
 Qed.
 
 Lemma VLSM_incl_can_emit
   (m : message)
   : can_emit X m -> can_emit Y m.
 Proof.
-  apply (VLSM_full_projection_can_emit (VLSM_incl_is_full_projection Hincl)).
+  by apply (VLSM_full_projection_can_emit (VLSM_incl_is_full_projection Hincl)).
 Qed.
 
 Definition VLSM_incl_valid_message
@@ -304,16 +306,16 @@ Lemma VLSM_incl_infinite_valid_trace
   : infinite_valid_trace X s ls -> infinite_valid_trace Y s ls.
 Proof.
   intros [Htr His]. split.
-  - revert Htr. apply VLSM_incl_infinite_valid_trace_from.
-  - revert His. apply VLSM_incl_initial_state.
+  - by apply VLSM_incl_infinite_valid_trace_from.
+  - by apply VLSM_incl_initial_state.
 Qed.
 
 Lemma VLSM_incl_valid_trace
   : forall t, valid_trace_prop X t -> valid_trace_prop Y t.
 Proof.
   intros [s tr | s tr]; simpl.
-  - apply VLSM_incl_finite_valid_trace.
-  - apply VLSM_incl_infinite_valid_trace.
+  - by apply VLSM_incl_finite_valid_trace.
+  - by apply VLSM_incl_infinite_valid_trace.
 Qed.
 
 End sec_VLSM_incl_properties.
@@ -384,8 +386,9 @@ Lemma vlsm_incl_pre_loaded_with_all_messages_vlsm
   : VLSM_incl X (pre_loaded_with_all_messages_vlsm X).
 Proof.
   apply VLSM_incl_finite_traces_characterization.
-  intros. split; [|apply H].
-  apply preloaded_weaken_valid_trace_from. destruct X. apply H.
+  intros. split; [| by apply H].
+  apply preloaded_weaken_valid_trace_from.
+  by destruct X; apply H.
 Qed.
 
 Lemma pre_loaded_vlsm_incl_relaxed
@@ -393,8 +396,7 @@ Lemma pre_loaded_vlsm_incl_relaxed
   (PimpliesQorValid : forall m : message, P m -> Q m \/ valid_message_prop (pre_loaded_vlsm X Q) m)
   : VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_vlsm X Q).
 Proof.
-  apply basic_VLSM_incl.
-  1, 3-4: cbv; itauto.
+  apply basic_VLSM_incl; cycle 1; [| by cbv; itauto..].
   intros _ _ m _ _ [Him | Hp].
   - by apply initial_message_is_valid; left.
   - apply PimpliesQorValid in Hp as [Hq | Hvalid]; [| done].
@@ -406,40 +408,40 @@ Lemma pre_loaded_vlsm_incl
   (PimpliesQ : forall m : message, P m -> Q m)
   : VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_vlsm X Q).
 Proof.
-  apply pre_loaded_vlsm_incl_relaxed; itauto.
+  by apply pre_loaded_vlsm_incl_relaxed; itauto.
 Qed.
 
 Lemma pre_loaded_vlsm_idem_l
   (P : message -> Prop)
   : VLSM_incl (pre_loaded_vlsm (pre_loaded_vlsm X P) P) (pre_loaded_vlsm X P).
 Proof.
-  apply basic_VLSM_strong_incl; cbv; itauto.
+  by apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
 Lemma pre_loaded_vlsm_idem_r
   (P : message -> Prop)
   : VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_vlsm (pre_loaded_vlsm X P) P).
 Proof.
-  apply basic_VLSM_incl_preloaded_with; cbv; itauto.
+  by apply basic_VLSM_incl_preloaded_with; cbv; itauto.
 Qed.
 
 Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_l
   : VLSM_incl (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun m => True)).
 Proof.
-  apply basic_VLSM_strong_incl; cbv; itauto.
+  by apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
 Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_r
   : VLSM_incl (pre_loaded_vlsm X (fun m => True)) (pre_loaded_with_all_messages_vlsm X).
 Proof.
-  apply basic_VLSM_strong_incl; cbv; itauto.
+  by apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
 Lemma pre_loaded_vlsm_incl_pre_loaded_with_all_messages
   (P : message -> Prop)
   : VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_with_all_messages_vlsm X).
 Proof.
-  apply basic_VLSM_strong_incl; cbv; itauto.
+  by apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
 Lemma vlsm_incl_pre_loaded
@@ -447,19 +449,19 @@ Lemma vlsm_incl_pre_loaded
   : VLSM_incl X (pre_loaded_vlsm X P).
 Proof.
   eapply VLSM_incl_trans; [| by apply pre_loaded_vlsm_incl].
-  apply basic_VLSM_strong_incl; cbv; itauto.
+  by apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
 Lemma pre_loaded_with_all_messages_vlsm_idem_l
   : VLSM_incl (pre_loaded_with_all_messages_vlsm (pre_loaded_with_all_messages_vlsm X)) (pre_loaded_with_all_messages_vlsm X).
 Proof.
-  apply basic_VLSM_strong_incl; cbv; itauto.
+  by apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
 Lemma pre_loaded_with_all_messages_vlsm_idem_r
   : VLSM_incl (pre_loaded_with_all_messages_vlsm X) (pre_loaded_with_all_messages_vlsm (pre_loaded_with_all_messages_vlsm X)).
 Proof.
-  apply basic_VLSM_incl_preloaded; cbv; itauto.
+  by apply basic_VLSM_incl_preloaded; cbv; itauto.
 Qed.
 
 Lemma pre_loaded_with_all_messages_can_emit
@@ -476,9 +478,8 @@ Lemma preloaded_weaken_finite_valid_trace_from
   : finite_valid_trace_from X from tr ->
     finite_valid_trace_from (pre_loaded_with_all_messages_vlsm X) from tr.
 Proof.
-  intros; eapply VLSM_incl_finite_valid_trace_from;
-    [apply vlsm_incl_pre_loaded_with_all_messages_vlsm |].
-  by destruct X.
+  by intros; eapply VLSM_incl_finite_valid_trace_from;
+    [apply vlsm_incl_pre_loaded_with_all_messages_vlsm | destruct X].
 Qed.
 
 Lemma preloaded_weaken_finite_valid_trace_from_to
@@ -486,9 +487,8 @@ Lemma preloaded_weaken_finite_valid_trace_from_to
   : finite_valid_trace_from_to X from to tr ->
     finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm X) from to tr.
 Proof.
-  intros; eapply VLSM_incl_finite_valid_trace_from_to;
-    [apply vlsm_incl_pre_loaded_with_all_messages_vlsm |].
-  by destruct X.
+  by intros; eapply VLSM_incl_finite_valid_trace_from_to;
+    [apply vlsm_incl_pre_loaded_with_all_messages_vlsm | destruct X].
 Qed.
 
 End sec_VLSM_incl_preloaded_properties.

--- a/theories/VLSM/Core/VLSMProjections/VLSMPartialProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMPartialProjection.v
@@ -110,14 +110,12 @@ Proof.
   apply finite_valid_trace_init_to_forget_last, proj1 in HtrX.
   specialize (partial_trace_project_extends_left _ _ _ Hsimul _ _ _ _ Hpr _ _ HsX)
     as Hpr_extends_left.
-  spec Hpr_extends_left.
-  { by rewrite app_nil_r. }
+  spec Hpr_extends_left; [by rewrite app_nil_r |].
   destruct Hpr_extends_left as [isY [preY [Hpr_tr HsY]]].
   rewrite !app_nil_r in Hpr_tr.
   specialize (VLSM_weak_partial_projection_finite_valid_trace_from _ _ _ _ Hpr_tr HtrX)
     as Hinit_to.
-  apply finite_valid_trace_from_app_iff, proj1, finite_valid_trace_last_pstate in Hinit_to.
-  by subst sY.
+  by apply finite_valid_trace_from_app_iff, proj1, finite_valid_trace_last_pstate in Hinit_to; subst.
 Qed.
 
 Lemma VLSM_weak_partial_projection_input_valid_transition
@@ -184,9 +182,9 @@ Lemma VLSM_partial_projection_initial_state
     vinitial_state_prop X sX -> vinitial_state_prop Y sY.
 Proof.
   intros sX sY trY Hpr HsX.
-  assert (HtrX : finite_valid_trace X sX []).
-  { split; [| done]. constructor. by apply initial_state_is_valid. }
-  apply (VLSM_partial_projection_finite_valid_trace _ _ _ _ Hpr HtrX).
+  eapply VLSM_partial_projection_finite_valid_trace; [done |].
+  split; [| done].
+  by constructor; apply initial_state_is_valid.
 Qed.
 
 Definition VLSM_partial_projection_weaken : VLSM_weak_partial_projection X Y trace_project :=

--- a/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
@@ -69,7 +69,7 @@ Lemma pre_VLSM_projection_transition_item_project_is_Some_rev
 Proof.
   intros [itemY HitemY].
   unfold pre_VLSM_projection_transition_item_project in HitemY.
-  destruct (label_project (l item)) as [lY|] eqn:HlY; [|congruence].
+  destruct (label_project (l item)) as [lY |] eqn: HlY; [| by congruence].
   by exists lY.
 Qed.
 
@@ -80,7 +80,7 @@ Lemma pre_VLSM_projection_transition_item_project_infinitely_often
 Proof.
   apply InfinitelyOften_impl.
   intro item.
-  apply pre_VLSM_projection_transition_item_project_is_Some.
+  by apply pre_VLSM_projection_transition_item_project_is_Some.
 Qed.
 
 Lemma pre_VLSM_projection_transition_item_project_finitely_many
@@ -90,7 +90,7 @@ Lemma pre_VLSM_projection_transition_item_project_finitely_many
 Proof.
   apply FinitelyManyBound_impl_rev.
   intro item.
-  apply pre_VLSM_projection_transition_item_project_is_Some_rev.
+  by apply pre_VLSM_projection_transition_item_project_is_Some_rev.
 Qed.
 
 Definition pre_VLSM_projection_finite_trace_project
@@ -188,10 +188,9 @@ Lemma VLSM_partial_projection_type_from_projection
 Proof.
   split; intros; inversion H; subst; clear H.
   exists (state_project s'X), (trace_project preX).  split.
-  - simpl. f_equal. f_equal. apply pre_VLSM_projection_finite_trace_project_app.
+  - by cbn; rewrite pre_VLSM_projection_finite_trace_project_app.
   - symmetry. apply (final_state_project _ _ _ _ Hsimul).
-    apply (finite_valid_trace_from_app_iff  X) in H1.
-    apply H1.
+    by apply (finite_valid_trace_from_app_iff  X) in H1; apply H1.
 Qed.
 
 End sec_projection_type_properties.
@@ -227,7 +226,7 @@ Lemma strong_projection_transition_consistency_None_weaken
     weak_projection_transition_consistency_None.
 Proof.
   intros Hstrong lX Hl s om s' om' Ht.
-  apply (Hstrong lX Hl _ _ _ _ (proj2 Ht)).
+  by apply (Hstrong lX Hl _ _ _ _ (proj2 Ht)).
 Qed.
 
 End sec_projection_transition_consistency_None.
@@ -301,7 +300,7 @@ Lemma strong_projection_valid_preservation_weaken
     weak_projection_valid_preservation.
 Proof.
   intros Hstrong lX lY Hl s om Hpv Hs Hom.
-  apply (Hstrong lX lY Hl). apply Hpv.
+  by apply (Hstrong lX lY Hl), Hpv.
 Qed.
 
 Definition weak_projection_transition_preservation_Some : Prop :=
@@ -319,7 +318,7 @@ Lemma strong_projection_transition_preservation_Some_weaken
     weak_projection_transition_preservation_Some.
 Proof.
   intros Hstrong lX lY Hl s om s' om' Ht.
-  apply (Hstrong lX lY Hl). apply Ht.
+  by apply (Hstrong lX lY Hl), Ht.
 Qed.
 
 Definition weak_projection_valid_message_preservation : Prop :=
@@ -450,10 +449,9 @@ Lemma VLSM_weak_partial_projection_from_projection
   : VLSM_weak_partial_projection X Y (VLSM_partial_trace_project_from_projection label_project state_project).
 Proof.
   split.
-  - apply VLSM_partial_projection_type_from_projection. apply Hsimul.
-  - simpl. intros sX trX sY trY Heq.
-    inversion Heq.
-    apply VLSM_weak_projection_finite_valid_trace_from.
+  - by apply VLSM_partial_projection_type_from_projection, Hsimul.
+  - cbn; intros sX trX sY trY [= <- <-].
+    by apply VLSM_weak_projection_finite_valid_trace_from.
 Qed.
 
 Lemma VLSM_weak_projection_valid_state
@@ -500,7 +498,7 @@ Proof.
   apply valid_trace_get_last in HtrX as Hs'X.
   apply valid_trace_forget_last in HtrX. subst.
   rewrite (final_state_project _ _ _ _ Hsimul); [| done].
-  apply valid_trace_add_default_last. eauto.
+  by apply valid_trace_add_default_last; eauto.
 Qed.
 
 Lemma VLSM_weak_projection_in_futures
@@ -509,8 +507,7 @@ Lemma VLSM_weak_projection_in_futures
 Proof.
   intros s1 s2 [tr Htr].
   exists (VLSM_weak_projection_trace_project Hsimul tr).
-  revert Htr.
-  apply VLSM_weak_projection_finite_valid_trace_from_to.
+  by apply VLSM_weak_projection_finite_valid_trace_from_to.
 Qed.
 
 End sec_weak_projection_properties.
@@ -605,10 +602,9 @@ Lemma VLSM_partial_projection_from_projection
   : VLSM_partial_projection X Y (VLSM_partial_trace_project_from_projection label_project state_project).
 Proof.
   split.
-  - apply VLSM_partial_projection_type_from_projection. apply Hsimul.
-  - simpl. intros sX trX sY trY Heq.
-    inversion Heq.
-    apply VLSM_projection_finite_valid_trace.
+  - by apply VLSM_partial_projection_type_from_projection, Hsimul.
+  - cbn; intros sX trX sY trY [= <- <-].
+    by apply VLSM_projection_finite_valid_trace.
 Qed.
 
 Lemma VLSM_projection_finite_valid_trace_from
@@ -618,8 +614,7 @@ Lemma VLSM_projection_finite_valid_trace_from
 Proof.
   specialize VLSM_partial_projection_from_projection as Hpart_simul.
   specialize (VLSM_partial_projection_finite_valid_trace_from Hpart_simul) as Hivt.
-  intros sX trX.
-  by apply Hivt.
+  by intros sX trX; apply Hivt.
 Qed.
 
 Definition VLSM_projection_weaken : VLSM_weak_projection X Y label_project state_project :=
@@ -681,8 +676,8 @@ Lemma VLSM_projection_finite_valid_trace_init_to
         (VLSM_projection_finite_trace_project Hsimul trX).
 Proof.
   intros. destruct H as [H Hinit]. split.
-  - revert H. apply VLSM_projection_finite_valid_trace_from_to.
-  - revert Hinit. apply VLSM_projection_initial_state.
+  - by apply VLSM_projection_finite_valid_trace_from_to.
+  - by apply VLSM_projection_initial_state.
 Qed.
 
 Lemma VLSM_projection_infinite_valid_trace
@@ -770,7 +765,7 @@ Lemma projection_friendly_trace_char
       /\ state_project sX = sY
       /\ VLSM_projection_finite_trace_project Hsimul trX = trY.
 Proof.
-  split; [apply Hfriendly|].
+  split; [by apply Hfriendly |].
   intros [sX [trX [HtrX [<- <-]]]].
   by apply VLSM_projection_finite_valid_trace.
 Qed.
@@ -866,7 +861,7 @@ Proof.
   - apply finite_valid_trace_from_to_singleton.
     assert (Hiom : option_valid_message_prop Y iom).
     {
-      destruct iom as [im|]; [|apply option_valid_message_None].
+      destruct iom as [im |]; [| by apply option_valid_message_None].
       by apply (Hmessage _ _ Hl _ _ (proj1 Ht)).
     }
     specialize (Hvalid _ _ Hl _ _ (proj1 Ht) IHHtr1 Hiom).
@@ -910,10 +905,10 @@ Lemma basic_VLSM_weak_projection_strengthen
   (Hstate : strong_projection_initial_state_preservation X Y state_project)
   : VLSM_projection X Y label_project state_project.
 Proof.
-  constructor; [apply Hweak|]. intros sX trX [HtrX HsX].
-  split.
-  - revert HtrX. apply (VLSM_weak_projection_finite_valid_trace_from Hweak).
-  - revert HsX. apply Hstate.
+  constructor; [by apply Hweak|].
+  intros sX trX [HtrX HsX]; split.
+  - by apply (VLSM_weak_projection_finite_valid_trace_from Hweak).
+  - by apply Hstate.
 Qed.
 
 Lemma basic_VLSM_projection
@@ -985,9 +980,9 @@ Proof.
   specialize (basic_VLSM_projection_type_preloaded X Y label_project state_project Htransition_None) as Htype.
   constructor; [done |].
   intros sX trX HtrX.
-  split; [|apply Hstate; apply HtrX].
+  split; [| by apply Hstate; apply HtrX].
   induction HtrX using finite_valid_trace_rev_ind.
-  - constructor. by apply initial_state_is_valid, Hstate.
+  - by constructor; apply initial_state_is_valid, Hstate.
   - rewrite (@pre_VLSM_projection_finite_trace_project_app _ (type (pre_loaded_with_all_messages_vlsm X)) (type Y) label_project state_project).
     apply (finite_valid_trace_from_app_iff (pre_loaded_with_all_messages_vlsm Y)).
     split; [done |].
@@ -999,8 +994,9 @@ Proof.
     destruct (label_project l) as [lY|] eqn:Hl.
     + apply (finite_valid_trace_singleton (pre_loaded_with_all_messages_vlsm Y)).
       assert (Hiom : option_valid_message_prop (pre_loaded_with_all_messages_vlsm Y) iom).
-      { destruct iom as [im|]; [|apply option_valid_message_None].
-        apply (any_message_is_valid_in_preloaded Y).
+      {
+        destruct iom as [im|]; [| by apply option_valid_message_None].
+        by apply (any_message_is_valid_in_preloaded Y).
       }
       apply (Hvalid _ _ Hl) in Hv.
       by apply (Htransition_Some _ _ Hl) in Ht.
@@ -1047,9 +1043,9 @@ Proof.
   specialize (basic_VLSM_projection_type_preloaded_with X Y P Q label_project state_project Htransition_None) as Htype.
   constructor; [done |].
   intros sX trX HtrX.
-  split; [|apply Hstate; apply HtrX].
+  split; [| by apply Hstate; apply HtrX].
   induction HtrX using finite_valid_trace_rev_ind.
-  - constructor. by apply initial_state_is_valid, Hstate.
+  - by constructor; apply initial_state_is_valid, Hstate.
   - rewrite (@pre_VLSM_projection_finite_trace_project_app _ (type (pre_loaded_vlsm X P)) (type Y) label_project state_project).
     apply (finite_valid_trace_from_app_iff (pre_loaded_vlsm Y Q)).
     split; [done |].
@@ -1062,7 +1058,7 @@ Proof.
     destruct (label_project l) as [lY|] eqn:Hl.
     + apply (finite_valid_trace_singleton (pre_loaded_vlsm Y Q)).
       assert (Hiom : option_valid_message_prop (pre_loaded_vlsm Y Q) iom).
-      { destruct iom as [im|]; [|apply option_valid_message_None].
+      { destruct iom as [im|]; [| by apply option_valid_message_None].
         by apply (Hmessage _ _ Hl) in Hpv.
       }
       apply (Hvalid _ _ Hl) in Hv.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -273,7 +273,7 @@ Definition induced_validator_transition_consistency_Some : Prop :=
     weak_projection_transition_consistency_Some.
 Proof.
   intros Hlbl Hst Htrans lX lY HlX_pr sX1 iom sX1' oom1 [_ Ht1] sX2' oom2 Ht2.
-  eapply Htrans; [done | auto | symmetry; eauto | done | done].
+  by eapply Htrans; [| auto | symmetry; auto | |].
 Qed.
 
 Context
@@ -433,7 +433,7 @@ Proof.
   induction Htr using finite_valid_trace_rev_ind
   ; [by apply (finite_valid_trace_from_empty XY2), initial_state_is_valid, His |].
   apply (finite_valid_trace_from_app_iff XY2).
-  split; [apply IHHtr |].
+  split; [by apply IHHtr |].
   apply (finite_valid_trace_singleton XY2).
   destruct Hx as [(_ & _ & lX & sX & [HlX_pr HsX_pr HpvX1]) Ht].
   cbn in Ht; destruct (vtransition _ _ _) as [_s'X _oom] eqn: H_tX1.
@@ -450,7 +450,7 @@ Proof.
   - cbn in *; rewrite <- HsX_pr.
     destruct (vtransition X2 _ _) as [_s'X2 _oom] eqn: H_tX2.
     apply (Htransition_Some2 _ _ HlX_pr _ _ _ _ HivtX1) in H_tX2 as [? ->].
-    congruence.
+    by congruence.
 Qed.
 
 (**
@@ -568,15 +568,14 @@ Proof.
   intros Hvalidator sY Hs.
   induction Hs using valid_state_prop_ind.
   - apply initial_state_is_valid.
-    exists (state_lift s). auto.
+    by exists (state_lift s); auto.
   - destruct Ht as [[_ [_ Hvalid]] Htrans].
     specialize (Hvalidator _ _ _ Hvalid IHHs)
       as (lX & sX & [HlX HsX HvX]).
     replace s' with (state_project (vtransition X lX (sX, om)).1).
     + eapply input_valid_transition_destination,
-        (VLSM_projection_input_valid_transition Hproji)
-      ; [|split]; [done | done |].
-      by apply injective_projections.
+        (VLSM_projection_input_valid_transition Hproji); [done |].
+      by split; [| apply injective_projections].
     + assert (HivtX : input_valid_transition X lX (sX, om) (vtransition X lX (sX, om)))
         by firstorder.
       destruct (vtransition _ _ _) as (sX', _om').
@@ -591,8 +590,8 @@ Lemma projection_validator_prop_alt_iff
   : projection_validator_prop_alt <-> projection_validator_prop Y label_project state_project.
 Proof.
   split; intros Hvalidator l si om Hvalid.
-  - apply Hvalidator; [apply Hvalid |].
-    apply validator_alt_free_states_are_projection_states; [done.. | apply Hvalid].
+  - apply Hvalidator; [by apply Hvalid |].
+    by apply validator_alt_free_states_are_projection_states; [.. | apply Hvalid].
   - intro HXisi; cbn.
     apply Hvalidator.
     repeat split; [| apply any_message_is_valid_in_preloaded | done].
@@ -628,19 +627,19 @@ Proof.
   intros sY trY HtrY.
   split; cycle 1.
   - exists (state_lift sY).
-    split; [apply Hstate_lift|].
-    apply Hinitial_lift, HtrY.
+    split; [by apply Hstate_lift |].
+    by apply Hinitial_lift, HtrY.
   - induction HtrY using finite_valid_trace_rev_ind.
     + apply (finite_valid_trace_from_empty Xi), initial_state_is_valid.
-      exists (state_lift si).
-      auto.
-    + apply (extend_right_finite_trace_from Xi); [done | split].
+      by exists (state_lift si); auto.
+    + apply (extend_right_finite_trace_from Xi); [done |].
+      split.
       * apply induced_validator_valid_is_input_valid; cbn; [done |].
-        apply Hvalidator, Hx.
+        by apply Hvalidator, Hx.
       * replace (sf, _) with (vtransition Y l (finite_trace_last si tr, iom))
           by apply Hx.
         apply projection_induced_valid_transition_eq; cbn.
-        apply Hvalidator, Hx.
+        by apply Hvalidator, Hx.
 Qed.
 
 (**
@@ -654,8 +653,8 @@ Lemma pre_loaded_with_all_messages_validator_proj_eq
   : VLSM_eq PreY Xi.
 Proof.
   apply VLSM_eq_incl_iff; split.
-  - apply pre_loaded_with_all_messages_validator_proj_incl.
-  - apply induced_validator_incl_preloaded_with_all_messages.
+  - by apply pre_loaded_with_all_messages_validator_proj_incl.
+  - by apply induced_validator_incl_preloaded_with_all_messages.
 Qed.
 
 End sec_pre_loaded_with_all_messages_validator_proj.
@@ -754,10 +753,10 @@ Lemma composite_projection_induced_validator_is_projection :
     composite_project_label (fun s => s i).
 Proof.
   apply projection_induced_validator_is_projection.
-  - apply component_label_projection_lift.
-  - apply component_state_projection_lift.
-  - apply component_transition_projection_Some.
-  - apply component_transition_projection_None.
+  - by apply component_label_projection_lift.
+  - by apply component_state_projection_lift.
+  - by apply component_transition_projection_Some.
+  - by apply component_transition_projection_None.
 Qed.
 
 End sec_component_projection_validator.
@@ -842,7 +841,7 @@ Proof.
     exists (lift_to_composite_state' IM i s).
     split; [by state_update_simpl |].
     by apply (composite_initial_state_prop_lift IM).
-  - by intros m [Him | Hpm]; right; [apply Hinits |].
+  - by intros m [Him | Hpm]; right; [by apply Hinits |].
   - intros l s iom [sX [<- Hv]].
     exists (existT i l), sX.
     by split; [apply composite_project_label_eq |..].
@@ -871,10 +870,10 @@ Lemma pre_composite_vlsm_induced_projection_validator_iff
       (pre_composite_vlsm_induced_validator IM constraint i).
 Proof.
   eapply VLSM_eq_trans;
-    [apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True |].
+    [by apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True |].
   eapply VLSM_eq_trans;
     [by apply preloaded_composite_vlsm_induced_projection_validator_iff |].
-  apply VLSM_eq_sym,
+  by apply VLSM_eq_sym,
     (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True
       (composite_vlsm_induced_validator IM constraint i)).
 Qed.
@@ -884,8 +883,8 @@ Lemma component_projection :
     (composite_project_label IM i) (fun s => s i).
 Proof.
   eapply VLSM_projection_eq_trans.
-  - apply composite_projection_induced_validator_is_projection.
-  - apply VLSM_eq_sym, pre_composite_vlsm_induced_projection_validator_iff.
+  - by apply composite_projection_induced_validator_is_projection.
+  - by apply VLSM_eq_sym, pre_composite_vlsm_induced_projection_validator_iff.
 Qed.
 
 Lemma composite_vlsm_induced_projection_validator_iff
@@ -895,10 +894,10 @@ Lemma composite_vlsm_induced_projection_validator_iff
       (composite_vlsm_induced_validator IM constraint i).
 Proof.
   eapply VLSM_eq_trans;
-    [apply (vlsm_is_pre_loaded_with_False composite_vlsm_induced_projection_validator)|].
+    [by apply (vlsm_is_pre_loaded_with_False composite_vlsm_induced_projection_validator) |].
   eapply VLSM_eq_trans;
     [by apply preloaded_composite_vlsm_induced_projection_validator_iff |].
-  apply VLSM_eq_sym,
+  by apply VLSM_eq_sym,
     (vlsm_is_pre_loaded_with_False
       (composite_vlsm_induced_validator IM constraint i)).
 Qed.
@@ -981,7 +980,7 @@ Proof.
     apply first_transition_valid in Hx as [Hvx Htx].
     split; [| done].
     (* using the [self_validator_vlsm_prop]erty. *)
-    revert Hvx; apply Hvalidator.
+    by eapply Hvalidator.
 Qed.
 
 (** We conclude that <<X>> and <<PreX>> are trace-equal. *)
@@ -990,10 +989,10 @@ Lemma pre_loaded_with_all_messages_self_validator_vlsm_eq
   : VLSM_eq PreX X.
 Proof.
   split.
-  - apply pre_loaded_with_all_messages_self_validator_vlsm_incl.
+  - by apply pre_loaded_with_all_messages_self_validator_vlsm_incl.
   - pose (vlsm_incl_pre_loaded_with_all_messages_vlsm X) as Hincl.
     destruct X as (T, M).
-    apply Hincl.
+    by apply Hincl.
 Qed.
 
 End sec_self_validator_vlsm.

--- a/theories/VLSM/Lib/FinExtras.v
+++ b/theories/VLSM/Lib/FinExtras.v
@@ -15,7 +15,7 @@ Lemma up_to_n_listing_length
   (n : nat)
   : length (up_to_n_listing n) = n.
 Proof.
-  induction n; simpl; congruence.
+  by induction n; simpl; congruence.
 Qed.
 
 Lemma up_to_n_full

--- a/theories/VLSM/Lib/FinFunExtras.v
+++ b/theories/VLSM/Lib/FinFunExtras.v
@@ -7,8 +7,8 @@ From VLSM.Lib Require Import Preamble ListExtras StdppExtras.
 Lemma listing_from_finite (A : Type) `{finite.Finite A} : Listing (enum A).
 Proof.
   constructor.
-  - apply NoDup_ListNoDup, NoDup_enum.
-  - intro a. apply elem_of_list_In, elem_of_enum.
+  - by apply NoDup_ListNoDup, NoDup_enum.
+  - by intro a; apply elem_of_list_In, elem_of_enum.
 Qed.
 
 Lemma map_option_listing
@@ -37,7 +37,7 @@ Proof.
     apply in_map_option.
     exists (g b).
     split; [done |].
-    apply f_surj.
+    by apply f_surj.
 Qed.
 
 Section sec_sum_listing.

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -17,7 +17,7 @@ Lemma union_size_ge_size1
 Proof.
   apply subseteq_size.
   apply subseteq_union.
-  set_solver.
+  by set_solver.
 Qed.
 
 Lemma union_size_ge_size2
@@ -26,7 +26,7 @@ Lemma union_size_ge_size2
 Proof.
   apply subseteq_size.
   apply subseteq_union.
-  set_solver.
+  by set_solver.
 Qed.
 
 Lemma union_size_ge_average
@@ -35,7 +35,7 @@ Lemma union_size_ge_average
 Proof.
   specialize (union_size_ge_size1 X Y) as Hx.
   specialize (union_size_ge_size2 X Y) as Hy.
-  lia.
+  by lia.
 Qed.
 
 Lemma difference_size_le_self
@@ -45,7 +45,8 @@ Proof.
   apply subseteq_size.
   apply elem_of_subseteq.
   intros x Hx.
-  apply elem_of_difference in Hx. itauto.
+  apply elem_of_difference in Hx.
+  by itauto.
 Qed.
 
 Lemma union_size_le_sum
@@ -55,7 +56,7 @@ Proof.
   specialize (size_union_alt X Y) as Halt.
   rewrite Halt.
   specialize (difference_size_le_self Y X).
-  lia.
+  by lia.
 Qed.
 
 Lemma intersection_size1
@@ -63,7 +64,7 @@ Lemma intersection_size1
   size (X ∩ Y) <= size X.
 Proof.
   apply (subseteq_size (X ∩ Y) X).
-  set_solver.
+  by set_solver.
 Qed.
 
 Lemma intersection_size2
@@ -71,7 +72,7 @@ Lemma intersection_size2
   size (X ∩ Y) <= size Y.
 Proof.
   apply (subseteq_size (X ∩ Y) Y).
-  set_solver.
+  by set_solver.
 Qed.
 
 Lemma difference_size_subset
@@ -79,35 +80,38 @@ Lemma difference_size_subset
   (Hsub : Y ⊆ X) :
   (Z.of_nat (size (X ∖ Y)) = Z.of_nat (size X) - Z.of_nat (size Y))%Z.
 Proof.
-  assert (Htemp : Y ∪ (X ∖ Y) ≡ X). {
+  assert (Htemp : Y ∪ (X ∖ Y) ≡ X).
+  {
     apply set_equiv_equivalence.
     intros a.
     split; intros Ha.
-    - set_solver.
+    - by set_solver.
     - destruct (@decide (a ∈ Y)).
       apply elem_of_dec_slow.
-      + apply elem_of_union. left. itauto.
-      + apply elem_of_union. right. set_solver.
+      + by apply elem_of_union; left; itauto.
+      + by apply elem_of_union; right; set_solver.
   }
-  assert (Htemp2 : size Y + size (X ∖ Y) = size X). {
+  assert (Htemp2 : size Y + size (X ∖ Y) = size X).
+  {
     specialize (size_union Y (X ∖ Y)) as Hun.
-    spec Hun. {
+    spec Hun.
+    {
       apply elem_of_disjoint.
       intros a Ha Ha2.
       apply elem_of_difference in Ha2.
-      itauto.
+      by itauto.
     }
     rewrite Htemp in Hun.
-    itauto.
+    by itauto.
   }
-  lia.
+  by lia.
 Qed.
 
 Lemma difference_with_intersection
   (X Y : C) :
   X ∖ Y ≡ X ∖ (X ∩ Y).
 Proof.
-  set_solver.
+  by set_solver.
 Qed.
 
 Lemma difference_size
@@ -116,7 +120,7 @@ Lemma difference_size
 Proof.
   rewrite difference_with_intersection.
   specialize (difference_size_subset X (X ∩ Y)) as Hdif.
-  set_solver.
+  by set_solver.
 Qed.
 
 Lemma difference_size_ge_disjoint_case
@@ -125,20 +129,17 @@ Lemma difference_size_ge_disjoint_case
 Proof.
   specialize (difference_size X Y).
   specialize (intersection_size2 X Y).
-  lia.
+  by lia.
 Qed.
 
 Lemma list_to_set_size
   (l : list A) :
   size (list_to_set l (C := C)) <= length l.
 Proof.
-  induction l.
-  - simpl.
-    rewrite size_empty. lia.
-  - simpl.
-    specialize (union_size_le_sum ({[a]}) (list_to_set l)) as Hun_size.
-    rewrite size_singleton in Hun_size.
-    lia.
+  induction l; cbn.
+  - by rewrite size_empty; lia.
+  - specialize (union_size_le_sum ({[a]}) (list_to_set l)) as Hun_size.
+    by rewrite size_singleton in Hun_size; lia.
 Qed.
 
 End sec_general.
@@ -158,7 +159,7 @@ Proof.
   intros a HaX.
   apply elem_of_filter in HaX.
   apply elem_of_filter.
-  set_solver.
+  by set_solver.
 Qed.
 
 Lemma filter_subprop
@@ -168,7 +169,7 @@ Proof.
   intros a HaP.
   apply elem_of_filter in HaP.
   apply elem_of_filter.
-  itauto.
+  by itauto.
 Qed.
 
 End sec_filter.
@@ -190,7 +191,7 @@ Proof.
   intros a Ha.
   apply elem_of_map in Ha.
   apply elem_of_map.
-  firstorder.
+  by firstorder.
 Qed.
 
 Lemma set_map_size_upper_bound

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -10,8 +10,8 @@ Lemma empty_nil [X:Type] (l:list X) :
   (forall v, ~In v l) -> l = [].
 Proof.
   clear.
-  destruct l as [| a]; [done |].
-  simpl. intro H. elim (H a). by left.
+  destruct l as [| a]; cbn; [done |].
+  by intro H; elim (H a); left.
 Qed.
 
 (** It is decidable whether a list is null or not. *)
@@ -66,8 +66,8 @@ Lemma remove_hd_last {X} :
   forall (hd1 hd2 d1 d2 : X) (tl : list X),
     List.last (hd1 :: hd2 :: tl) d1 = List.last (hd2 :: tl) d2.
 Proof.
-  intros. induction tl; [done |].
-  cbn in *. by destruct tl.
+  induction tl; cbn; [done |].
+  by destruct tl.
 Qed.
 
 Lemma unroll_last {S} : forall (random a : S) (l : list S),
@@ -86,7 +86,7 @@ Lemma last_app
 Proof.
   generalize dependent def.
   induction l1; [done |].
-  intro def. by rewrite <- !app_comm_cons, !unroll_last.
+  by intro def; rewrite <- !app_comm_cons, !unroll_last.
 Qed.
 
 Lemma last_map
@@ -123,10 +123,10 @@ Lemma incl_singleton {A} : forall (l : list A) (a : A),
   forall b, In b l -> b = a.
 Proof.
   intros. induction l; inversion H0; subst.
-  - destruct (H b); [by left | done | inversion H1].
+  - by destruct (H b); [left | done | inversion H1].
   - apply IHl; [| done].
     apply incl_tran with (a0 :: l); [| done].
-    apply incl_tl. apply incl_refl.
+    by apply incl_tl, incl_refl.
 Qed.
 
 Lemma Exists_first
@@ -143,25 +143,25 @@ Lemma Exists_first
          ~Exists P prefix.
 
 Proof.
-  induction l;[solve[inversion Hsomething]|].
+  induction l; [by inversion Hsomething |].
   destruct (decide (P a)).
   - exists nil, l, a.
     rewrite Exists_nil.
-    itauto.
+    by itauto.
   - apply Exists_cons in Hsomething.
-    destruct Hsomething;[exfalso;tauto|].
+    destruct Hsomething; [by itauto |].
     specialize (IHl H);clear H.
     destruct IHl as [prefix [suffix [first [Hf [-> Hnone_before]]]]].
     exists (a :: prefix), suffix, first.
     rewrite Exists_cons.
-    itauto.
+    by itauto.
 Qed.
 
 Lemma in_not_in : forall A (x y : A) (l:list A),
   x ∈ l ->
   ~ y ∈ l ->
   x <> y.
-Proof. itauto congruence. Qed.
+Proof. by itauto congruence. Qed.
 
 Definition inb {A} (Aeq_dec : forall x y:A, {x = y} + {x <> y}) (x : A) (xs : list A) :=
   if in_dec Aeq_dec x xs then true else false.
@@ -172,7 +172,7 @@ Lemma in_correct `{EqDecision X} :
 Proof.
   intros s msg.
   unfold inb.
-  destruct (in_dec _ _ _); itauto congruence.
+  by destruct (in_dec _ _ _); itauto congruence.
 Qed.
 
 Lemma in_correct_refl `{EqDecision X} :
@@ -212,7 +212,7 @@ Lemma map_incl {A B} (f : B -> A) : forall s s',
 Proof.
   intros s s' Hincl fx Hin.
   apply in_map_iff .
-  apply in_map_iff in Hin as (x & Heq & Hin). eauto.
+  by apply in_map_iff in Hin as (x & Heq & Hin); eauto.
 Qed.
 
 Definition app_cons {A}
@@ -225,16 +225,15 @@ Lemma append_nodup_left {A}:
   forall (l1 l2 : list A), List.NoDup (l1 ++ l2) -> List.NoDup l1.
 Proof.
   induction l1; intros.
-  - constructor.
+  - by constructor.
   - inversion H. apply IHl1 in H3. constructor; [| done].
-    rewrite in_app_iff in H2. itauto.
+    by rewrite in_app_iff in H2; itauto.
 Qed.
 
 Lemma append_nodup_right {A}:
   forall (l1 l2 : list A), List.NoDup (l1 ++ l2) -> List.NoDup l2.
 Proof.
-  induction l1; cbn; intros; [done |].
-  inversion H. auto.
+  by induction l1; cbn; intros; [| inversion H; auto].
 Qed.
 
 Lemma last_is_last {A} : forall (l : list A) (x dummy: A),
@@ -274,9 +273,9 @@ Lemma is_member_correct {W} `{StrictlyComparable W}
 Proof.
   intros l w.
   induction l as [| hd tl IHl]; cbn.
-  - itauto congruence.
+  - by itauto congruence.
   - rewrite compare_asymmetric, <- compare_eq.
-    destruct (compare hd w) eqn: Hcmp; cbn; itauto congruence.
+    by destruct (compare hd w) eqn: Hcmp; cbn; itauto congruence.
 Qed.
 
 Lemma is_member_correct' {W} `{StrictlyComparable W}
@@ -284,16 +283,14 @@ Lemma is_member_correct' {W} `{StrictlyComparable W}
 Proof.
   intros.
   rewrite <- is_member_correct.
-  split; [congruence |].
-  apply not_true_is_false.
+  split; [by congruence |].
+  by apply not_true_is_false.
 Qed.
 
 Lemma In_app_comm {X} : forall l1 l2 (x : X), In x (l1 ++ l2) <-> In x (l2 ++ l1).
 Proof.
-  intros l1 l2 x; split; intro H_in;
-  apply in_or_app; apply in_app_or in H_in;
-    destruct H_in as [cat | dog];
-    itauto.
+  by intros l1 l2 x; split; intro H_in;
+    apply in_or_app; apply in_app_or in H_in as [cat | dog]; itauto.
 Qed.
 
 Lemma nth_error_last
@@ -308,7 +305,7 @@ Proof.
   generalize dependent l.
   induction n; intros.
   - destruct l; inversion Hlast. symmetry in H0.
-    apply length_zero_iff_nil in H0. by subst.
+    by apply length_zero_iff_nil in H0; subst.
   - destruct l; inversion Hlast.
     specialize (IHn l H0 _last). rewrite unroll_last.
     simpl. rewrite IHn. f_equal.
@@ -335,7 +332,7 @@ Lemma list_suffix_map
   (n : nat)
   : List.map f (list_suffix l n) = list_suffix (List.map f l) n.
 Proof.
-  revert l. induction n; intros [| a l]. 1-3: done. apply IHn.
+  by revert l; induction n; intros [| a l]; [.. | apply IHn].
 Qed.
 
 Fixpoint list_prefix
@@ -389,7 +386,7 @@ Lemma list_prefix_map
   (n : nat)
   : List.map f (list_prefix l n) = list_prefix (List.map f l) n.
 Proof.
-  revert l. induction n; intros [| a l]. 1-3: done. by cbn; rewrite IHn.
+  by revert l; induction n; intros [| a l]; cbn; [.. | rewrite IHn].
 Qed.
 
 Lemma list_prefix_length
@@ -399,9 +396,8 @@ Lemma list_prefix_length
   (Hlen : n <= length l)
   : length (list_prefix l n) = n.
 Proof.
-  revert l Hlen.
-  induction n; intros [|a l] Hlen; cbn in *
-  ; [done | done | inversion Hlen | rewrite IHn; lia].
+  by revert l Hlen; induction n; intros [|a l] Hlen; cbn in *;
+    [| | inversion Hlen | rewrite IHn; lia].
 Qed.
 
 Lemma list_suffix_length
@@ -410,7 +406,7 @@ Lemma list_suffix_length
   (n : nat)
   : length (list_suffix l n) = length l - n.
 Proof.
-  revert l. induction n; intros [|a l]. 1-3: done. apply IHn.
+  by revert l; induction n; intros [|a l]; [.. | apply IHn].
 Qed.
 
 Lemma list_prefix_prefix
@@ -421,9 +417,8 @@ Lemma list_prefix_prefix
   : list_prefix (list_prefix l n2) n1 = list_prefix l n1.
 Proof.
   generalize dependent n1. generalize dependent n2.
-  induction l; intros [| n2] [| n1] Hn; try done.
-  - inversion Hn.
-  - simpl. f_equal. apply IHl. lia.
+  induction l; intros [| n2] [| n1] Hn; [done .. | by inversion Hn | done |].
+  by simpl; f_equal; apply IHl; lia.
 Qed.
 
 Lemma list_prefix_suffix
@@ -432,8 +427,7 @@ Lemma list_prefix_suffix
   (n : nat)
   : list_prefix l n ++ list_suffix l n = l.
 Proof.
-  revert n. induction l; intros [|n]. 1-3: done.
-  cbn. f_equal. apply IHl.
+  by revert n; induction l; intros [| n]; cbn; [.. | rewrite IHl].
 Qed.
 
 Definition list_segment
@@ -490,9 +484,8 @@ Fixpoint list_annotate
   : list (dsig P).
 Proof.
   destruct l as [| a l].
-  - exact [].
-  -
-  exact ((dexist a (Forall_hd Hs)) :: list_annotate A P Pdec l (Forall_tl Hs)).
+  - by exact [].
+  - by exact ((dexist a (Forall_hd Hs)) :: list_annotate A P Pdec l (Forall_tl Hs)).
 Defined.
 
 Lemma list_annotate_length
@@ -503,8 +496,7 @@ Lemma list_annotate_length
   (Hs : Forall P l)
   : length (list_annotate P l Hs) = length l.
 Proof.
-  induction l; [done |].
-  by cbn; rewrite IHl.
+  by induction l; cbn; [| rewrite IHl].
 Qed.
 
 Lemma list_annotate_pi
@@ -519,8 +511,7 @@ Proof.
   revert Hs Hs'.
   induction l; [done |].
   intros; simpl.
-  f_equal; [|apply IHl].
-  by apply dsig_eq.
+  by f_equal; [apply dsig_eq | apply IHl].
 Qed.
 
 Lemma list_annotate_eq
@@ -535,8 +526,7 @@ Lemma list_annotate_eq
 Proof.
   split; [|intro; subst; apply list_annotate_pi].
   revert Hl1 l2 Hl2.
-  induction l1; destruct l2; simpl; intros.
-  1-3: done.
+  induction l1; destruct l2; simpl; intros; [done.. |].
   inversion H.
   apply IHl1 in H2.
   by subst.
@@ -560,10 +550,9 @@ Lemma list_annotate_app
   (Hs : Forall P (l1 ++ l2))
   : list_annotate P (l1 ++ l2) Hs = list_annotate P l1 (proj1 (proj1 (@Forall_app _ P l1 l2) Hs)) ++ list_annotate P l2 (proj2 (proj1 (@Forall_app _ P l1 l2) Hs)).
 Proof.
-  induction l1; [apply list_annotate_pi|].
-  simpl. f_equal.
-  - by apply dsig_eq.
-  - rewrite IHl1. f_equal; apply list_annotate_pi.
+  induction l1; cbn; [by apply list_annotate_pi |].
+  f_equal; [by apply dsig_eq |].
+  by rewrite IHl1; f_equal; apply list_annotate_pi.
 Qed.
 
 Lemma nth_error_list_annotate
@@ -583,7 +572,7 @@ Proof.
   - inversion Hs; subst. exists (Some (dexist a (Forall_hd Hs))).
     by rewrite list_annotate_unroll.
   - by exists None.
-  - rewrite list_annotate_unroll; eauto.
+  - by rewrite list_annotate_unroll; eauto.
 Qed.
 
 Fixpoint nth_error_filter_index
@@ -622,29 +611,24 @@ Proof.
   destruct (decide (P a)).
   - destruct n1; destruct n2.
     + by inversion Hin1; inversion Hin2; subst.
-    + destruct (nth_error_filter_index P l n2)
-      ; inversion Hin1; inversion Hin2; subst.
-      lia.
-    + inversion Hle.
-    + destruct in1, in2.
-      * lia.
-      * lia.
-      * destruct (nth_error_filter_index P l n2); inversion Hin2.
+    + by destruct (nth_error_filter_index P l n2)
+      ; inversion Hin1; inversion Hin2; subst; lia.
+    + by inversion Hle.
+    + destruct in1, in2; [lia | lia | |].
+      * by destruct (nth_error_filter_index P l n2); inversion Hin2.
       * assert (Hle' : n1 <= n2) by lia.
         specialize (IHl n1 n2 Hle').
         destruct (nth_error_filter_index P l n1) eqn:Hin1'; inversion Hin1;
         subst; clear Hin1.
         destruct (nth_error_filter_index P l n2) eqn:Hin2'; inversion Hin2
         ; subst; clear Hin2.
-        specialize (IHl in1 eq_refl in2 eq_refl).
-        lia.
+        by specialize (IHl in1 eq_refl in2 eq_refl); lia.
   - specialize (IHl n1 n2 Hle).
     destruct (nth_error_filter_index P l n1) eqn:Hin1'; inversion Hin1
     ; subst; clear Hin1.
     destruct (nth_error_filter_index P l n2) eqn:Hin2'; inversion Hin2
     ; subst; clear Hin2.
-    specialize (IHl n0 eq_refl n3 eq_refl).
-    lia.
+    by specialize (IHl n0 eq_refl n3 eq_refl); lia.
 Qed.
 
 Fixpoint Forall_filter
@@ -654,7 +638,7 @@ Fixpoint Forall_filter
   (l : list A) : Forall P (filter P l).
 Proof.
   destruct l; cbn; [done |].
-  destruct (decide (P a)); eauto.
+  by destruct (decide (P a)); eauto.
 Defined.
 
 (**
@@ -737,9 +721,9 @@ Lemma list_prefix_nth
 Proof.
   revert s n Hi.
   induction i; intros [| a s] [| n] Hi; try done.
-  - inversion Hi.
-  - inversion Hi.
-  - cbn. rewrite (IHi s n); [done | lia].
+  - by inversion Hi.
+  - by inversion Hi.
+  - by cbn; rewrite (IHi s n); [| lia].
 Qed.
 
 Lemma nth_error_length
@@ -750,11 +734,9 @@ Lemma nth_error_length
   (Hnth : nth_error l n = Some a)
   : S n <= length l.
 Proof.
-  generalize dependent a. generalize dependent l.
-  induction n; intros [|a l] b Hnth; simpl; inversion Hnth.
-  - lia.
-  - specialize (IHn l b H0).
-    lia.
+  revert l a Hnth.
+  by induction n; intros [| a l] b Hnth; cbn; inversion Hnth;
+    [| specialize (IHn l b H0)]; lia.
 Qed.
 
 Lemma list_prefix_nth_last
@@ -770,10 +752,9 @@ Proof.
   specialize (list_prefix_length l (S n) Hlen); intro Hpref_len.
   symmetry in Hpref_len.
   specialize (list_prefix_nth l (S n) n); intro Hpref.
-  rewrite <- Hpref in Hnth.
-  - specialize (nth_error_last (list_prefix l (S n)) n Hpref_len _last); intro Hlast.
-    rewrite Hlast in Hnth. by inversion Hnth.
-  - constructor.
+  rewrite <- Hpref in Hnth; [| by constructor].
+  specialize (nth_error_last (list_prefix l (S n)) n Hpref_len _last); intro Hlast.
+  by rewrite Hlast in Hnth; inversion Hnth.
 Qed.
 
 Lemma list_suffix_nth
@@ -785,12 +766,10 @@ Lemma list_suffix_nth
   : nth_error (list_suffix s n) (i - n) = nth_error s i.
 Proof.
   revert s n Hi.
-  induction i; intros [| a s] [| n] Hi; try done.
-  - inversion Hi.
-  - simpl. apply nth_error_None. simpl. lia.
-  - simpl.
-    apply IHi.
-    lia.
+  induction i; intros [| a s] [| n] Hi; cbn; try done.
+  - by inversion Hi.
+  - by apply nth_error_None; cbn; lia.
+  - by apply IHi; lia.
 Qed.
 
 Lemma list_suffix_last
@@ -801,14 +780,14 @@ Lemma list_suffix_last
   (_default : A)
   : List.last (list_suffix l i) _default  = List.last l _default.
 Proof.
-  revert l Hlt. induction i; intros [|a l] Hlt; try done.
+  revert l Hlt; induction i; intros [| a l] Hlt; [done.. |].
   simpl in Hlt.
   assert (Hlt': i < length l) by lia.
   specialize (IHi l Hlt').
   rewrite unroll_last. simpl.
   rewrite IHi.
   destruct l.
-  - inversion Hlt; lia.
+  - by inversion Hlt; lia.
   - by rewrite unroll_last, unroll_last.
 Qed.
 
@@ -820,8 +799,8 @@ Lemma list_suffix_last_default
   (_default : A)
   : List.last (list_suffix l i) _default  = _default.
 Proof.
-  revert l Hlast. induction i; intros [|a l] Hlast; try done.
-  apply IHi. by inversion Hlast.
+  revert l Hlast; induction i; intros [|a l] Hlast; [done.. |].
+  by apply IHi; inversion Hlast.
 Qed.
 
 Lemma list_segment_nth
@@ -896,7 +875,7 @@ Lemma nth_error_map
   (n : nat)
   : nth_error (List.map f l) n = option_map f (nth_error l n).
 Proof.
-  revert n. induction l; intros [| n]; firstorder.
+  by revert n; induction l; intros [| n]; firstorder.
 Qed.
 
 Lemma exists_finite
@@ -905,7 +884,7 @@ Lemma exists_finite
   : (exists n : index, P n) <-> Exists P (enum index).
 Proof.
   rewrite Exists_exists; split.
-  - intros [n Hn]; eexists; split; [apply elem_of_enum | done].
+  - by intros [n Hn]; eexists; split; [apply elem_of_enum |].
   - by intros (n & _ & Hn); eexists.
 Qed.
 
@@ -944,22 +923,20 @@ Proof.
   revert l1' l2' Happ_rev.
   induction l; intros.
   - symmetry in Happ_rev.
-    apply app_eq_nil in Happ_rev as [Hl1' Hl2'].
-    subst. exists [], []. repeat split.
+    apply app_eq_nil in Happ_rev as [Hl1' Hl2']; subst.
+    by exists [], [].
   - simpl in Happ_rev.
     destruct (f a) eqn:Hfa; swap 1 2.
-    + specialize (IHl _ _ Happ_rev) as [_l1 [l2 [Hl [H_l1 Hl2]]]].
-      subst.
-      exists (a :: _l1), l2. by cbn; rewrite Hfa.
+    + destruct (IHl _ _ Happ_rev) as [_l1 [l2 [-> [<- <-]]]].
+      by exists (a :: _l1), l2; cbn; rewrite Hfa.
     + destruct l1' as [|_b l1']; swap 1 2.
       * change (_b :: l1') with ([_b] ++ l1') in Happ_rev.
         rewrite <- app_assoc in Happ_rev. inversion Happ_rev.
         subst _b.
-        specialize (IHl _ _ H1) as [_l1 [l2 [Hl [H_l1 Hl2]]]].
-        subst.
-        exists (a :: _l1), l2. by cbn; rewrite Hfa.
+        specialize (IHl _ _ H1) as [_l1 [l2 [-> [<- <-]]]].
+        by exists (a :: _l1), l2; cbn; rewrite Hfa.
       * simpl in Happ_rev. subst.
-        exists [], (a :: l). by cbn; rewrite Hfa.
+        by exists [], (a :: l); cbn; rewrite Hfa.
 Qed.
 
 Lemma map_option_length
@@ -972,7 +949,7 @@ Proof.
   induction l; [done |].
   inversion Hfl; subst.
   spec IHl H2; cbn.
-  destruct (f a); cbn; congruence.
+  by destruct (f a); cbn; congruence.
 Qed.
 
 Lemma map_option_nth
@@ -991,7 +968,8 @@ Proof.
   induction l; intros; simpl in *; [lia |].
   inversion Hfl; subst.
   destruct (f a) eqn: Hfa; [| done].
-  destruct i; firstorder. apply H. lia.
+  destruct i; firstorder.
+  by apply H; lia.
 Qed.
 
 (** [map_option] can be expressed as a [list_filter_map]. *)
@@ -1004,8 +982,8 @@ Proof.
   induction l using rev_ind; [done |].
   rewrite map_option_app, IHl, list_filter_map_app; cbn; clear IHl.
   destruct (decide _).
-  - cbv. by destruct i as [? ->].
-  - simpl. destruct (f x); [| done]. by elim n.
+  - by cbv; destruct i as [? ->].
+  - by destruct (f x); [elim n |].
 Qed.
 
 (** Unpack list of [option A] into list of [A]. *)
@@ -1013,7 +991,7 @@ Definition cat_option {A : Type} : list (option A) -> list A :=
   @map_option (option A) A id.
 
 Example cat_option1 : cat_option [Some 1; Some 5; None; Some 6; None] = [1; 5; 6].
-Proof. itauto. Qed.
+Proof. by itauto. Qed.
 
 Lemma cat_option_length
   {A : Type}
@@ -1021,7 +999,7 @@ Lemma cat_option_length
     (Hfl : Forall (fun a => a <> None) l)
   : length (cat_option l) = length l.
 Proof.
-  apply map_option_length; itauto.
+  by apply map_option_length; itauto.
 Qed.
 
 Lemma cat_option_length_le
@@ -1029,10 +1007,9 @@ Lemma cat_option_length_le
   (l : list (option A))
   : length (cat_option l) <= length l.
 Proof.
-  induction l.
-  - itauto.
-  - simpl.
-    destruct (id a) eqn : eq_id; simpl in *; subst a; simpl; lia.
+  induction l; cbn.
+  - by itauto.
+  - by destruct (id a) eqn: eq_id; simpl in *; subst a; simpl; lia.
 Qed.
 
 Lemma cat_option_app
@@ -1040,8 +1017,8 @@ Lemma cat_option_app
   (l1 l2 : list (option A)) :
   cat_option (l1 ++ l2) = cat_option l1 ++ cat_option l2.
 Proof.
-  induction l1.
-  - simpl in *. itauto.
+  induction l1; cbn.
+  - by itauto.
   - by destruct a; cbn in *; rewrite IHl1.
 Qed.
 
@@ -1055,11 +1032,10 @@ Lemma cat_option_nth
   (dummya : A)
   : Some (nth i (cat_option l) dummya) = (nth i l (Some dummya)).
 Proof.
-  specialize (@map_option_nth (option A) A id l). simpl in *.
+  specialize (@map_option_nth (option A) A id l); cbn.
   intros.
   unfold id in *.
-  apply H.
-  all : itauto.
+  by apply H; itauto.
 Qed.
 
 Lemma nth_error_eq
@@ -1070,14 +1046,13 @@ Lemma nth_error_eq
 Proof.
   generalize dependent l2.
   induction l1; intros [| a2 l2] Hnth; [done |..].
-  - specialize (Hnth 0); simpl in Hnth. inversion Hnth.
-  - specialize (Hnth 0); simpl in Hnth. inversion Hnth.
-  - assert (H0 := Hnth 0). simpl in H0.
-    inversion H0; subst.
+  - by specialize (Hnth 0); simpl in Hnth; inversion Hnth.
+  - by specialize (Hnth 0); simpl in Hnth; inversion Hnth.
+  - assert (H0 := Hnth 0); cbn in H0; inversion H0; subst.
     f_equal.
     apply IHl1.
     intro n.
-    apply (Hnth (S n)).
+    by apply (Hnth (S n)).
 Qed.
 
 (* TODO remove (we have Exists_first) *)
@@ -1095,9 +1070,9 @@ Lemma exists_first
          ~Exists P prefix.
 Proof.
   induction l.
-  - inversion Hsomething.
+  - by inversion Hsomething.
   - destruct (Pdec a).
-    + exists [], l, a. rewrite Exists_nil. itauto.
+    + by exists [], l, a; rewrite Exists_nil; itauto.
     + assert (Hl : Exists P l) by (inversion Hsomething; subst; done).
       specialize (IHl Hl).
       destruct IHl as [prefix [suffix [first [Hfirst [Heq Hprefix]]]]].
@@ -1141,8 +1116,8 @@ Lemma elem_of_one_element_decompositions
 Proof.
   revert suf. revert x. revert pre.
   induction l; intros pre x suf; split; simpl; intro H.
-  - inversion H.
-  - destruct pre; inversion H.
+  - by inversion H.
+  - by destruct pre; inversion H.
   - inversion H; subst; [done |].
     apply elem_of_list_fmap in H2 as [x0 [Heq Hin]].
     destruct x0 as ((prex0,x0),sufx0).
@@ -1150,7 +1125,7 @@ Proof.
     apply IHl in Hin.
     by inversion Heq; subst.
   - destruct pre.
-    + inversion H. left.
+    + by inversion H; left.
     + right. apply elem_of_list_fmap.
       rewrite <- app_comm_cons in H.
       inversion H. subst. clear H.
@@ -1166,7 +1141,8 @@ Lemma in_one_element_decompositions_iff
   : In (pre, x, suf) (one_element_decompositions l)
   <-> pre ++ [x] ++ suf = l.
 Proof.
-  rewrite <- elem_of_list_In. apply elem_of_one_element_decompositions.
+  rewrite <- elem_of_list_In.
+  by apply elem_of_one_element_decompositions.
 Qed.
 
 Definition two_element_decompositions
@@ -1227,8 +1203,8 @@ Proof.
   - destruct pre1 as [| a1 pre1]; destruct pre2 as [|a2 pre2]. 1-3: eauto.
     inversion Heql; subst a1; clear Heql.
     inversion Heq; subst a2; clear Heq.
-    destruct (IHl pre1 suf1 pre2 suf2 H1 H2)
-          as [Heq | [[suf1' Hgt] | [suf2' Hlt]]]; subst; eauto.
+    by destruct (IHl pre1 suf1 pre2 suf2 H1 H2)
+      as [Heq | [[suf1' Hgt] | [suf2' Hlt]]]; subst; eauto.
 Qed.
 
 Lemma list_max_exists
@@ -1237,11 +1213,11 @@ Lemma list_max_exists
    In (list_max l) l.
 Proof.
   induction l.
-  - simpl in nz. lia.
+  - by simpl in nz; lia.
   - simpl in *.
     destruct (a <=? (list_max l)) eqn : eq_leb.
     + assert (Nat.max a (list_max l) = list_max l) by lia.
-      itauto congruence.
+      by itauto congruence.
     + assert (Nat.max a (list_max l) = a) by lia.
       by rewrite H; left.
 Qed.
@@ -1252,15 +1228,16 @@ Lemma list_max_exists2
    In (list_max l) l.
 Proof.
   destruct (list_max l) eqn : eq_max.
-  - destruct l;[itauto congruence|].
+  - destruct l; [by itauto congruence |].
     specialize (list_max_le (n :: l) 0) as Hle.
     destruct Hle as [Hle _].
     rewrite eq_max in Hle. spec Hle. apply Nat.le_refl.
     rewrite Forall_forall in Hle.
     specialize (Hle n). spec Hle; [left |].
-    simpl. lia.
+    by simpl; lia.
   - specialize (list_max_exists l) as Hmax.
-    spec Hmax. lia. rewrite <- eq_max. itauto.
+    spec Hmax; [lia |].
+    by rewrite <- eq_max.
 Qed.
 
 (**
@@ -1274,7 +1251,7 @@ Definition mode
   filter (fun a => (count_occ decide_eq l a) = mode_value) l.
 
 Example mode1 : mode [1; 1; 2; 3; 3] = [1; 1; 3; 3].
-Proof. itauto. Qed.
+Proof. by itauto. Qed.
 
 (**
   Computes the list suff which satisfies <<pref ++ suff = l>> or
@@ -1297,9 +1274,9 @@ Fixpoint complete_prefix
   end.
 
 Example complete_prefix_some : complete_prefix [1;2;3;4] [1;2] = Some [3;4].
-Proof. itauto. Qed.
+Proof. by itauto. Qed.
 Example complete_prefix_none : complete_prefix [1;2;3;4] [1;3] = None.
-Proof. itauto. Qed.
+Proof. by itauto. Qed.
 
 Lemma complete_prefix_empty
   `{EqDecision A}
@@ -1328,24 +1305,24 @@ Proof.
       * inversion H; subst.
         rewrite decide_True; [| done].
         by rewrite (IHl pref suff).
-   - generalize dependent suff.
-     generalize dependent pref.
-     induction l; intros.
-     + destruct pref; destruct suff;
-       simpl in H; itauto (auto || congruence).
-     + destruct pref eqn : eq_pref.
-       rewrite complete_prefix_empty in H.
-       inversion H.
-       itauto.
-       simpl.
-       simpl in H.
-       destruct (decide (a = a0)); [| done].
-       destruct (complete_prefix l l0) eqn : eq_cp; [| done].
-       inversion H; subst.
-       f_equal.
-       specialize (IHl l0 suff).
-       spec IHl; [| done].
-       by rewrite eq_cp.
+  - generalize dependent suff.
+    generalize dependent pref.
+    induction l; intros.
+    + by destruct pref; destruct suff;
+        simpl in H; itauto (auto || congruence).
+    + destruct pref eqn : eq_pref.
+      rewrite complete_prefix_empty in H.
+      inversion H.
+      itauto.
+      simpl.
+      simpl in H.
+      destruct (decide (a = a0)); [| done].
+      destruct (complete_prefix l l0) eqn : eq_cp; [| done].
+      inversion H; subst.
+      f_equal.
+      specialize (IHl l0 suff).
+      spec IHl; [| done].
+      by rewrite eq_cp.
 Qed.
 
 (**
@@ -1362,7 +1339,7 @@ Definition complete_suffix
   end.
 
 Example complete_suffix_some : complete_suffix [1;2;3;4] [3;4] = Some [1;2].
-Proof. itauto. Qed.
+Proof. by itauto. Qed.
 
 Lemma complete_suffix_correct
   `{EqDecision A}
@@ -1399,7 +1376,7 @@ Proof.
   unfold complete_suffix. simpl.
   rewrite complete_prefix_empty.
   f_equal.
-  apply rev_involutive.
+  by apply rev_involutive.
 Qed.
 
 (** Elements belonging to first type in a list of a sum type. *)
@@ -1421,28 +1398,28 @@ Definition list_sum_project_right
 Lemma fold_right_andb_false l:
   fold_right andb false l = false.
 Proof.
-  induction l; [done |].
-  simpl. rewrite IHl. apply andb_false_r.
+  induction l; cbn; [done |].
+  by rewrite IHl, andb_false_r.
 Qed.
 
 Definition Listing_finite_transparent `{EqDecision A} {l : list A} (finite_l : Listing l) : finite.Finite A.
 Proof.
   exists l.
-  - apply NoDup_ListNoDup. apply finite_l.
-  - intro. apply elem_of_list_In. apply finite_l.
+  - by apply NoDup_ListNoDup, finite_l.
+  - by intro; apply elem_of_list_In, finite_l.
 Defined.
 
 Lemma Listing_finite `{EqDecision A} {l : list A} (finite_l : Listing l) : finite.Finite A.
 Proof.
-  apply (Listing_finite_transparent finite_l).
+  by eapply Listing_finite_transparent.
 Qed.
 
 Lemma sumbool_forall [A : Type] [P Q : A → Prop]:
   (∀ x : A, {P x} + {Q x}) → ∀ l : list A, {Forall P l} + {Exists Q l}.
 Proof.
   induction l.
-  left. constructor.
-  by refine (if X a then if IHl then left _ else right _ else right _); constructor.
+  - by left; constructor.
+  - by refine (if X a then if IHl then left _ else right _ else right _); constructor.
 Qed.
 
 Lemma list_sum_decrease [A:Type] (f g: A -> nat) (l: list A):
@@ -1452,8 +1429,8 @@ Proof.
   induction 2; cbn.
   - apply PeanoNat.Nat.add_lt_le_mono; [done |].
     induction l; cbn; [done |].
-    apply PeanoNat.Nat.add_le_mono; firstorder.
-  - apply PeanoNat.Nat.add_le_lt_mono; firstorder.
+    by apply PeanoNat.Nat.add_le_mono; firstorder.
+  - by apply PeanoNat.Nat.add_le_lt_mono; firstorder.
 Qed.
 
 (**
@@ -1476,7 +1453,7 @@ Proof.
   induction l.
   apply Hstart.
   intro x.
-  apply Hstep, IHl.
+  by apply Hstep, IHl.
 Qed.
 
 (**
@@ -1491,7 +1468,7 @@ Lemma fold_left_ind_rev
   forall l, P l (fold_left f l x0).
 Proof.
   induction l using rev_ind.
-  - apply Hstart.
+  - by apply Hstart.
   - by rewrite fold_left_app; apply Hstep.
 Qed.
 
@@ -1527,7 +1504,7 @@ Proof. by inversion 1. Qed.
 
 Lemma ForAll_list_suffix : forall m x, ForAllSuffix x -> ForAllSuffix (list_suffix x m).
 Proof.
-  induction m; simpl; intros [] **. 1-3: done.
+  induction m; simpl; intros [] **; [done.. |].
   by apply fsFurther in H; apply IHm.
 Qed.
 
@@ -1550,7 +1527,7 @@ Lemma ForAllSuffix_subsumption [A : Type] (P Q : list A -> Prop)
   (HPQ : forall l, P l -> Q l)
   : forall l, ForAllSuffix P l -> ForAllSuffix Q l.
 Proof.
-  induction 1; constructor; auto.
+  by induction 1; constructor; auto.
 Qed.
 
 Definition ForAllSuffix1 [A : Type] (P : A -> Prop) : list A -> Prop :=
@@ -1559,7 +1536,7 @@ Definition ForAllSuffix1 [A : Type] (P : A -> Prop) : list A -> Prop :=
 Lemma ForAllSuffix1_Forall [A : Type] (P : A -> Prop)
   : forall l, ForAllSuffix1 P l <-> Forall P l.
 Proof.
-  split; induction 1; constructor; auto.
+  by split; induction 1; constructor; auto.
 Qed.
 
 Definition ExistsSuffix1 [A : Type] (P : A -> Prop) : list A -> Prop :=
@@ -1583,9 +1560,8 @@ Lemma fsFurther2_transitive [A : Type] (R : A -> A -> Prop) {HT : Transitive R}
 Proof.
   inversion 1. subst. destruct l.
   - by repeat constructor.
-  - inversion H3. subst.
-    constructor; [| done].
-    by transitivity b.
+  - inversion H3; subst.
+    by constructor; [transitivity b |].
 Qed.
 
 Lemma ForAllSuffix2_filter [A : Type] (R : A -> A -> Prop) `{HT : Transitive _ R}
@@ -1602,7 +1578,7 @@ Proof.
   induction l; cbn; [done |].
   case_decide.
   - by inversion Hl.
-  - apply IHl. by eapply fsFurther2_transitive.
+  - by apply IHl; eapply fsFurther2_transitive.
 Qed.
 
 Lemma list_subseteq_tran : forall (A : Type) (l m n : list A),
@@ -1614,14 +1590,13 @@ Qed.
 
 #[export] Instance list_subseteq_dec `{EqDecision A} : RelDecision (@subseteq (list A) _).
 Proof.
-  intros x.
-  induction x.
-  - left. apply list_subseteq_nil.
-  - intro y. destruct (IHx y) as [Hsub | Hnsub].
+  intros x; induction x.
+  - by left; apply list_subseteq_nil.
+  - intro y; destruct (IHx y) as [Hsub | Hnsub].
     + destruct (decide (a ∈ y)).
-      * left. intros b Hb. inversion Hb; subst; [done |]. by apply Hsub.
-      * right. intro Hsub'. elim n. apply Hsub'. left.
-    + right. intro Hsub. elim Hnsub.
+      * by left; intros b Hb; inversion Hb; subst; [| apply Hsub].
+      * by right; intro Hsub'; elim n; apply Hsub'; left.
+    + right; intro Hsub; elim Hnsub.
       by intros b Hb; apply Hsub; right.
 Qed.
 
@@ -1629,14 +1604,14 @@ Lemma elem_of_empty_nil [X:Type] (l:list X) :
   (forall v, v ∉ l) -> l = [].
 Proof.
   destruct l as [| a]; [done |].
-  intro H. elim (H a). left.
+  by intro H; elim (H a); left.
 Qed.
 
 Lemma nodup_append_left {A}:
   forall (l1 l2 : list A), NoDup (l1 ++ l2) -> NoDup l1.
 Proof.
   induction l1; intros.
-  - constructor.
+  - by constructor.
   - inversion H. apply IHl1 in H3. constructor; [| done]. intro. apply H2.
     by apply elem_of_app; left.
 Qed.
@@ -1647,7 +1622,7 @@ Proof.
   intros. destruct l; [done |].
   exfalso.
   specialize (H a (elem_of_list_here _ _)).
-  inversion H.
+  by inversion H.
 Qed.
 
 Lemma Listing_NoDup {A} {l : list A} : Listing l -> NoDup l.
@@ -1682,7 +1657,7 @@ Lemma take_app_inv :
     take n l = l' ++ [x] -> exists n' : nat, n = S n'.
 Proof.
   induction n as [| n']; intros l l' x H.
-  - contradict H. rewrite take_0. apply app_cons_not_nil.
+  - by rewrite take_0 in H; apply app_cons_not_nil in H.
   - by exists n'.
 Qed.
 

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -17,13 +17,13 @@ Lemma set_eq_extract_forall
   (l1 l2 : set A)
   : set_eq l1 l2 <-> forall a, (a ∈ l1 <-> a ∈ l2).
 Proof.
-  unfold set_eq. firstorder.
+  by unfold set_eq; firstorder.
 Qed.
 
 Lemma set_eq_fin_set `{FinSet A Cm} (s1 s2 : Cm) :
   s1 ≡ s2 <-> set_eq (elements s1) (elements s2).
 Proof.
-  rewrite set_eq_extract_forall, set_equiv. by setoid_rewrite elem_of_elements.
+  by rewrite set_eq_extract_forall, set_equiv; setoid_rewrite elem_of_elements.
 Qed.
 
 Lemma set_eq_proj1 {A} : forall (s1 s2 : set A),
@@ -48,7 +48,7 @@ Qed.
 Lemma set_eq_comm {A} : forall s1 s2 : set A,
   set_eq s1 s2 <-> set_eq s2 s1.
 Proof.
-  firstorder.
+  by firstorder.
 Qed.
 
 Lemma set_eq_tran {A} : forall s1 s2 s3 : set A,
@@ -56,8 +56,7 @@ Lemma set_eq_tran {A} : forall s1 s2 s3 : set A,
   set_eq s2 s3 ->
   set_eq s1 s3.
 Proof.
-  intros.
-  split; apply PreOrder_Transitive with s2; apply H || apply H0.
+  by intros; split; apply PreOrder_Transitive with s2; firstorder.
 Qed.
 
 Lemma set_eq_empty_iff
@@ -79,7 +78,7 @@ Proof.
   intros a s1 s2 Heq.
   rewrite !set_eq_extract_forall in *.
   setoid_rewrite elem_of_cons.
-  firstorder.
+  by firstorder.
 Qed.
 
 Lemma set_eq_Forall
@@ -89,13 +88,13 @@ Lemma set_eq_Forall
   (P : A -> Prop)
   : Forall P s1 <-> Forall P s2.
 Proof.
-  rewrite !Forall_forall. firstorder.
+  by rewrite !Forall_forall; firstorder.
 Qed.
 
 Lemma set_union_comm `{EqDecision A}  : forall (s1 s2 : list A),
   set_eq (set_union s1 s2) (set_union s2 s1).
 Proof.
-  intros s1 s2; split; intro x; rewrite !set_union_iff; itauto.
+  by intros s1 s2; split; intro x; rewrite !set_union_iff; itauto.
 Qed.
 
 Lemma set_union_empty `{EqDecision A}  : forall (s1 s2 : list A),
@@ -133,7 +132,7 @@ Proof.
   intros.
   unfold subseteq, list_subseteq.
   setoid_rewrite set_union_iff.
-  split; itauto.
+  by firstorder.
 Qed.
 
 Lemma set_union_iterated_nodup `{EqDecision A}
@@ -141,15 +140,11 @@ Lemma set_union_iterated_nodup `{EqDecision A}
   (H : forall s, s ∈ ss -> NoDup s) :
   NoDup (fold_right set_union [] ss).
 Proof.
-  intros.
-  generalize dependent ss.
-  induction ss.
-  - by intros; apply NoDup_nil.
-  - intros.
-    simpl.
-    apply set_union_nodup.
-    + apply H; left.
-    + apply IHss. by intros; apply H; right.
+  induction ss; cbn.
+  - by apply NoDup_nil.
+  - apply set_union_nodup.
+    + by apply H; left.
+    + by apply IHss; intros; apply H; right.
 Qed.
 
 Lemma set_union_in_iterated
@@ -160,19 +155,17 @@ Lemma set_union_in_iterated
 Proof.
   rewrite Exists_exists.
   induction ss; split; simpl.
-  - intro H; inversion H.
-  - intros [x [Hin _]]; inversion Hin.
-  - intro Hin. apply set_union_iff in Hin.
-    destruct Hin as [Hina0 | Hinss].
-    + exists a0. rewrite elem_of_cons. by split; [left |].
-    + apply IHss in Hinss. destruct Hinss as [x [Hinss Hinx]].
-      setoid_rewrite elem_of_cons. eauto.
+  - by intro H; inversion H.
+  - by intros (x & Hin & _); inversion Hin.
+  - intro Hin; apply set_union_iff in Hin as [Hina0 | Hinss].
+    + by exists a0; rewrite elem_of_cons; split; [left |].
+    + apply IHss in Hinss as (x & Hinss & Hinx).
+      by setoid_rewrite elem_of_cons; eauto.
   - rewrite set_union_iff.
-    intros [x [Hx Ha]].
-    apply elem_of_cons in Hx.
-    destruct Hx; subst.
+    intros (x & Hx & Ha).
+    apply elem_of_cons in Hx as [-> |].
     + by left.
-    + right. apply IHss. by exists x.
+    + by right; apply IHss; exists x.
 Qed.
 
 Lemma set_union_iterated_subseteq
@@ -189,8 +182,7 @@ Proof.
   destruct H as [x [Hx Ha]].
   exists x.
   unfold incl in Hincl.
-  split; [| done].
-  by apply Hincl.
+  by split; [apply Hincl |].
 Qed.
 
 Lemma set_union_empty_left `{EqDecision A}  : forall (s : list A),
@@ -205,12 +197,11 @@ Lemma map_list_subseteq {A B} : forall (f : B -> A) (s s' : list B),
   s ⊆ s' -> (map f s) ⊆ (map f s').
 Proof.
   intro f; induction s; intros; simpl.
-  - apply list_subseteq_nil.
+  - by apply list_subseteq_nil.
   - assert (Hs : s ⊆ s') by (intros b Hs; apply H; right; done).
     spec IHs s' Hs.
     intros b Hs'.
-    apply elem_of_cons in Hs'.
-    destruct Hs' as [-> |]; [| by apply IHs].
+    apply elem_of_cons in Hs' as [-> |]; [| by apply IHs].
     by apply elem_of_list_fmap_1, H; left.
 Qed.
 
@@ -218,7 +209,7 @@ Lemma map_set_eq {A B} (f : B -> A) : forall s s',
   set_eq s s' ->
   set_eq (map f s) (map f s').
 Proof.
-  split; apply map_list_subseteq; apply H.
+  by split; apply map_list_subseteq; apply H.
 Qed.
 
 Lemma set_map_nodup {A B} `{EqDecision A} (f : B -> A) : forall (s : set B),
@@ -241,19 +232,16 @@ Lemma set_map_exists {A B} `{EqDecision A} (f : B -> A) : forall y s,
   y ∈ (set_map f s) <->
   exists x, x ∈ s /\ f x = y.
 Proof.
-  intros.
-  induction s; split; intros; simpl in H.
-  - inversion H.
-  - destruct H as [x [Hx Hf]].
-    inversion Hx.
-  - apply set_add_iff in H. destruct H as [Heq | Hin]; subst.
-    + exists a. by split; [left |].
-    + apply IHs in Hin. destruct Hin as [x [Hin Heq]]; subst.
-      exists x. by split; [right |].
-  - simpl. destruct H as [x [Hx Hf]]; subst; simpl; apply set_add_iff.
-    apply elem_of_cons in Hx.
-    destruct Hx.
-    + by subst; left.
+  induction s; split; intros; cbn in *.
+  - by inversion H.
+  - by destruct H as (x & Hx & Hf); inversion Hx.
+  - apply set_add_iff in H as [Heq | Hin]; subst.
+    + by exists a; split; [left |].
+    + apply IHs in Hin as (x & Hin & Heq); subst.
+      by exists x; split; [right |].
+  - destruct H as [x [Hx Hf]]; subst; simpl; apply set_add_iff.
+    apply elem_of_cons in Hx as [-> |].
+    + by left.
     + by right; apply IHs; exists x.
 Qed.
 
@@ -261,11 +249,11 @@ Lemma set_map_subseteq {A B} `{EqDecision A} (f : B -> A) : forall s s',
   s ⊆ s' ->
   (set_map f s) ⊆ (set_map f s').
 Proof.
-  induction s; intros; intro msg; intros.
-  - inversion H0.
-  - simpl in H0. apply set_add_elim in H0. destruct H0.
-    + subst. apply set_map_elem_of. apply H. left.
-    + apply IHs; [| done]. by intros x Hel; apply H; right.
+  induction s; cbn; intros s' Hsub msg Hin; [by inversion Hin |].
+  apply set_add_elim in Hin as [-> |].
+  - by apply set_map_elem_of, Hsub; left.
+  - apply IHs; [| done].
+    by intros x Hin'; apply Hsub; right.
 Qed.
 
 Lemma set_map_eq {A B} `{EqDecision A} (f : B -> A) : forall s s',
@@ -279,8 +267,10 @@ Lemma set_map_singleton {A B} `{EqDecision A} (f : B -> A) : forall s a,
   set_map f s = [a] ->
   forall b, b ∈ s -> f b = a.
 Proof.
-  intros. apply (set_map_elem_of f) in H0. rewrite H in H0. apply elem_of_cons in H0.
-  destruct H0; [done | inversion H0].
+  intros s a H b H0.
+  apply (set_map_elem_of f) in H0.
+  rewrite H in H0.
+  by apply elem_of_cons in H0 as []; [| inversion H0].
 Qed.
 
 Lemma filter_set_add `{StrictlyComparable X} P
@@ -310,7 +300,7 @@ Proof.
   induction l; cbn; [done |]; intros H_not_in.
   rewrite decide_False; cycle 1.
   - by intros ->; apply H_not_in; left.
-  - rewrite elem_of_cons in H_not_in. rewrite IHl; itauto.
+  - by rewrite elem_of_cons in H_not_in; rewrite IHl; itauto.
 Qed.
 
 Lemma set_remove_not_elem_of `{EqDecision A} : forall x (s : list A),
@@ -320,13 +310,14 @@ Proof.
   induction s; cbn; intros; [done |].
   rewrite decide_False; cycle 1.
   - by intros ->; contradict H; left.
-  - rewrite IHs; [done |]. rewrite elem_of_cons in H. itauto.
+  - rewrite IHs; [done |].
+    by rewrite elem_of_cons in H; itauto.
 Qed.
 
 Lemma set_remove_elim `{EqDecision A} : forall x (s : list A),
   NoDup s -> ~ x ∈ (set_remove x s).
 Proof.
-  intros x s HND Hnelem. apply set_remove_iff in Hnelem; itauto.
+  by intros x s HND Hnelem; apply set_remove_iff in Hnelem; itauto.
 Qed.
 
 Lemma set_remove_first `{EqDecision A} : forall x y (s : list A),
@@ -340,19 +331,13 @@ Lemma set_remove_nodup_1 `{EqDecision A} : forall x (s : list A),
   ~ x ∈ (set_remove x s) ->
   NoDup s.
 Proof.
-  induction s; intros.
-  - constructor.
-  - simpl in H0 . destruct (decide (x = a)).
-    + cbn in H; subst. constructor; [done |]. by rewrite decide_True in H.
-    + rewrite elem_of_cons in H0.
-      simpl in H.
-      rewrite decide_False in H; auto.
-      inversion H; subst.
-      constructor.
-      * intro Ha; apply (set_remove_3 _ x) in Ha; auto.
-      * apply IHs; [done |].
-        intro Hx.
-        by contradict H0; right.
+  induction s; intros; [by constructor |].
+  simpl in H0; destruct (decide (x = a)); subst.
+  - by cbn in H; rewrite decide_True in H; constructor.
+  - rewrite elem_of_cons in H0.
+    simpl in H; rewrite decide_False in H by done; inversion H; subst; clear H.
+    constructor; [| by firstorder].
+    by intro Ha; apply (set_remove_3 _ x) in Ha; auto.
 Qed.
 
 Lemma set_remove_elem_of_iff `{EqDecision A} :  forall x y (s : list A),
@@ -377,11 +362,10 @@ Lemma set_add_length
   : S (length s) = length (set_add x s).
 Proof.
   revert x Hx.
-  induction s; intros; [done |].
-  simpl.
-  destruct (decide (x = a)); [subst; elim Hx; left|].
-  simpl. f_equal. apply IHs.
-  by intro Hs; elim Hx; right.
+  induction s; cbn; intros; [done |].
+  destruct (decide (x = a)); [by subst; elim Hx; left |].
+  cbn; f_equal.
+  by apply IHs; intro Hs; apply Hx; right.
 Qed.
 
 Lemma set_remove_length
@@ -393,7 +377,7 @@ Lemma set_remove_length
 Proof.
   generalize dependent x. induction s; intros; inversion Hx; subst.
   - by rewrite set_remove_first.
-  - cbn. destruct (decide (x = a)); firstorder.
+  - by cbn; destruct (decide (x = a)); [| cbn; rewrite <- IHs].
 Qed.
 
 Lemma set_eq_remove `{EqDecision A} : forall x (s1 s2 : list A),
@@ -403,7 +387,7 @@ Lemma set_eq_remove `{EqDecision A} : forall x (s1 s2 : list A),
   set_eq (set_remove x s1) (set_remove x s2).
 Proof.
   intros x s1 s2 HND1 HND2 [].
-  split; intros a Hin; rewrite set_remove_iff in *; itauto.
+  by split; intros a Hin; rewrite set_remove_iff in *; itauto.
 Qed.
 
 Lemma subseteq_remove_union `{EqDecision A} : forall x (s1 s2 : list A),
@@ -414,7 +398,7 @@ Lemma subseteq_remove_union `{EqDecision A} : forall x (s1 s2 : list A),
 Proof.
   intros. intros y Hin. apply set_remove_iff in Hin.
   - apply set_union_intro. destruct Hin. apply set_union_elim in H1.
-    rewrite set_remove_iff; itauto.
+    by rewrite set_remove_iff; itauto.
   - by apply set_union_nodup.
 Qed.
 
@@ -426,7 +410,7 @@ Lemma set_eq_remove_union_elem_of  `{EqDecision A} : forall x (s1 s2 : list A),
 Proof.
   split; intros msg Hin; apply set_union_iff; apply set_union_iff in Hin
   ; destruct Hin; try by left.
-  - apply set_remove_iff in H2; itauto.
+  - by apply set_remove_iff in H2; itauto.
   - destruct (decide (msg = x)); subst.
     + by left.
     + by right; apply set_remove_iff.
@@ -449,7 +433,7 @@ Proof.
     + apply set_remove_iff in H2 as []; [| done].
       by apply set_union_iff; right.
     + intro; subst.
-      apply set_remove_iff in H2; itauto.
+      by apply set_remove_iff in H2; itauto.
   - apply set_union_iff.
     apply set_remove_iff in Hin as []; [| done].
     apply set_union_iff in H2 as []; [by left |].
@@ -465,7 +449,7 @@ Lemma set_diff_nodup' `{EqDecision A} (l l' : list A)
   : NoDup l -> NoDup (set_diff l l').
 Proof.
   induction 1 as [|x l H H' IH]; simpl.
-  - constructor.
+  - by constructor.
   - case_decide.
     + by apply IH.
     + by apply set_add_nodup, IH.
@@ -480,7 +464,7 @@ Proof.
   apply nodup_append; [| done | |].
   - by apply set_diff_nodup.
   - by intros; apply (set_diff_elim2 a s1).
-  - setoid_rewrite set_diff_iff. itauto.
+  - by setoid_rewrite set_diff_iff; itauto.
 Qed.
 
 Lemma add_remove_inverse `{EqDecision X}:
@@ -491,8 +475,8 @@ Proof.
   induction lv as [| hd tl IHlv]; cbn; intros.
   - by rewrite decide_True.
   - rewrite elem_of_cons in H.
-    destruct (decide (v = hd)) eqn: Heq; subst; cbn; [itauto |].
-    rewrite Heq, IHlv; itauto.
+    destruct (decide (v = hd)) eqn: Heq; subst; cbn; [by itauto |].
+    by rewrite Heq, IHlv; itauto.
 Qed.
 
 Lemma set_union_iterated_empty `{EqDecision A} :
@@ -528,9 +512,8 @@ Lemma set_remove_list_1
 Proof.
   unfold set_remove_list in Hin.
   induction l1.
-  - simpl in Hin; itauto.
-  - simpl in Hin.
-    by apply set_remove_1, IHl1 in Hin.
+  - by simpl in Hin; itauto.
+  - by simpl in Hin; apply set_remove_1, IHl1 in Hin.
 Qed.
 
 Lemma set_prod_nodup `(s1: set A) `(s2: set B):
@@ -570,15 +553,14 @@ Lemma set_diff_filter_iff `{EqDecision A} (a:A) l r:
   a ∈ (set_diff_filter l r) <-> (a ∈ l /\ ~a ∈ r).
 Proof.
   induction l;simpl.
-  - cbn. split; intros; [|itauto].
-    inversion H.
+  - by cbn; split; intros; [inversion H | itauto].
   - unfold set_diff_filter in *.
     rewrite filter_cons.
     destruct (decide (~ a0 ∈ r)).
     + rewrite 2 elem_of_cons, IHl.
-      split; itauto congruence.
+      by split; itauto congruence.
     + rewrite elem_of_cons.
-      split;itauto congruence.
+      by split; itauto congruence.
 Qed.
 
 Lemma set_diff_filter_nodup `{EqDecision A} (l r:list A):
@@ -600,12 +582,10 @@ Proof.
   unfold set_diff_filter.
   rewrite 2 filter_cons.
   destruct (decide (~ a0 ∈ a)); destruct (decide (~ a0 ∈ b)).
-  - simpl. unfold set_diff_filter in IHl. lia.
-  - itauto.
-  - simpl.
-    apply le_S.
-    apply IHl.
-  - apply IHl.
+  - by simpl; unfold set_diff_filter in IHl; lia.
+  - by itauto.
+  - by simpl; apply le_S, IHl.
+  - by apply IHl.
 Qed.
 
 (**
@@ -619,13 +599,13 @@ Lemma len_set_diff_decrease `{EqDecision A} (new:A) (l a b: list A)
       (H_new_is_relevant: new ∈ l):
   length (set_diff_filter l a) < length (set_diff_filter l b).
 Proof.
-  induction l; [inversion H_new_is_relevant|];
+  induction l; [by inversion H_new_is_relevant |];
     apply elem_of_cons in H_new_is_relevant; destruct H_new_is_relevant.
   - subst a0.
     unfold set_diff_filter.
     rewrite 2 filter_cons.
-    destruct (decide (~ new ∈ a)); [tauto|].
-    destruct (decide (~ new ∈ b));[|contradict n0; itauto].
+    destruct (decide (~ new ∈ a)); [by itauto |].
+    destruct (decide (~ new ∈ b)); [| by contradict n0; itauto].
     simpl.
     by apply le_n_S, len_set_diff_incl_le.
   - specialize (IHl H);clear H.
@@ -634,14 +614,14 @@ Proof.
     destruct (decide (~ a0 ∈ a)); destruct (decide (~ a0 ∈ b)).
     + simpl.
       rewrite <- Nat.succ_lt_mono.
-      apply IHl.
+      by apply IHl.
     + contradict n.
       apply H_subseteq.
       by destruct (decide (a0 ∈ b)).
     + simpl.
       apply Nat.lt_lt_succ_r.
-      apply IHl.
-    + apply IHl.
+      by apply IHl.
+    + by apply IHl.
 Qed.
 
 Lemma len_set_diff_map_set_add `{EqDecision B} (new:B) `{EqDecision A} (f: B -> A)
@@ -651,14 +631,13 @@ Lemma len_set_diff_map_set_add `{EqDecision B} (new:B) `{EqDecision A} (f: B -> 
   length (set_diff_filter l (map f (set_add new a))) <
     length (set_diff_filter l (map f a)).
 Proof.
-  apply len_set_diff_decrease with (f new).
+  apply len_set_diff_decrease with (f new); [.. | done].
   - intro x. rewrite 2 elem_of_list_fmap.
     intros [x0 [Hx0 Hin]]. exists x0.
-    rewrite set_add_iff. itauto.
+    by rewrite set_add_iff; itauto.
   - split; [| done].
     apply elem_of_list_fmap_1.
     by apply set_add_iff; left.
-  - done.
 Qed.
 
 Add Parametric Relation A : (set A) (@set_eq A)
@@ -668,13 +647,12 @@ Add Parametric Relation A : (set A) (@set_eq A)
 Add Parametric Morphism A : (@elem_of_list A)
   with signature @eq A ==> @set_eq A ==> iff as set_eq_elem_of.
 Proof.
-  intros a l1 l2 H.
-  split;apply H.
+  by intros a l1 l2 H; split; apply H.
 Qed.
 
 Add Parametric Morphism A : (@elem_of_list A)
   with signature @eq A ==> @list_subseteq A ==> Basics.impl as set_elem_of_subseteq.
-Proof. firstorder. Qed.
+Proof. by firstorder. Qed.
 
 Lemma set_union_iterated_preserves_prop
   `{EqDecision A}
@@ -687,7 +665,7 @@ Proof.
   apply set_union_in_iterated in H. rewrite Exists_exists in H.
   destruct H as [s [Hins Hina]].
   apply Hp with (s := s).
-  itauto.
+  by itauto.
 Qed.
 
 Lemma filter_set_eq {X} P Q
@@ -728,32 +706,22 @@ Proof.
   - generalize dependent a.
     generalize dependent haystack.
     induction haystack.
-    + intros.
-      simpl in H.
-      inversion H.
+    + by intros; cbn in H; inversion H.
     + intros.
       unfold fold_right in H.
       rewrite set_union_iff in H.
       destruct H.
-      * setoid_rewrite elem_of_cons. eauto.
+      * by setoid_rewrite elem_of_cons; eauto.
       * destruct (IHhaystack a0 H) as (needle & Hin1 & Hin2).
-        setoid_rewrite elem_of_cons. eauto.
+        by setoid_rewrite elem_of_cons; eauto.
    - generalize dependent a.
      generalize dependent haystack.
      induction haystack.
-     + intros.
-       simpl in *.
-       destruct H.
-       destruct H as [Ha Hx].
-       inversion Hx.
-     + intros.
-       destruct H as [needle [Hin Hin2]].
-       rewrite elem_of_cons in Hin2.
-       destruct Hin2.
-       * cbn. rewrite set_union_iff, <- H; auto.
-       * simpl.
-         rewrite set_union_iff.
-         right.
+     + by cbn; intros a (x & Ha & Hx); inversion Hx.
+     + intros a0 (needle & Hin & Hin2).
+       apply elem_of_cons in Hin2 as [<- |]; cbn.
+       * by apply set_union_iff; auto.
+       * apply set_union_iff; right.
          apply IHhaystack.
          by exists needle.
 Qed.

--- a/theories/VLSM/Lib/Measurable.v
+++ b/theories/VLSM/Lib/Measurable.v
@@ -55,18 +55,18 @@ Lemma sum_weights_subseteq
   vs ⊆ vs' ->
   (sum_weights vs <= sum_weights vs')%R.
 Proof.
-  induction vs; intros; try apply sum_weights_positive.
+  induction vs; intros; [by apply sum_weights_positive |].
   specialize (sum_weights_in a vs' H0) as Hvs'.
   spec Hvs'; [by apply H1; left |].
-  rewrite Hvs'. simpl.
+  rewrite Hvs'; cbn.
   apply Rplus_le_compat_l.
-  inversion H. subst.  clear H.
-  apply IHvs; [done | |].
-  - by apply set_remove_nodup.
-  - intros v Hv. apply set_remove_iff; [done |].
-    split.
-    + by apply H1; right.
-    + by intros ->.
+  inversion H; subst; clear H.
+  apply IHvs; [done | by apply set_remove_nodup |].
+  intros v Hv.
+  apply set_remove_iff; [done |].
+  split.
+  - by apply H1; right.
+  - by intros ->.
 Qed.
 
 Lemma set_eq_nodup_sum_weight_eq

--- a/theories/VLSM/Lib/NatExtras.v
+++ b/theories/VLSM/Lib/NatExtras.v
@@ -49,7 +49,7 @@ Lemma find_largest_nat_with_property_bounded_None
 Proof.
   induction bound; simp find_largest_nat_with_property_bounded; [by split; [lia |] |].
   case_decide as HP; split; [done | | |].
-  - intro Hmax; contradict HP; apply Hmax; lia.
+  - by intro Hmax; contradict HP; apply Hmax; lia.
   - intros.
     destruct (decide (n < bound)); [by eapply IHbound |].
     by replace n with bound; [| lia].
@@ -102,11 +102,11 @@ Proof.
       simplify_list_eq.
       by inversion 1; [| eapply Hfirst].
     + intros (Hi & Hposi & Hfirst).
-      apply elem_of_cons in Hi as [<- | Hi]; [congruence |].
+      apply elem_of_cons in Hi as [<- | Hi]; [by congruence |].
       apply elem_of_list_split in Hi as (prefix' & suffix & ->).
       by erewrite Hfirst in Hpos; [| rewrite app_comm_cons | left].
     + intros (Hi & Hposi & Hfirst).
-      apply elem_of_cons in Hi as [<- | Hi]; [congruence |].
+      apply elem_of_cons in Hi as [<- | Hi]; [by congruence |].
       apply IHindices; [done |].
       split_and!; [done.. |].
       intros prefix suffix -> j Hj.

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -31,26 +31,26 @@ Tactic Notation "spec" hyp(H) constr(a) constr(b) constr(c) constr(d) constr(e) 
 Lemma Is_true_iff_eq_true: forall x: bool, x = true <-> x.
 Proof.
   split.
-  - apply Is_true_eq_left.
-  - apply Is_true_eq_true.
+  - by apply Is_true_eq_left.
+  - by apply Is_true_eq_true.
 Qed.
 
 Lemma and_proper_l (A B C : Prop) : (A -> (B <-> C)) -> (A /\ B) <-> (A /\ C).
-Proof. firstorder. Qed.
+Proof. by firstorder. Qed.
 
 Lemma impl_proper (A B C : Prop) : (A -> (B <-> C)) -> (A -> B) <-> (A -> C).
-Proof. firstorder. Qed.
+Proof. by firstorder. Qed.
 
 (** ** Decidable propositions *)
 
 Lemma Decision_iff : forall {P Q}, (P <-> Q) -> Decision P -> Decision Q.
-Proof. firstorder. Qed.
+Proof. by firstorder. Qed.
 Lemma Decision_and : forall {P Q}, Decision P -> Decision Q -> Decision (P /\ Q).
-Proof. firstorder. Qed.
+Proof. by firstorder. Qed.
 Lemma Decision_or : forall {P Q}, Decision P -> Decision Q -> Decision (P \/ Q).
-Proof. firstorder. Qed.
+Proof. by firstorder. Qed.
 Lemma Decision_not : forall {P}, Decision P -> Decision (~P).
-Proof. firstorder. Qed.
+Proof. by firstorder. Qed.
 
 #[export] Instance bool_decision {b : bool} : Decision b :=
 match b with
@@ -79,7 +79,7 @@ Lemma tc_reflect
   (P : A -> Prop)
   (Hreflects : forall dm m, R dm m -> P m -> P dm)
   : forall dm m, tc R dm m -> P m -> P dm.
-Proof. induction 1; firstorder. Qed.
+Proof. by induction 1; firstorder. Qed.
 
 (** Characterization of [tc] in terms of the last transitivity step. *)
 Lemma tc_r_iff `(R : relation A) :
@@ -88,7 +88,7 @@ Proof.
   split.
   - intros Htc; apply tc_nsteps in Htc as (n & Hn & Hsteps).
     induction Hsteps; [lia |].
-    destruct n; [inversion Hsteps; subst; by left |].
+    destruct n; [by inversion Hsteps; subst; left |].
     spec IHHsteps; [lia |]; right; destruct IHHsteps as [Hyz | (y0 & Hyy0 & Hy0z)].
     + by exists y; split; [constructor |].
     + exists y0; split; [| done].
@@ -160,7 +160,7 @@ Proof.
   subst b2 pa1 pa2.
   unfold dexist.
   replace (bool_decide_pack (P a) e1) with (bool_decide_pack (P a) e2); [done |].
-  apply proof_irrel.
+  by apply proof_irrel.
 Qed.
 
 Lemma dec_sig_sigT_eq_rev
@@ -177,8 +177,7 @@ Lemma dec_sig_sigT_eq_rev
 Proof.
   subst pa1 pa2.
   unfold dexist.
-  replace (bool_decide_pack (P a) e1) with (bool_decide_pack (P a) e2)
-  ; [| apply proof_irrel].
+  replace (bool_decide_pack (P a) e1) with (bool_decide_pack (P a) e2); [| by apply proof_irrel].
   apply inj_pair2_eq_dec.
   intros x y; destruct (decide (` x = ` y)).
   - by left; apply dsig_eq.
@@ -226,7 +225,7 @@ Lemma asymmetric_minimal_among_iff
   : forall m, minimal_among R P m <-> strict_minimal_among R P m.
 Proof.
   unfold minimal_among, strict_minimal_among; specialize asymmetry.
-  firstorder.
+  by firstorder.
 Qed.
 
 (** The minimality definitions are equivalent for [StrictOrder]s. *)
@@ -234,7 +233,7 @@ Lemma strict_minimal_among_iff
   `(R : relation A) `{!StrictOrder R} (P : A -> Prop)
   : forall m, minimal_among R P m <-> strict_minimal_among R P m.
 Proof.
-  apply asymmetric_minimal_among_iff; typeclasses eauto.
+  by apply asymmetric_minimal_among_iff; typeclasses eauto.
 Qed.
 
 (** Dually, a maximal element is a minimal element w.r.t. the inverse relation. *)
@@ -293,7 +292,7 @@ Lemma compare_asymmetric' {A} `{CompareAsymmetric A} :
 Proof.
   intros x y.
   rewrite compare_asymmetric.
-  destruct (compare y x); cbn; firstorder congruence.
+  by destruct (compare y x); cbn; firstorder congruence.
 Qed.
 
 (** Strictly-ordered comparisons are asymmetric. *)
@@ -303,11 +302,11 @@ Proof.
   intros x y; destruct (compare y x) eqn: Hyx.
   - by rewrite compare_eq in *.
   - destruct (compare x y) eqn: Hxy; cbn; [| | done].
-    + apply compare_eq in Hxy; subst. by rewrite compare_eq_refl in Hyx.
+    + by apply compare_eq in Hxy; subst; rewrite compare_eq_refl in Hyx.
     + assert (Hxx : compare x x = Lt) by (eapply compare_transitive; done).
       by rewrite compare_eq_refl in Hxx.
   - destruct (compare x y) eqn: Hxy; cbn; [| done |].
-    + apply compare_eq in Hxy; subst. by rewrite compare_eq_refl in Hyx.
+    + by apply compare_eq in Hxy; subst; rewrite compare_eq_refl in Hyx.
     + assert (Hxx : compare x x = Gt) by (eapply compare_transitive; done).
       by rewrite compare_eq_refl in Hxx.
 Qed.
@@ -321,7 +320,7 @@ Definition compare_lt {A} (compare : A -> A -> comparison) (x y : A) : Prop :=
   : RelDecision (compare_lt compare).
 Proof.
   intros x y; unfold compare_lt.
-  typeclasses eauto.
+  by typeclasses eauto.
 Qed.
 
 (** *** Properties of [compare_lt] *)
@@ -430,8 +429,8 @@ Lemma CompareStrictOrder_dsig_compare
   : CompareStrictOrder (dsig_compare P).
 Proof.
   split.
-  - apply dsig_compare_reflexive.
-  - apply dsig_compare_transitive.
+  - by apply dsig_compare_reflexive.
+  - by apply dsig_compare_transitive.
 Qed.
 
 #[export] Instance StrictlyComparable_dsig
@@ -459,7 +458,7 @@ Lemma option_compare_reflexive
   (X : Type) `{StrictlyComparable X}
   : CompareReflexive (option_compare X).
 Proof.
-  intros [x |] [y |]; cbn; rewrite ?compare_eq; firstorder congruence.
+  by intros [x |] [y |]; cbn; rewrite ?compare_eq; firstorder congruence.
 Qed.
 
 Lemma option_compare_transitive

--- a/theories/VLSM/Lib/RealsExtras.v
+++ b/theories/VLSM/Lib/RealsExtras.v
@@ -10,22 +10,18 @@ Definition list_sum_R : list R -> R :=
 Lemma Rplusminus_assoc : forall r1 r2 r3,
   (r1 + r2 - r3)%R = (r1 + (r2 - r3))%R.
 Proof.
-  intros. unfold Rminus.
-  apply Rplus_assoc.
+  by intros; unfold Rminus; apply Rplus_assoc.
 Qed.
 
 Lemma Rplusminus_assoc_r : forall r1 r2 r3,
   (r1 - r2 + r3)%R = (r1 + (- r2 + r3))%R.
 Proof.
-  intros. unfold Rminus.
-  apply Rplus_assoc.
+  by intros; unfold Rminus; apply Rplus_assoc.
 Qed.
 
 Lemma Rplus_opp_l : forall r, (Ropp r + r)%R = 0%R.
 Proof.
-  intros.
-  rewrite Rplus_comm.
-  apply Rplus_opp_r.
+  by intros; rewrite Rplus_comm, Rplus_opp_r.
 Qed.
 
 Lemma Rplus_ge_reg_neg_r : forall r1 r2 r3,
@@ -33,9 +29,9 @@ Lemma Rplus_ge_reg_neg_r : forall r1 r2 r3,
 Proof.
   intros.
   apply Rge_le.
-  apply Rle_ge in H.
-  apply Rle_ge in H0.
-  apply (Rplus_ge_reg_neg_r r1 r2 r3 H H0).
+  eapply Rplus_ge_reg_neg_r.
+  - by apply Rle_ge in H.
+  - by apply Rle_ge in H0.
 Qed.
 
 Lemma Rminus_lt_r : forall r1 r2,
@@ -60,11 +56,10 @@ Lemma Rtotal_le_gt : forall x y,
   (x <= y)%R \/ (x > y)%R.
 Proof.
   unfold Rle. intros x y.
-  destruct (Rtotal_order x y) as [Hlt | [Heq | Hgt]]; auto.
+  by destruct (Rtotal_order x y) as [Hlt | [Heq | Hgt]]; auto.
 Qed.
 
 #[export] Instance Rle_transitive : Transitive Rle.
 Proof.
-  intros x y z.
-  apply Rle_trans.
+  by intros x y z; apply Rle_trans.
 Qed.

--- a/theories/VLSM/Lib/SortedLists.v
+++ b/theories/VLSM/Lib/SortedLists.v
@@ -25,10 +25,12 @@ Proof.
   split.
   - intro x. induction x; intros; destruct y; split; intros; try done.
     + simpl in H. destruct (compare a a0) eqn: Hcmp; try done.
-      apply compare_eq in Hcmp as ->. by apply IHx in H as ->.
-    + inversion H; subst; cbn. by rewrite compare_eq_refl, IHx.
+      apply compare_eq in Hcmp as ->.
+      by apply IHx in H as ->.
+    + inversion H; subst; cbn.
+      by rewrite compare_eq_refl, IHx.
   - intros x y. generalize dependent x.
-    induction y; intros; destruct x; destruct z; try done
+    by induction y; intros; destruct x; destruct z; try done
     ; destruct c; try done
     ; inversion H; clear H; destruct (compare a0 a) eqn:Ha0; try done
     ; inversion H0; clear H0; destruct (compare a a1) eqn:Ha1; try done
@@ -43,8 +45,7 @@ Defined.
 Lemma list_compare_eq_dec {A} {compare : A -> A -> comparison} `{CompareStrictOrder A compare} :
   (forall x y : list A, {x = y} + {x <> y}).
 Proof.
-  intros.
-  apply compare_eq_dec.
+  by intros; apply compare_eq_dec.
 Qed.
 
 Fixpoint add_in_sorted_list_fn {A} (compare : A -> A -> comparison) (x : A) (l : list A) : list A :=
@@ -62,8 +63,8 @@ Lemma add_in_sorted_list_no_empty {A} (compare : A -> A -> comparison) : forall 
   add_in_sorted_list_fn compare msg sigma <> [].
 Proof.
   unfold not. intros. destruct sigma; simpl in H.
-  - inversion H.
-  - destruct (compare msg a); inversion H.
+  - by inversion H.
+  - by destruct (compare msg a); inversion H.
 Qed.
 
 Lemma add_in_sorted_list_in {A} {compare : A -> A -> comparison} `{CompareStrictOrder A compare} : forall msg msg' sigma,
@@ -74,13 +75,14 @@ Proof.
   - rewrite elem_of_cons in H0.
     by destruct H0 as [H0 | H0]; subst; try inversion H0; left.
   - destruct (compare msg a) eqn:Hcmp.
-    + rewrite compare_eq in Hcmp; subst. by right.
+    + by rewrite compare_eq in Hcmp; subst; right.
     + rewrite elem_of_cons in H0.
       by destruct H0 as [Heq | Hin]; subst; [left | right].
     + rewrite elem_of_cons in H0.
       destruct H0 as [Heq | Hin]; subst.
       * by right; left.
-      * rewrite elem_of_cons. apply IHsigma in Hin as []; itauto.
+      * rewrite elem_of_cons.
+        by apply IHsigma in Hin as []; itauto.
 Qed.
 
 Lemma add_in_sorted_list_in_rev {A} {compare : A -> A -> comparison} `{CompareStrictOrder A compare} : forall msg msg' sigma,
@@ -88,9 +90,9 @@ Lemma add_in_sorted_list_in_rev {A} {compare : A -> A -> comparison} `{CompareSt
   msg' ∈ (add_in_sorted_list_fn compare msg sigma).
 Proof.
   intros. induction sigma; simpl in H0.
-  - destruct H0 as [H0 | H0]; subst; [left | inversion H0].
+  - by destruct H0 as [H0 | H0]; subst; [left | inversion H0].
   - rewrite elem_of_cons in H0; cbn.
-    destruct H0 as [Heq | Heq], (compare msg a) eqn: Hcmp
+    by destruct H0 as [Heq | Heq], (compare msg a) eqn: Hcmp
     ; rewrite !elem_of_cons; rewrite ?compare_eq in Hcmp; subst; itauto.
 Qed.
 
@@ -121,12 +123,12 @@ Lemma LocallySorted_ForAll2 [A : Type] (R : A -> A -> Prop)
 Proof.
   induction l; split; intro Hl.
   - by constructor.
-  - constructor.
+  - by constructor.
   - inversion Hl; subst.
     + by repeat constructor.
-    + apply IHl in H1. by constructor.
-  - apply proj2 in IHl. inversion Hl; subst.
-    destruct l; constructor; auto.
+    + by apply IHl in H1; constructor.
+  - apply proj2 in IHl; inversion Hl; subst.
+    by destruct l; constructor; auto.
 Qed.
 
 Lemma LocallySorted_filter [A : Type] (R : A -> A -> Prop) {HT : Transitive R}
@@ -142,7 +144,8 @@ Lemma LocallySorted_tl {A} {compare : A -> A -> comparison} `{CompareStrictOrder
     LocallySorted (compare_lt compare) sigma.
 Proof.
   intros. apply Sorted_LocallySorted_iff in H0.
-  inversion H0; subst; clear H0. by apply Sorted_LocallySorted_iff.
+  inversion H0; subst; clear H0.
+  by apply Sorted_LocallySorted_iff.
 Qed.
 
 Lemma add_in_sorted_list_sorted {A} {compare : A -> A -> comparison} `{CompareStrictOrder A compare} : forall msg sigma,
@@ -152,15 +155,15 @@ Proof.
   induction 1; cbn; try constructor; destruct (compare msg a) eqn: Hcmpa.
   - by constructor.
   - by constructor; [constructor |].
-  - constructor; [constructor | red].
-    by rewrite compare_asymmetric, Hcmpa.
+  - constructor; [constructor |].
+    by red; rewrite compare_asymmetric, Hcmpa.
   - by constructor.
   - by constructor; [constructor |].
   - cbn in IHLocallySorted.
     destruct (compare msg b) eqn: Hcmpb.
-    + rewrite compare_eq in Hcmpb. by constructor.
-    + constructor; [done | red].
-      by rewrite compare_asymmetric, Hcmpa.
+    + by rewrite compare_eq in Hcmpb; constructor.
+    + constructor; [done |].
+      by red; rewrite compare_asymmetric, Hcmpa.
     + by constructor.
 Qed.
 
@@ -174,8 +177,8 @@ Lemma LocallySorted_elem_of_lt {A} {lt : relation A} `{StrictOrder A lt} :
 Proof.
   intros x y s LS IN. revert y x LS IN.
   induction s.
-  - inversion 2.
-  - do 2 inversion 1; subst; firstorder.
+  - by inversion 2.
+  - by do 2 inversion 1; subst; firstorder.
 Qed.
 
 Lemma add_in_sorted_list_existing {A} {compare : A -> A -> comparison} `{CompareStrictOrder A compare} : forall msg sigma,
@@ -183,13 +186,13 @@ Lemma add_in_sorted_list_existing {A} {compare : A -> A -> comparison} `{Compare
   msg ∈ sigma ->
   add_in_sorted_list_fn compare msg sigma = sigma.
 Proof.
-  induction sigma; intros; [inversion H1 |].
+  induction sigma; intros; [by inversion H1 |].
   rewrite elem_of_cons in H1.
   destruct H1 as [Heq | Hin].
   - by subst; simpl; rewrite compare_eq_refl.
   - apply LocallySorted_tl in H0 as LS.
     spec IHsigma LS Hin. simpl.
-    destruct (compare msg a) eqn:Hcmp; try rewrite IHsigma. 1, 3: done.
+    destruct (compare msg a) eqn:Hcmp; try rewrite IHsigma; [done | | done].
     apply (@LocallySorted_elem_of_lt _ _ compare_lt_strict_order msg a sigma H0) in Hin.
     unfold compare_lt in Hin.
     by rewrite compare_asymmetric, Hcmp in Hin; inversion Hin.
@@ -217,9 +220,7 @@ Proof.
     pose proof (LocallySorted_elem_of_lt x1 x2 s2 LS2 H0).
     pose proof (StrictOrder_Irreflexive x1) as ltIrr.
     destruct H as [Hirr Htr].
-    pose proof (Htr x1 x2 x1 H2 H3) as Hlt.
-    unfold complement in ltIrr.
-    itauto.
+    by pose proof (Htr x1 x2 x1 H2 H3) as Hlt.
   }
   subst.
   split; [done |].
@@ -255,14 +256,8 @@ Proof.
   split; [| by intros ->].
   generalize dependent s2.
   induction s1; destruct s2; intros; [done | | |].
-  - destruct H. exfalso. pose proof (H0 a).
-    rewrite elem_of_cons in H1.
-    specialize (H1 (or_introl (eq_refl a))).
-    inversion H1.
-  - destruct H. exfalso. pose proof (H a).
-    rewrite elem_of_cons in H1.
-    specialize (H1 (or_introl (eq_refl a))).
-    inversion H1.
+  - by destruct H as [_ H]; apply subseteq_empty in H; inversion H.
+  - by destruct H as [H _]; apply subseteq_empty in H; inversion H.
   - apply (set_eq_first_equal a a0 s1 s2 LS1 LS2) in H. destruct H; subst.
     apply Sorted_LocallySorted_iff, Sorted_inv in LS1 as [LS1 _].
     apply Sorted_LocallySorted_iff in LS1.
@@ -288,9 +283,8 @@ Proof.
   induction alfa.
   - intros.
     split.
-    apply LSorted_nil.
-    simpl in *.
-    by rewrite Hconcat in Hsorted.
+    + by apply LSorted_nil.
+    + by simpl in *; rewrite Hconcat in Hsorted.
   - intros.
     apply Sorted_LocallySorted_iff in Hsorted.
     apply Sorted_StronglySorted in Hsorted; [| done].
@@ -299,11 +293,8 @@ Proof.
     apply StronglySorted_inv in Hsorted.
     destruct Hsorted.
     specialize (IHalfa beta (alfa ++ beta)).
-    spec IHalfa.
-    apply Sorted_LocallySorted_iff.
-    by apply StronglySorted_Sorted.
-    specialize (IHalfa eq_refl).
-    destruct IHalfa.
+    spec IHalfa; [by apply Sorted_LocallySorted_iff, StronglySorted_Sorted |].
+    destruct (IHalfa eq_refl).
     split; [| done].
     destruct alfa; constructor; [done |].
     rewrite Forall_forall in H0.
@@ -329,7 +320,7 @@ Proof.
   rewrite Forall_forall in Hneed.
   specialize (Hneed y).
   spec Hneed; [| done].
-  apply elem_of_app; right; left.
+  by apply elem_of_app; right; left.
 Qed.
 
 Lemma lsorted_pair_wise_unordered

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -9,16 +9,12 @@ Lemma elem_of_take {A : Type} (l : list A) (n : nat) (x : A) :
 Proof.
   generalize dependent n.
   induction l; intros n H.
-  - simpl in H. destruct n; simpl in H; inversion H.
-  - simpl in H.
-    destruct n.
-    { simpl in H. inversion H. }
+  - by simpl in H; destruct n; simpl in H; inversion H.
+  - destruct n; [by inversion H |].
     simpl in H.
-    apply elem_of_cons in H.
-    destruct H as [H|H].
-    { subst. simpl. left. }
-    simpl. right.
-    eauto.
+    apply elem_of_cons in H as [-> | H].
+    + by left.
+    + by right; eapply IHl.
 Qed.
 
 Lemma map_skipn [A B : Type] (f : A -> B) (l : list A) (n : nat) :
@@ -81,10 +77,8 @@ Lemma existsb_Exists {A} (f : A -> bool):
   forall l, existsb f l = true <-> Exists (fun x => f x = true) l.
 Proof.
   intro l.
-  rewrite Exists_exists.
-  rewrite existsb_exists.
-  setoid_rewrite elem_of_list_In.
-  auto.
+  rewrite Exists_exists, existsb_exists.
+  by setoid_rewrite elem_of_list_In.
 Qed.
 
 Lemma Exists_last
@@ -101,20 +95,19 @@ Lemma Exists_last
          ~Exists P suffix.
 
 Proof.
-  induction l using rev_ind;[solve[inversion Hsomething]|].
+  induction l using rev_ind; [by inversion Hsomething |].
   destruct (decide (P x)).
   - exists l, nil, x.
     rewrite Exists_nil.
-    itauto.
+    by itauto.
   - apply Exists_app in Hsomething.
-    destruct Hsomething.
-    2:{ inversion H; [done |]. inversion H1. }
+    destruct Hsomething; [| by inversion H; [| inversion H1]].
     specialize (IHl H);clear H.
     destruct IHl as [prefix [suffix [last [Hf [-> Hnone_after]]]]].
     exists prefix, (suffix ++ [x]), last.
     simpl. rewrite app_assoc_reverse. simpl.
     rewrite Exists_app. rewrite Exists_cons. rewrite Exists_nil.
-    itauto.
+    by itauto.
 Qed.
 
 Lemma existsb_last
@@ -160,7 +153,7 @@ Proof.
   setoid_rewrite <-not_true_iff_false.
   setoid_rewrite existsb_Exists.
   apply Exists_first.
-  - typeclasses eauto.
+  - by typeclasses eauto.
   - by apply existsb_Exists.
 Qed.
 
@@ -175,10 +168,10 @@ Definition maximal_elements_list
   filter (fun a => Forall (fun b => (~ precedes a b)) l) l.
 
 Example maximal_elements_list1: maximal_elements_list Nat.lt [1; 4; 2; 4] = [4;4].
-Proof. itauto. Qed.
+Proof. by itauto. Qed.
 
 Example maximal_elements_list2 : maximal_elements_list Nat.le [1; 4; 2; 4] = [].
-Proof. itauto. Qed.
+Proof. by itauto. Qed.
 
 (**
   Returns all elements <<x>> of a set <<S>> such that <<x>> does not compare less
@@ -199,8 +192,7 @@ Proof.
   - by rewrite 2 filter_nil.
   - rewrite 2 filter_cons.
     setoid_rewrite elem_of_cons in H1.
-    destruct (decide (P a)); destruct (decide (Q a)); [|firstorder ..].
-    rewrite IHl; [done |]. firstorder.
+    by destruct (decide (P a)), (decide (Q a)); [rewrite IHl | ..]; firstorder.
 Qed.
 
 Lemma ext_elem_of_filter {A} P Q
@@ -225,10 +217,10 @@ Proof.
     apply filter_ext_elem_of.
     intros.
     specialize (Hext a H2).
-    rewrite Hext. itauto.
+    by rewrite Hext; itauto.
   - apply filter_ext_elem_of. intros.
     specialize (ext_elem_of_filter _ _ l H1 a H2) as Hext; cbn in Hext.
-    destruct (decide (P a)); destruct (decide (Q a)); itauto.
+    by destruct (decide (P a)), (decide (Q a)); itauto.
 Qed.
 
 Lemma NoDup_elem_of_remove A (l l' : list A) a :
@@ -260,7 +252,7 @@ Lemma list_suffix_lookup
   (Hi : n <= i)
   : list_suffix s n !! (i - n) = s !! i.
 Proof.
-  revert s n Hi; induction i; intros [| a s] [| n] Hi; cbn; try done; [| apply IHi]; lia.
+  by revert s n Hi; induction i; intros [| a s] [| n] Hi; cbn; try done; [| apply IHi]; lia.
 Qed.
 
 Lemma list_difference_singleton_not_in `{EqDecision A} :
@@ -290,7 +282,7 @@ Lemma longer_subseteq_has_dups `{EqDecision A} :
   forall l1 l2 : list A, l1 ⊆ l2 -> length l1 > length l2 ->
   exists (i1 i2 : nat) (a : A), i1 ≠ i2 ∧ l1 !! i1 = Some a /\ l1 !! i2 = Some a.
 Proof.
-  induction l1; [inversion 2 |].
+  induction l1; [by inversion 2 |].
   intros l2 Hl12 Hlen12.
   destruct (decide (a ∈ l1)).
   - exists 0.
@@ -298,20 +290,20 @@ Proof.
     by exists (S i2), a.
   - edestruct (IHl1 (list_difference l2 [a]))
            as (i1 & i2 & a' & Hi12 & Hli1 & Hli2); cycle 2.
-    + exists (S i1), (S i2), a'; cbn; itauto.
+    + by exists (S i1), (S i2), a'; cbn; itauto.
     + intros x Hx.
       rewrite elem_of_list_difference, elem_of_list_singleton.
       by split; [apply Hl12; right | by contradict n; subst].
     + cbn in Hlen12.
       assert (Ha : a ∈ l2) by (apply Hl12; left).
-      specialize (list_difference_singleton_length_in _ _ Ha) as Hlen'; lia.
+      by specialize (list_difference_singleton_length_in _ _ Ha) as Hlen'; lia.
 Qed.
 
 Lemma ForAllSuffix2_lookup [A : Type] (R : A -> A -> Prop) l
   : ForAllSuffix2 R l <-> forall n a b, l !! n = Some a -> l !! (S n) = Some b -> R a b.
 Proof.
   split.
-  - induction 1; cbn; [inversion 2 |].
+  - induction 1; cbn; [by inversion 2 |].
     destruct n as [| n']; cbn.
     + by destruct l; do 2 inversion 1; subst.
     + by intros; eapply IHForAllSuffix.
@@ -324,7 +316,11 @@ Proof.
 Qed.
 
 Lemma stdpp_nat_le_sum (x y : nat) : x <= y <-> exists z, y = x + z.
-Proof. split; [exists (y - x); lia | intros [z ->]; lia]. Qed.
+Proof.
+  split.
+  - by exists (y - x); lia.
+  - by intros [z ->]; lia.
+Qed.
 
 Lemma ForAllSuffix2_transitive_lookup
   [A : Type] (R : A -> A -> Prop) {HT : Transitive R} (l : list A)
@@ -334,7 +330,7 @@ Proof.
   split; intro Hall; [| by intros n a b; apply Hall; lia].
   intros m n a b Hlt.
   apply stdpp_nat_le_sum in Hlt as [k ->]; rewrite Nat.add_comm.
-  revert a b; induction k; cbn; [apply Hall |].
+  revert a b; induction k; cbn; [by apply Hall |].
   intros a b Ha Hb.
   assert (Hlt : k + S m < length l) by (apply lookup_lt_Some in Hb; lia).
   apply lookup_lt_is_Some in Hlt as [c Hc].
@@ -363,7 +359,7 @@ Proof.
   intros.
   apply elem_of_list_In.
   apply elem_of_list_In in H0.
-  apply elem_of_list_filter; auto.
+  by apply elem_of_list_filter.
 Qed.
 
 Lemma filter_incl_fn {A} P Q
@@ -394,12 +390,11 @@ Lemma filter_eq_fn {A} P Q
   filter P s = filter Q s.
 Proof.
   induction s; intros; [done |].
-  assert (IHs' : forall a : A, In a s -> P a <-> Q a).
-  { by intros; apply H1; right. }
-  apply IHs in IHs'. clear IHs.
-  erewrite !filter_cons, decide_ext; cycle 1.
-  - by apply H1; left.
+  assert (IHs' : forall a : A, In a s -> P a <-> Q a) by (intros; apply H1; right; done).
+  apply IHs in IHs'.
+  erewrite !filter_cons, decide_ext.
   - by rewrite IHs'.
+  - by apply H1; left.
 Qed.
 
 Lemma nth_error_filter
@@ -414,10 +409,10 @@ Lemma nth_error_filter
 Proof.
   generalize dependent a. generalize dependent n.
   induction l.
-  - intros; simpl in Hnth. destruct n; inversion Hnth.
+  - by intros []; cbn; inversion 1.
   - intros. rewrite filter_cons in Hnth. simpl. destruct (decide (P a)).
     + destruct n.
-      * inversion Hnth; subst. by exists 0.
+      * by inversion Hnth; subst; exists 0.
       * simpl in Hnth.
         specialize (IHl n a0 Hnth).
         destruct IHl as [nth [Hnth' Ha0]].
@@ -434,17 +429,17 @@ Lemma filter_subseteq {A} P `{∀ (x:A), Decision (P x)} (s1 s2 : list A) :
   (filter P s1) ⊆ (filter P s2).
 Proof.
   induction s1; intros; intro x; intros.
-  - contradict H1.
-    rewrite filter_nil; intro Hx. inversion Hx.
+  - by apply not_elem_of_nil in H1.
   - rewrite filter_cons in H1.
     destruct (decide (P a)).
     + rewrite elem_of_cons in H1.
       destruct H1.
       * subst; apply elem_of_list_filter.
-        split; [done |].
-        apply H0; left.
-      * apply IHs1; [| done]. by intros y Hel; apply H0; right.
-    + apply IHs1; [| done]. by intros y Hel; apply H0; right.
+        by split; [| apply H0; left].
+      * apply IHs1; [| done].
+        by intros y Hel; apply H0; right.
+    + apply IHs1; [| done].
+      by intros y Hel; apply H0; right.
 Qed.
 
 Lemma filter_subseteq_fn {A} P Q
@@ -452,35 +447,26 @@ Lemma filter_subseteq_fn {A} P Q
   (forall a, P a -> Q a) ->
   forall (s : list A), filter P s ⊆ filter Q s.
 Proof.
-  induction s; simpl.
-  - rewrite filter_nil; intros x Hx; inversion Hx.
-  - intro x; intros.
-    rewrite filter_cons in H2.
-    destruct (decide (P a)).
-    + rewrite elem_of_cons in H2.
-      rewrite filter_cons.
-      destruct (decide (Q a)); [| itauto].
-      destruct H2.
-      * by subst; left.
-      * by right; apply IHs.
-    + rewrite filter_cons.
-      destruct (decide (Q a)).
-      * by right; apply IHs.
-      * by apply IHs.
+  induction s; cbn; intros x H2; [by inversion H2 |].
+  destruct (decide (P a)), (decide (Q a)); rewrite ?elem_of_cons in H2.
+  - by destruct H2 as [-> |]; [left | right; apply IHs].
+  - by itauto.
+  - by right; apply IHs.
+  - by itauto.
 Qed.
 
 Lemma filter_incl {A} P `{∀ (x:A), Decision (P x)} s1 s2 :
   incl s1 s2 ->
   incl (filter P s1) (filter P s2).
 Proof.
-  induction s1; intros; intro x; intros.
-  - contradict H1; auto.
-  - rewrite filter_cons in H1.
-    destruct (decide (P a)).
-    + destruct H1.
-      * subst. apply filter_in; [| done]. by apply H0; left.
-      * apply IHs1; [| done]. by intros y HIn; apply H0; right.
-    + apply IHs1; [| done]. by intros y HIn; apply H0; right.
+  induction s1; cbn; intros H0 x H1; [done |].
+  destruct (decide (P a)).
+  - destruct H1 as [-> |].
+    + by apply filter_in; [apply H0; left |].
+    + apply IHs1; [| done].
+      by intros y HIn; apply H0; right.
+  - apply IHs1; [| done].
+    by intros y HIn; apply H0; right.
 Qed.
 
 Lemma Forall_filter_nil {A} P `{∀ (x:A), Decision (P x)} l :
@@ -488,10 +474,11 @@ Lemma Forall_filter_nil {A} P `{∀ (x:A), Decision (P x)} l :
 Proof.
   rewrite Forall_forall.
   split; intro Hnone.
-  - induction l; [done |].
+  - induction l; cbn; [done |].
     setoid_rewrite elem_of_cons in Hnone.
-    cbn. rewrite decide_False; auto.
-  - intros x Hel Px. contradict Hel. eapply filter_nil_not_elem_of; eauto.
+    by rewrite decide_False; auto.
+  - intros x Hel Px.
+    by eapply filter_nil_not_elem_of in Px.
 Qed.
 
 Lemma nodup_append {A} : forall (l1 l2 : list A),
@@ -508,7 +495,7 @@ Proof.
     + by apply (H1 a); [left |].
   - apply IHl1; [done | done | |]; intros.
     + by apply H1; right.
-    + apply H2 in H. rewrite elem_of_cons in H. itauto.
+    + by apply H2 in H; rewrite elem_of_cons in H; itauto.
 Qed.
 
 Lemma elem_of_list_annotate_forget
@@ -522,10 +509,10 @@ Lemma elem_of_list_annotate_forget
   : (proj1_sig xP) ∈ l.
 Proof.
   induction l.
-  - inversion Hin.
+  - by inversion Hin.
   - rewrite list_annotate_unroll,elem_of_cons in Hin.
-    destruct Hin as [Heq | Hin].
-    + subst xP. left.
+    destruct Hin as [-> | Hin].
+    + by left.
     + by right; apply (IHl (Forall_tl Hs)).
 Qed.
 
@@ -538,9 +525,9 @@ Lemma elem_of_list_annotate
   (xP : dsig P)
   : xP ∈ (list_annotate P l Hs) <-> (` xP) ∈ l.
 Proof.
-  split; [apply elem_of_list_annotate_forget |].
+  split; [by apply elem_of_list_annotate_forget |].
   destruct xP as [x Hpx]; cbn.
-  induction 1; cbn; rewrite elem_of_cons, dsig_eq; cbn; auto.
+  by induction 1; cbn; rewrite elem_of_cons, dsig_eq; cbn; auto.
 Qed.
 
 Lemma elem_of_map_option
@@ -551,8 +538,8 @@ Lemma elem_of_map_option
   : b ∈ map_option f l <-> exists a : A, a ∈ l /\ f a = Some b.
 Proof.
   induction l as [| h t]; cbn.
-  - setoid_rewrite elem_of_nil. firstorder.
-  - destruct (f h) eqn: Heq; setoid_rewrite elem_of_cons
+  - by setoid_rewrite elem_of_nil; firstorder.
+  - by destruct (f h) eqn: Heq; setoid_rewrite elem_of_cons
     ; firstorder; subst; itauto (eauto || congruence).
 Qed.
 
@@ -569,9 +556,9 @@ Proof.
   generalize dependent a.
   induction la1; intros; destruct lb1 as [|b0 lb1]; simpl in *
   ; inversion Heq; subst.
-  - contradict Ha. left.
+  - by contradict Ha; left.
   - by exists lb1.
-  - contradict Ha. rewrite elem_of_cons, elem_of_app, elem_of_cons; auto.
+  - by contradict Ha; rewrite elem_of_cons, elem_of_app, elem_of_cons; auto.
   - specialize (IHla1 a0 lb1 b la2 lb2 H1 Ha).
     destruct IHla1 as [la0b Hla0b].
     by exists la0b; subst.
@@ -584,7 +571,7 @@ Lemma list_max_elem_of_exists
 Proof.
   induction l; simpl in *; [lia |].
   rewrite elem_of_cons.
-  destruct (Nat.max_spec_le a (list_max l)) as [[H ->] | [H ->]]; itauto lia.
+  by destruct (Nat.max_spec_le a (list_max l)) as [[H ->] | [H ->]]; itauto lia.
 Qed.
 
 Lemma in_map_option
@@ -594,7 +581,7 @@ Lemma in_map_option
   (b : B)
   : In b (map_option f l) <-> exists a : A, In a l /\ f a = Some b.
 Proof.
-  setoid_rewrite <- elem_of_list_In; apply elem_of_map_option.
+  by setoid_rewrite <- elem_of_list_In; apply elem_of_map_option.
 Qed.
 
 Lemma elem_of_map_option_rev
@@ -606,7 +593,7 @@ Lemma elem_of_map_option_rev
   (l : list A)
   : a ∈ l -> b ∈ map_option f l.
 Proof.
-  intro Ha; apply elem_of_map_option; exists a; itauto.
+  by intro Ha; apply elem_of_map_option; exists a; itauto.
 Qed.
 
 Lemma in_map_option_rev
@@ -628,7 +615,7 @@ Lemma map_option_subseteq
   (Hincl : l1 ⊆ l2)
   : (map_option f l1) ⊆ (map_option f l2).
 Proof.
-  intros b. rewrite !elem_of_map_option. firstorder.
+  by intros b; rewrite !elem_of_map_option; firstorder.
 Qed.
 
 Lemma elem_of_cat_option
@@ -637,7 +624,7 @@ Lemma elem_of_cat_option
   (a : A)
   : a ∈ (cat_option l) <-> exists b : (option A), b ∈ l /\ b = Some a.
 Proof.
-  apply elem_of_map_option.
+  by apply elem_of_map_option.
 Qed.
 
 Lemma in_cat_option
@@ -646,7 +633,7 @@ Lemma in_cat_option
   (a : A)
   : In a (cat_option l) <-> exists b : (option A), In b l /\ b = Some a.
 Proof.
-  apply in_map_option.
+  by apply in_map_option.
 Qed.
 
 Lemma map_option_incl
@@ -656,8 +643,7 @@ Lemma map_option_incl
   (Hincl : incl l1 l2)
   : incl (map_option f l1) (map_option f l2).
 Proof.
-  intro b. repeat rewrite in_map_option.
-  firstorder.
+  by intros b; rewrite !in_map_option; firstorder.
 Qed.
 
 Lemma list_max_elem_of_exists2
@@ -666,16 +652,16 @@ Lemma list_max_elem_of_exists2
    (list_max l) ∈ l.
 Proof.
   destruct (list_max l) eqn : eq_max.
-  - destruct l;[itauto congruence|].
+  - destruct l; [by itauto congruence |].
     specialize (list_max_le (n :: l) 0) as Hle.
     destruct Hle as [Hle _].
     rewrite eq_max in Hle. spec Hle. apply Nat.le_refl.
     rewrite Forall_forall in Hle.
     specialize (Hle n). spec Hle. left.
     assert (Hn0: n = 0) by lia.
-    rewrite Hn0; left.
+    by rewrite Hn0; left.
   - specialize (list_max_elem_of_exists l) as Hmax.
-    rewrite <- eq_max; itauto lia.
+    by rewrite <- eq_max; itauto lia.
 Qed.
 
 Lemma mode_not_empty
@@ -690,14 +676,14 @@ Proof.
 
   assert (Hmaxp: list_max occurrences > 0). {
     rewrite Heqoccurrences, Heql'; cbn.
-    rewrite decide_True; [lia | done].
+    by rewrite decide_True; [lia |].
   }
 
   assert (exists a, (count_occ decide_eq l' a) = list_max occurrences). {
     assert (In (list_max occurrences) occurrences) by (apply list_max_exists; done).
     rewrite Heqoccurrences, in_map_iff in H.
     destruct H as (x & Heq & Hin).
-    rewrite Heqoccurrences. eauto.
+    by rewrite Heqoccurrences; eauto.
   }
 
   assert (exists a, In a (mode l')). {
@@ -712,10 +698,8 @@ Proof.
     apply filter_in; [done |].
     by rewrite H, Heqoccurrences.
   }
-  destruct H.
-  intros contra.
-  rewrite contra in H0.
-  destruct H0; inversion H0.
+  intros contra; rewrite contra in H0.
+  by destruct H0 as [? []].
 Qed.
 
 (**

--- a/theories/VLSM/Lib/StdppListFinSet.v
+++ b/theories/VLSM/Lib/StdppListFinSet.v
@@ -144,7 +144,7 @@ Lemma set_diff_iff a l l' :
   a ∈ set_diff l l' <-> a ∈ l /\ ~ a ∈ l'.
 Proof.
   split.
-  - eauto using set_diff_elim1, set_diff_elim2.
+  - by eauto using set_diff_elim1, set_diff_elim2.
   - by intros []; apply set_diff_intro.
 Qed.
 

--- a/theories/VLSM/Lib/StdppListSet.v
+++ b/theories/VLSM/Lib/StdppListSet.v
@@ -37,8 +37,8 @@ Lemma set_add_intro1 :
   forall (a b : A) (x : set), a ∈ x -> a ∈ set_add b x.
 Proof.
   induction x; cbn.
-  - inversion 1.
-  - destruct (decide (b = a0)); rewrite !elem_of_cons; itauto.
+  - by inversion 1.
+  - by destruct (decide (b = a0)); rewrite !elem_of_cons; itauto.
 Qed.
 
 Lemma set_add_intro2 :
@@ -54,7 +54,7 @@ Qed.
 Lemma set_add_intro :
   forall (a b : A) (x : set), a = b \/ a ∈ x -> a ∈ set_add b x.
 Proof.
-  intros a b x [H1| H2]; auto.
+  by intros a b x [H1| H2]; auto.
 Qed.
 
 Lemma set_add_elim :
@@ -68,24 +68,23 @@ Qed.
 Lemma set_add_not_empty :
   forall (a : A) (x : set), set_add a x <> empty_set.
 Proof.
-  induction x; cbn; [done |].
-  by destruct (decide (a = a0)).
+  by induction x as [| a' x']; cbn; [| destruct (decide (a = a'))].
 Qed.
 
 Lemma set_add_iff a b l :
   a ∈ set_add b l <-> a = b \/ a ∈ l.
 Proof.
   split.
-  - apply set_add_elim.
-  - apply set_add_intro.
+  - by apply set_add_elim.
+  - by apply set_add_intro.
 Qed.
 
 Lemma set_add_nodup a l :
   NoDup l -> NoDup (set_add a l).
 Proof.
   induction 1 as [| x l H H' IH]; cbn.
-  - constructor; [| by apply NoDup_nil]; inversion 1.
-  - destruct (decide (a = x)) as [<- | Hax]; constructor
+  - by constructor; [inversion 1| apply NoDup_nil].
+  - by destruct (decide (a = x)) as [<- | Hax]; constructor
     ; rewrite ?set_add_iff; itauto.
 Qed.
 
@@ -93,44 +92,43 @@ Lemma set_remove_1 (a b : A) (l : set) :
   a ∈ set_remove b l -> a ∈ l.
 Proof.
   induction l as [| x xs Hrec]; cbn; [done |].
-  destruct (decide (b = x)); rewrite !elem_of_cons; itauto.
+  by destruct (decide (b = x)); rewrite !elem_of_cons; itauto.
 Qed.
 
 Lemma set_remove_2 (a b : A) (l : set) :
   NoDup l -> a ∈ set_remove b l -> a <> b.
 Proof.
-  induction l as [| x l IH]; intro Hnd; cbn.
-  - inversion 1.
-  - inversion_clear Hnd.
-    destruct (decide (b = x)) as [<- | Hbx].
-    + by intros Ha ->.
-    + rewrite elem_of_cons. itauto (auto || congruence).
+  induction l as [| x l IH]; intro Hnd; cbn; [by inversion 1 |].
+  inversion_clear Hnd.
+  destruct (decide (b = x)) as [<- | Hbx].
+  - by intros Ha ->.
+  - by rewrite elem_of_cons; firstorder subst.
 Qed.
 
 Lemma set_remove_3 (a b : A) (l : set) :
   a ∈ l -> a <> b -> a ∈ set_remove b l.
 Proof.
   induction l as [| x xs Hrec]; cbn.
-  - inversion 1.
-  - destruct (decide (b = x)) as [<- | Hbx]; rewrite !elem_of_cons; itauto.
+  - by inversion 1.
+  - by destruct (decide (b = x)) as [<- | Hbx]; rewrite !elem_of_cons; itauto.
 Qed.
 
 Lemma set_remove_iff (a b : A) (l : set) :
   NoDup l -> a ∈ set_remove b l <-> a ∈ l /\ a <> b.
 Proof.
-  split; [split |].
-  - eapply set_remove_1; eauto.
-  - eapply set_remove_2; eauto.
-  - destruct 1; apply set_remove_3; auto.
+  repeat split.
+  - by eapply set_remove_1.
+  - by eapply set_remove_2.
+  - by destruct 1; apply set_remove_3.
 Qed.
 
 Lemma set_remove_nodup a l
   : NoDup l -> NoDup (set_remove a l).
 Proof.
-  induction 1 as [| x l H H' IH]; cbn; [constructor |].
+  induction 1 as [| x l H H' IH]; cbn; [by constructor |].
   destruct (decide (a = x)) as [<- | Hax]; [done |].
   constructor; [| done].
-  rewrite set_remove_iff; itauto.
+  by rewrite set_remove_iff; itauto.
 Qed.
 
 Lemma set_union_intro :
@@ -138,40 +136,38 @@ Lemma set_union_intro :
     a ∈ x \/ a ∈ y -> a ∈ set_union x y.
 Proof.
   induction y; cbn.
-  - rewrite elem_of_nil; itauto.
-  - rewrite elem_of_cons, set_add_iff; itauto.
+  - by rewrite elem_of_nil; itauto.
+  - by rewrite elem_of_cons, set_add_iff; itauto.
 Qed.
 
 Lemma set_union_elim :
   forall (a : A) (x y : set),
     a ∈ set_union x y -> a ∈ x \/ a ∈ y.
 Proof.
-  induction y; cbn; rewrite ?elem_of_cons, ?set_add_iff; itauto.
+  by induction y; cbn; rewrite ?elem_of_cons, ?set_add_iff; itauto.
 Qed.
 
 Lemma set_union_iff a l l' :
   a ∈ set_union l l' <-> a ∈ l \/ a ∈ l'.
 Proof.
   split.
-  - apply set_union_elim.
-  - apply set_union_intro.
+  - by apply set_union_elim.
+  - by apply set_union_intro.
 Qed.
 
 Lemma set_union_nodup l l' :
   NoDup l -> NoDup l' -> NoDup (set_union l l').
 Proof.
-  induction 2 as [| x' l' ? ? IH]; cbn; [done |].
-  by apply set_add_nodup.
+  by induction 2 as [| x' l' ? ? IH]; cbn; [| apply set_add_nodup].
 Qed.
 
 Lemma set_diff_intro :
   forall (a : A) (x y : set),
     a ∈ x -> ~ a ∈ y -> a ∈ set_diff x y.
 Proof.
-  induction x; cbn.
-  - inversion 1.
-  - intros y; destruct (decide (a0 ∈ y))
-    ; rewrite elem_of_cons, ?set_add_iff; firstorder congruence.
+  induction x; cbn; [by inversion 1 |].
+  by intros y; destruct (decide (a0 ∈ y));
+    rewrite elem_of_cons, ?set_add_iff; firstorder congruence.
 Qed.
 
 Lemma set_diff_elim1 :
@@ -179,22 +175,21 @@ Lemma set_diff_elim1 :
     a ∈ set_diff x y -> a ∈ x.
 Proof.
   induction x; cbn; [done |]; intros y.
-  destruct (decide (a0 ∈ y)); rewrite elem_of_cons, ?set_add_iff; firstorder.
+  by destruct (decide (a0 ∈ y)); rewrite elem_of_cons, ?set_add_iff; firstorder.
 Qed.
 
 Lemma set_diff_elim2 :
   forall (a : A) (x y : set), a ∈ set_diff x y -> ~ a ∈ y.
 Proof.
-  induction x; cbn.
-  - inversion 1.
-  - intros y. destruct (decide (a0 ∈ y)); rewrite ?set_add_iff; firstorder congruence.
+  induction x; cbn; [by inversion 1 |].
+  by intros y; destruct (decide (a0 ∈ y)); rewrite ?set_add_iff; firstorder congruence.
 Qed.
 
 Lemma set_diff_iff a l l' :
   a ∈ set_diff l l' <-> a ∈ l /\ ~ a ∈ l'.
 Proof.
   split.
-  - eauto using set_diff_elim1, set_diff_elim2.
+  - by eauto using set_diff_elim1, set_diff_elim2.
   - by destruct 1; apply set_diff_intro.
 Qed.
 
@@ -202,8 +197,8 @@ Lemma set_diff_nodup l l' :
   NoDup l -> NoDup (set_diff l l').
 Proof.
   induction 1 as [| x l H H' IH]; cbn.
-  - constructor.
-  - by case_decide; [done |]; apply set_add_nodup.
+  - by constructor.
+  - by case_decide; [| apply set_add_nodup].
 Qed.
 
 End sec_fst_defs.

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -15,8 +15,8 @@ Lemma ForAll_subsumption [A:Type] (P Q: Stream A -> Prop)
   : forall s, ForAll P s -> ForAll Q s.
 Proof.
   apply ForAll_coind.
-  - intros s Hp. apply HPQ. revert Hp. apply fHere.
-  - apply fFurther.
+  - by intros s Hp; apply fHere in Hp; apply HPQ.
+  - by apply fFurther.
 Qed.
 
 Lemma Exists_Str_nth_tl [A : Type] (P : Stream A -> Prop)
@@ -53,20 +53,19 @@ Lemma ForAll1_subsumption [A:Type] (P Q: A -> Prop)
   (HPQ : forall a, P a -> Q a)
   : forall s, ForAll1 P s -> ForAll1 Q s.
 Proof.
-  apply ForAll_subsumption.
-  intro s. apply HPQ.
+  by apply ForAll_subsumption; intro s; apply HPQ.
 Qed.
 
 Lemma ForAll1_forall [A : Type] (P : A -> Prop) s
   : ForAll1 P s <-> forall n, P (Str_nth n s).
 Proof.
   split; intros.
-  - apply ForAll_Str_nth_tl with (m := n) in H. apply H.
+  - by apply ForAll_Str_nth_tl with (m := n) in H; apply H.
   - apply ForAll_coind with (fun s : Stream A => forall n : nat, P (Str_nth n s))
     ; intros.
     + by specialize (H0 0).
     + by specialize (H0 (S n)).
-    + apply H.
+    + by apply H.
 Qed.
 
 Definition ForAll2 [A : Type] (R : A -> A -> Prop) := ForAll (fun s => R (hd s) (hd (tl s))).
@@ -75,21 +74,20 @@ Lemma ForAll2_subsumption [A:Type] (R1 R2 : A -> A -> Prop)
   (HR : forall a b, R1 a b -> R2 a b)
   : forall s, ForAll2 R1 s -> ForAll2 R2 s.
 Proof.
-  apply ForAll_subsumption.
-  intro s. apply HR.
+  by apply ForAll_subsumption; intro s; apply HR.
 Qed.
 
 Lemma ForAll2_forall [A : Type] (R : A -> A -> Prop) s
   : ForAll2 R s <-> forall n, R (Str_nth n s) (Str_nth (S n) s).
 Proof.
   split; intros.
-  - apply ForAll_Str_nth_tl with (m := n) in H.
-    apply fHere in H. by rewrite tl_nth_tl in H.
+  - apply ForAll_Str_nth_tl with (m := n), fHere in H.
+    by rewrite tl_nth_tl in H.
   - apply ForAll_coind with (fun s : Stream A => forall n : nat, R (Str_nth n s) (Str_nth (S n) s))
     ; intros.
-    + by specialize (H0 0).
-    + by specialize (H0 (S n)).
-    + apply H.
+    + by apply (H0 0).
+    + by apply (H0 (S n)).
+    + by apply H.
 Qed.
 
 Lemma recons
@@ -131,7 +129,7 @@ Lemma stream_app_f_equal
   (Hs : EqSt s1 s2)
   : EqSt (stream_app l1 s1) (stream_app l2 s2).
 Proof.
-  by subst; induction l2; [ | constructor].
+  by subst; induction l2; [| constructor].
 Qed.
 
 Lemma stream_app_inj_l
@@ -232,19 +230,20 @@ Lemma elem_of_stream_prefix
 Proof.
   revert l a.
   induction n; simpl; split; intros.
-  - inversion H.
-  - destruct H as [k [Hk _]]. lia.
+  - by inversion H.
+  - by destruct H as [k [Hk _]]; lia.
   - destruct l as (b, l).
     inversion H; subst.
-    + exists 0. split; [lia | done].
+    + by exists 0; split; [lia |].
     + apply IHn in H2 as [k [Hlt Heq]].
-      exists (S k). split; [lia | done].
+      by exists (S k); split; [lia |].
   - destruct l as (b, l).
     destruct H as [k [Hlt Heq]].
     destruct k.
-    + unfold Str_nth in Heq. simpl in Heq. subst. left.
-    + unfold Str_nth in *. simpl in Heq.
-      right. apply IHn. exists k. split; [lia | done].
+    + by unfold Str_nth in Heq; simpl in Heq; subst; left.
+    + unfold Str_nth in *; simpl in Heq.
+      right; apply IHn.
+      by exists k; split; [lia |].
 Qed.
 
 Lemma stream_prefix_app_l
@@ -255,8 +254,7 @@ Lemma stream_prefix_app_l
   (Hle : n <= length l)
   : stream_prefix (stream_app l s) n = list_prefix l n.
 Proof.
-  revert n Hle; induction l; intros [| n] Hle.
-  1-3: by inversion Hle.
+  revert n Hle; induction l; intros [| n] Hle; [by inversion Hle.. |].
   by cbn in *; rewrite IHl; [| lia].
 Qed.
 
@@ -271,9 +269,9 @@ Proof.
   generalize dependent l.
   generalize dependent s.
   induction n.
-  - intros s [| a l] Hge; cbn in *; [done | lia].
+  - by intros s [| a l] Hge; cbn in *; [| lia].
   - intros s [| a l] Hge; cbn in *; [done |].
-    rewrite <- IHn; [done | lia].
+    by rewrite <- IHn; [| lia].
 Qed.
 
 Lemma stream_prefix_map
@@ -314,8 +312,7 @@ Proof.
   split.
   - intros Hp n i Hlt.
     specialize (Hi _ _ Hlt).
-    apply nth_error_nth with (d := hd s) in Hi.
-    rewrite Hi. apply Hp.
+    by apply nth_error_nth with (d := hd s) in Hi; rewrite Hi.
   - intros Hp n.
     assert (Hn : n < S n) by lia.
     specialize (Hp _ _ Hn).
@@ -339,10 +336,8 @@ Proof.
     + intros. rewrite lookup_ge_None_2 in H0; [done |].
       by rewrite stream_prefix_length.
     + pose proof (stream_prefix_length s n) as Hlen.
-      rewrite (Hi n i) by lia.
-      rewrite (Hi n (S i)) by lia.
-      intros a b Ha Hb.
-      inversion Ha; subst. inversion Hb; subst. apply Hp.
+      rewrite (Hi n i), (Hi n (S i)) by lia.
+      by do 2 inversion 1; subst.
   - intros Hp n.
     specialize (Hp (S (S n)) n).
     rewrite !Hi in Hp by lia.
@@ -425,7 +420,7 @@ Lemma stream_suffix_nth
   (i : nat)
   : Str_nth i (stream_suffix s n) = Str_nth (i + n) s.
 Proof.
-  apply Str_nth_plus.
+  by apply Str_nth_plus.
 Qed.
 
 Lemma stream_prefix_suffix
@@ -436,7 +431,7 @@ Lemma stream_prefix_suffix
 Proof.
   generalize dependent l. unfold stream_suffix.
   induction n; [done |]; intros [a l]; cbn.
-  f_equal. apply IHn.
+  by f_equal; apply IHn.
 Qed.
 
 Lemma stream_prefix_prefix
@@ -447,9 +442,8 @@ Lemma stream_prefix_prefix
   : list_prefix (stream_prefix l n2) n1 = stream_prefix l n1.
 Proof.
   revert l n2 Hn.
-  induction n1; intros [a l]; intros [| n2] Hn; cbn.
-  1-3: by inversion Hn.
-  rewrite IHn1; [done | lia].
+  induction n1; intros [a l]; intros [| n2] Hn; cbn; [by inversion Hn.. |].
+  by rewrite IHn1; [| lia].
 Qed.
 
 Definition stream_segment
@@ -503,7 +497,7 @@ Proof.
     clear Hle.
     assert (Hs: n1 + k - n1 = k) by lia.
     rewrite Hs in Heq.
-    rewrite Heq, stream_prefix_nth; [do 2 f_equal |]; lia.
+    by rewrite Heq, stream_prefix_nth; [do 2 f_equal |]; lia.
 Qed.
 
 Lemma stream_prefix_segment
@@ -555,9 +549,7 @@ Proof.
     by apply app_inv_head in Hl1.
   - repeat rewrite app_length.
     unfold stream_segment.
-    repeat rewrite list_suffix_length.
-    repeat rewrite stream_prefix_length.
-    lia.
+    by rewrite !list_suffix_length, !stream_prefix_length; lia.
 Qed.
 
 Definition monotone_nat_stream_prop
@@ -567,7 +559,8 @@ Definition monotone_nat_stream_prop
 Lemma monotone_nat_stream_prop_from_successor s
   : ForAll2 lt s <-> monotone_nat_stream_prop s.
 Proof.
-  apply ForAll2_transitive_lookup. unfold Transitive. lia.
+  apply ForAll2_transitive_lookup.
+  by typeclasses eauto.
 Qed.
 
 Lemma monotone_nat_stream_rev
@@ -577,8 +570,7 @@ Lemma monotone_nat_stream_rev
 Proof.
   intros n1 n2 Hle.
   destruct (decide (n1 <= n2)); [lia|].
-  specialize (Hs n2 n1).
-  spec Hs; lia.
+  by specialize (Hs n2 n1); spec Hs; lia.
 Qed.
 
 Lemma monotone_nat_stream_find s (Hs : monotone_nat_stream_prop s) (n : nat)
@@ -587,16 +579,15 @@ Proof.
   induction n.
   - destruct (hd s) eqn:Hhd .
     + by right; exists 0; left.
-    + left. lia.
-  - destruct (decide (hd s <= S n)); [|left; lia].
+    + by left; lia.
+  - destruct (decide (hd s <= S n)); [| by left; lia].
     right.
     destruct IHn as [Hlt | [k Hk]]
     ; [exists 0; left; cbv in *; lia|].
     destruct (decide (Str_nth (S k) s = S n))
     ; [by exists (S k); left|].
-    exists k. right.
-    specialize (Hs k (S k)).
-    spec Hs; lia.
+    exists k; right.
+    by specialize (Hs k (S k)); spec Hs; lia.
 Qed.
 
 Definition monotone_nat_stream :=
@@ -607,10 +598,7 @@ Lemma monotone_nat_stream_tl
   (Hs : monotone_nat_stream_prop s)
   : monotone_nat_stream_prop (tl s).
 Proof.
-  intros n1 n2 Hlt.
-  specialize (Hs (S n1) (S n2)).
-  apply Hs.
-  lia.
+  by intros n1 n2 Hlt; apply (Hs (S n1) (S n2)); lia.
 Qed.
 
 CoFixpoint nat_sequence_from (n : nat) : Stream nat
@@ -620,22 +608,20 @@ Definition nat_sequence : Stream nat := nat_sequence_from 0.
 
 Lemma nat_sequence_from_nth : forall m n, Str_nth n (nat_sequence_from m) = n + m.
 Proof.
-  intros m n. revert m.
-  induction n; [done |].
-  intros. simpl.
-  unfold Str_nth. simpl.
-  unfold Str_nth in IHn. rewrite IHn. lia.
+  intros m n; revert m.
+  induction n; cbn; intros; [done |].
+  by unfold Str_nth in IHn |- *; cbn; rewrite IHn; lia.
 Qed.
 
 Lemma nat_sequence_nth : forall n, Str_nth n nat_sequence = n.
 Proof.
-  intros. unfold nat_sequence. rewrite nat_sequence_from_nth. lia.
+  by intros; unfold nat_sequence; rewrite nat_sequence_from_nth; lia.
 Qed.
 
 Lemma nat_sequence_from_sorted : forall n, ForAll2 lt (nat_sequence_from n).
 Proof.
-  intro n.
-  apply ForAll2_forall. intro m. rewrite !nat_sequence_from_nth. lia.
+  intro n; apply ForAll2_forall; intro m.
+  by rewrite !nat_sequence_from_nth; lia.
 Qed.
 
 Definition nat_sequence_sorted : ForAll2 lt nat_sequence :=
@@ -644,8 +630,7 @@ Definition nat_sequence_sorted : ForAll2 lt nat_sequence :=
 Lemma nat_sequence_from_prefix_sorted
   : forall m n, LocallySorted lt (stream_prefix (nat_sequence_from m) n).
 Proof.
-  intros. apply LocallySorted_ForAll2. apply stream_prefix_ForAll2.
-  apply nat_sequence_from_sorted.
+  by intros; apply LocallySorted_ForAll2, stream_prefix_ForAll2, nat_sequence_from_sorted.
 Qed.
 
 Definition nat_sequence_prefix_sorted
@@ -720,7 +705,7 @@ Proof.
   intros [a s] H.
   inversion H. simpl in H1. apply IH in H1.
   constructor; [| done].
-  rewrite Exists1_exists in *. firstorder.
+  by rewrite Exists1_exists in *; firstorder.
 Qed.
 
 Lemma FinitelyManyBound_impl_rev
@@ -731,8 +716,5 @@ Proof.
   exists n.
   apply ForAll1_forall.
   rewrite ForAll1_forall in Hn.
-  intros n' Hn'.
-  elim (Hn n').
-  revert Hn'.
-  apply HPQ.
+  by firstorder.
 Qed.

--- a/theories/VLSM/Lib/StreamFilters.v
+++ b/theories/VLSM/Lib/StreamFilters.v
@@ -24,8 +24,9 @@ Lemma filtering_subsequence_sorted
   (Hfs : filtering_subsequence P s ns)
   : ForAll2 lt ns.
 Proof.
-  apply proj2 in Hfs. revert Hfs. apply ForAll2_subsumption.
-  intros. apply H.
+  destruct Hfs as [_ Hfs].
+  revert Hfs; apply ForAll2_subsumption.
+  by intros a b H; apply H.
 Qed.
 
 Lemma filtering_subsequence_prefix_sorted
@@ -67,8 +68,8 @@ Lemma filtering_subsequence_witness
   (k : nat)
   : P (Str_nth (Str_nth k ss) s).
 Proof.
-  apply proj2 in Hfs. rewrite ForAll2_forall in Hfs.
-  apply Hfs.
+  destruct Hfs as [_ Hfs].
+  by rewrite ForAll2_forall in Hfs; apply Hfs.
 Qed.
 
 (**
@@ -89,7 +90,7 @@ Proof.
   apply monotone_nat_stream_prop_from_successor in Hss_sorted.
   apply monotone_nat_stream_find with (n := n) in Hss_sorted.
   destruct Hss_sorted  as [Hlt | [k Hk]].
-  - destruct Hfs as [Hfs _]. by elim (Hfs n).
+  - by destruct Hfs as [Hfs _]; elim (Hfs n).
   - destruct Hk as [Heq | Hk]; subst; [by exists k |].
     exfalso. apply proj2 in Hfs.
     rewrite ForAll2_forall in Hfs.
@@ -113,8 +114,8 @@ Proof.
   apply (@set_equality_predicate _ lt _).
   - by apply filtering_subsequence_prefix_sorted with P s.
   - apply LocallySorted_filter.
-    + unfold Transitive. lia.
-    + apply nat_sequence_prefix_sorted.
+    + by typeclasses eauto.
+    + by apply nat_sequence_prefix_sorted.
   - unfold ListSetExtras.set_eq, subseteq, list_subseteq.
     setoid_rewrite elem_of_list_filter.
     setoid_rewrite elem_of_stream_prefix.
@@ -126,19 +127,17 @@ Proof.
       eexists; split; [| done].
       destruct (decide (i = k)); [subst; lia|].
       cut (Str_nth i ss < Str_nth k ss); [lia|].
-      apply ForAll2_transitive_lookup; [unfold Transitive; lia| | lia].
+      apply ForAll2_transitive_lookup; [by typeclasses eauto | | lia].
       by apply filtering_subsequence_sorted in Hfs.
     + destruct H as [Hpa [_a [Hlt H_a]]].
       subst _a.
-      specialize (filtering_subsequence_witness_rev _ _ _ Hfs _ Hpa)
-        as [k' Hk'].
-      subst.
+      destruct (filtering_subsequence_witness_rev _ _ _ Hfs _ Hpa) as [k' ->].
       exists k'.
       split; [| done].
       apply filtering_subsequence_sorted in Hfs.
       apply monotone_nat_stream_prop_from_successor in Hfs.
       specialize (monotone_nat_stream_rev _ Hfs k' k) as Hle.
-      feed specialize Hle; lia.
+      by feed specialize Hle; lia.
 Qed.
 
 Lemma filtering_subsequence_prefix_length
@@ -356,15 +355,15 @@ Proof.
   intros.
   destruct Hev; simpl.
   - destruct (decide _); [| done].
-    exists 0. split_and!; f_equal; [lia | done | lia].
+    by exists 0; split_and!; f_equal; [lia | | lia].
   - destruct (decide _); simpl.
-    + exists 0. split_and!; f_equal; [lia | done | lia].
+    + by exists 0; split_and!; f_equal; [lia | | lia].
     + specialize (H (tl s) Hev (S n)) as (k & Heq & Hp & Hnp).
       exists (S k). rewrite Heq.
       split; [f_equal; lia|].
       split; [done |].
       intros. destruct i; [done |].
-      apply Hnp. lia.
+      by apply Hnp; lia.
 Qed.
 
 Lemma stream_filter_fst_pos_infinitely_often
@@ -373,8 +372,8 @@ Lemma stream_filter_fst_pos_infinitely_often
   (n : nat)
   : InfinitelyOften P s -> InfinitelyOften P (stream_filter_fst_pos s Hev n).2.
 Proof.
-  destruct (stream_filter_fst_pos_characterization s Hev n) as [k [Heq _]].
-  rewrite Heq. apply InfinitelyOften_nth_tl.
+  destruct (stream_filter_fst_pos_characterization s Hev n) as (k & -> & _).
+  by apply InfinitelyOften_nth_tl.
 Qed.
 
 Lemma stream_filter_fst_pos_le
@@ -383,8 +382,8 @@ Lemma stream_filter_fst_pos_le
   (n : nat)
   : n <= (stream_filter_fst_pos s Hev n).1.
 Proof.
-  destruct (stream_filter_fst_pos_characterization s Hev n) as [k [Heq _]].
-  rewrite Heq. simpl. lia.
+  destruct (stream_filter_fst_pos_characterization s Hev n) as (k & -> & _).
+  by cbn; lia.
 Qed.
 
 Lemma stream_filter_fst_pos_nth_tl_has_property
@@ -405,7 +404,7 @@ Proof.
   intros i [Hlt_i Hilt].
   apply stdpp_nat_le_sum in Hlt_i as [i' ->].
   rewrite Nat.add_comm, <- Str_nth_plus.
-  apply Hnp. simpl in *. lia.
+  by apply Hnp; cbn in *; lia.
 Qed.
 
 (**
@@ -441,7 +440,7 @@ Proof.
     assert (Htl : (stream_filter_fst_pos s (fHere (Exists1 P) s Hinf) n0).2 = Str_nth_tl (S k) s).
     { by rewrite Heq. }
     exists k.
-    rewrite Hk. simpl. simpl in Htl. rewrite <- Htl. eauto.
+    by rewrite Hk; cbn in *; rewrite <- Htl; eauto.
   - replace
       (Str_nth_tl (S n) (stream_filter_positions s Hinf n0))
       with (tl (Str_nth_tl n (stream_filter_positions s Hinf n0)))
@@ -464,7 +463,7 @@ Proof.
     rewrite tl_nth_tl, Str_nth_tl_plus in Htl.
     rewrite Str_nth_plus in Hp.
     rewrite <- Htl.
-    replace (n0 + S (k + kn)) with (S (n0 + kn + k)) by lia. eauto.
+    by replace (n0 + S (k + kn)) with (S (n0 + kn + k)) by lia; eauto.
 Qed.
 
 Lemma stream_filter_positions_monotone
@@ -475,8 +474,8 @@ Proof.
   revert s Hinf n.
   cofix H.
   intros.
-  constructor; simpl; [|apply H].
-  apply stream_filter_fst_pos_le.
+  constructor; simpl; [| by apply H].
+  by apply stream_filter_fst_pos_le.
 Qed.
 
 (** [stream_filter_positions] produces a [filtering_sequence]. *)
@@ -506,7 +505,7 @@ Proof.
     intros i [Hle Hlt].
     apply stdpp_nat_le_sum in Hle as [k' ->].
     rewrite Nat.add_comm, <- Str_nth_tl_plus. simpl.
-    apply Hnp. lia.
+    by apply Hnp; lia.
 Qed.
 
 (**
@@ -560,7 +559,7 @@ Lemma stream_map_option_prefix
 Proof.
   subst map_opt_pre m.
   rewrite !(map_option_as_filter f (stream_prefix s n)).
-  apply fitering_subsequence_stream_filter_map_prefix.
+  by apply fitering_subsequence_stream_filter_map_prefix.
 Qed.
 
 Program Definition stream_map_option_prefix_ex
@@ -613,14 +612,10 @@ Proof.
     rewrite Heq1.
     simpl.
     destruct _k; [lia|].
-    exfalso. apply (H_k 0); [lia | by eexists].
+    by exfalso; apply (H_k 0); [lia | eexists].
   }
   induction n; intros; rewrite stream_filter_positions_unroll; unfold Streams.Str_nth; simpl.
-  - replace (k + 0) with k by lia.
-    apply Hfirst.
+  - by rewrite Hfirst; lia.
   - unfold Streams.Str_nth in IHn.
-    rewrite IHn.
-    simpl. replace (k + S n) with (S (k + n)) by lia.
-    f_equal. f_equal.
-    apply Hfirst.
+    by rewrite IHn, Hfirst; lia.
 Qed.

--- a/theories/VLSM/Lib/Temporal.v
+++ b/theories/VLSM/Lib/Temporal.v
@@ -36,7 +36,7 @@ Proof.
       by apply (f_equal (@Streams.tl _)) in Heqfs.
   - induction 1.
     + by constructor.
-    + rewrite unfold_Stream. by constructor.
+    + by rewrite unfold_Stream; constructor.
 Qed.
 
 Lemma Forever_map [A B:Type] (f: A -> B) (P: Stream B -> Prop): forall s,
@@ -50,7 +50,7 @@ Proof.
     + by rewrite (unfold_Stream (map f (Cons a s))).
     + by apply lem.
   - cofix lem. destruct s.
-    inversion 1; subst; constructor; [done |]. by apply lem.
+    by inversion 1; subst; constructor; [| apply lem].
 Qed.
 
 Definition progress [A:Type] (R: A -> A -> Prop) : Stream A -> Prop :=
@@ -62,9 +62,8 @@ Proof.
   cofix not_eventually.
   destruct s.
   constructor.
-  by contradict H; constructor.
-  apply not_eventually.
-  by contradict H; constructor.
+  - by contradict H; constructor.
+  - by apply not_eventually; contradict H; constructor.
 Qed.
 
 Lemma forever_impl [A:Type] (P Q : Stream A -> Prop):
@@ -72,23 +71,23 @@ Lemma forever_impl [A:Type] (P Q : Stream A -> Prop):
 Proof.
   cofix forever_impl.
   destruct s, 1.
-  inversion 1. subst.
-  constructor;auto.
+  inversion 1; subst.
+  by constructor; auto.
 Qed.
 
 Lemma eventually_impl [A:Type] (P Q : Stream A -> Prop):
   forall s, Forever (fun s => P s -> Q s) s -> Eventually P s -> Eventually Q s.
 Proof.
   induction 2.
-  - apply ehere. apply fhere in H. auto.
-  - apply elater. apply flater in H. auto.
+  - by apply fhere in H; apply ehere, H.
+  - by apply flater in H; apply elater, IHEventually.
 Qed.
 
 Lemma forever_tauto [A:Type] (P: Stream A -> Prop):
   (forall s, P s) -> forall s, Forever P s.
 Proof.
   cofix forever_tauto.
-  destruct s;constructor;auto.
+  by destruct s; constructor; auto.
 Qed.
 
 Lemma use_eventually [A:Type] (P Q : Stream A -> Prop):
@@ -96,9 +95,8 @@ Lemma use_eventually [A:Type] (P Q : Stream A -> Prop):
             exists s', P s' /\ Forever Q s'.
 Proof.
   induction 1.
-  exists s;itauto.
-  inversion 1. subst.
-  itauto.
+  - by exists s; itauto.
+  - by inversion 1; subst; itauto.
 Qed.
 
 Lemma refutation [A:Type] [R:A -> A-> Prop] (HR: well_founded R)
@@ -124,9 +122,9 @@ Proof.
   destruct s.
   intro H.
   constructor.
-  - intro a. by destruct (H a).
+  - by intro a; destruct (H a).
   - apply forall_forever.
-    intro a. by destruct (H a).
+    by intro a; destruct (H a).
 Qed.
 
 Lemma not_forever [A:Type] (P: Stream A -> Prop):
@@ -135,7 +133,8 @@ Proof.
   intros s H. apply Classical_Prop.NNPP.
   contradict H.
   apply not_eventually in H.
-  revert H. apply forever_impl,forever_tauto. intro. apply Classical_Prop.NNPP.
+  revert H; apply forever_impl, forever_tauto.
+  by intro; apply Classical_Prop.NNPP.
 Qed.
 
 Lemma stabilization [A:Type] [R:A -> A-> Prop] (HR: well_founded R)
@@ -167,7 +166,7 @@ Proof.
     destruct H as [x H _]. revert Hprogress.
     clear s.
     induction H;intro Hprogress.
-    + destruct s. simpl in H. simpl in H |- *. congruence.
+    + by destruct s; cbn in *; congruence.
     + simpl. intro. subst a0.
       apply elater.
       inversion Hprogress; subst s0.
@@ -178,5 +177,5 @@ Proof.
       * by constructor.
   - apply the_lemma.
     + by destruct Hprogress.
-    + intro x. by destruct (H x).
+    + by intro x; destruct (H x).
 Qed.

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -40,7 +40,7 @@ Lemma zero_predecessors
 Proof.
   apply length_zero_iff_nil in Ha.
   apply Forall_filter_nil in Ha.
-  apply Ha.
+  by apply Ha.
 Qed.
 
 (** Finds an element minimizing [count_predecessors] in <<min :: remainder>>. *)
@@ -68,9 +68,8 @@ Proof.
   induction l'.
   - by intros; left.
   - intro a0. simpl.
-    destruct (decide (count_predecessors a < count_predecessors a0));
-    [specialize (IHl' a)|specialize (IHl' a0)];
-    destruct IHl'; rewrite elem_of_cons; itauto.
+    by destruct (decide (count_predecessors a < count_predecessors a0));
+      [destruct (IHl' a) | destruct (IHl' a0)]; rewrite elem_of_cons; itauto.
 Qed.
 
 Lemma min_predecessors_correct
@@ -82,7 +81,7 @@ Lemma min_predecessors_correct
 Proof.
   unfold mins; clear mins. unfold min; clear min. generalize dependent a.
   induction l'; intros; rewrite Forall_forall; intros.
-  - simpl in H; inversion H; subst; [simpl; lia|inversion H2].
+  - by simpl in H; inversion H; subst; cbn; [lia | inversion H2].
   - rewrite elem_of_cons in H.
     setoid_rewrite Forall_forall in IHl'.
     destruct H as [Heq | Hin]; subst.
@@ -224,9 +223,7 @@ Proof.
   specialize (min_predecessors_correct l' a); simpl; intro Hall.
   rewrite Forall_forall in Hall.
   rewrite Hl in Hinx.
-  specialize (Hall x Hinx).
-  unfold min.
-  lia.
+  by specialize (Hall x Hinx); unfold min; lia.
 Qed.
 
 End sec_min_predecessors.
@@ -251,7 +248,7 @@ Qed.
   `{StrictOrder A preceeds} (P : A -> Prop)
   : StrictOrder (precedes_P preceeds P).
 Proof.
-  split; typeclasses eauto.
+  by split; typeclasses eauto.
 Qed.
 
 Section sec_topologically_sorted.
@@ -334,10 +331,8 @@ Proof.
   apply elem_of_list_split in Ha.
   destruct Ha as [la1 [la2 Ha]].
   specialize (topologically_sorted_occurrences_ordering a b Hab la1 la2 Ha l1 l2 Heq).
-  intros [lab Hlab].
-  subst.
-  rewrite elem_of_app.
-  right; left.
+  intros [lab ->].
+  by rewrite elem_of_app; right; left.
 Qed.
 
 (**
@@ -355,9 +350,9 @@ Proof.
   destruct Hb as [l12 [l3 Hb']].
   specialize (top_sort_before a b Hab Ha l12 l3 Hb').
   intros Ha12. apply elem_of_list_split in Ha12.
-  destruct Ha12 as [l1 [l2 Ha12]].
-  subst l12.
-  exists l1, l2, l3. by rewrite Hb', <- app_assoc.
+  destruct Ha12 as [l1 [l2 ->]].
+  exists l1, l2, l3.
+  by rewrite Hb', <- app_assoc.
 Qed.
 
 End sec_topologically_sorted_fixed_list.
@@ -431,7 +426,7 @@ Proof.
              (init ++ [a]) P Hl Hts a b Hab init [] eq_refl l1 l2 Heq)
         as [lab Hlab].
   rewrite Hlab in Heq. apply (f_equal length) in Heq.
-  rewrite !app_length in Heq. cbn in Heq. lia.
+  by rewrite !app_length in Heq; cbn in Heq; lia.
 Qed.
 
 Section sec_top_sort.
@@ -478,7 +473,7 @@ Proof.
   remember (min_predecessors precedes (a :: l) l a) as min.
   remember (set_remove min l) as l'.
   destruct (decide (min = a)); try rewrite e.
-  - subst. by apply set_eq_cons, IHn.
+  - by subst; apply set_eq_cons, IHn.
   - specialize (min_predecessors_in precedes (a :: l) l a).
     rewrite <- Heqmin. simpl. intros [Heq | Hin]; [done |].
     specialize (IHn (a :: l')).
@@ -487,17 +482,17 @@ Proof.
     specialize (IHn Hlen).
     split; intros x Hx; rewrite elem_of_cons in Hx;
       destruct Hx as [Heq|Hinx]; try (subst x).
-    + right. apply IHn. left.
+    + by right; apply IHn; left.
     + destruct (decide (x = min)); try subst x.
-      * left.
+      * by left.
       * specialize (set_remove_3 _ _ l Hinx n1).
         rewrite <- Heql'. intro Hinx'.
         by right; apply IHn; right.
     + by right.
     + apply IHn in Hinx.
       rewrite elem_of_cons in Hinx.
-      destruct Hinx as [-> | Hinx]; [left |].
-      right. subst. by apply set_remove_1 in Hinx.
+      destruct Hinx as [-> | Hinx]; [left | right]; subst.
+      by apply set_remove_1 in Hinx.
 Qed.
 
 Lemma top_sort_nodup
@@ -509,8 +504,7 @@ Proof.
   remember (length l) as len.
   generalize dependent l.
   induction len; intros.
-  - symmetry in Heqlen. apply length_zero_iff_nil in Heqlen. subst l.
-    constructor.
+  - by cbn; symmetry in Heqlen; apply length_zero_iff_nil in Heqlen; subst.
   - destruct l as [| a l]; [by constructor |].
     simpl.
     assert (Hl' : NoDup l) by (inversion Hl; done).
@@ -561,9 +555,10 @@ Lemma top_sort_sorted : topologically_sorted precedes (top_sort l).
 Proof.
   intro a; intros.
   intro Ha2.
-  assert (Ha : a ∈ l). {
+  assert (Ha : a ∈ l).
+  {
     apply top_sort_set_eq.
-    rewrite Heq. simpl. rewrite elem_of_app, elem_of_cons. auto.
+    by cbn in Heq; rewrite Heq, elem_of_app, elem_of_cons; auto.
   }
   unfold top_sort in Heq.
   remember (length l) as n.
@@ -647,8 +642,8 @@ Definition topological_sorting
 Corollary top_sort_correct : topological_sorting l (top_sort l).
 Proof.
   split.
-  - apply top_sort_set_eq.
-  - apply top_sort_sorted.
+  - by apply top_sort_set_eq.
+  - by apply top_sort_sorted.
 Qed.
 
 (** ** Maximal elements *)
@@ -661,28 +656,26 @@ Lemma maximal_element_in
   a ∈ l.
 Proof.
   unfold get_maximal_element in Hmax.
-  assert (exists l', l' ++ [a] = top_sort l). {
-    destruct l.
-    - simpl in Hmax. itauto congruence.
-    - specialize (@exists_last _ (top_sort (a0 :: l0))) as Hlast.
-      spec Hlast. unfold top_sort. simpl. itauto congruence.
-      destruct Hlast as [l' [a' Heq]].
-      rewrite Heq in Hmax.
-      rewrite Heq.
-      exists l'.
-      specialize (last_error_is_last l' a') as Hlast.
-      itauto congruence.
+  assert (exists l', l' ++ [a] = top_sort l).
+  {
+    destruct l; [by simpl in Hmax; itauto congruence |].
+    specialize (@exists_last _ (top_sort (a0 :: l0))) as Hlast.
+    spec Hlast. unfold top_sort. simpl. itauto congruence.
+    destruct Hlast as [l' [a' Heq]].
+    rewrite Heq in Hmax.
+    rewrite Heq.
+    exists l'.
+    specialize (last_error_is_last l' a') as Hlast.
+    by itauto congruence.
   }
-  assert (a ∈ (top_sort l)). {
-    destruct H as [l' Heq].
-    rewrite <- Heq.
-    apply elem_of_app.
-    right. left.
+  assert (a ∈ (top_sort l)).
+  {
+    destruct H as [l' <-].
+    by apply elem_of_app; right; left.
   }
   specialize (top_sort_correct) as [Htop _].
   destruct Htop as [_ Htop].
-  specialize (Htop a H0).
-  itauto.
+  by specialize (Htop a H0); itauto.
 Qed.
 
 Lemma get_maximal_element_correct
@@ -710,8 +703,7 @@ Proof.
     unfold Irreflexive in Hirr. unfold complement in Hirr.
     unfold Reflexive in Hirr.
     assert (P max) by (eapply Forall_forall; done).
-    specialize (Hirr (exist _ max H)).
-    itauto.
+    by specialize (Hirr (exist _ max H)); itauto.
   - rewrite HeqA in Hmax.
     specialize (@exists_last _ (a0 :: sufA)) as Hex.
     spec Hex. itauto congruence.
@@ -725,9 +717,7 @@ Proof.
     rewrite Heq in HeqA.
     specialize (Htop HeqA).
     subst a'.
-    contradict Htop.
-    apply elem_of_app.
-    right. left.
+    by contradict Htop; apply elem_of_app; right; left.
 Qed.
 
 Lemma get_maximal_element_some
@@ -735,15 +725,14 @@ Lemma get_maximal_element_some
   exists a, get_maximal_element = Some a.
 Proof.
   unfold get_maximal_element.
-  destruct l.
-  - congruence.
-  - simpl.
-    exists (List.last
-       (top_sort_n (length l0)
-          (if decide (min_predecessors precedes (a :: l0) l0 a = a)
-           then l0
-           else a :: set_remove (min_predecessors precedes (a :: l0) l0 a) l0))
-       (min_predecessors precedes (a :: l0) l0 a)). itauto.
+  destruct l; cbn; [by congruence |].
+  exists (List.last
+     (top_sort_n (length l0)
+        (if decide (min_predecessors precedes (a :: l0) l0 a = a)
+         then l0
+         else a :: set_remove (min_predecessors precedes (a :: l0) l0 a) l0))
+     (min_predecessors precedes (a :: l0) l0 a)).
+  by itauto.
 Qed.
 
 End sec_top_sort.
@@ -776,14 +765,14 @@ Corollary simple_topologically_sorted_precedes_closed_remove_last
   (Hpc : precedes_closed precedes l)
   : precedes_closed precedes init.
 Proof.
-  eapply topologically_sorted_precedes_closed_remove_last;
-    [typeclasses eauto | apply Forall_True | done..].
+  by eapply topologically_sorted_precedes_closed_remove_last;
+    [typeclasses eauto | apply Forall_True | ..].
 Qed.
 
 Corollary simple_top_sort_correct : forall l,
   topological_sorting precedes l (top_sort precedes l).
 Proof.
-  intro; eapply top_sort_correct; [typeclasses eauto | apply Forall_True].
+  by intro; eapply top_sort_correct; [typeclasses eauto | apply Forall_True].
 Qed.
 
 Corollary simple_maximal_element_in l
@@ -791,7 +780,7 @@ Corollary simple_maximal_element_in l
   (Hmax : get_maximal_element precedes l = Some a) :
   a ∈ l.
 Proof.
-  eapply maximal_element_in; [typeclasses eauto | apply Forall_True | done].
+  by eapply maximal_element_in; [typeclasses eauto | apply Forall_True |].
 Qed.
 
 Corollary simple_get_maximal_element_correct l
@@ -800,14 +789,14 @@ Corollary simple_get_maximal_element_correct l
   (Hmax : get_maximal_element precedes l = Some max) :
   ~ precedes max a.
 Proof.
-  eapply get_maximal_element_correct; [typeclasses eauto | apply Forall_True | done..].
+  by eapply get_maximal_element_correct; [typeclasses eauto | apply Forall_True | ..].
 Qed.
 
 Corollary simple_get_maximal_element_some
   l (Hne : l <> []) :
   exists a, get_maximal_element precedes l = Some a.
 Proof.
-  eapply get_maximal_element_some; [apply Forall_True | done].
+  by eapply get_maximal_element_some; [apply Forall_True |].
 Qed.
 
 End sec_simple_top_sort.


### PR DESCRIPTION
I made sure that all subgoals end with the use of `by`, refactoring some proofs as I went along.

Also with @bmmoore we agreed that we should write `by congruence`, `by itauto` even though `congruence` and `itauto` are succeed-or-fail style tactics.

Similarly we should also write `by firstorder`.