### PR TITLE
port to Coq 8.16, add CI job for 8.16

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - 'coqorg/coq:8.16-ocaml-4.14-flambda'
           - 'coqorg/coq:8.15-ocaml-4.14-flambda'
       fail-fast: false
     steps:

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ contains a formalization of VLSMs and their theory in the Coq proof assistant.
 ## Meta
 
 - License: [BSD 3-Clause "New" or "Revised" License](LICENSE.md)
-- Compatible Coq versions: 8.15
+- Compatible Coq versions: 8.15 or later
 - Additional dependencies:
-  - [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.7.0
+  - [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.7.0 or later
   - [Itauto](https://gitlab.inria.fr/fbesson/itauto)
   - [Coq-Equations](https://github.com/mattam82/Coq-Equations)
 - Coq namespace: `VLSM`

--- a/coq-vlsm.opam
+++ b/coq-vlsm.opam
@@ -17,7 +17,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "coq" {>= "8.15"}
-  "coq-stdpp" {>= "1.7.0" & < "1.8.0"}
+  "coq-stdpp" {>= "1.7.0"}
   "coq-itauto" 
   "coq-equations" 
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -45,15 +45,15 @@ license:
   file: LICENSE.md
 
 supported_coq_versions:
-  text: 8.15
+  text: 8.15 and later
   opam: '{>= "8.15"}'
 
 dependencies:
 - opam:
     name: coq-stdpp
-    version: '{>= "1.7.0" & < "1.8.0"}'
+    version: '{>= "1.7.0"}'
   description: |-
-    [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.7.0
+    [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.7.0 or later
 - opam:
     name: coq-itauto
   description: |-
@@ -64,6 +64,7 @@ dependencies:
     [Coq-Equations](https://github.com/mattam82/Coq-Equations)
 
 tested_coq_opam_versions:
+- version: '8.16-ocaml-4.14-flambda'
 - version: '8.15-ocaml-4.14-flambda'
 
 namespace: VLSM

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -424,7 +424,7 @@ Proof.
     }
     specialize (valid_generated_state_message X _ _ Hs0 _ _ Hs0) as Hgen.
     unfold non_byzantine in Hi.
-    pose proof (Hdec := elem_of_dec_slow).
+    pose proof (Hdec := elem_of_dec_slow (H6 := H6)).
     rewrite elem_of_elements in Hi; setoid_rewrite set_diff_iff in Hi.
     apply not_and_r in Hi as [Hi | Hi];
       [by elim Hi; apply elem_of_list_to_set, elem_of_enum |].

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -62,7 +62,7 @@ Context
   `{FinSet message Cm}
   {is_equivocating_tracewise_no_has_been_sent_dec :
     RelDecision (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
-  (limited_constraint := tracewise_limited_equivocation_constraint IM threshold sender)
+  (limited_constraint := tracewise_limited_equivocation_constraint (Ci := Ci) IM threshold sender)
   (Limited : VLSM message := composite_vlsm IM limited_constraint)
   (Hvalidator: forall i : index, component_message_validator_prop IM limited_constraint i)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -1437,8 +1437,9 @@ Lemma ELMO_initial_state_not_heavy :
 Proof.
   intros s Hs.
   unfold ELMO_not_heavy, not_heavy.
-  replace (equivocation_fault s) with 0%R; [by apply rt_positive |].
-  by symmetry; apply sum_weights_empty, ELMO_initial_state_equivocating_validators.
+  replace (equivocation_fault s) with 0%R.
+  - by apply (rt_positive (H6 := H6)).
+  - by symmetry; apply sum_weights_empty, ELMO_initial_state_equivocating_validators.
 Qed.
 
 Lemma ELMO_not_heavy_send_message :

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -68,7 +68,8 @@ Proof.
     as [[[is His] ->] | (l & [s' om'] & om & [(_ & _ & _ & Hv) Ht])]; simpl.
   - exists ∅.
     + by intros v Hv; contradict Hv; apply Hno_initial_equivocation.
-    + by rewrite sum_weights_empty; [apply rt_positive |].
+    + rewrite sum_weights_empty; [|done].
+      by apply (rt_positive (H6 := H6)).
   - by cbv in Hv, Ht; rewrite Ht in Hv.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -94,7 +94,8 @@ Lemma coeqv_limited_equivocation_state_not_heavy s
 Proof.
   induction 1 using valid_state_prop_ind.
   - destruct s, Hs as [_ ->]; cbn in *.
-    by rewrite sum_weights_empty; [apply rt_positive |].
+    rewrite sum_weights_empty; [| done].
+    by apply (rt_positive (H6 := H7)).
   - destruct Ht as [(_ & _ & _ & Hc) Ht]
     ; cbn in Ht; unfold annotated_transition in Ht; destruct (vtransition _ _ _)
     ; inversion_clear Ht.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -149,7 +149,9 @@ Lemma input_valid_transition_reflects_trace_witnessing_equivocation_prop
 Proof.
   apply finite_valid_trace_init_to_last in Htr as Hlst.
   intros v; split; simpl in *; rewrite Hlst in *.
-  - by intros Hv; eapply equivocating_validators_is_equivocating_tracewise_iff.
+  - intros Hv.
+    by eapply equivocating_validators_is_equivocating_tracewise_iff
+      with (ReachableThreshold0 := H11).
   - intros (msg & Hsender & Heqv).
     apply Hincl.
     specialize (Hwitness v);

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
@@ -38,7 +38,7 @@ Context
   (threshold : R)
   `{ReachableThreshold index Ci threshold}
   `{!finite.Finite index}
-  (Limited : VLSM message := equivocators_limited_equivocations_vlsm IM threshold)
+  (Limited : VLSM message := equivocators_limited_equivocations_vlsm (Ci := Ci) IM threshold)
   (equivocating : Ci)
   (Fixed : VLSM message := equivocators_fixed_equivocations_vlsm IM (elements equivocating))
   .
@@ -82,7 +82,7 @@ Context
   (threshold : R)
   `{ReachableThreshold index Ci threshold}
   `{!finite.Finite index}
-  (XE : VLSM message := equivocators_limited_equivocations_vlsm IM threshold)
+  (XE : VLSM message := equivocators_limited_equivocations_vlsm (Ci := Ci) IM threshold)
   .
 
 (**

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
@@ -135,10 +135,11 @@ Proof.
   - subst s.
     unfold not_heavy, Equivocation.not_heavy,
       equivocation_fault, Equivocation.equivocation_fault; simpl.
-    etransitivity; [| by apply rt_positive].
-    pose proof (Heqv_is := equivocating_indices_equivocating_validators IM threshold is).
+    pose proof (Heqv_is := @equivocating_indices_equivocating_validators _ _ _ _
+        IM _ _ _ H1 _ _ _ _ _ _ _ _ H9 is).
     rewrite equivocating_indices_initially_empty in Heqv_is by done.
     simpl in Heqv_is; apply sum_weights_empty in Heqv_is.
+    pose proof (rt_positive (H6 := H8)).
     by cbv in Heqv_is |- *; lra.
   - by replace s with (fst (composite_transition equivocator_IM l (s0, oim))); [done |]
     ; cbn in *; rewrite Ht.
@@ -235,7 +236,8 @@ Proof.
     apply valid_trace_add_default_last, valid_trace_last_pstate,
       valid_state_limited_equivocation in Htr.
     transitivity (equivocation_fault (finite_trace_last is tr)); [| done].
-    pose proof (Heq := equivocating_indices_equivocating_validators IM threshold (finite_trace_last is tr)).
+    pose proof (@equivocating_indices_equivocating_validators _ _ _ _ IM
+     threshold _ _ _ _ _ _ _ _ _ _ _ H9).
     by unfold equivocation_fault; apply sum_weights_subseteq.
 Qed.
 

--- a/theories/VLSM/Core/ReachableThreshold.v
+++ b/theories/VLSM/Core/ReachableThreshold.v
@@ -98,10 +98,13 @@ Proof.
       apply sum_weights_list_permutation_proper.
       rewrite elements_disj_union.
       * apply Permutation_app_tail.
-        etransitivity; [by symmetry; apply elements_list_to_set, set_remove_nodup |].
-        apply elements_proper.
-        intro x.
-        by rewrite elem_of_difference, !elem_of_list_to_set, set_remove_iff, elem_of_singleton.
+        etransitivity.
+        -- symmetry.
+           by apply (elements_list_to_set (H6 := H6)), set_remove_nodup.
+        -- apply elements_proper.
+           intro x.
+           rewrite elem_of_difference, !elem_of_list_to_set.
+           by rewrite set_remove_iff, elem_of_singleton.
       * intros x; rewrite elem_of_difference, elem_of_list_to_set, elem_of_singleton.
         by intros [] ?; eapply Hdisj; [apply elem_of_elements, Hincl |].
 Qed.
@@ -124,7 +127,8 @@ Proof.
   intros vss Hvss.
   destruct (pivotal_validator_extension ∅ vss)
     as (vs & Hincl & Hvs & v & Hv & Hvs').
-  - by rewrite sum_weights_empty; [apply rt_positive |].
+  - rewrite sum_weights_empty; [| done].
+    by apply (rt_positive (H6 := H6)).
   - by apply disjoint_empty_r.
   - by rewrite sum_weights_union_empty.
   - rewrite sum_weights_union_empty in Hvs, Hvs'.

--- a/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
+++ b/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
@@ -27,7 +27,7 @@ Context
   (IM : index -> VLSM message)
   `{forall i, ComputableSentMessages (IM i)}
   `{forall i, ComputableReceivedMessages (IM i)}
-  `{!FullMessageDependencies message_dependencies full_message_dependencies}
+  `{FullMessageDependencies message Cm message_dependencies full_message_dependencies}
   `{forall i, MessageDependencies (IM i) message_dependencies}
   (state_destructor : forall i, vstate (IM i) -> set (vtransition_item (IM i) * vstate (IM i)))
   (state_size : forall i, vstate (IM i) -> nat)
@@ -650,7 +650,7 @@ Context
   (IM : index -> VLSM message)
   `{forall i, ComputableSentMessages (IM i)}
   `{forall i, ComputableReceivedMessages (IM i)}
-  `{!FullMessageDependencies message_dependencies full_message_dependencies}
+  `{FullMessageDependencies message Cm message_dependencies full_message_dependencies}
   `{forall i, MessageDependencies (IM i) message_dependencies}
   `{forall i s, Decision (vinitial_state_prop (IM i) s)}
   (state_destructor : forall i, vstate (IM i) -> set (vtransition_item (IM i) * vstate (IM i)))

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -802,5 +802,6 @@ Proof.
   rewrite stream_concat_unroll, stream_prepend_prefix_r by done.
   rewrite <- IHn at 2.
   do 2 f_equal.
-  by apply minus_plus.
+  rewrite Nat.add_comm.
+  by apply Nat.add_sub.
 Qed.


### PR DESCRIPTION
Minimal changes to support both Coq 8.15 and 8.16. We start to test continuously with both versions, then we can drop 8.15 after a while.