### PR TITLE
construct Inhabited typeclass members without tactics

### DIFF
--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -35,13 +35,14 @@ Context
   `{Inhabited (sig initial_annotation_prop)}
   .
 
-Definition annotated_initial_state_prop (sa : annotated_state) :=
+Definition annotated_initial_state_prop (sa : annotated_state) : Prop :=
   vinitial_state_prop X (original_state sa) /\ initial_annotation_prop (state_annotation sa).
 
-#[export] Program Instance annotated_initial_state_prop_inhabited
-  : Inhabited (sig annotated_initial_state_prop) :=
-  populate (exist _ {| original_state := ` (vs0 X); state_annotation := ` inhabitant  |} _).
+#[export] Program Instance annotated_initial_state_prop_inhabited :
+  Inhabited {sa : annotated_state | annotated_initial_state_prop sa} :=
+    populate (exist _ {| original_state := `(vs0 X); state_annotation := `inhabitant; |} _).
 Next Obligation.
+Proof.
   split; cbn.
   - by destruct (vs0 X).
   - by destruct inhabitant.

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -23,10 +23,11 @@ From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces 
 (** ** Definition and basic properties *)
 
 Section sec_byzantine_traces.
+
 Context
-    {message : Type}
-    (M : VLSM message)
-    .
+  {message : Type}
+  (M : VLSM message)
+  .
 
 (**
   The first definition says that a trace has the [byzantine_trace_prop]erty
@@ -81,10 +82,13 @@ Definition all_messages_type : VLSMType message :=
   ensure that the sets of labels and messages are both non-empty.
 *)
 
-Definition all_messages_s0 := exist (fun s: @state _ all_messages_type => True) tt I.
+Program Definition all_messages_s0 : {_ : @state _ all_messages_type | True} :=
+  exist _ tt _.
+Next Obligation.
+Proof. done. Defined.
 
-Instance all_messages_state_inh : Inhabited (sig  (fun s: @state _ all_messages_type => True)) :=
-  {| inhabitant := all_messages_s0 |}.
+#[export] Instance all_messages_state_inh : Inhabited {_ : @state _ all_messages_type | True} :=
+  populate all_messages_s0.
 
 (**
   The [transition] function of the [emit_any_message_vlsm] generates the

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -167,17 +167,16 @@ Definition composite_initial_state_prop
   :=
     forall n : index, vinitial_state_prop (IM n) (s n).
 
-Definition composite_initial_state
-  := sig composite_initial_state_prop.
+Definition composite_initial_state : Type :=
+  {s : composite_state | composite_initial_state_prop s}.
 
-Definition composite_s0 : composite_initial_state.
-Proof.
-  exists (fun (n : index) => proj1_sig (vs0 (IM n))).
-  by intro i; destruct (vs0 (IM i)) as [s Hs].
-Defined.
+Program Definition composite_s0 : composite_initial_state :=
+  exist _ (fun (n : index) => `(vs0 (IM n))) _.
+Next Obligation.
+Proof. by intros i; destruct (vs0 (IM i)). Defined.
 
 #[export] Instance composite_initial_state_inh : Inhabited composite_initial_state :=
-  {| inhabitant := composite_s0 |}.
+  populate composite_s0.
 
 (**
   A message has the [initial_message_prop]erty in the composite

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -35,14 +35,13 @@ Definition UMOComponent_initial_state_type (i : Address) : Type :=
 Program Definition UMOComponent_initial_state
   (i : Address) : UMOComponent_initial_state_type i := MkState [] i.
 Next Obligation.
+Proof.
   by compute.
 Defined.
 
-#[export]
-Instance Inhabited_UMOComponent_initial_state_type
-  (i : Address)
-  : Inhabited (UMOComponent_initial_state_type i)
-  := {| inhabitant := UMOComponent_initial_state i |}.
+#[export] Instance Inhabited_UMOComponent_initial_state_type (i : Address) :
+  Inhabited (UMOComponent_initial_state_type i) :=
+    populate (UMOComponent_initial_state i).
 
 Definition UMOComponent_transition
   (l : Label) (s : State) (om : option Message)

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -55,8 +55,10 @@ Definition coeqv_limited_equivocation_constraint
   : Prop :=
   (sum_weights (coeqv_composite_transition_message_equivocators l som) <= threshold)%R.
 
-#[export] Instance empty_validators_inhabited : Inhabited {s : Cv | s = ∅}
-  := populate (exist _ _ eq_refl).
+#[export] Program Instance empty_validators_inhabited : Inhabited {s : Cv | s = ∅} :=
+  populate (exist _ ∅ _).
+Next Obligation.
+Proof. done. Defined.
 
 Definition coeqv_limited_equivocation_vlsm : VLSM message :=
   annotated_vlsm (free_composite_vlsm IM) Cv (fun s => s = ∅)

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -533,19 +533,19 @@ Definition equivocator_initial_state_prop
   : Prop
   := is_singleton_state bs /\ vinitial_state_prop X (equivocator_state_zero bs).
 
-Definition equivocator_initial_state
-  := sig equivocator_initial_state_prop.
+Definition equivocator_initial_state : Type :=
+  {bs : equivocator_state | equivocator_initial_state_prop bs}.
 
-Definition equivocator_s0 : equivocator_initial_state.
+Program Definition equivocator_s0 : equivocator_initial_state :=
+  exist _ (mk_singleton_state (proj1_sig (vs0 X))) _.
+Next Obligation.
 Proof.
-  exists (mk_singleton_state (proj1_sig (vs0 X))).
-  unfold mk_singleton_state.
-  unfold equivocator_initial_state_prop.
-  by split; [|destruct (vs0 X)].
+  unfold mk_singleton_state, equivocator_initial_state_prop; cbn.
+  by split; [| destruct (vs0 X)].
 Defined.
 
-Instance equivocator_initial_state_inh : Inhabited equivocator_initial_state :=
-  {| inhabitant := equivocator_s0 |}.
+#[export] Instance equivocator_initial_state_inh : Inhabited equivocator_initial_state :=
+  populate equivocator_s0.
 
 Definition equivocator_transition
   (bl : equivocator_label)

--- a/theories/VLSM/Core/Speculation.v
+++ b/theories/VLSM/Core/Speculation.v
@@ -33,9 +33,9 @@ match s with
 | _         => False
 end.
 
-#[export] Program Instance speculative_sig :
+#[export] Program Instance speculative_s0 :
   Inhabited {s : SpeculativeState | speculative_initial_state_prop s} :=
-populate (exist _ (Actual (`(vs0 X))) _).
+    populate (exist _ (Actual (`(vs0 X))) _).
 Next Obligation.
 Proof. by destruct (vs0 X). Qed.
 

--- a/theories/VLSM/Core/Speculation.v
+++ b/theories/VLSM/Core/Speculation.v
@@ -8,7 +8,6 @@ From VLSM.Core Require Import VLSM Plans.
   This module introduces the speculative VLSM construction. It models the
   speculative execution of transitions from the underlying VLSM which can then
   be committed or rolled back.
-
 *)
 
 Section sec_speculative.
@@ -34,12 +33,11 @@ match s with
 | _         => False
 end.
 
-#[export] Instance speculative_s0 :
-  Inhabited {s : SpeculativeState | speculative_initial_state_prop s}.
-Proof.
-  constructor; split with (Actual (` (vs0 X))).
-  by destruct (vs0 X).
-Defined.
+#[export] Program Instance speculative_sig :
+  Inhabited {s : SpeculativeState | speculative_initial_state_prop s} :=
+populate (exist _ (Actual (`(vs0 X))) _).
+Next Obligation.
+Proof. by destruct (vs0 X). Qed.
 
 Definition speculative_transition
   (sl : SpeculativeLabel) (ssim : SpeculativeState * option message)

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -188,8 +188,15 @@ Context
 Definition projection_induced_initial_state_prop (sY : stateTY) : Prop :=
   exists sX, state_project sX = sY /\ vinitial_state_prop X sX.
 
-Instance projection_induced_initial_state_inh : Inhabited (sig projection_induced_initial_state_prop)
-  := populate (exist _ (state_project (` (vs0 X))) (ex_intro _ _ (conj (eq_refl _) (proj2_sig _)))).
+#[export] Program Instance projection_induced_initial_state_inh :
+  Inhabited {sY : stateTY | projection_induced_initial_state_prop sY} :=
+    populate (exist _ (state_project (` (vs0 X))) _).
+Next Obligation.
+Proof.
+  exists (` (vs0 X)).
+  split; [done |].
+  by destruct (`(vs0 X)); cbn.
+Defined.
 
 Definition projection_induced_initial_message_prop : message -> Prop := const False.
 


### PR DESCRIPTION
The `Inhabited` typeclass lives in the sort `Type`, not in `Prop`. Hence, its members have computational meaning and should normally not be constructed using tactics (which can easily make terms blow up). Here is the standard approach to separate `Type` terms from `Prop` terms.