### PR TITLE
add badges in README.md for CI and coqdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # VLSM
 
+[![Docker CI][docker-action-shield]][docker-action-link]
+[![coqdoc][coqdoc-shield]][coqdoc-link]
+
+[docker-action-shield]: https://github.com/runtimeverification/vlsm/workflows/Test%20PR/badge.svg?branch=master
+[docker-action-link]: https://github.com/runtimeverification/vlsm/actions?query=workflow:"Test%20PR"
+
+[coqdoc-shield]: https://img.shields.io/badge/docs-coqdoc-blue.svg
+[coqdoc-link]: https://runtimeverification.github.io/vlsm-docs/latest/coqdoc/toc.html
+
 A validating labelled state transition and message production system
 (VLSM) abstractly models a distributed system with faults. This project
 contains a formalization of VLSMs and their theory in the Coq proof assistant.

--- a/meta.yml
+++ b/meta.yml
@@ -4,7 +4,8 @@ shortname: vlsm
 organization: runtimeverification
 community: false
 dune: false
-coqdoc: false
+action: true
+coqdoc: true
 
 synopsis: >-
   Coq formalization of validating labelled state transition


### PR DESCRIPTION
Now that we have Actions based CI it's easy to add a badge with CI status. I also add a badge for the latest coqdoc.