### PR TITLE
Replace some Unicode characters with their ASCII counterparts.

### DIFF
--- a/scripts/unicode-to-ascii.sh
+++ b/scripts/unicode-to-ascii.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Find all files that contain Unicode characters that we don't like.
+files=$(grep -El "∧|∨|→|↔|∀|∃|≠" $(find -name "*.v"))
+
+# Replace each unicode character with its ASCII equivalent.
+sed -i 's/∧/\/\\/g' $files
+sed -i 's/∨/\\\//g' $files
+sed -i 's/→/->/g' $files
+sed -i 's/↔/<->/g' $files
+sed -i 's/∀/forall/g' $files
+sed -i 's/∃/exists/g' $files
+sed -i 's/≠/<>/g' $files

--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -70,7 +70,7 @@ Definition annotated_transition
 
 Definition annotated_vlsm_machine : VLSMMachine annotated_type :=
   {| initial_state_prop := fun s : @state _ annotated_type => annotated_initial_state_prop s
-  ; initial_message_prop := λ m : message, vinitial_message_prop X m
+  ; initial_message_prop := fun m : message => vinitial_message_prop X m
   ; valid := annotated_valid
   ; transition := annotated_transition
   |}.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -85,7 +85,7 @@ Context
   (byzantine: Ci)
   (non_byzantine : Ci := difference (list_to_set (enum index)) byzantine)
   (Hlimit: (sum_weights (byzantine) <= `threshold)%R)
-  (PreNonByzantine := pre_loaded_fixed_non_byzantine_vlsm IM byzantine (λ i : index, i) sender)
+  (PreNonByzantine := pre_loaded_fixed_non_byzantine_vlsm IM byzantine (fun i : index => i) sender)
   (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) index Ci
     := equivocation_dec_tracewise IM (fun i => i) sender)
   (tracewise_not_heavy := not_heavy (1 := Htracewise_BasicEquivocation))

--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -700,7 +700,7 @@ Proof.
   generalize (enum index), (NoDup_enum index) as Hnodup, (elem_of_enum i) as Hi.
   induction l; intros; [by inversion Hi |].
   inversion Hnodup; subst.
-  assert (Hnil : forall i, i ∉ l -> filter (λ i0 : index, idx i0 = idx i) l = []).
+  assert (Hnil : forall i, i ∉ l -> filter (fun i0 : index => idx i0 = idx i) l = []).
   {
     intros; apply Forall_filter_nil, Forall_forall.
     intros j Hj; contradict Hj.

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -761,7 +761,7 @@ Proof.
     + intros Ha.
       apply local_equivocators_simple_add_Receive in Ha; [| done..].
       destruct Ha as [| (<- & Hnot_s & m & Hm & Hincomp)]; [by apply lefo_prev, IHHs |].
-      assert (adr (state m) ≠ adr s) by (destruct Hincomp; congruence).
+      assert (adr (state m) <> adr s) by (destruct Hincomp; congruence).
       by revert Hincomp; apply lefo_last, not_adr_received.
   - destruct s as [s_obs s_a].
     unfold local_equivocators_full; cbn.
@@ -863,7 +863,7 @@ Lemma equivocators_of_msg_subset_of_recv (s : State) (m : Message) :
   full_node s m ->
   forall a,
     local_equivocators_simple (state m) a
-    → local_equivocators_simple (s <+> MkObservation Receive m) a.
+    -> local_equivocators_simple (s <+> MkObservation Receive m) a.
 Proof.
   intros Hfull a []; destruct m as [ms]; cbn in *.
   assert (forall x, x ∈ messages ms -> x ∈ messages (s <+> MkObservation Receive (MkMessage ms)))
@@ -924,7 +924,7 @@ Lemma incomparable_iff (m1 m2 : Message) :
   incomparable m1 m2
     <->
   adr (state m1) = adr (state m2)
-  /\ m1 ≠ m2
+  /\ m1 <> m2
   /\ m1 ∉ sentMessages (state m2)
   /\ m2 ∉ sentMessages (state m1).
 Proof.
@@ -1276,7 +1276,7 @@ Proof.
   - intros m Hm.
     apply can_emit_has_trace in Hm as (is & tr & item & Htr & Houtput).
     apply (can_emit_from_valid_trace
-            (pre_loaded_vlsm Ei (λ msg : Message, msg ∈ Message_dependencies m)))
+            (pre_loaded_vlsm Ei (fun msg : Message => msg ∈ Message_dependencies m)))
       with is (tr ++ [item]); cycle 1.
     + apply Exists_exists; eexists.
       by split; [apply elem_of_app; right; left |].
@@ -1643,7 +1643,7 @@ Qed.
   It might be possible to use something weaker than [UMO_reachable full_node]
   to prove
   [CompositeHasBeenObserved ELMOComponent (elements ∘ Message_dependencies) s m
-  <-> ∃ (k : index) (l : label), rec_obs (s k) (MkObservation l m)]
+  <-> exists (k : index) (l : label), rec_obs (s k) (MkObservation l m)]
   but [CompositeHasBeenObserved] can recurse into sent or received messages
   and [rec_obs] only into received messages so we need some deep structural
   assumption about what [Send] observations are allowed, even recursively
@@ -1655,7 +1655,7 @@ Lemma ELMO_CHBO_in_messages :
   forall m,
     CompositeHasBeenObserved ELMOComponent Message_dependencies s m
       <->
-    ∃ (k : index), m ∈ messages (s k).
+    exists (k : index), m ∈ messages (s k).
 Proof.
   intros s Hs m; split.
   - intros [Hobs|m' Hobs Hdepth];
@@ -2364,7 +2364,7 @@ Qed.
   Let si be a reachable state in (ELMOComponent i) and
   m a message such that
   ELMOComponentValid Receive si (Some m) in (ELMOComponent i),
-  adr m ≠ i and adr m ∉ local_equivocators_full si, and
+  adr m <> i and adr m ∉ local_equivocators_full si, and
   also there is no message m' ∈ received_messages(si) with m' ⊥ m.
 
   Suppose σ is a valid state in ELMOProtocol such that σ i = si,
@@ -2505,7 +2505,7 @@ Lemma all_intermediary_transitions_are_receive
   (Htr_m: finite_valid_trace_from_to
           (pre_loaded_with_all_messages_vlsm (ELMOComponent i_m))
           (sigma i_m) (state m) tr_m)
-  : Forall (λ item : transition_item, l item = Receive) tr_m.
+  : Forall (fun item : transition_item => l item = Receive) tr_m.
 Proof.
   apply Forall_forall; intros item Hitem.
   eapply ELMOComponent_elem_of_ram_trace in Hitem as H_item;
@@ -2555,7 +2555,7 @@ Lemma lift_receive_trace
   (Htr_m:
     finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm (ELMOComponent i_m))
       (sigma i_m) (state m) tr_m)
-  (Htr_m_receive: Forall (λ item : transition_item, l item = Receive) tr_m)
+  (Htr_m_receive: Forall (fun item : transition_item => l item = Receive) tr_m)
   (Htr_m_inputs_in_sigma:
     forall (item : transition_item) (msg : Message),
       item ∈ tr_m -> input item = Some msg ->
@@ -2884,7 +2884,7 @@ Proof.
   - pose (Hti := Ht); destruct Hti as [(_ & _ & Hv) Hti];
       inversion Hv as [? ? [? ? ? Hlocal_ok] |]; subst; inversion Hti; subst om'.
     apply ELMO_msg_valid_full_has_sender in ELMO_mv_msg_valid_full0 as Hsender.
-    cut (∃ gamma,
+    cut (exists gamma,
           in_futures ELMOProtocol sigma gamma /\
           gamma i = sigma i /\
           component_reflects_composite (state_update ELMOComponent gamma i s') i /\
@@ -2973,7 +2973,7 @@ Proof.
       - by constructor.
       - by subst sigma'; cbn; rewrite Heqi_m; destruct m.
     }
-    assert (i ≠ i_m) by (contradict Hm_not_by_i; subst; done).
+    assert (i <> i_m) by (contradict Hm_not_by_i; subst; done).
     assert (ELMOComponentRAMTransition i Receive (sigma' i) (sigma i <+> MkObservation Receive m) m).
     {
       subst sigma'; state_update_simpl; rewrite Heqi.

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -1121,7 +1121,7 @@ Proof.
   revert us Hall Hvsp.
   generalize (enum index) as is.
   induction is as [| i is']; cbn; intros us Hall Hvsp.
-  - replace us with (λ n : index, MkState [] (idx n)).
+  - replace us with (fun n : index => MkState [] (idx n)).
     + by constructor; apply initial_state_is_valid; compute.
     + extensionality i; rewrite Hall; [done |].
       by apply not_elem_of_nil.
@@ -1157,8 +1157,8 @@ Proof.
   remember (finite_trace_last _ _) as ftl.
   change (finite_trace_last _ _)
     with (finite_trace_last
-            (lift_to_MO_state (λ j : index, MkState [] (idx j)) i s')
-            (lift_to_MO_trace (λ j : index, MkState [] (idx j)) i tr)) in Heqftl.
+            (lift_to_MO_state (fun j : index => MkState [] (idx j)) i s')
+            (lift_to_MO_trace (fun j : index => MkState [] (idx j)) i tr)) in Heqftl.
   apply valid_trace_forget_last, first_transition_valid in Hfvt; cbn in *.
   destruct Hfvt as [[Hvps [Hovmp [Hv1 Hv2]]] Ht]; cbn in Hv1, Hv2.
   unfold lift_to_MO_trace in Heqftl; cbn in Heqftl.

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -1577,7 +1577,7 @@ Proof.
   revert us Hall Hvsp.
   generalize (enum index) as is.
   induction is as [| i is']; cbn; intros us Hall Hvsp.
-  - replace us with (λ n : index, MkState [] (idx n)).
+  - replace us with (fun n : index => MkState [] (idx n)).
     + by constructor; apply initial_state_is_valid; compute.
     + extensionality i; rewrite Hall; [done |].
       by apply not_elem_of_nil.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1427,7 +1427,7 @@ Qed.
 
 Definition ComputableSentMessages_has_been_sent
   `{!ComputableSentMessages vlsm}
-  : vstate vlsm → message → Prop :=
+  : vstate vlsm -> message -> Prop :=
   computable_messages_oracle_rel csm_computable_oracle.
 
 #[export] Instance computable_sent_message_has_been_sent_dec
@@ -1466,7 +1466,7 @@ Qed.
 
 Definition ComputableReceivedMessages_has_been_sent
   `{!ComputableReceivedMessages vlsm}
-  : vstate vlsm → message → Prop
+  : vstate vlsm -> message -> Prop
   := computable_messages_oracle_rel crm_computable_oracle.
 
 #[export] Instance computable_received_message_has_been_sent_dec

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -688,7 +688,7 @@ Proof.
   specialize
     (@lift_to_composite_generalized_preloaded_VLSM_embedding
       message (sub_index (elements(equivocating_validators sf))) _ (sub_IM IM (elements(equivocating_validators sf)))
-      (λ msg : message, msg ∈ message_dependencies m)
+      (fun msg : message => msg ∈ message_dependencies m)
       (composite_has_been_directly_observed IM s))
     as Hproj.
   spec Hproj.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -2072,7 +2072,7 @@ Proof.
       (free_sub_free_constraint IM (free_constraint IM)))
       (EquivocatorsComposition.equivocators_state_project
         (SubProjectionTraces.sub_IM IM (finite.enum index))
-        (λ i : sub_index (finite.enum index), initial_descriptors (` i))
+        (fun i : sub_index (finite.enum index) => initial_descriptors (` i))
         (composite_state_sub_projection equivocator_IM (finite.enum index) s))
       (finite_trace_sub_projection IM (finite.enum index) trX)).
     { revert HtrX.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -189,7 +189,7 @@ Qed.
   [replayable_message_prop]erty for the [equivocators_fixed_equivocations_constraint].
 *)
 Lemma fixed_equivocation_has_replayable_message_prop
-  : replayable_message_prop IM (λ _ : message, False)
+  : replayable_message_prop IM (fun _ : message => False)
     (strong_fixed_equivocation_constraint IM equivocating)
     (equivocators_fixed_equivocations_constraint IM (elements equivocating)).
 Proof.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -158,7 +158,7 @@ Proof.
       composite_apply_plan equivocator_IM full_replay_state
         (map (initial_new_machine_transition_item is)
           l) in
-    (∀ i : index,
+    (forall i : index,
       tr_full_replay_is.2 i =
       match @decide  (sub_index_prop equivocating i) (sub_index_prop_dec equivocating i) with
       | left e =>

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1534,7 +1534,7 @@ Definition sub_element_state (s : vstate (IM j)) sub_i
   : vstate (sub_IM IM (elements indices) sub_i) :=
   match (decide (` sub_i = j)) with
   | left e =>
-    eq_rect_r (λ j : index, vstate (IM j)) s e
+    eq_rect_r (fun j : index => vstate (IM j)) s e
   | right _ => ` (vs0 (IM (` sub_i)))
   end.
 

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -206,8 +206,8 @@ Proof.
   induction l; inversion 1 as []; subst.
   - inversion 1 as [| ? ? Hna _]; subst; cbn.
     rewrite state_update_eq.
-    replace (foldr Nat.add 0 (map (λ i : index, state_size i (s i)) l))
-       with (foldr Nat.add 0 (map (λ i : index,
+    replace (foldr Nat.add 0 (map (fun i : index => state_size i (s i)) l))
+       with (foldr Nat.add 0 (map (fun i : index =>
                state_size i (lift_to_composite_state IM s a si i)) l))
     ; [lia |].
     revert Hna; clear; induction l; [done |].
@@ -368,7 +368,7 @@ Record ChoosingWell
     forall Hs'' : valid_state_prop RFree s',
       choose s' Hs' indices = choose s' Hs'' indices;
   cw_chosen_index_in_indices :
-    indices ≠ [] -> (choose s' Hs' indices).1 ∈ indices;
+    indices <> [] -> (choose s' Hs' indices).1 ∈ indices;
   cw_chosen_position_exists :
     forall (i : index) (n : nat),
       choose s' Hs' indices = (i, n) ->
@@ -382,8 +382,8 @@ Lemma choosing_well_position_exists :
     (s' : composite_state IM) (Hs' : valid_state_prop RFree s')
     (indices : list index) (Hwell : ChoosingWell choose s' Hs' indices)
     (i_n :=  choose s' Hs' indices),
-      composite_state_destructor s' i_n.1 ≠ [] ->
-      composite_state_destructor s' i_n.1 !! i_n.2 ≠ None.
+      composite_state_destructor s' i_n.1 <> [] ->
+      composite_state_destructor s' i_n.1 !! i_n.2 <> None.
 Proof.
   intros choose s' Hs' indices Hchoose i_n Hdestruct.
   eapply not_eq_None_Some, cw_chosen_position_exists; [done | |].

--- a/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
+++ b/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
@@ -300,7 +300,7 @@ Qed.
 *)
 Definition find_decomposition
   (P : set (composite_transition_item IM * composite_state IM) -> nat -> Prop)
-  `{forall s, RelDecision (λ i, P (composite_state_destructor IM state_destructor s i))}
+  `{forall s, RelDecision (fun i => P (composite_state_destructor IM state_destructor s i))}
   (s : composite_state IM)
   (indices : list index)
   : option (index * nat) :=
@@ -601,7 +601,7 @@ Proof.
   assert (destination item = s') as <-
     by (eapply composite_tv_state_destructor_destination, elem_of_list_lookup_2; eauto).
   exists m; constructor; [done.. |].
-  cut (output item ≠ Some m).
+  cut (output item <> Some m).
   {
     intro.
     destruct (composite_has_been_sent_stepwise_props IM (free_constraint IM)) as [_ ].

--- a/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
@@ -60,7 +60,7 @@ Lemma elem_of_pre_VLSM_stuttering_embedding_finite_trace_project :
   forall (trX : list (@transition_item _ TX)) (itemY : @transition_item _ TY),
     itemY ∈ pre_VLSM_stuttering_embedding_finite_trace_project trX
       <->
-    exists (itemX : @transition_item _ TX), itemY ∈ transition_item_project itemX ∧ itemX ∈ trX.
+    exists (itemX : @transition_item _ TX), itemY ∈ transition_item_project itemX /\ itemX ∈ trX.
 Proof. by intros; apply elem_of_list_bind. Qed.
 
 End sec_pre_definitions.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -722,7 +722,7 @@ Proof. by intros sj; apply state_update_eq. Qed.
 
 Lemma component_transition_projection_None
   : weak_projection_transition_consistency_None X (type (IM i))
-    composite_project_label (λ s : vstate X, s i).
+    composite_project_label (fun s : vstate X => s i).
 Proof.
   intros [j lj] HlX sX iom s'X oom [_ Ht]; cbn in Ht.
   destruct (vtransition _ _ _) as (si', om'); inversion Ht; subst.
@@ -733,7 +733,7 @@ Qed.
 
 Lemma component_transition_projection_Some
   : induced_validator_transition_consistency_Some X (type (IM i))
-    composite_project_label (λ s : vstate X, s i).
+    composite_project_label (fun s : vstate X => s i).
 Proof.
   intros [j1 lj1] [j2 lj2] lj; unfold composite_project_label; cbn.
   case_decide as Hj1; [| done]; subst j1.

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -147,9 +147,9 @@ End sec_general.
 Section sec_filter.
 
 Context
-  (P P2 : A → Prop)
-  `{!∀ x, Decision (P x)}
-  `{!∀ x, Decision (P2 x)}
+  (P P2 : A -> Prop)
+  `{!forall x, Decision (P x)}
+  `{!forall x, Decision (P2 x)}
   (X Y : C).
 
 Lemma filter_subset

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -585,7 +585,7 @@ Proof.
 Qed.
 
 Fixpoint nth_error_filter_index
-  {A} P `{∀ (x:A), Decision (P x)}
+  {A} P `{forall (x:A), Decision (P x)}
   (l : list A)
   (n : nat)
   :=
@@ -602,7 +602,7 @@ Fixpoint nth_error_filter_index
   end.
 
 Lemma nth_error_filter_index_le
-  {A} P `{∀ (x:A), Decision (P x)}
+  {A} P `{forall (x:A), Decision (P x)}
   (l : list A)
   (n1 n2 : nat)
   (Hle : n1 <= n2)
@@ -1424,8 +1424,8 @@ Proof.
   by eapply Listing_finite_transparent.
 Qed.
 
-Lemma sumbool_forall [A : Type] [P Q : A → Prop]:
-  (∀ x : A, {P x} + {Q x}) → ∀ l : list A, {Forall P l} + {Exists Q l}.
+Lemma sumbool_forall [A : Type] [P Q : A -> Prop]:
+  (forall x : A, {P x} + {Q x}) -> forall l : list A, {Forall P l} + {Exists Q l}.
 Proof.
   induction l.
   - by left; constructor.
@@ -1592,7 +1592,7 @@ Proof.
 Qed.
 
 Lemma list_subseteq_tran : forall (A : Type) (l m n : list A),
- l ⊆ m → m ⊆ n → l ⊆ n.
+ l ⊆ m -> m ⊆ n -> l ⊆ n.
 Proof.
   intros A l m n Hlm Hmn x y.
   by apply Hmn, Hlm.
@@ -1784,6 +1784,6 @@ Next Obligation.
 Qed.
 
 Definition element_of_filter
-  `{EqDecision A} [P : A -> Prop] `{∀ x, Decision (P x)} [l : list A]
+  `{EqDecision A} [P : A -> Prop] `{forall x, Decision (P x)} [l : list A]
   : dsig (fun i => i ∈ filter P l) -> dsig (fun i => i ∈ l) :=
   element_of_subseteq (list_filter_subseteq P l).

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -274,7 +274,7 @@ Proof.
 Qed.
 
 Lemma filter_set_add `{StrictlyComparable X} P
-  `{∀ (x:X), Decision (P x)} :
+  `{forall (x:X), Decision (P x)} :
   forall (l:list X) x, ~ P x ->
   filter P l = filter P (set_add x l).
 Proof.
@@ -661,7 +661,7 @@ Proof.
 Qed.
 
 Lemma filter_set_eq {X} P Q
- `{∀ (x:X), Decision (P x)} `{∀ (x:X), Decision (Q x)}
+ `{forall (x:X), Decision (P x)} `{forall (x:X), Decision (Q x)}
    (l : list X)
    (resf := filter P l)
    (resg := filter Q l) :

--- a/theories/VLSM/Lib/NeList.v
+++ b/theories/VLSM/Lib/NeList.v
@@ -49,7 +49,7 @@ Definition ne_list_app {A} (l1 l2 : ne_list A) := ne_list_foldr nel_cons l2 l1.
 
 Inductive ne_list_equiv `{Equiv A} : Equiv (ne_list A) :=
 | ne_one_equiv x y : x ≡ y -> nel_singl x ≡ nel_singl y
-| ne_cons_equiv x y l k : x ≡ y → l ≡ k → x ::: l ≡ y ::: k.
+| ne_cons_equiv x y l k : x ≡ y -> l ≡ k -> x ::: l ≡ y ::: k.
 
 #[export] Existing Instance ne_list_equiv.
 
@@ -146,7 +146,7 @@ Qed.
   fun a nel => a ∈ ne_list_to_list nel.
 
 #[export] Instance ne_list_subseteq {A} : SubsetEq (ne_list A) :=
-  fun l1 l2 => forall x, x ∈ l1 → x ∈ l2.
+  fun l1 l2 => forall x, x ∈ l1 -> x ∈ l2.
 
 #[export] Instance elem_of_ne_list_dec `{dec : EqDecision A} :
   RelDecision (∈@{ne_list A}).

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -85,9 +85,9 @@ Proof.
 Qed.
 
 Lemma tc_wf_projected
-  `{R1 : relation A} `(R2 : relation B) `{!Transitive R2} (f : A → B) :
-  (∀ x y, R1 x y → R2 (f x) (f y)) →
-  wf R2 → wf (tc R1).
+  `{R1 : relation A} `(R2 : relation B) `{!Transitive R2} (f : A -> B) :
+  (forall x y, R1 x y -> R2 (f x) (f y)) ->
+  wf R2 -> wf (tc R1).
 Proof.
   intros Hpreserve.
   apply wf_projected with f.

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -184,7 +184,7 @@ Definition maximal_elements_set
     filter (fun a => set_Forall (fun b => ~ precedes a b) s) s.
 
 Lemma filter_ext_elem_of {A} P Q
- `{∀ (x:A), Decision (P x)} `{∀ (x:A), Decision (Q x)} (l:list A) :
+ `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)} (l:list A) :
  (forall a, a ∈ l -> (P a <-> Q a)) ->
  filter P l = filter Q l.
 Proof.
@@ -196,7 +196,7 @@ Proof.
 Qed.
 
 Lemma ext_elem_of_filter {A} P Q
- `{∀ (x:A), Decision (P x)} `{∀ (x:A), Decision (Q x)}
+ `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)}
  (l : list A) :
  filter P l = filter Q l -> forall a, a ∈ l -> (P a <-> Q a).
 Proof.
@@ -207,7 +207,7 @@ Proof.
 Qed.
 
 Lemma filter_complement {X} P Q
- `{∀ (x:X), Decision (P x)} `{∀ (x:X), Decision (Q x)}
+ `{forall (x:X), Decision (P x)} `{forall (x:X), Decision (Q x)}
  (l : list X) :
  filter P l = filter Q l <->
  filter (fun x => ~ P x) l = filter (fun x => ~ Q x) l.
@@ -280,7 +280,7 @@ Qed.
 
 Lemma longer_subseteq_has_dups `{EqDecision A} :
   forall l1 l2 : list A, l1 ⊆ l2 -> length l1 > length l2 ->
-  exists (i1 i2 : nat) (a : A), i1 ≠ i2 ∧ l1 !! i1 = Some a /\ l1 !! i2 = Some a.
+  exists (i1 i2 : nat) (a : A), i1 <> i2 /\ l1 !! i1 = Some a /\ l1 !! i2 = Some a.
 Proof.
   induction l1; [by inversion 2 |].
   intros l2 Hl12 Hlen12.
@@ -351,7 +351,7 @@ Proof.
   by apply drop_S.
 Qed.
 
-Lemma filter_in {A} P `{∀ (x:A), Decision (P x)} x s :
+Lemma filter_in {A} P `{forall (x:A), Decision (P x)} x s :
   In x s ->
   P x ->
   In x (filter P s).
@@ -363,7 +363,7 @@ Proof.
 Qed.
 
 Lemma filter_incl_fn {A} P Q
-  `{∀ (x:A), Decision (P x)} `{∀ (x:A), Decision (Q x)} :
+  `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)} :
   (forall a, P a -> Q a) ->
   forall s, incl (filter P s) (filter Q s).
 Proof.
@@ -374,7 +374,7 @@ Proof.
 Qed.
 
 Lemma filter_length_fn {A} P Q
-  `{∀ (x:A), Decision (P x)} `{∀ (x:A), Decision (Q x)}
+  `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)}
   s (Hfg : Forall (fun a => P a -> Q a) s) :
   length (filter P s) <= length (filter Q s).
 Proof.
@@ -385,7 +385,7 @@ Proof.
 Qed.
 
 Lemma filter_eq_fn {A} P Q
- `{∀ (x:A), Decision (P x)} `{∀ (x:A), Decision (Q x)} s :
+ `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)} s :
   (forall a, In a s -> P a <-> Q a) ->
   filter P s = filter Q s.
 Proof.
@@ -398,7 +398,7 @@ Proof.
 Qed.
 
 Lemma nth_error_filter
-  {A} P `{∀ (x:A), Decision (P x)}
+  {A} P `{forall (x:A), Decision (P x)}
   (l : list A)
   (n : nat)
   (a : A)
@@ -424,7 +424,7 @@ Proof.
       by rewrite Hnth'.
 Qed.
 
-Lemma filter_subseteq {A} P `{∀ (x:A), Decision (P x)} (s1 s2 : list A) :
+Lemma filter_subseteq {A} P `{forall (x:A), Decision (P x)} (s1 s2 : list A) :
   s1 ⊆ s2 ->
   (filter P s1) ⊆ (filter P s2).
 Proof.
@@ -443,7 +443,7 @@ Proof.
 Qed.
 
 Lemma filter_subseteq_fn {A} P Q
-  `{∀ (x:A), Decision (P x)} `{∀ (x:A), Decision (Q x)} :
+  `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)} :
   (forall a, P a -> Q a) ->
   forall (s : list A), filter P s ⊆ filter Q s.
 Proof.
@@ -455,7 +455,7 @@ Proof.
   - by itauto.
 Qed.
 
-Lemma filter_incl {A} P `{∀ (x:A), Decision (P x)} s1 s2 :
+Lemma filter_incl {A} P `{forall (x:A), Decision (P x)} s1 s2 :
   incl s1 s2 ->
   incl (filter P s1) (filter P s2).
 Proof.
@@ -469,7 +469,7 @@ Proof.
     by intros y HIn; apply H0; right.
 Qed.
 
-Lemma Forall_filter_nil {A} P `{∀ (x:A), Decision (P x)} l :
+Lemma Forall_filter_nil {A} P `{forall (x:A), Decision (P x)} l :
   Forall (fun a : A => ~ P a) l <-> filter P l = [].
 Proof.
   rewrite Forall_forall.


### PR DESCRIPTION
This is the equivalent of https://github.com/runtimeverification/casper-cbc-proofs/pull/542 for vlsm.