### PR TITLE
Remove lemma `nodup_append`

### DIFF
--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -1620,10 +1620,7 @@ Qed.
 Lemma nodup_append_left {A}:
   forall (l1 l2 : list A), NoDup (l1 ++ l2) -> NoDup l1.
 Proof.
-  induction l1; intros.
-  - by constructor.
-  - inversion H. apply IHl1 in H3. constructor; [| done]. intro. apply H2.
-    by apply elem_of_app; left.
+  by intros l1 l2 [? _]%NoDup_app.
 Qed.
 
 Lemma subseteq_empty {A} : forall (l : list A),

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -448,11 +448,7 @@ Qed.
 Lemma set_diff_nodup' `{EqDecision A} (l l' : list A)
   : NoDup l -> NoDup (set_diff l l').
 Proof.
-  induction 1 as [|x l H H' IH]; simpl.
-  - by constructor.
-  - case_decide.
-    + by apply IH.
-    + by apply set_add_nodup, IH.
+  by apply set_diff_nodup.
 Qed.
 
 Lemma diff_app_nodup `{EqDecision A} : forall (s1 s2 : list A),

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -461,9 +461,9 @@ Lemma diff_app_nodup `{EqDecision A} : forall (s1 s2 : list A),
   NoDup (set_diff s1 s2 ++ s2).
 Proof.
   intros.
-  apply nodup_append; [| done |].
+  apply NoDup_app; split_and!; [| | done].
   - by apply set_diff_nodup.
-  - by intros; apply (set_diff_elim2 a s1).
+  - by intros a; apply (set_diff_elim2 a s1).
 Qed.
 
 Lemma add_remove_inverse `{EqDecision X}:
@@ -521,7 +521,7 @@ Lemma set_prod_nodup `(s1: set A) `(s2: set B):
   NoDup (set_prod s1 s2).
 Proof.
   intros Hs1 H22; induction Hs1; cbn; [by constructor |].
-  apply nodup_append; [| done |].
+  apply NoDup_app; split_and!; [| | done].
   - by apply NoDup_fmap; [congruence |].
   - intros [a b].
     rewrite elem_of_list_fmap, elem_of_list_prod.

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -458,13 +458,12 @@ Qed.
 Lemma diff_app_nodup `{EqDecision A} : forall (s1 s2 : list A),
   NoDup s1 ->
   NoDup s2 ->
-  NoDup ((set_diff s1 s2) ++ s2).
+  NoDup (set_diff s1 s2 ++ s2).
 Proof.
   intros.
-  apply nodup_append; [| done | |].
+  apply nodup_append; [| done |].
   - by apply set_diff_nodup.
   - by intros; apply (set_diff_elim2 a s1).
-  - by setoid_rewrite set_diff_iff; itauto.
 Qed.
 
 Lemma add_remove_inverse `{EqDecision X}:
@@ -522,14 +521,11 @@ Lemma set_prod_nodup `(s1: set A) `(s2: set B):
   NoDup (set_prod s1 s2).
 Proof.
   intros Hs1 H22; induction Hs1; cbn; [by constructor |].
-  apply nodup_append; [| done | |].
+  apply nodup_append; [| done |].
   - by apply NoDup_fmap; [congruence |].
   - intros [a b].
     rewrite elem_of_list_fmap, elem_of_list_prod.
-    by intros [_ [[= <- _] _]] [].
-  - intros [a b].
-    rewrite elem_of_list_prod, elem_of_list_fmap.
-    by intros [Ha _] [_ [[= -> _] _]].
+    by intros [_ [[= -> _] _]] [].
 Qed.
 
 (**

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -481,23 +481,6 @@ Proof.
     by eapply filter_nil_not_elem_of in Px.
 Qed.
 
-Lemma nodup_append {A} : forall (l1 l2 : list A),
-  NoDup l1 ->
-  NoDup l2 ->
-  (forall a, a ∈ l1 -> ~ a ∈ l2) ->
-  NoDup (l1 ++ l2).
-Proof.
-  induction l1 as [| h t]; cbn; intros l2 Hn1 Hn2 Hdisj; [done |].
-  inversion Hn1; subst; clear Hn1.
-  constructor.
-  - intros Hin.
-    apply elem_of_app in Hin as []; [done |].
-    by apply Hdisj with h; [left |].
-  - apply IHt; [done.. |].
-    intros a Hin.
-    by apply Hdisj; right.
-Qed.
-
 Lemma elem_of_list_annotate_forget
   {A : Type}
   (P : A -> Prop)

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -470,7 +470,7 @@ Proof.
 Qed.
 
 Lemma Forall_filter_nil {A} P `{∀ (x:A), Decision (P x)} l :
- Forall (fun a : A => ~ P a) l <-> filter P l = [].
+  Forall (fun a : A => ~ P a) l <-> filter P l = [].
 Proof.
   rewrite Forall_forall.
   split; intro Hnone.
@@ -485,17 +485,17 @@ Lemma nodup_append {A} : forall (l1 l2 : list A),
   NoDup l1 ->
   NoDup l2 ->
   (forall a, a ∈ l1 -> ~ a ∈ l2) ->
-  (forall a, a ∈ l2 -> ~ a ∈ l1) ->
   NoDup (l1 ++ l2).
 Proof.
-  induction l1; simpl; intros; [done |].
-  inversion H; subst; clear H. constructor.
-  - intro. apply elem_of_app in H. destruct H as [Inl1 | InL2].
-    + by apply H5.
-    + by apply (H1 a); [left |].
-  - apply IHl1; [done | done | |]; intros.
-    + by apply H1; right.
-    + by apply H2 in H; rewrite elem_of_cons in H; itauto.
+  induction l1 as [| h t]; cbn; intros l2 Hn1 Hn2 Hdisj; [done |].
+  inversion Hn1; subst; clear Hn1.
+  constructor.
+  - intros Hin.
+    apply elem_of_app in Hin as []; [done |].
+    by apply Hdisj with h; [left |].
+  - apply IHt; [done.. |].
+    intros a Hin.
+    by apply Hdisj; right.
 Qed.
 
 Lemma elem_of_list_annotate_forget


### PR DESCRIPTION
I removed the lemma `nodup_append`, because `NoDup_app` from the standard library (or is it stdpp?) can be used instead. In a later PR, uses of this lemma in casper-cbc-proofs will also have to be fixed.

I also removed `set_diff_nodup'` because it is exactly the same as `set_diff_nodup`. @palmskog You should take a look to see whether the TODO in the comment above `set_diff_nodup'` is still relevant.

I also fixed indentation in one place, which is not related to this PR, but I didn't want to forget about it.