### PR TITLE
fix or suppress deprecations on current Coq master

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,7 @@
 -Q theories/VLSM VLSM
 
 -arg -w -arg -future-coercion-class-field
+-arg -w -arg -deprecated-tacopt-without-locality
 
 theories/VLSM/Lib/SsrExport.v
 theories/VLSM/Lib/Preamble.v

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1615,7 +1615,7 @@ Definition sub_label_element_project
   : option (vlabel (IM j)) :=
   match decide (j = ` (projT1 l)) with
   | left e => Some (eq_rect_r (fun j => vlabel (IM j)) (projT2 l) e)
-  | in_right => None
+  | right _ => None
   end.
 
 Definition sub_state_element_project

--- a/theories/VLSM/dune
+++ b/theories/VLSM/dune
@@ -2,6 +2,8 @@
  (name VLSM)
  (package coq-vlsm)
  (synopsis "Core definitions in Coq for VLSMs")
- (flags :standard -w -deprecated-instance-without-locality))
+ (flags :standard 
+   -w -future-coercion-class-field
+   -w -deprecated-tacopt-without-locality))
 
 (include_subdirs qualified)


### PR DESCRIPTION
For both coq_makefile and Dune. This is useful since we hope to add CI checking against Coq master in the near future.