### PR TITLE
annotate ListSet lemma with unnecessary assumption

### DIFF
--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -441,14 +441,18 @@ Proof.
 Qed.
 
 (**
-  An improved version of the [set_diff_nodup] Lemma not requiring [NoDup]
+  An improved version of the [set_diff_nodup] lemma not requiring [NoDup]
   for the second argument.
 *)
-(* TODO(palmskog): consider submitting a PR to Coq's stdlib. *)
+(* TODO: submit PR to Coq's stdlib ListSet with this improved version *)
 Lemma set_diff_nodup' `{EqDecision A} (l l' : list A)
   : NoDup l -> NoDup (set_diff l l').
 Proof.
-  by apply set_diff_nodup.
+ induction 1 as [|x l H H' IH]; simpl.
+ - by constructor.
+ - case_decide.
+   + by apply IH.
+   + by apply set_add_nodup, IH.
 Qed.
 
 Lemma diff_app_nodup `{EqDecision A} : forall (s1 s2 : list A),

--- a/theories/VLSM/Lib/StdppListSet.v
+++ b/theories/VLSM/Lib/StdppListSet.v
@@ -193,12 +193,17 @@ Proof.
   - by destruct 1; apply set_diff_intro.
 Qed.
 
+(*
+ TODO: change statement when Coq's stdlib drops
+ the unnecessary second premise in ListSet
+*)
 Lemma set_diff_nodup l l' :
-  NoDup l -> NoDup (set_diff l l').
+  NoDup l -> NoDup l' -> NoDup (set_diff l l').
 Proof.
   induction 1 as [| x l H H' IH]; cbn.
   - by constructor.
-  - by case_decide; [| apply set_add_nodup].
+  - intro Hl'; specialize (IH Hl').
+    by case_decide; [| apply set_add_nodup].
 Qed.
 
 End sec_fst_defs.


### PR DESCRIPTION
The point of the StdppListSet module was always to mirror Coq Stdlib ListSet module in as much detail as possible. Here I annotate a lemma with an unnecessary premise from Stdlib and its improved alternative that lives elsewhere.

The earliest Coq version release where a change to Stdlib might be included is 8.18.0 that will likely appear in fall 2023.