### PR TITLE
Replace some `~` with `∉`

### DIFF
--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -2291,7 +2291,7 @@ Proof.
         intros [Heqv].
         eapply global_equivocators_simple_step_update_receive in Heqv;
           [| by constructor; state_update_simpl].
-        assert (Hm0_not_sent : ~ m0 ∈ sentMessages (s i)).
+        assert (Hm0_not_sent : m0 ∉ sentMessages (s i)).
         {
           intro Hm0; eapply adr_of_sentMessages in Hm0;
             [| by eapply ELMO_full_node_reachable, valid_state_project_preloaded].

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -159,7 +159,7 @@ Qed.
 
 Lemma in_not_in : forall A (x y : A) (l:list A),
   x ∈ l ->
-  ~ y ∈ l ->
+  y ∉ l ->
   x <> y.
 Proof. by itauto congruence. Qed.
 

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -295,7 +295,7 @@ Proof.
 Qed.
 
 Lemma set_add_new `{EqDecision A}:
-  forall (x:A) l, ~x ∈ l -> set_add x l = l++[x].
+  forall (x:A) l, x ∉ l -> set_add x l = l++[x].
 Proof.
   induction l; cbn; [done |]; intros H_not_in.
   rewrite decide_False; cycle 1.
@@ -304,7 +304,7 @@ Proof.
 Qed.
 
 Lemma set_remove_not_elem_of `{EqDecision A} : forall x (s : list A),
-  ~ x ∈ s ->
+  x ∉ s ->
   set_remove x s = s.
 Proof.
   induction s; cbn; intros; [done |].
@@ -315,7 +315,7 @@ Proof.
 Qed.
 
 Lemma set_remove_elim `{EqDecision A} : forall x (s : list A),
-  NoDup s -> ~ x ∈ (set_remove x s).
+  NoDup s -> x ∉ (set_remove x s).
 Proof.
   by intros x s HND Hnelem; apply set_remove_iff in Hnelem; itauto.
 Qed.
@@ -328,7 +328,7 @@ Qed.
 
 Lemma set_remove_nodup_1 `{EqDecision A} : forall x (s : list A),
   NoDup (set_remove x s) ->
-  ~ x ∈ (set_remove x s) ->
+  x ∉ (set_remove x s) ->
   NoDup s.
 Proof.
   induction s; intros; [by constructor |].
@@ -419,7 +419,7 @@ Qed.
 Lemma set_eq_remove_union_not_elem_of  `{EqDecision A} : forall x (s1 s2 : list A),
   NoDup s1 ->
   NoDup s2 ->
-  ~ x ∈ s1 ->
+  x ∉ s1 ->
   set_eq (set_union s1 (set_remove x s2)) (set_remove x (set_union s1 s2)).
 Proof.
   intros.
@@ -464,7 +464,7 @@ Qed.
 
 Lemma add_remove_inverse `{EqDecision X}:
   forall (lv : list X) (v : X),
-    ~ v ∈ lv ->
+    v ∉ lv ->
     set_remove v (set_add v lv) = lv.
 Proof.
   induction lv as [| hd tl IHlv]; cbn; intros.
@@ -542,13 +542,13 @@ Definition set_diff_filter `{EqDecision A} (l r : list A) :=
   [set_diff_iff].
 *)
 Lemma set_diff_filter_iff `{EqDecision A} (a:A) l r:
-  a ∈ (set_diff_filter l r) <-> (a ∈ l /\ ~a ∈ r).
+  a ∈ (set_diff_filter l r) <-> (a ∈ l /\ a ∉ r).
 Proof.
   induction l;simpl.
   - by cbn; split; intros; [inversion H | itauto].
   - unfold set_diff_filter in *.
     rewrite filter_cons.
-    destruct (decide (~ a0 ∈ r)).
+    destruct (decide (a0 ∉ r)).
     + rewrite 2 elem_of_cons, IHl.
       by split; itauto congruence.
     + rewrite elem_of_cons.
@@ -573,7 +573,7 @@ Proof.
   induction l; [done |].
   unfold set_diff_filter.
   rewrite 2 filter_cons.
-  destruct (decide (~ a0 ∈ a)); destruct (decide (~ a0 ∈ b)).
+  destruct (decide (a0 ∉ a)); destruct (decide (a0 ∉ b)).
   - by simpl; unfold set_diff_filter in IHl; lia.
   - by itauto.
   - by simpl; apply le_S, IHl.
@@ -587,7 +587,7 @@ Qed.
 *)
 Lemma len_set_diff_decrease `{EqDecision A} (new:A) (l a b: list A)
       (H_subseteq: forall x, x ∈ b -> x ∈ a)
-      (H_new_is_new: new ∈ a /\ ~new ∈ b)
+      (H_new_is_new: new ∈ a /\ new ∉ b)
       (H_new_is_relevant: new ∈ l):
   length (set_diff_filter l a) < length (set_diff_filter l b).
 Proof.
@@ -596,14 +596,14 @@ Proof.
   - subst a0.
     unfold set_diff_filter.
     rewrite 2 filter_cons.
-    destruct (decide (~ new ∈ a)); [by itauto |].
-    destruct (decide (~ new ∈ b)); [| by contradict n0; itauto].
+    destruct (decide (new ∉ a)); [by itauto |].
+    destruct (decide (new ∉ b)); [| by contradict n0; itauto].
     simpl.
     by apply le_n_S, len_set_diff_incl_le.
   - specialize (IHl H);clear H.
     unfold set_diff_filter.
     rewrite 2 filter_cons.
-    destruct (decide (~ a0 ∈ a)); destruct (decide (~ a0 ∈ b)).
+    destruct (decide (a0 ∉ a)); destruct (decide (a0 ∉ b)).
     + simpl.
       rewrite <- Nat.succ_lt_mono.
       by apply IHl.
@@ -618,7 +618,7 @@ Qed.
 
 Lemma len_set_diff_map_set_add `{EqDecision B} (new:B) `{EqDecision A} (f: B -> A)
       (a: list B) (l: list A)
-      (H_new_is_new: ~(f new) ∈ (map f a))
+      (H_new_is_new: (f new) ∉ (map f a))
       (H_new_is_relevant: (f new) ∈ l):
   length (set_diff_filter l (map f (set_add new a))) <
     length (set_diff_filter l (map f a)).

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -165,7 +165,7 @@ Qed.
 Definition maximal_elements_list
   {A} (precedes: relation A) `{!RelDecision precedes} (l : list A)
   : list A :=
-  filter (fun a => Forall (fun b => (~ precedes a b)) l) l.
+  filter (fun a => Forall (fun b => ~ precedes a b) l) l.
 
 Example maximal_elements_list1: maximal_elements_list Nat.lt [1; 4; 2; 4] = [4;4].
 Proof. by itauto. Qed.
@@ -531,7 +531,7 @@ Lemma occurrences_ordering
   (a b : A)
   (la1 la2 lb1 lb2 : list A)
   (Heq : la1 ++ a :: la2 = lb1 ++ b :: lb2)
-  (Ha : ~a ∈ (b :: lb2))
+  (Ha : a ∉ (b :: lb2))
   : exists lab : list A, lb1 = la1 ++ a :: lab.
 Proof.
   generalize dependent lb2. generalize dependent la2.

--- a/theories/VLSM/Lib/StdppListFinSet.v
+++ b/theories/VLSM/Lib/StdppListFinSet.v
@@ -120,7 +120,7 @@ Qed.
 
 Lemma set_diff_intro :
   forall (a : A) (x y : set),
-    a ∈ x -> ~ a ∈ y -> a ∈ set_diff x y.
+    a ∈ x -> a ∉ y -> a ∈ set_diff x y.
 Proof.
   by intros; apply elem_of_difference.
 Qed.
@@ -134,14 +134,14 @@ Proof.
 Qed.
 
 Lemma set_diff_elim2 :
-  forall (a : A) (x y : set), a ∈ set_diff x y -> ~ a ∈ y.
+  forall (a : A) (x y : set), a ∈ set_diff x y -> a ∉ y.
 Proof.
   unfold set_diff; intros a x y Hxy.
   by apply elem_of_difference in Hxy as [_ Hny].
 Qed.
 
 Lemma set_diff_iff a l l' :
-  a ∈ set_diff l l' <-> a ∈ l /\ ~ a ∈ l'.
+  a ∈ set_diff l l' <-> a ∈ l /\ a ∉ l'.
 Proof.
   split.
   - by eauto using set_diff_elim1, set_diff_elim2.

--- a/theories/VLSM/Lib/StdppListSet.v
+++ b/theories/VLSM/Lib/StdppListSet.v
@@ -163,7 +163,7 @@ Qed.
 
 Lemma set_diff_intro :
   forall (a : A) (x y : set),
-    a ∈ x -> ~ a ∈ y -> a ∈ set_diff x y.
+    a ∈ x -> a ∉ y -> a ∈ set_diff x y.
 Proof.
   induction x; cbn; [by inversion 1 |].
   by intros y; destruct (decide (a0 ∈ y));
@@ -179,14 +179,14 @@ Proof.
 Qed.
 
 Lemma set_diff_elim2 :
-  forall (a : A) (x y : set), a ∈ set_diff x y -> ~ a ∈ y.
+  forall (a : A) (x y : set), a ∈ set_diff x y -> a ∉ y.
 Proof.
   induction x; cbn; [by inversion 1 |].
   by intros y; destruct (decide (a0 ∈ y)); rewrite ?set_add_iff; firstorder congruence.
 Qed.
 
 Lemma set_diff_iff a l l' :
-  a ∈ set_diff l l' <-> a ∈ l /\ ~ a ∈ l'.
+  a ∈ set_diff l l' <-> a ∈ l /\ a ∉ l'.
 Proof.
   split.
   - by eauto using set_diff_elim1, set_diff_elim2.

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -268,7 +268,7 @@ Definition topologically_sorted
     (Hab : precedes a b)
     (l1 l2 : list A)
     (Heq : l = l1 ++ [b] ++ l2)
-    , ~a ∈ l2.
+    , a ∉ l2.
 
 (**
   The following properties assume that <<precedes>> determines a [StrictOrder]


### PR DESCRIPTION
This is the equivalent of https://github.com/runtimeverification/casper-cbc-proofs/pull/544 for vlsm