### PR TITLE
update documentation for Coq 8.16 and new Platform release

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:8.16-ocaml-4.14-flambda'
-          - 'coqorg/coq:8.15-ocaml-4.14-flambda'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -46,7 +46,7 @@ Choose "y", in order to allow opam to modify `~/.profile`.
 ### Install a switch for opam
 
 ```shell
-opam switch create coq-8.15 --packages=ocaml-variants.4.13.1+options,ocaml-option-flambda
+opam switch create coq-8.16 --packages=ocaml-variants.4.14.1+options,ocaml-option-flambda
 ```
 
 ### Update the current shell environment
@@ -59,7 +59,7 @@ eval $(opam env)
 
 ```shell
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq.8.15.2 coq-stdpp.1.7.0 coq-itauto
+opam install coq.8.16.1 coq-stdpp.1.8.0 coq-itauto
 ```
 
 ### Clone the project repository
@@ -81,17 +81,17 @@ make -j $(nproc)
 
 The latest Coq Platform release is always available using [this link](https://github.com/coq/platform/releases/latest). 
 
-However, for the purposes of demonstration, we will assume the archive is called `2022.04.1.zip`.
+However, for the purposes of demonstration, we will assume the archive is called `2022.09.1.zip`.
 
 ```shell
-wget https://github.com/coq/platform/archive/refs/tags/2022.04.1.zip
-unzip 2022.04.1.zip
+wget https://github.com/coq/platform/archive/refs/tags/2022.09.1.zip
+unzip 2022.09.1.zip
 ```
 
 ### Run the Platform scripts
 
 ```shell
-cd platform-2022.04.1
+cd platform-2022.09.1
 ./coq_platform_make.sh
 ```
 
@@ -99,17 +99,11 @@ cd platform-2022.04.1
 
 The Platform scripts will create a new opam switch, whose
 name can be viewed by running `opam switch`. Here, we assume
-the switch is called `__coq-platform.2022.04.1~8.15~2022.04`.
+the switch is called `__coq-platform.2022.09.1~8.16~2022.09`.
 
 ```shell
-opam switch __coq-platform.2022.04.1~8.15~2022.04
+opam switch __coq-platform.2022.09.1~8.16~2022.09
 eval $(opam env)
-```
-
-### Install the itauto library
-
-```shell
-opam install coq-itauto
 ```
 
 ### Clone the project repository
@@ -127,11 +121,11 @@ make -j $(nproc)
 
 ## Editor instructions
 
-We recommend using the Visual Studio Code editor, which you can download and install from [here](https://code.visualstudio.com/).
+We recommend using the Visual Studio Code (VS Code) editor, which you can download and install from [here](https://code.visualstudio.com/).
 
-After installing Visual Studio Code, you need to install the **Remote - WSL** extension. Click the *Connect to WSL* button, to open a new editor window in the WSL environment and open the project folder from inside this window.
+After installing VS Code, you need to install the **Remote - WSL** extension. Click the *Connect to WSL* button, to open a new editor window in the WSL environment and open the project folder from inside this window.
 
-Then install following extensions in the Remote WSL environment:
+Then, install the following extensions in the Remote WSL environment:
 
 - [the **VsCoq** extension](https://marketplace.visualstudio.com/items?itemName=maximedenes.vscoq)
 - [the **Fast Unicode Math Characters** extension](https://marketplace.visualstudio.com/items?itemName=GuidoTapia2.unicode-math-vscode)

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -43,7 +43,7 @@ DUPLICATES.md: $(DOCVFILES)
 alectryon: $(ALECTRYONHTMLFILES)
 .PHONY: alectryon
 
-# requires https://github.com/palmskog/rvdpdgraph/tree/v8.15
+# requires https://github.com/palmskog/rvdpdgraph/tree/v8.16
 rvdpd: $(SVGFILES)
 .PHONY: rvdpd
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 [docker-action-shield]: https://github.com/runtimeverification/vlsm/workflows/Test%20PR/badge.svg?branch=master
 [docker-action-link]: https://github.com/runtimeverification/vlsm/actions?query=workflow:"Test%20PR"
 
+
 [coqdoc-shield]: https://img.shields.io/badge/docs-coqdoc-blue.svg
 [coqdoc-link]: https://runtimeverification.github.io/vlsm-docs/latest/coqdoc/toc.html
+
 
 A validating labelled state transition and message production system
 (VLSM) abstractly models a distributed system with faults. This project
@@ -16,9 +18,9 @@ contains a formalization of VLSMs and their theory in the Coq proof assistant.
 ## Meta
 
 - License: [BSD 3-Clause "New" or "Revised" License](LICENSE.md)
-- Compatible Coq versions: 8.15 or later
+- Compatible Coq versions: 8.16 and later
 - Additional dependencies:
-  - [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.7.0 or later
+  - [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.8.0 or later
   - [Itauto](https://gitlab.inria.fr/fbesson/itauto)
   - [Coq-Equations](https://github.com/mattam82/Coq-Equations)
 - Coq namespace: `VLSM`

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install the project dependencies via opam, do:
 
 ```shell
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq.8.15.2 coq-stdpp.1.7.0 coq-itauto coq-equations
+opam install coq.8.16.1 coq-stdpp.1.8.0 coq-itauto coq-equations
 ```
 
 To build the project when you have all dependencies installed, do:

--- a/coq-vlsm.opam
+++ b/coq-vlsm.opam
@@ -16,8 +16,8 @@ contains a formalization of VLSMs and their theory in the Coq proof assistant.""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {>= "8.15"}
-  "coq-stdpp" {>= "1.7.0"}
+  "coq" {>= "8.16"}
+  "coq-stdpp" {>= "1.8.0"}
   "coq-itauto" 
   "coq-equations" 
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -45,15 +45,15 @@ license:
   file: LICENSE.md
 
 supported_coq_versions:
-  text: 8.15 and later
-  opam: '{>= "8.15"}'
+  text: 8.16 and later
+  opam: '{>= "8.16"}'
 
 dependencies:
 - opam:
     name: coq-stdpp
-    version: '{>= "1.7.0"}'
+    version: '{>= "1.8.0"}'
   description: |-
-    [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.7.0 or later
+    [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.8.0 or later
 - opam:
     name: coq-itauto
   description: |-
@@ -65,7 +65,6 @@ dependencies:
 
 tested_coq_opam_versions:
 - version: '8.16-ocaml-4.14-flambda'
-- version: '8.15-ocaml-4.14-flambda'
 
 namespace: VLSM
 

--- a/meta.yml
+++ b/meta.yml
@@ -94,7 +94,7 @@ build: |-
 
   ```shell
   opam repo add coq-released https://coq.inria.fr/opam/released
-  opam install coq.8.15.2 coq-stdpp.1.7.0 coq-itauto coq-equations
+  opam install coq.8.16.1 coq-stdpp.1.8.0 coq-itauto coq-equations
   ```
 
   To build the project when you have all dependencies installed, do:


### PR DESCRIPTION
Since the [new Coq 8.16 Platform](https://github.com/coq/platform/releases/tag/2022.09.1) is out, I update the documentation on installing VLSM. In particular, itauto is now part of the Platform, so those who use Platform installers and scripts can build VLSM right away.

8.15 also has known soundness bugs, which, although they are very unlikely to affect us, points to recommending 8.16 going forward.