### PR TITLE
Remove unnecessary parentheses.

### DIFF
--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -80,7 +80,7 @@ Lemma incl_equivocating_validators_equivocation_fault
   `{Heqv: BasicEquivocation st validator }
   `{EqDecision validator}
   : forall s1 s2,
-    (equivocating_validators s1) ⊆ (equivocating_validators s2) ->
+    equivocating_validators s1 ⊆ equivocating_validators s2 ->
     (equivocation_fault s1 <= equivocation_fault s2)%R.
 Proof.
   intros s1 s2 H_incl.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -112,13 +112,13 @@ Qed.
 Section sec_strong_fixed_equivocation.
 
 Definition sent_by_non_equivocating s m
-  := exists i, i ∉ (elements equivocating) /\ has_been_sent (IM i) (s i) m.
+  := exists i, i ∉ elements equivocating /\ has_been_sent (IM i) (s i) m.
 
 #[export] Instance sent_by_non_equivocating_dec : RelDecision sent_by_non_equivocating.
 Proof.
   intros s m.
   apply @Decision_iff with (P := Exists (fun i => has_been_sent (IM i) (s i) m)
-    (filter (fun i => i ∉ (elements equivocating)) (enum index))).
+    (filter (fun i => i ∉ elements equivocating) (enum index))).
   - rewrite Exists_exists. apply exist_proper. intro i.
     rewrite elem_of_list_filter. apply and_iff_compat_r.
     split; [intros [Hi Hl]; done | split; [done |]].
@@ -224,7 +224,7 @@ Context
   `{forall i : index, HasBeenSentCapability (IM i)}
   `{forall i : index, HasBeenReceivedCapability (IM i)}
   (indices1 indices2 : Ci)
-  (Hincl : (elements indices1) ⊆ (elements indices2))
+  (Hincl : elements indices1 ⊆ elements indices2)
   .
 
 Lemma equivocators_composition_for_directly_observed_index_incl_embedding
@@ -454,7 +454,7 @@ Qed.
   (Ht : input_valid_transition Fixed l (s, iom) (sf, Some om))
   : strong_fixed_equivocation IM equivocators base_s om.
 Proof.
-  destruct (decide (projT1 l ∈ (elements equivocators))).
+  destruct (decide (projT1 l ∈ elements equivocators)).
   - apply
       (fixed_input_valid_transition_sub_projection_helper Hs_pr _ e) in Ht.
     by right; eexists _,_,_.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -20,7 +20,7 @@ Context
   .
 
 Definition equivocator_can_emit (m : message) : Prop :=
-  exists i, i ∈ (elements equivocators) /\ can_emit (pre_loaded_with_all_messages_vlsm (IM i)) m.
+  exists i, i ∈ elements equivocators /\ can_emit (pre_loaded_with_all_messages_vlsm (IM i)) m.
 
 Definition dependencies_with_non_equivocating_senders_were_sent s m : Prop :=
   forall dm, msg_dep_happens_before message_dependencies dm m ->

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -375,7 +375,7 @@ Lemma equivocating_messages_are_equivocator_emitted
   (Him : can_emit (free_composite_vlsm IM) im)
   (Hnobserved : ¬ composite_has_been_directly_observed IM s im) :
     exists j : index,
-      j ∈ (msg_dep_message_equivocators IM full_message_dependencies sender s im (Cv := Ci))
+      j ∈ msg_dep_message_equivocators IM full_message_dependencies sender s im (Cv := Ci)
         /\
       can_emit (pre_loaded_vlsm (IM j) (fun dm => msg_dep_rel message_dependencies dm im)) im.
 Proof.
@@ -401,7 +401,7 @@ Lemma equivocating_messages_dependencies_are_directly_observed_or_equivocator_em
   (Hnobserved : ¬ composite_has_been_directly_observed IM s im)
   : forall dm, msg_dep_happens_before message_dependencies dm im ->
     composite_has_been_directly_observed IM s dm \/
-    exists dm_i, dm_i ∈ (msg_dep_message_equivocators IM full_message_dependencies sender s im (Cv := Ci)) /\
+    exists dm_i, dm_i ∈ msg_dep_message_equivocators IM full_message_dependencies sender s im (Cv := Ci) /\
       can_emit (pre_loaded_with_all_messages_vlsm (IM dm_i)) dm.
 Proof.
   intros dm Hdm.

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -314,7 +314,7 @@ Context
   }.
 
 Lemma equivocating_validators_is_equivocating_tracewise_iff s v
-  : v ∈ (equivocating_validators s) <-> is_equivocating_tracewise_no_has_been_sent s v.
+  : v ∈ equivocating_validators s <-> is_equivocating_tracewise_no_has_been_sent s v.
 Proof.
   unfold equivocating_validators.
   simpl.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -79,7 +79,7 @@ Context
 Program Instance equivocating_indices_BasicEquivocation :
   BasicEquivocation (composite_state equivocator_IM) index Ci threshold
   := {
-    is_equivocating := fun s v => v ∈ (equivocating_indices (enum index) s) ;
+    is_equivocating := fun s v => v ∈ equivocating_indices (enum index) s ;
     state_validators := fun s => list_to_set(enum index)
   }.
 Next Obligation.
@@ -141,7 +141,7 @@ Lemma equivocators_transition_preserves_equivocating_indices
   (l: composite_label equivocator_IM)
   (s0: composite_state equivocator_IM)
   (Ht: composite_transition equivocator_IM l (s0, iom) = (s, oom))
-  : (equivocating_indices index_listing s0) ⊆ (equivocating_indices index_listing s).
+  : equivocating_indices index_listing s0 ⊆ equivocating_indices index_listing s.
 Proof.
   intros i Hi.
   apply elem_of_list_filter.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -28,7 +28,7 @@ Definition state_has_fixed_equivocation
   (s : composite_state equivocator_IM)
   : Prop
   :=
-  (equivocating_indices IM (enum index) s) ⊆ equivocating.
+  equivocating_indices IM (enum index) s ⊆ equivocating.
 
 Definition equivocators_fixed_equivocations_constraint
   (l : composite_label equivocator_IM)
@@ -613,7 +613,7 @@ Lemma not_equivocating_sent_message_has_been_directly_observed_in_projection
   (lst := finite_trace_last is tr)
   (item: transition_item)
   (Hitem: item ∈ tr)
-  (Hitem_not_equiv: (projT1 (l item)) ∉ equivocating)
+  (Hitem_not_equiv: projT1 (l item) ∉ equivocating)
   (m: message)
   (Hm: field_selector output m item)
   (descriptors: equivocator_descriptors IM)
@@ -890,7 +890,7 @@ Lemma equivocator_vlsm_trace_project_reflect_non_equivocating
   (item: composite_transition_item (equivocator_IM IM))
   (Hitem: item ∈ tr)
   (Houtput: output item = Some m)
-  (Hno_equiv_item: (projT1 (l item)) ∉ equivocating)
+  (Hno_equiv_item: projT1 (l item) ∉ equivocating)
   : trace_has_message (field_selector output) m trX.
 Proof.
   apply elem_of_list_split in Hitem.
@@ -963,12 +963,12 @@ Lemma projection_has_not_been_directly_observed_is_equivocating
   (m: message)
   (Hno: ~ composite_has_been_directly_observed IM sX m)
   : forall item : composite_transition_item (equivocator_IM IM),
-      item ∈ tr -> output item = Some m -> (projT1 (l item)) ∈ equivocating.
+      item ∈ tr -> output item = Some m -> projT1 (l item) ∈ equivocating.
 Proof.
   destruct (free_equivocators_valid_trace_project descriptors is tr Hproper Htr)
     as [trX [initial_descriptors [_ [Htr_project [Hlast_state HtrX]]]]].
   intros item Hitem Houtput.
-  destruct (decide ((projT1 (l item)) ∈ (elements equivocating)));
+  destruct (decide (projT1 (l item) ∈ elements equivocating));
     [by apply elem_of_elements |].
   elim Hno. clear Hno.
   apply composite_has_been_directly_observed_sent_received_iff.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -267,7 +267,7 @@ Lemma finite_trace_projection_list_in_rev
   (tr : list (composite_transition_item IM))
   (j : index)
   (itemj : vtransition_item (IM j))
-  (Hitemj : itemj ∈ (VLSM_projection_finite_trace_project (preloaded_component_projection IM j) tr))
+  (Hitemj : itemj ∈ VLSM_projection_finite_trace_project (preloaded_component_projection IM j) tr)
   : exists (itemX : composite_transition_item IM), itemX ∈ tr /\
     output itemX = output itemj /\
     input itemX = input itemj /\

--- a/theories/VLSM/Lib/ListFinSetExtras.v
+++ b/theories/VLSM/Lib/ListFinSetExtras.v
@@ -19,7 +19,7 @@ Definition set_union (x y : set) : set := x ∪ y.
 Definition set_diff (x y : set) : set := x ∖ y.
 
 Lemma set_union_subseteq_left :
-  forall (s1 s2 : set), s1 ⊆ (set_union s1 s2).
+  forall (s1 s2 : set), s1 ⊆ set_union s1 s2.
 Proof. by intros s1 s2 x Hincl; apply set_union_intro; left. Qed.
 
 Lemma set_union_subseteq_iff :

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -115,13 +115,13 @@ Proof.
 Qed.
 
 Lemma set_union_subseteq_left `{EqDecision A}  : forall (s1 s2 : list A),
-  s1 ⊆ (set_union s1 s2).
+  s1 ⊆ set_union s1 s2.
 Proof.
   by intros; intros x H; apply set_union_intro; left.
 Qed.
 
 Lemma set_union_subseteq_right `{EqDecision A}  : forall (s1 s2 : list A),
-  s2 ⊆ (set_union s1 s2).
+  s2 ⊆ set_union s1 s2.
 Proof.
   by intros; intros x H; apply set_union_intro; right.
 Qed.
@@ -151,7 +151,7 @@ Lemma set_union_in_iterated
   `{EqDecision A}
   (ss : list (set A))
   (a : A)
-  : a ∈ (fold_right set_union [] ss) <-> Exists (fun s => a ∈ s) ss.
+  : a ∈ fold_right set_union [] ss <-> Exists (fun s => a ∈ s) ss.
 Proof.
   rewrite Exists_exists.
   induction ss; split; simpl.
@@ -172,8 +172,8 @@ Lemma set_union_iterated_subseteq
   `{EqDecision A}
   (ss ss': list (set A))
   (Hincl : ss ⊆ ss') :
-  (fold_right set_union [] ss) ⊆
-  (fold_right set_union [] ss').
+  fold_right set_union [] ss ⊆
+  fold_right set_union [] ss'.
 Proof.
   intros a H.
   apply set_union_in_iterated in H.
@@ -194,7 +194,7 @@ Proof.
 Qed.
 
 Lemma map_list_subseteq {A B} : forall (f : B -> A) (s s' : list B),
-  s ⊆ s' -> (map f s) ⊆ (map f s').
+  s ⊆ s' -> map f s ⊆ map f s'.
 Proof.
   intro f; induction s; intros; simpl.
   - by apply list_subseteq_nil.
@@ -221,7 +221,7 @@ Qed.
 
 Lemma set_map_elem_of {A B} `{EqDecision A} (f : B -> A) : forall x s,
   x ∈ s ->
-  (f x) ∈ (set_map f s).
+  f x ∈ set_map f s.
 Proof.
   induction s; intros; inversion H; subst; clear H; simpl.
   - by apply set_add_intro2.
@@ -229,7 +229,7 @@ Proof.
 Qed.
 
 Lemma set_map_exists {A B} `{EqDecision A} (f : B -> A) : forall y s,
-  y ∈ (set_map f s) <->
+  y ∈ set_map f s <->
   exists x, x ∈ s /\ f x = y.
 Proof.
   induction s; split; intros; cbn in *.
@@ -247,7 +247,7 @@ Qed.
 
 Lemma set_map_subseteq {A B} `{EqDecision A} (f : B -> A) : forall s s',
   s ⊆ s' ->
-  (set_map f s) ⊆ (set_map f s').
+  set_map f s ⊆ set_map f s'.
 Proof.
   induction s; cbn; intros s' Hsub msg Hin; [by inversion Hin |].
   apply set_add_elim in Hin as [-> |].
@@ -315,7 +315,7 @@ Proof.
 Qed.
 
 Lemma set_remove_elim `{EqDecision A} : forall x (s : list A),
-  NoDup s -> ~ x ∈ (set_remove x s).
+  NoDup s -> ~ x ∈ set_remove x s.
 Proof.
   by intros x s HND Hnelem; apply set_remove_iff in Hnelem; itauto.
 Qed.
@@ -328,7 +328,7 @@ Qed.
 
 Lemma set_remove_nodup_1 `{EqDecision A} : forall x (s : list A),
   NoDup (set_remove x s) ->
-  ~ x ∈ (set_remove x s) ->
+  ~ x ∈ set_remove x s ->
   NoDup s.
 Proof.
   induction s; intros; [by constructor |].
@@ -343,7 +343,7 @@ Qed.
 Lemma set_remove_elem_of_iff `{EqDecision A} :  forall x y (s : list A),
   NoDup s ->
   y ∈ s ->
-  x ∈ s <-> x = y \/ x ∈ (set_remove y s).
+  x ∈ s <-> x = y \/ x ∈ set_remove y s.
 Proof.
   intros. split; intros.
   - destruct (decide (x = y)).
@@ -393,8 +393,8 @@ Qed.
 Lemma subseteq_remove_union `{EqDecision A} : forall x (s1 s2 : list A),
   NoDup s1 ->
   NoDup s2 ->
-  (set_remove x (set_union s1 s2)) ⊆
-  (set_union s1 (set_remove x s2)).
+  set_remove x (set_union s1 s2) ⊆
+  set_union s1 (set_remove x s2).
 Proof.
   intros. intros y Hin. apply set_remove_iff in Hin.
   - apply set_union_intro. destruct Hin. apply set_union_elim in H1.
@@ -506,7 +506,7 @@ Lemma set_remove_list_1
   `{EqDecision A}
   (a : A)
   (l1 l2 : list A)
-  (Hin : a ∈ (set_remove_list l1 l2)) :
+  (Hin : a ∈ set_remove_list l1 l2) :
   a ∈ l2.
 Proof.
   unfold set_remove_list in Hin.
@@ -546,7 +546,7 @@ Definition set_diff_filter `{EqDecision A} (l r : list A) :=
   [set_diff_iff].
 *)
 Lemma set_diff_filter_iff `{EqDecision A} (a:A) l r:
-  a ∈ (set_diff_filter l r) <-> (a ∈ l /\ ~a ∈ r).
+  a ∈ set_diff_filter l r <-> a ∈ l /\ ~a ∈ r.
 Proof.
   induction l;simpl.
   - by cbn; split; intros; [inversion H | itauto].
@@ -622,8 +622,8 @@ Qed.
 
 Lemma len_set_diff_map_set_add `{EqDecision B} (new:B) `{EqDecision A} (f: B -> A)
       (a: list B) (l: list A)
-      (H_new_is_new: ~(f new) ∈ (map f a))
-      (H_new_is_relevant: (f new) ∈ l):
+      (H_new_is_new: f new ∉ map f a)
+      (H_new_is_relevant: f new ∈ l):
   length (set_diff_filter l (map f (set_add new a))) <
     length (set_diff_filter l (map f a)).
 Proof.
@@ -655,7 +655,7 @@ Lemma set_union_iterated_preserves_prop
   (ss : list (set A))
   (P : A -> Prop)
   (Hp : forall (s : set A), forall (a : A), (s ∈ ss /\ a ∈ s) -> P a) :
-  forall (a : A), a ∈ (fold_right set_union [] ss) -> P a.
+  forall (a : A), a ∈ fold_right set_union [] ss -> P a.
 Proof.
   intros.
   apply set_union_in_iterated in H. rewrite Exists_exists in H.
@@ -683,7 +683,7 @@ Proof.
   - by eapply elem_of_list_filter, H1', elem_of_list_filter.
 Qed.
 
-Lemma subseteq_appr : forall A (l m n : list A), l ⊆ n -> l ⊆ (m ++ n).
+Lemma subseteq_appr : forall A (l m n : list A), l ⊆ n -> l ⊆ m ++ n.
 Proof.
   intros A l m n x y yinl.
   apply x in yinl.
@@ -694,9 +694,9 @@ Lemma elem_of_union_fold
   `{EqDecision A}
   (haystack : list (list A))
   (a : A) :
-  a ∈ (fold_right set_union [] haystack)
+  a ∈ fold_right set_union [] haystack
   <->
-  exists (needle : list A), (a ∈ needle) /\ (needle ∈ haystack).
+  exists (needle : list A), a ∈ needle /\ needle ∈ haystack.
 Proof.
   split.
   - generalize dependent a.

--- a/theories/VLSM/Lib/SortedLists.v
+++ b/theories/VLSM/Lib/SortedLists.v
@@ -72,7 +72,7 @@ Qed.
 Lemma add_in_sorted_list_in
   {A} {compare : A -> A -> comparison} `{CompareStrictOrder A compare} :
   forall msg msg' sigma,
-    msg' ∈ (add_in_sorted_list_fn compare msg sigma) ->
+    msg' ∈ add_in_sorted_list_fn compare msg sigma ->
     msg = msg' \/ msg' ∈ sigma.
 Proof.
   intros. induction sigma; simpl in H0.
@@ -93,7 +93,7 @@ Lemma add_in_sorted_list_in_rev
   {A} {compare : A -> A -> comparison} `{CompareStrictOrder A compare} :
   forall msg msg' sigma,
     msg = msg' \/ msg' ∈ sigma ->
-    msg' ∈ (add_in_sorted_list_fn compare msg sigma).
+    msg' ∈ add_in_sorted_list_fn compare msg sigma.
 Proof.
   intros. induction sigma; simpl in H0.
   - by destruct H0 as [H0 | H0]; subst; [left | inversion H0].
@@ -105,7 +105,7 @@ Qed.
 Lemma add_in_sorted_list_iff
   {A} {compare : A -> A -> comparison} `{CompareStrictOrder A compare} :
   forall msg msg' sigma,
-    msg' ∈ (add_in_sorted_list_fn compare msg sigma) <->
+    msg' ∈ add_in_sorted_list_fn compare msg sigma <->
     msg = msg' \/ msg' ∈ sigma.
 Proof.
   intros; split.
@@ -116,7 +116,7 @@ Qed.
 Lemma add_in_sorted_list_head
   {A} {compare : A -> A -> comparison} `{CompareStrictOrder A compare} :
   forall msg sigma,
-    msg ∈ (add_in_sorted_list_fn compare msg sigma).
+    msg ∈ add_in_sorted_list_fn compare msg sigma.
 Proof.
   by intros; apply add_in_sorted_list_iff; left.
 Qed.
@@ -124,7 +124,7 @@ Qed.
 Lemma add_in_sorted_list_tail
   {A} {compare : A -> A -> comparison} `{CompareStrictOrder A compare} :
   forall msg sigma,
-    sigma ⊆ (add_in_sorted_list_fn compare msg sigma).
+    sigma ⊆ add_in_sorted_list_fn compare msg sigma.
 Proof.
   intros msg sigma x Hin.
   by apply add_in_sorted_list_iff; right.
@@ -357,7 +357,7 @@ Proof.
   rewrite Hconcat1 in Hin_y.
   apply elem_of_app in Hin_y.
   rewrite elem_of_cons in Hin_y.
-  assert (y =x \/ y ∈ (pref1 ++ suf1)). {
+  assert (y =x \/ y ∈ pref1 ++ suf1). {
     destruct Hin_y as [Hin_y|Hin_y]; [|destruct Hin_y].
     - by right; apply elem_of_app; left.
     - by left.

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -224,7 +224,7 @@ Proof.
 Qed.
 
 Lemma NoDup_elem_of_remove A (l l' : list A) a :
-  NoDup (l ++ a :: l') -> NoDup (l ++ l') /\ a ∉ (l ++ l').
+  NoDup (l ++ a :: l') -> NoDup (l ++ l') /\ a ∉ l ++ l'.
 Proof.
   intros Hnda.
   apply NoDup_app in Hnda.
@@ -426,7 +426,7 @@ Qed.
 
 Lemma filter_subseteq {A} P `{∀ (x:A), Decision (P x)} (s1 s2 : list A) :
   s1 ⊆ s2 ->
-  (filter P s1) ⊆ (filter P s2).
+  filter P s1 ⊆ filter P s2.
 Proof.
   induction s1; intros; intro x; intros.
   - by apply not_elem_of_nil in H1.
@@ -488,8 +488,8 @@ Lemma elem_of_list_annotate_forget
   (l : list A)
   (Hs : Forall P l)
   (xP : dsig P)
-  (Hin : xP ∈ (list_annotate P l Hs))
-  : (proj1_sig xP) ∈ l.
+  (Hin : xP ∈ list_annotate P l Hs)
+  : proj1_sig xP ∈ l.
 Proof.
   induction l.
   - by inversion Hin.
@@ -506,7 +506,7 @@ Lemma elem_of_list_annotate
   (l : list A)
   (Hs : Forall P l)
   (xP : dsig P)
-  : xP ∈ (list_annotate P l Hs) <-> (` xP) ∈ l.
+  : xP ∈ list_annotate P l Hs <-> (` xP) ∈ l.
 Proof.
   split; [by apply elem_of_list_annotate_forget |].
   destruct xP as [x Hpx]; cbn.
@@ -531,7 +531,7 @@ Lemma occurrences_ordering
   (a b : A)
   (la1 la2 lb1 lb2 : list A)
   (Heq : la1 ++ a :: la2 = lb1 ++ b :: lb2)
-  (Ha : ~a ∈ (b :: lb2))
+  (Ha : ~a ∈ b :: lb2)
   : exists lab : list A, lb1 = la1 ++ a :: lab.
 Proof.
   generalize dependent lb2. generalize dependent la2.
@@ -550,7 +550,7 @@ Qed.
 Lemma list_max_elem_of_exists
    (l : list nat)
    (nz : list_max l > 0) :
-   (list_max l) ∈ l.
+   list_max l ∈ l.
 Proof.
   induction l; simpl in *; [lia |].
   rewrite elem_of_cons.
@@ -596,7 +596,7 @@ Lemma map_option_subseteq
   (f : A -> option B)
   (l1 l2 : list A)
   (Hincl : l1 ⊆ l2)
-  : (map_option f l1) ⊆ (map_option f l2).
+  : map_option f l1 ⊆ map_option f l2.
 Proof.
   by intros b; rewrite !elem_of_map_option; firstorder.
 Qed.
@@ -605,7 +605,7 @@ Lemma elem_of_cat_option
   {A : Type}
   (l : list (option A))
   (a : A)
-  : a ∈ (cat_option l) <-> exists b : (option A), b ∈ l /\ b = Some a.
+  : a ∈ cat_option l <-> exists b : option A, b ∈ l /\ b = Some a.
 Proof.
   by apply elem_of_map_option.
 Qed.
@@ -632,7 +632,7 @@ Qed.
 Lemma list_max_elem_of_exists2
    (l : list nat)
    (Hne : l <> []) :
-   (list_max l) ∈ l.
+   list_max l ∈ l.
 Proof.
   destruct (list_max l) eqn : eq_max.
   - destruct l; [by itauto congruence |].

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -230,7 +230,7 @@ Lemma elem_of_stream_prefix
   (l : Stream A)
   (n : nat)
   (a : A)
-  : a ∈ (stream_prefix l n) <-> exists k : nat, k < n /\ Str_nth k l = a.
+  : a ∈ stream_prefix l n <-> exists k : nat, k < n /\ Str_nth k l = a.
 Proof.
   revert l a.
   induction n; simpl; split; intros.

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -307,7 +307,7 @@ Proof.
   { rewrite Forall_forall in Hl. apply Hl. rewrite Heqa, !elem_of_app, elem_of_list_singleton. auto. }
   specialize (Hts a b Hab lb1 lb2 Heqb).
   rewrite Heqa in Heqb.
-  assert (Ha : a ∉ (b :: lb2)).
+  assert (Ha : a ∉ b :: lb2).
   { intro Ha. apply Hts.
     rewrite elem_of_cons in Ha.
     destruct Ha; subst; [| done].
@@ -416,7 +416,7 @@ Proof.
   rewrite Forall_forall in Hpc. rewrite Forall_forall.
   subst l.
   intros b Hb a Hab.
-  assert (Hb' : b ∈ (init ++ [final])) by (apply elem_of_app; left; done).
+  assert (Hb' : b ∈ init ++ [final]) by (apply elem_of_app; left; done).
   specialize (Hpc b Hb' a Hab).
   apply elem_of_app in Hpc.
   destruct Hpc as [Ha | Ha]; [done |].
@@ -668,7 +668,7 @@ Proof.
     specialize (last_error_is_last l' a') as Hlast.
     by itauto congruence.
   }
-  assert (a ∈ (top_sort l)).
+  assert (a ∈ top_sort l).
   {
     destruct H as [l' <-].
     by apply elem_of_app; right; left.
@@ -690,7 +690,7 @@ Proof.
   specialize (Htop max a contra).
 
   assert (Hinmax: max ∈ l) by (apply maximal_element_in; itauto).
-  assert (Hinatop : a ∈ (top_sort l)) by (apply Hseteq; itauto).
+  assert (Hinatop : a ∈ top_sort l) by (apply Hseteq; itauto).
   apply elem_of_list_split in Hinatop.
   destruct Hinatop as [prefA [sufA HeqA]].
   unfold get_maximal_element in Hmax.


### PR DESCRIPTION
This is the equivalent of https://github.com/runtimeverification/casper-cbc-proofs/pull/543 for vlsm.