### PR TITLE
remove spec tactic with multiple arguments

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -429,7 +429,7 @@ Proof.
     rewrite set_diff_iff in Hi.
     apply not_and_r in Hi as [Hi | Hi]; [elim Hi; apply elem_of_enum|].
     apply dec_stable in Hi.
-    spec Hgen (message_as_byzantine_label m i Hi).
+    specialize (Hgen (message_as_byzantine_label m i Hi)).
     spec Hgen.
     { split; [| done].
       cbn. unfold fixed_byzantine_IM, update_IM. simpl.

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -80,7 +80,7 @@ Proof.
   apply elem_of_list_fmap in Hitem as [((pre, _item), _suf) [Heq_item Hitem]].
   apply elem_of_list_filter, proj2, elem_of_one_element_decompositions in Hitem.
   subst tr _item.
-  spec Hinput_none item.
+  specialize (Hinput_none item).
   spec Hinput_none; [| by congruence].
   by apply elem_of_app; right; apply elem_of_app; do 2 left.
 Qed.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -151,7 +151,7 @@ Proof.
   - by intros Hv; eapply equivocating_validators_is_equivocating_tracewise_iff with (Cm := Cm).
   - intros (msg & Hsender & Heqv).
     apply Hincl.
-    spec Hwitness v;
+    specialize (Hwitness v);
     rewrite finite_trace_last_is_last in Hwitness;
     apply Hwitness.
     exists msg. split; [done |].
@@ -194,7 +194,7 @@ Proof.
     simpl in Heqv. destruct Heqv as [Heq_m Heqv].
     by inversion Heq_m.
   - elim Hnv.
-    spec Hwitness v.
+    specialize (Hwitness v).
     apply finite_valid_trace_from_to_last in Htr as Hs.
     simpl in Hs, Hwitness. rewrite Hs in Hwitness.
     apply Hwitness. exists m'. split; [done |].
@@ -390,9 +390,9 @@ Proof.
               _ Htr'_lst m
             ) as [Hconsistency _].
           spec Hconsistency; [by exists is, tr', Htr' |].
-          by spec Hconsistency is' tr'' Htr''.
+          by specialize (Hconsistency is' tr'' Htr'').
         }
-        spec Hwitness v.
+        specialize (Hwitness v).
         rewrite finite_trace_last_is_last in Hwitness.
         simpl in Hwitness.
         apply Hwitness.
@@ -517,10 +517,10 @@ Proof.
     destruct
       (equivocating_validators_witness_last_char _ _ _ _ _ _ Htr'_item Hwitness)
       as [[Heq Hwitness'] | [msg [Heq_om [v [Hsender [Hnv Hneq]]]]]].
-    + spec IHn (length tr').
+    + specialize (IHn (length tr')).
       rewrite app_length in Hn. simpl in Hn.
       spec IHn; [lia|].
-      spec IHn is tr'.
+      specialize (IHn is tr').
       spec IHn; [by subst m; setoid_rewrite Heq |].
       specialize (IHn eq_refl).
       destruct Htr'_item as [Htr'_item Hinit].
@@ -531,7 +531,7 @@ Proof.
         split; [| done].
         by apply finite_valid_trace_from_to_forget_last in Htr'.
       }
-      spec IHn Hwitness'.
+      specialize (IHn Hwitness').
       destruct IHn as [is' [tr'' [[Htr'' Hinit'] Hprefix]]].
       specialize
         (finite_valid_trace_from_to_app PreFree _ _ _ _ _ Htr'' Hitem)
@@ -553,20 +553,20 @@ Proof.
         by subst.
       }
       destruct Hwitness' as [is' [tr''[Htr'' Hwitness']]].
-      spec IHm (set_size (equivocating_validators s)) (length tr'').
+      specialize (IHm (set_size (equivocating_validators s)) (length tr'')).
       spec IHm.
       {
         rewrite Hneq.
         setoid_rewrite size_union; [by rewrite size_singleton; unfold size; lia |].
         by intro v'; rewrite elem_of_singleton; intros ->.
       }
-      spec IHm is' tr''.
+      specialize (IHm is' tr'').
       apply finite_valid_trace_init_to_last in Htr'' as Htr''_lst.
       simpl in *.
       rewrite Htr''_lst in IHm.
       specialize (IHm eq_refl eq_refl).
       spec IHm; [by apply finite_valid_trace_init_to_forget_last in Htr'' |].
-      spec IHm Hwitness'.
+      specialize (IHm Hwitness').
       destruct IHm as [is'' [tr''' [[Htr''' Hinit'] Hprefix]]].
       apply proj1, finite_valid_trace_from_to_app_split, proj2 in Htr'_item as Hitem.
       simpl in *.
@@ -702,7 +702,7 @@ Proof.
     by exists i.
   }
   apply elem_of_elements in Hequivocating_v.
-  spec Hproj (@dexist _ _ (fun v => sub_index_prop_dec (elements(equivocating_validators sf)) v) v Hequivocating_v).
+  specialize (Hproj (@dexist _ _ (fun v => sub_index_prop_dec (elements(equivocating_validators sf)) v) v Hequivocating_v)).
   by apply (VLSM_embedding_can_emit Hproj).
 Qed.
 
@@ -762,7 +762,7 @@ Proof.
     apply Free_has_sender in Hiom as _Hsender.
     destruct (sender im) as [v|] eqn:Hsender; [| by congruence].
     clear _Hsender.
-    spec Heqv v.
+    specialize (Heqv v).
     rewrite finite_trace_last_is_last in Heqv.
     simpl in Heqv.
     assert (Hpre_s : valid_state_prop (pre_loaded_with_all_messages_vlsm Free) s).

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -436,7 +436,7 @@ Proof.
   apply Htransition in Hemitted. clear Htransition.
   remember (s0 i) as s0i. clear s0 Heqs0i.
   remember (s1 i) as s1i. clear s1 Heqs1i.
-  spec Hsender_safety i.
+  specialize (Hsender_safety i).
   spec Hsender_safety; [by eexists _,_, _ |].
   rewrite Hsender_safety in Hj; subst.
   by eexists _,_, _.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -64,7 +64,7 @@ Proof.
   apply Forall_filter_nil.
   apply Forall_forall.
   intros i _.
-  spec Hs i.
+  specialize (Hs i).
   destruct Hs as [Hs _].
   by congruence.
 Qed.
@@ -362,7 +362,7 @@ Lemma lift_initial_to_equivocators_state
 Proof.
   unfold vinitial_state_prop in *. simpl in *.
   unfold composite_initial_state_prop in *.
-  by intro i; spec Hs i.
+  by intro i; specialize (Hs i).
 Qed.
 
 Definition newmachine_descriptors_list

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -762,7 +762,7 @@ Proof.
     specialize (IHtr _ Htr).
     specialize (equivocators_transition_item_project_proper_characterization descriptors x)
       as Hproperx.
-    spec Hproperx Hdescriptors.
+    specialize (Hproperx Hdescriptors).
     destruct Hproperx as [oitem [final_descriptors' [Hprojectx [Hitemx Hproperx]]]].
     specialize (Hproperx (finite_trace_last is tr)).
     rewrite equivocators_trace_project_app_iff in Hproject_tr.
@@ -784,7 +784,7 @@ Proof.
 
     destruct l as (i, li). simpl in *.
     destruct (decide (i = eqv)).
-    + subst. spec His_tr eqv. spec Htr_x eqv.
+    + subst. specialize (His_tr eqv). specialize (Htr_x eqv).
       destruct (descriptors eqv) eqn:Hvin_desc_eqv;
         [by simpl in Hex_new; rewrite Hex_new in Hex_new' |].
       destruct (final_descriptors' eqv) eqn:Hfin_desc_eqv'.
@@ -814,7 +814,7 @@ Proof.
     (equivocators_trace_project_preserves_equivocating_indices _ _ _ _ _ _
       Htr Hproper Hproject_tr
     ) as Hincl.
-  intros eqv Heqv. spec Hincl eqv Heqv.
+  intros eqv Heqv. specialize (Hincl eqv Heqv).
   apply set_union_iff in Hincl.
   clear Heqv.
   destruct Hincl as [|Heqv]; [done |].
@@ -977,7 +977,7 @@ Proof.
     as Hproperx.
   unfold final_state in Hproper.
   rewrite finite_trace_last_is_last in Hproper.
-  spec Hproperx Hproper.
+  specialize (Hproperx Hproper).
   destruct Hproperx as [oitem [final_descriptors' [Hprojectx [Hitemx Hproperx]]]].
   specialize (Hproperx (finite_trace_last is tr)).
   unfold equivocators_trace_project.
@@ -1016,7 +1016,7 @@ Proof.
       (zero_descriptor IM) is tr
     ) as Hproject.
   simpl in Hproject. spec Hproject; [by apply zero_descriptor_proper |].
-  spec Hproject Htr.
+  specialize (Hproject Htr).
   destruct Hproject as [trX [initial_descriptors [Hproject _]]].
   exists trX.
   replace initial_descriptors with (zero_descriptor IM) in Hproject; [done |].
@@ -1184,7 +1184,7 @@ Proof.
     as Hcommute.
   assert (Hfinali : final_descriptors i = eqv_final) by (subst; state_update_simpl; done).
   rewrite Hfinali in Hcommute.
-  spec Hcommute Hprojecti.
+  specialize (Hcommute Hprojecti).
   destruct Hcommute as [Hiniti Hcommute].
   clear -Hex Hcommute. subst.
   apply Exists_exists in Hex. destruct Hex as [x [Hx Hm]].
@@ -1510,7 +1510,7 @@ Proof.
     (preloaded_equivocators_valid_trace_from_project (zero_descriptor IM) sX trX)
     as Hproject.
   simpl in Hproject; spec Hproject; [by apply zero_descriptor_proper |].
-  spec Hproject Hpre_tr.
+  specialize (Hproject Hpre_tr).
   destruct Hproject as [_trX [initial_descriptors [_Htr_pr [_ Hlst]]]].
   rewrite Htr_pr in _Htr_pr.
   by inversion _Htr_pr; subst.
@@ -1809,7 +1809,7 @@ Proof.
       final_descriptors lst) as Hproperx.
     unfold final_state in Hproper. rewrite Htr_lst in Hproper.
     rewrite finite_trace_last_is_last in Hproper.
-    spec Hproperx Hproper.
+    specialize (Hproperx Hproper).
     destruct Hproperx as [oitem [final_descriptors' [Hprojectx [Hitemx Hproperx]]]].
     specialize (Hproperx (finite_trace_last is tr')).
     apply equivocators_trace_project_app_iff in Hpr_trX.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -457,7 +457,7 @@ Proof.
       as Hzero.
     unfold final_state in Hproper.
     rewrite Htr_lst, finite_trace_last_is_last in Hproper.
-    spec Hproperx (proj1 Hproper).
+    specialize (Hproperx (proj1 Hproper)).
     destruct Hproperx as [oitem [final_descriptors' [Hprojectx [Hitemx Hproperx]]]].
     specialize (Hproperx (finite_trace_last is tr')).
     unfold equivocators_trace_project.
@@ -1123,7 +1123,7 @@ Proof.
       (equivocators_fixed_equivocations_constraint IM equivocating)
       (composite_has_been_directly_observed IM sX)
     ) as Hproject.
-  spec Hproject is tr.
+  specialize (Hproject is tr).
   spec Hproject.
   { subst sX.
     rewrite <- (valid_trace_get_last Htr) in Hdescriptors |- *.
@@ -1132,7 +1132,7 @@ Proof.
         _ _ (valid_trace_forget_last Htr) descriptors Hdescriptors
       ).
   }
-  spec Hproject (valid_trace_forget_last Htr).
+  specialize (Hproject (valid_trace_forget_last Htr)).
 
   rewrite HeqsX in n.
   clear HeqsX.
@@ -1176,8 +1176,7 @@ Proof.
     ) as Hitem_equivocating.
   clear Hdescriptors n.
   spec Hitem_equivocating; [by rewrite Heqtr, !elem_of_app, elem_of_cons; auto |].
-  spec Hitem_equivocating Houtput_select.
-
+  specialize (Hitem_equivocating Houtput_select).
   (*
     Phase III (b):
     Consider a projection trX' obtained using the final_descriptor_m as above,

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -268,7 +268,7 @@ Proof.
       apply (VLSM_incl_valid_message (VLSM_eq_proj1 HeqXE)); [by left|].
       by apply (fixed_equivocating_messages_sent_by_non_equivocating_are_valid eqv_state_s).
     }
-    spec Hreplay eqv_state_s.
+    specialize (Hreplay eqv_state_s).
     spec Hreplay.
     { by apply (VLSM_eq_valid_state HeqXE), (VLSM_eq_valid_state HeqXE). }
     spec Hreplay.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -172,7 +172,7 @@ Proof.
     intros Hcut; specialize (Hcut _ (incl_refl _) ltac:(apply NoDup_enum)).
     unfold replayed_initial_state_from, composite_apply_plan.
     rewrite _apply_plan_last; extensionality i.
-    spec Hcut i; unfold composite_apply_plan in Hcut; unfold spawn_initial_state
+    specialize (Hcut i); unfold composite_apply_plan in Hcut; unfold spawn_initial_state
     ; simpl in *; rewrite Hcut.
     unfold lift_equivocators_sub_state_to.
     case_decide; [| done].
@@ -187,7 +187,7 @@ Proof.
     subst tr_full_replay_is.
     rewrite map_app, (composite_apply_plan_app equivocator_IM); simpl in *
     ; destruct (composite_apply_plan _ _ _) as (aitems, afinal); simpl in *.
-    spec IHl i; destruct_dec_sig x ix Hix Heqx; subst x; simpl in *.
+    specialize (IHl i); destruct_dec_sig x ix Hix Heqx; subst x; simpl in *.
     case_decide as _Hix; cycle 1;
       destruct (decide (ix = i)); subst; equivocator_state_update_simpl; [done | done | |].
     + rewrite decide_False in IHl.
@@ -289,7 +289,7 @@ Lemma equivocator_state_descriptor_project_replayed_initial_state_from_left full
     equivocator_state_descriptor_project (lst i) (eqv_descriptors i) =
     equivocator_state_descriptor_project (full_replay_state i) (eqv_descriptors i).
 Proof.
-  intro i. spec Heqv_descriptors i.
+  intro i. specialize (Heqv_descriptors i).
   unfold equivocator_state_descriptor_project.
   unfold existing_descriptor in Heqv_descriptors.
   destruct (eqv_descriptors i) as [sn|ji]; [done |].
@@ -348,7 +348,7 @@ Lemma equivocator_state_descriptor_project_replayed_trace_from_left full_replay_
     equivocator_state_descriptor_project (lst i) (eqv_descriptors i) =
     equivocator_state_descriptor_project (full_replay_state i) (eqv_descriptors i).
 Proof.
-  intro i. spec Heqv_descriptors i.
+  intro i. specialize (Heqv_descriptors i).
   unfold equivocator_state_descriptor_project.
   unfold existing_descriptor in Heqv_descriptors.
   destruct (eqv_descriptors i) as [sn|ji]; [done |].

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -177,7 +177,7 @@ Proof.
     | ?H -> _ => cut H
     end.
     { intro Hivt.
-      spec Happ_extend Hivt.
+      specialize (Happ_extend Hivt).
       match goal with
       |- ?H /\ _ => assert (Hproject : H)
       end.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -566,7 +566,7 @@ Proof.
   - rewrite <- app_comm_cons in Hproject.
     apply equivocator_vlsm_trace_project_cons in Hproject.
     destruct Hproject as [da [prefixa [tr' [Ha [Hproject Heq]]]]].
-    spec IHbprefix tr' da Hproject.
+    specialize (IHbprefix tr' da Hproject).
     destruct IHbprefix as [dmiddle [prefix' [suffix [Hprefix [Hsuffix Htr']]]]].
     exists dmiddle.
     exists (prefixa ++ prefix'). exists suffix.
@@ -696,7 +696,7 @@ Proof.
     specialize (equivocator_state_last_n X s) as Hs_lst.
     apply equivocator_state_project_Some_rev in Heqsi.
     spec Hn; [lia|].
-    spec Hn n.
+    specialize (Hn n).
     destruct_equivocator_state_project s' i s'i Hi; [|lia].
     by simpl in Hn; subst.
   - eexists; split; [done |].

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -114,7 +114,7 @@ Lemma preloaded_equivocator_vlsm_trace_project_valid_item
 Proof.
   specialize (preloaded_equivocator_vlsm_valid_trace_project_inv2 X bs bf btr) as Hinv2.
   spec Hinv2; [by intro contra; subst; inversion Hitem |].
-  spec Hinv2 Hbtr.
+  specialize (Hinv2 Hbtr).
   apply elem_of_list_split in Hitem.
   destruct Hitem as [bprefix [bsuffix Heq]].
   subst btr.
@@ -141,7 +141,7 @@ Proof.
     as Hsuffix'.
   spec Hsuffix'; [by cbn; rewrite Hitemx |].
   subst dsuffix.
-  spec Hsuffix' Hsuffix.
+  specialize (Hsuffix' Hsuffix).
   subst bitem.
   destruct
     (equivocator_valid_transition_project_inv2 _ l lst s iom oom Hv Ht _ _ _ Hitemx)
@@ -169,7 +169,7 @@ Proof.
     + remember (bprefix ++ _) as btr.
       specialize (equivocator_vlsm_trace_project_inv X btr) as Hinv.
       spec Hinv; [by destruct bprefix; subst |].
-      spec Hinv i.
+      specialize (Hinv i).
       spec Hinv; [by subst; eexists |].
       specialize (Hinv bs) as [lst_i Hlst_i].
       by eexists.
@@ -321,7 +321,7 @@ Proof.
         as [Hom Hsame].
       subst om'.
       specialize (existing_false_label_equivocator_transition_size X Ht _ Hidesc) as Ht_size.
-      spec oracle_step_update msg.
+      specialize (oracle_step_update msg).
       split.
       * intros [i [s'i [Hs'i Hbri]]].
         apply equivocator_state_project_Some_rev in Hs'i as Hlti.
@@ -332,8 +332,8 @@ Proof.
            destruct Hbri as [H | Hbri]; [| by right; eexists _,_].
            by left; revert H; apply Hselector_io.
         -- right. exists i, s'i. split; [| done].
-           spec Hnot_same i.
-           spec Hnot_same; [lia|]. spec Hnot_same n.
+           specialize (Hnot_same i).
+           spec Hnot_same; [lia|]. specialize (Hnot_same n).
            simpl in Hnot_same. rewrite Hs'i in Hnot_same.
            destruct_equivocator_state_project s i si Hlti'; [|lia].
            by cbn in Hnot_same; congruence.
@@ -357,7 +357,8 @@ Proof.
               simpl in Hsame.
               by destruct_equivocator_state_project s' ins _sidesc' Hins; [subst |lia].
            ++ exists ins, sins. split; [| done].
-              spec Hnot_same ins. spec Hnot_same; [lia|]. spec Hnot_same n.
+              specialize (Hnot_same ins). spec Hnot_same; [lia|].
+              specialize (Hnot_same n).
               simpl in Hnot_same. rewrite Hsins in Hnot_same.
               destruct_equivocator_state_project s' ins _sins Hins; [|lia].
               cbn in Hnot_same; congruence.
@@ -378,7 +379,7 @@ Proof.
         as [Hom Hlast].
       subst om'.
       specialize (existing_true_label_equivocator_transition_size X Ht _ Hidesc) as Ht_size.
-      spec oracle_step_update msg.
+      specialize (oracle_step_update msg).
       split.
       * intros [i [s'i [Hs'i Hbri]]].
         apply equivocator_state_project_Some_rev in Hs'i as Hlti.
@@ -389,7 +390,7 @@ Proof.
            destruct Hbri as [H | Hbri]; [| by right; eexists _,_].
            by left; revert H; apply Hselector_io.
         -- right. exists i, s'i. split; [| done].
-           spec Hnot_last i.
+           specialize (Hnot_last i).
            spec Hnot_last; [lia|].
            simpl in Hnot_last. rewrite Hs'i in Hnot_last.
            destruct_equivocator_state_project s i si Hlti'; [|lia].
@@ -404,7 +405,7 @@ Proof.
            destruct_equivocator_state_project  s' (equivocator_state_n s) _sidesc' Hlst; [|lia].
            by subst.
         -- apply equivocator_state_project_Some_rev in Hsins as Hltins.
-           spec Hnot_last ins. spec Hnot_last; [lia|].
+           specialize (Hnot_last ins). spec Hnot_last; [lia|].
            simpl in Hnot_last. rewrite Hsins in Hnot_last.
            exists ins, sins. split; [| done].
            destruct_equivocator_state_project s' ins _sins Hltins'; [|lia].

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -552,7 +552,7 @@ Proof.
     rewrite! app_assoc in Hmsg.
     by destruct (Hmsg eq_refl Hin_m Hitem); [left | right].
   }
-  spec IHtr Htr.
+  specialize (IHtr Htr).
   rewrite finite_trace_sub_projection_app.
   apply finite_valid_trace_from_app_iff.
   split; [done |].

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -950,7 +950,7 @@ Lemma map_option_length
 Proof.
   induction l; [done |].
   inversion Hfl; subst.
-  spec IHl H2; cbn.
+  specialize (IHl H2); cbn.
   by destruct (f a); cbn; congruence.
 Qed.
 

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -67,7 +67,7 @@ Proof.
   split; intros; [|subst; apply set_eq_refl].
   destruct l as [| hd tl]; [done |].
   destruct H.
-  spec H hd (elem_of_list_here hd tl).
+  specialize (H hd (elem_of_list_here hd tl)).
   by inversion H.
 Qed.
 
@@ -199,7 +199,7 @@ Proof.
   intro f; induction s; intros; simpl.
   - by apply list_subseteq_nil.
   - assert (Hs : s ⊆ s') by (intros b Hs; apply H; right; done).
-    spec IHs s' Hs.
+    specialize (IHs s' Hs).
     intros b Hs'.
     apply elem_of_cons in Hs' as [-> |]; [| by apply IHs].
     by apply elem_of_list_fmap_1, H; left.

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -5,26 +5,10 @@ From Coq Require Import Eqdep_dec.
 
 (** * General utility definitions, lemmas, and tactics *)
 
-(** ** Tactics for specializing hypotheses *)
-
 Tactic Notation "spec" hyp(H) :=
   match type of H with ?a -> _ =>
   let H1 := fresh in (assert (H1: a);
   [|generalize (H H1); clear H H1; intro H]) end.
-Tactic Notation "spec_save" hyp(H) :=
-  match type of H with ?a -> _ =>
-  let H1 := fresh in (assert (H1: a);
-  [|generalize (H H1); clear H; intro H]) end.
-Tactic Notation "spec" hyp(H) constr(a) :=
-  (generalize (H a); clear H; intro H).
-Tactic Notation "spec" hyp(H) constr(a) constr(b) :=
-  (generalize (H a b); clear H; intro H).
-Tactic Notation "spec" hyp(H) constr(a) constr(b) constr(c) :=
-  (generalize (H a b c); clear H; intro H).
-Tactic Notation "spec" hyp(H) constr(a) constr(b) constr(c) constr(d) :=
-  (generalize (H a b c d); clear H; intro H).
-Tactic Notation "spec" hyp(H) constr(a) constr(b) constr(c) constr(d) constr(e) :=
-  (generalize (H a b c d e); clear H; intro H).
 
 (** ** Basic logic *)
 

--- a/theories/VLSM/Lib/SortedLists.v
+++ b/theories/VLSM/Lib/SortedLists.v
@@ -209,7 +209,7 @@ Proof.
   destruct H1 as [Heq | Hin].
   - by subst; simpl; rewrite compare_eq_refl.
   - apply LocallySorted_tl in H0 as LS.
-    spec IHsigma LS Hin. simpl.
+    specialize (IHsigma LS Hin). simpl.
     destruct (compare msg a) eqn:Hcmp; try rewrite IHsigma; [done | | done].
     apply (@LocallySorted_elem_of_lt _ _ compare_lt_strict_order msg a sigma H0) in Hin.
     unfold compare_lt in Hin.

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -391,7 +391,7 @@ Proof.
   destruct (decide (m = n)); [done |].
   elim (HI (Str_nth n l)).
   by destruct (decide (m < n))
-  ; [spec Hl m n|spec Hl n m]; (spec Hl; [lia|])
+  ; [specialize (Hl m n)|specialize (Hl n m)]; (spec Hl; [lia|])
   ; rewrite Hmn in Hl.
 Qed.
 


### PR DESCRIPTION
As discussed with  @bmmoore and @wkolowski and @traiansf, I here remove the multiple-argument versions of the `spec` tactic. The single-argument version is kept.