### PR TITLE
Standardize spaces

### DIFF
--- a/scripts/standardize-spaces.sh
+++ b/scripts/standardize-spaces.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Add missing space after a comma.
+sed -i 's/,\([^ ]\)/, \1/g' $(find -name "*.v")
+
+# Add missing space after a semicolon.
+sed -i 's/;\([^ ]\)/; \1/g' $(find -name "*.v")
+
+# Add missing space after a tilde.
+sed -i 's/~\([^ ]\)/~ \1/g' $(find -name "*.v")
+
+# Add missing space around a :=
+sed -i 's/:=\([^ ]\)/:= \1/g' $(find -name "*.v")
+sed -i 's/\([^ ]\):=/\1 :=/g' $(find -name "*.v")
+
+# Remove superfluous space after a '(' and before a ')'.
+# Note: this might require manual tinkering to ensure no
+# weird corner cases are present.
+sed -i 's/( /(/g' $(find -name "*.v")
+sed -i 's/ )/)/g' $(find -name "*.v")
+
+# Remove superfluous space after a '[' and before a ']'.
+# Note: this might require manual tinkering to ensure no
+# weird corner cases are present.
+sed -i 's/\[ /[/g' $(find -name "*.v")
+sed -i 's/ ]/]/g' $(find -name "*.v")
+
+# Add missing space around a |
+sed -i 's/|\([^]}| -]\)/| \1/g' $(find -name "*.v")
+sed -i 's/\([^[{| ]\)|/\1 |/g' $(find -name "*.v")
+
+# Add missing space after a colon.
+sed -i 's/:\([^ =:>/]\)/: \1/g' $(find -name "*.v")
+
+# Add missing space before a colon and fix the known corner cases.
+# Note: you should use `git add --patch` to browse through the changes
+# manually and exclude the ones where the ':' was moved inside a comment.
+sed -i 's/\([^ :]\):/\1 :/g' $(find -name "*.v")
+sed -i 's/eqn :/eqn:/g' $(find -name "*.v")
+sed -i 's/ eq :/ eq:/g' $(find -name "*.v")
+sed -i 's/https :/https:/g' $(find -name "*.v")
+sed -i 's/TODO :/TODO:/g' $(find -name "*.v")
+sed -i 's/case :/case:/g' $(find -name "*.v")
+sed -i 's/exact :/exact:/g' $(find -name "*.v")
+sed -i 's/let :/let:/g' $(find -name "*.v")
+sed -i 's/apply :/apply:/g' $(find -name "*.v")
+sed -i 's/move :/move:/g' $(find -name "*.v")
+sed -i 's/ \([0-9]\) :/ \1:/g' $(find -name "*.v")
+sed -i 's/-\([0-9]\) :/-\1:/g' $(find -name "*.v")

--- a/scripts/standardize-spaces.sh
+++ b/scripts/standardize-spaces.sh
@@ -4,6 +4,8 @@
 sed -i 's/,\([^ ]\)/, \1/g' $(find -name "*.v")
 
 # Add missing space after a semicolon.
+# Note: this clashes with the notation << ; >>
+# which needs to be fixed manually.
 sed -i 's/;\([^ ]\)/; \1/g' $(find -name "*.v")
 
 # Add missing space after a tilde.
@@ -26,6 +28,8 @@ sed -i 's/\([^\{]\)\[ /\1[/g' $(find -name "*.v")
 sed -i 's/ ]\([^}]\)/]\1/g' $(find -name "*.v")
 
 # Add missing space around a |
+# Note: this affects the notation [| |] which
+# needs to be fixed manually.
 sed -i 's/|\([^]}| -]\)/| \1/g' $(find -name "*.v")
 sed -i 's/\([^[{| ]\)|/\1 |/g' $(find -name "*.v")
 

--- a/scripts/standardize-spaces.sh
+++ b/scripts/standardize-spaces.sh
@@ -22,8 +22,8 @@ sed -i 's/ )/)/g' $(find -name "*.v")
 # Remove superfluous space after a '[' and before a ']'.
 # Note: this might require manual tinkering to ensure no
 # weird corner cases are present.
-sed -i 's/\[ /[/g' $(find -name "*.v")
-sed -i 's/ ]/]/g' $(find -name "*.v")
+sed -i 's/\([^\{]\)\[ /\1[/g' $(find -name "*.v")
+sed -i 's/ ]\([^}]\)/]\1/g' $(find -name "*.v")
 
 # Add missing space around a |
 sed -i 's/|\([^]}| -]\)/| \1/g' $(find -name "*.v")

--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -337,7 +337,7 @@ Proof.
   intros [s1 ann1] [s2 ann2]
   ; unfold annotated_transition; cbn
   ; intros <- iom sX1' oom1
-  ;destruct (vtransition _ _ _) as (si', om').
+  ; destruct (vtransition _ _ _) as (si', om').
   inversion_clear 1; intros sX2' oom2; inversion_clear 1.
   by cbn; state_update_simpl.
 Qed.

--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -129,7 +129,7 @@ Qed.
 Lemma annotate_trace_from_app sa tr1 tr2
   : annotate_trace_from sa (tr1 ++ tr2) =
     annotate_trace_from sa tr1 ++
-      annotate_trace_from (finite_trace_last sa ( annotate_trace_from sa tr1)) tr2.
+      annotate_trace_from (finite_trace_last sa (annotate_trace_from sa tr1)) tr2.
 Proof.
   revert sa.
   induction tr1 as [| item tr1]; [done |].

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -253,7 +253,7 @@ Proof.
       replace (lifted_alt_state s first) with s
         by (unfold lifted_alt_state, lift_to_composite_state'; state_update_simpl; done).
       apply proj2 in Ht.
-      change (vtransition M l (s: vstate M, om0) = (s', om')) in Ht.
+      change (vtransition M l (s : vstate M, om0) = (s', om')) in Ht.
       rewrite Ht.
       f_equal.
       by apply state_update_twice.
@@ -316,7 +316,7 @@ Lemma validator_component_byzantine_fault_tolerance
     (IM : index -> VLSM message)
     (constraint : composite_label IM -> composite_state IM  * option message -> Prop)
     (i : index)
-    (Hvalidator: component_projection_validator_prop IM constraint i)
+    (Hvalidator : component_projection_validator_prop IM constraint i)
     : forall tr, byzantine_trace_prop (IM i) tr ->
         valid_trace_prop (pre_composite_vlsm_induced_projection_validator IM constraint i) tr.
 Proof.
@@ -345,7 +345,7 @@ Context
   (X := composite_vlsm IM constraint)
   (PreLoadedX := pre_loaded_with_all_messages_vlsm X)
   (FreeX := free_composite_vlsm IM)
-  (Hvalidator: forall i : index, component_message_validator_prop IM constraint i)
+  (Hvalidator : forall i : index, component_message_validator_prop IM constraint i)
   .
 
 (**

--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -245,15 +245,15 @@ Proof.
   - exists om'.
     assert (option_valid_message_prop Alt om0) as Hom0
       by apply alt_option_valid_message.
-    cut (input_valid_transition Alt (existT first l) (lifted_alt_state s,om0) (lifted_alt_state s', om'))
+    cut (input_valid_transition Alt (existT first l) (lifted_alt_state s, om0) (lifted_alt_state s', om'))
       ; [by apply input_valid_transition_outputs_valid_state_message |].
     split.
     + by repeat split; [.. | apply Ht].
     + simpl.
       replace (lifted_alt_state s first) with s
-        by (unfold lifted_alt_state,lift_to_composite_state'; state_update_simpl; done).
+        by (unfold lifted_alt_state, lift_to_composite_state'; state_update_simpl; done).
       apply proj2 in Ht.
-      change (vtransition M l (s: vstate M,om0) = (s',om')) in Ht.
+      change (vtransition M l (s: vstate M, om0) = (s', om')) in Ht.
       rewrite Ht.
       f_equal.
       by apply state_update_twice.

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -93,7 +93,7 @@ Definition fixed_byzantine_IM : index -> VLSM message :=
   update_IM IM byzantine (fun i => emit_any_signed_message_vlsm A sender (` i)).
 
 Lemma fixed_byzantine_IM_no_initial_messages
-  : forall i m, ~vinitial_message_prop (fixed_byzantine_IM i) m.
+  : forall i m, ~ vinitial_message_prop (fixed_byzantine_IM i) m.
 Proof.
   unfold fixed_byzantine_IM, update_IM. simpl.
   intros i m Hm.

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -436,7 +436,7 @@ Proof.
       by rewrite @decide_True.
     }
     cbn in Hgen.
-    destruct (vtransition _ _ _) as (si', _om) eqn:Ht.
+    destruct (vtransition _ _ _) as (si', _om) eqn: Ht.
     specialize (Hgen _ _ eq_refl).
     replace _om with (Some m) in Hgen; [by eexists |].
     clear -Ht.

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -769,7 +769,7 @@ Qed.
 End sec_assuming_initial_messages_lift.
 
 Context
-  (Hvalidator:
+  (Hvalidator :
     forall i : index, i ∉ selection ->
     component_message_validator_prop IM (fixed_equivocation_constraint IM selection) i)
   .

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -97,7 +97,7 @@ Lemma fixed_byzantine_IM_no_initial_messages
 Proof.
   unfold fixed_byzantine_IM, update_IM. simpl.
   intros i m Hm.
-  by case_decide; [|destruct (no_initial_messages_in_IM i m)].
+  by case_decide; [| destruct (no_initial_messages_in_IM i m)].
 Qed.
 
 Lemma fixed_byzantine_IM_preserves_channel_authentication
@@ -338,7 +338,7 @@ Proof.
       A sender fixed_byzantine_IM_sender_safety
       fixed_byzantine_IM_no_initial_messages fixed_byzantine_IM_preserves_channel_authentication)
     in Hv as Hnoequiv.
-  destruct om as [m|]; [| done].
+  destruct om as [m |]; [| done].
   destruct Hnoequiv as [Hsent | Hseeded]; [by left |].
   right.
   split; [done |].
@@ -414,7 +414,7 @@ Proof.
     subst.
     unfold sub_IM, fixed_byzantine_IM, update_IM in Him.
     simpl in Him.
-    by case_decide; [|destruct (no_initial_messages_in_IM i im)].
+    by case_decide; [| destruct (no_initial_messages_in_IM i im)].
   - destruct Hseeded as [[i [Hi Hsender]] Hvalid].
     pose (X := (composite_vlsm fixed_byzantine_IM non_byzantine_not_equivocating_constraint)).
     pose (s0 := proj1_sig (composite_s0 fixed_byzantine_IM)).
@@ -604,7 +604,7 @@ Proof.
     + split; [| done].
       apply sub_IM_no_equivocation_preservation in Hv as Hnoequiv; [| done..].
       destruct om as [m |]; [| done].
-      destruct Hnoequiv as [Hsent|Hseeded]; [by left | right].
+      destruct Hnoequiv as [Hsent | Hseeded]; [by left | right].
       split; [done |].
       destruct (induced_sub_projection_valid_projection IM
         (elements selection_complement) _ _ _ _ Hv) as (i & Hi & Hiv).
@@ -650,7 +650,7 @@ Proof.
   intros l s om Hv HsY HomY.
   split.
   - by apply lift_sub_valid, Hv.
-  - destruct om as [m|]; [| done].
+  - destruct om as [m |]; [| done].
     apply proj2 in Hv as Hc.
     destruct Hc as [_ [_ [Hc _]]].
     destruct Hc as [Hsent | Hseeded].

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -461,7 +461,7 @@ Proof.
   - intros (byzantine & Hlimited & Hbyzantine).
     apply lift_fixed_byzantine_traces_to_limited in Hbyzantine
        as [Hbtr Heqv_byzantine] ; [| done].
-    eexists _,_, byzantine; do 3 (split; [done |]); split.
+    eexists _, _, byzantine; do 3 (split; [done |]); split.
     + extensionality sub_i; destruct_dec_sig sub_i i Hi Heqsub_i; subst; cbn.
       unfold lift_sub_state.
       by rewrite (lift_sub_state_to_eq _ _ _ _ _ Hi).
@@ -474,7 +474,7 @@ Proof.
     ; [by apply fixed_non_equivocating_incl_fixed_non_byzantine |].
     apply fixed_non_equivocating_traces_char.
     symmetry in His_pr, Htr_pr.
-    eexists _,_; split; [| done].
+    eexists _, _; split; [| done].
     eapply msg_dep_fixed_limited_equivocation_witnessed in Hbtr as [_ Hbtr]; [| done..].
     revert Hbtr; apply VLSM_incl_finite_valid_trace.
     apply fixed_equivocation_vlsm_composition_index_incl.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -125,7 +125,7 @@ Proof.
   apply map_eq_cons in Hitem_suf_pr as [item [suf [Heqitem_suf [Hitem_pr Hsuf_pr]]]].
   subst tr item_suf. clear Hsuf_pr.
   subst itemX. cbn in Hm0.
-  change (pre ++ item::suf) with (pre ++ [item] ++ suf) in Htr.
+  change (pre ++ item:: suf) with (pre ++ [item] ++ suf) in Htr.
   destruct Htr as [Htr Hinit].
   apply (finite_valid_trace_from_to_app_split PreNonByzantine) in Htr.
   destruct Htr as [Hpre Hitem].

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -64,7 +64,7 @@ Context
     RelDecision (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
   (limited_constraint := tracewise_limited_equivocation_constraint (Ci := Ci) IM threshold sender)
   (Limited : VLSM message := composite_vlsm IM limited_constraint)
-  (Hvalidator: forall i : index, component_message_validator_prop IM limited_constraint i)
+  (Hvalidator : forall i : index, component_message_validator_prop IM limited_constraint i)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   (can_emit_signed : channel_authentication_prop IM Datatypes.id sender)
   (message_dependencies : message -> Cm)
@@ -83,9 +83,9 @@ Context
 Section sec_fixed_limited_selection.
 
 Context
-  (byzantine: Ci)
+  (byzantine : Ci)
   (non_byzantine : Ci := difference (list_to_set (enum index)) byzantine)
-  (Hlimit: (sum_weights byzantine <= threshold)%R)
+  (Hlimit : (sum_weights byzantine <= threshold)%R)
   (PreNonByzantine := pre_loaded_fixed_non_byzantine_vlsm IM byzantine (fun i : index => i) sender)
   (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) index Ci threshold
     := equivocation_dec_tracewise IM threshold (fun i => i) sender)
@@ -125,7 +125,7 @@ Proof.
   apply map_eq_cons in Hitem_suf_pr as [item [suf [Heqitem_suf [Hitem_pr Hsuf_pr]]]].
   subst tr item_suf. clear Hsuf_pr.
   subst itemX. cbn in Hm0.
-  change (pre ++ item:: suf) with (pre ++ [item] ++ suf) in Htr.
+  change (pre ++ item :: suf) with (pre ++ [item] ++ suf) in Htr.
   destruct Htr as [Htr Hinit].
   apply (finite_valid_trace_from_to_app_split PreNonByzantine) in Htr.
   destruct Htr as [Hpre Hitem].
@@ -285,7 +285,7 @@ Context
   (Hchannel : channel_authentication_prop IM Datatypes.id sender)
   (Hsender_safety : sender_safety_alt_prop IM Datatypes.id sender :=
     channel_authentication_sender_safety _ _ _ Hchannel)
-  (Hvalidator:
+  (Hvalidator :
     forall i : index,
       msg_dep_limited_equivocation_message_validator_prop (Cv := Ci)
         IM threshold full_message_dependencies sender i)
@@ -299,9 +299,9 @@ Context
   for weight-limited equivocation.
 *)
 Lemma lift_pre_loaded_fixed_non_byzantine_valid_transition_to_limited
-  (byzantine: Ci)
+  (byzantine : Ci)
   (non_byzantine := difference (list_to_set (enum index)) byzantine)
-  (Hlimited: (sum_weights byzantine <= threshold)%R)
+  (Hlimited : (sum_weights byzantine <= threshold)%R)
   sub_l sub_s iom sub_sf oom
   (Ht_sub : input_valid_transition
       (pre_loaded_fixed_non_byzantine_vlsm IM byzantine Datatypes.id sender)
@@ -355,12 +355,12 @@ Existing Instance elem_of_dec_slow.
   is included in <<byzantine>>.
 *)
 Lemma lift_fixed_byzantine_traces_to_limited
-  (s: composite_state IM)
-  (tr: list (composite_transition_item IM))
-  (byzantine: Ci)
+  (s : composite_state IM)
+  (tr : list (composite_transition_item IM))
+  (byzantine : Ci)
   (non_byzantine := difference (list_to_set (enum index)) byzantine)
-  (Hlimited: (sum_weights byzantine <= threshold)%R)
-  (Hbyzantine:
+  (Hlimited : (sum_weights byzantine <= threshold)%R)
+  (Hbyzantine :
     fixed_byzantine_trace_alt_prop IM byzantine Datatypes.id sender s tr)
   (s_reset_byzantine :=
     lift_sub_state IM (elements non_byzantine)

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -537,7 +537,7 @@ Proof.
   - by apply valid_initial_state_message.
   - apply (valid_generated_state_message X2) with s _om _s om l. 1-2, 4: done.
     apply constraint_subsumption_input_valid; [done |].
-    by split_and!; [exists _om | exists _s|].
+    by split_and!; [exists _om | exists _s |].
 Qed.
 
 Lemma constraint_subsumption_incl
@@ -780,8 +780,8 @@ Proof.
     + by subst; rewrite state_update_twice.
     + rewrite state_update_twice_neq by done.
       apply input_valid_transition_destination with (existT j lj) (state_update s i si) om omj'.
-      by repeat split; [done | done |..]; cbn; rewrite state_update_neq;
-        [..| rewrite Htj |].
+      by repeat split; [done | done | ..]; cbn; rewrite state_update_neq;
+        [.. | rewrite Htj |].
 Qed.
 
 Lemma lift_to_composite_valid_preservation :
@@ -1186,7 +1186,7 @@ Proof.
   unfold i in Heq.
   rewrite Heq.
   destruct (vtransition (IM x) v (s' x, input)).
-  split; [done|].
+  split; [done |].
   unfold i.
   by state_update_simpl.
 Qed.
@@ -1328,7 +1328,7 @@ Lemma relevant_components
   (forall (i : index), i ∈ li -> (res' i) = res i).
 Proof.
   induction a using rev_ind.
-  - by split; [apply finite_valid_plan_empty|].
+  - by split; [apply finite_valid_plan_empty |].
   - simpl in *.
     apply finite_valid_plan_from_app_iff in Hpr.
     destruct Hpr as [Hrem Hsingle].
@@ -1730,7 +1730,7 @@ Proof.
       assert (Hss1 : input_valid_transition RFree (existT i li)
                   (state_update IM s j (s1 j), om) (s1, om')).
       {
-        repeat split; [by apply IHHs2 | by apply any_message_is_valid_in_preloaded |..]
+        repeat split; [by apply IHHs2 | by apply any_message_is_valid_in_preloaded | ..]
         ; cbn; state_update_simpl; [done |].
         replace (vtransition _ _ _) with (s' i, om').
         f_equal; extensionality k; apply f_equal with (f := fun s => s k) in Heqs'.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -959,7 +959,7 @@ Lemma input_valid_transition_preloaded_project_active
       {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
       (X := composite_vlsm IM constraint)
       l s im s' om:
-  input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s,im) (s',om) ->
+  input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s, im) (s', om) ->
   input_valid_transition (pre_loaded_with_all_messages_vlsm (IM (projT1 l))) (projT2 l)
                          (s (projT1 l), im) (s' (projT1 l), om).
 Proof.
@@ -976,7 +976,7 @@ Lemma input_valid_transition_project_active
       {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
       (X := composite_vlsm IM constraint)
       l s im s' om:
-  input_valid_transition X l (s,im) (s',om) ->
+  input_valid_transition X l (s, im) (s', om) ->
   input_valid_transition (pre_loaded_with_all_messages_vlsm (IM (projT1 l))) (projT2 l)
                          (s (projT1 l), im) (s' (projT1 l), om).
 Proof.
@@ -990,12 +990,12 @@ Lemma input_valid_transition_preloaded_project_any {V} (i:V)
       {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
       (X := composite_vlsm IM constraint)
       (l:vlabel X) s im s' om:
-  input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s,im) (s',om) ->
+  input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s, im) (s', om) ->
   (s i = s' i \/
    exists li, (l = existT i li) /\
    input_valid_transition (pre_loaded_with_all_messages_vlsm (IM i))
                           li
-                          (s i,im) (s' i,om)).
+                          (s i, im) (s' i, om)).
 Proof.
   intro Hptrans.
   destruct l as [j lj].
@@ -1018,12 +1018,12 @@ Lemma input_valid_transition_project_any {V} (i:V)
       {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
       (X := composite_vlsm IM constraint)
       (l:vlabel X) s im s' om:
-  input_valid_transition X l (s,im) (s',om) ->
+  input_valid_transition X l (s, im) (s', om) ->
   (s i = s' i \/
    exists li, (l = existT i li) /\
    input_valid_transition (pre_loaded_with_all_messages_vlsm (IM i))
                           li
-                          (s i,im) (s' i,om)).
+                          (s i, im) (s' i, om)).
 Proof.
   intro Hproto.
   apply preloaded_weaken_input_valid_transition in Hproto.
@@ -1502,7 +1502,7 @@ Context
   (constraint2 : composite_label IM2 -> composite_state IM2 * option message -> Prop)
   (constraint_projection
     : forall s1, valid_state_prop (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM1)) s1 ->
-      forall l1 om, constraint1 l1 (s1,om) ->
+      forall l1 om, constraint1 l1 (s1, om) ->
     constraint2 (same_IM_label_rew l1) (same_IM_state_rew s1, om))
   (seed : message -> Prop)
   .

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -908,7 +908,7 @@ Ltac state_update_simpl :=
 
 Lemma valid_state_project_preloaded_to_preloaded
       message `{EqDecision index} (IM : index -> VLSM message) constraint
-      (X:=composite_vlsm IM constraint)
+      (X := composite_vlsm IM constraint)
       (s: vstate (pre_loaded_with_all_messages_vlsm X)) i:
   valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
   valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i).
@@ -927,7 +927,7 @@ Qed.
 
 Lemma valid_state_project_preloaded
       message `{EqDecision index} (IM : index -> VLSM message) constraint
-      (X:=composite_vlsm IM constraint)
+      (X := composite_vlsm IM constraint)
       (s: vstate X) i:
   valid_state_prop X s ->
   valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i).

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -919,7 +919,7 @@ Proof.
   - by apply preloaded_valid_initial_state, (Hs i).
   - destruct l as [j lj].
     simpl in Ht. unfold vtransition in Ht. simpl in Ht.
-    destruct (vtransition (IM j) _ _) as (si', _om') eqn:Hti.
+    destruct (vtransition (IM j) _ _) as (si', _om') eqn: Hti.
     inversion_clear Ht.
     destruct (decide (i = j)); subst; state_update_simpl; [| done].
     by apply preloaded_protocol_generated with lj (s j) om _om'; [| apply Hv |].
@@ -986,10 +986,10 @@ Proof.
   by apply input_valid_transition_preloaded_project_active.
 Qed.
 
-Lemma input_valid_transition_preloaded_project_any {V} (i:V)
+Lemma input_valid_transition_preloaded_project_any {V} (i: V)
       {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
       (X := composite_vlsm IM constraint)
-      (l:vlabel X) s im s' om:
+      (l: vlabel X) s im s' om:
   input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s, im) (s', om) ->
   (s i = s' i \/
    exists li, (l = existT i li) /\
@@ -1014,10 +1014,10 @@ Proof.
     by state_update_simpl.
 Qed.
 
-Lemma input_valid_transition_project_any {V} (i:V)
+Lemma input_valid_transition_project_any {V} (i: V)
       {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
       (X := composite_vlsm IM constraint)
-      (l:vlabel X) s im s' om:
+      (l: vlabel X) s im s' om:
   input_valid_transition X l (s, im) (s', om) ->
   (s i = s' i \/
    exists li, (l = existT i li) /\
@@ -1127,7 +1127,7 @@ Context
   {message : Type}
   {index : Type}
   `{EqDecision index}
-  (IM :index -> VLSM message)
+  (IM : index -> VLSM message)
   (Free := free_composite_vlsm IM)
   .
 

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -947,7 +947,7 @@ Lemma composite_transition_project_active
       vtransition (IM (projT1 l)) (projT2 l) (s (projT1 l), im) = (s' (projT1 l), om).
 Proof.
   intros.
-  destruct l;simpl.
+  destruct l; simpl.
   simpl in H.
   destruct (vtransition (IM x) v (s x, im)).
   inversion H.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -119,7 +119,7 @@ Qed.
 Lemma state_update_twice
            (s : composite_state)
            (i : index)
-           (si si': vstate (IM i))
+           (si si' : vstate (IM i))
   : state_update (state_update s i si) i si' = state_update s i si'.
 Proof.
   apply functional_extensionality_dep_good.
@@ -909,7 +909,7 @@ Ltac state_update_simpl :=
 Lemma valid_state_project_preloaded_to_preloaded
       message `{EqDecision index} (IM : index -> VLSM message) constraint
       (X := composite_vlsm IM constraint)
-      (s: vstate (pre_loaded_with_all_messages_vlsm X)) i:
+      (s : vstate (pre_loaded_with_all_messages_vlsm X)) i :
   valid_state_prop (pre_loaded_with_all_messages_vlsm X) s ->
   valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i).
 Proof.
@@ -928,7 +928,7 @@ Qed.
 Lemma valid_state_project_preloaded
       message `{EqDecision index} (IM : index -> VLSM message) constraint
       (X := composite_vlsm IM constraint)
-      (s: vstate X) i:
+      (s : vstate X) i :
   valid_state_prop X s ->
   valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i).
 Proof.
@@ -956,9 +956,9 @@ Proof.
 Qed.
 
 Lemma input_valid_transition_preloaded_project_active
-      {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
+      {message} `{EqDecision V} {IM : V -> VLSM message} {constraint}
       (X := composite_vlsm IM constraint)
-      l s im s' om:
+      l s im s' om :
   input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s, im) (s', om) ->
   input_valid_transition (pre_loaded_with_all_messages_vlsm (IM (projT1 l))) (projT2 l)
                          (s (projT1 l), im) (s' (projT1 l), om).
@@ -973,9 +973,9 @@ Proof.
 Qed.
 
 Lemma input_valid_transition_project_active
-      {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
+      {message} `{EqDecision V} {IM : V -> VLSM message} {constraint}
       (X := composite_vlsm IM constraint)
-      l s im s' om:
+      l s im s' om :
   input_valid_transition X l (s, im) (s', om) ->
   input_valid_transition (pre_loaded_with_all_messages_vlsm (IM (projT1 l))) (projT2 l)
                          (s (projT1 l), im) (s' (projT1 l), om).
@@ -986,10 +986,10 @@ Proof.
   by apply input_valid_transition_preloaded_project_active.
 Qed.
 
-Lemma input_valid_transition_preloaded_project_any {V} (i: V)
-      {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
+Lemma input_valid_transition_preloaded_project_any {V} (i : V)
+      {message} `{EqDecision V} {IM : V -> VLSM message} {constraint}
       (X := composite_vlsm IM constraint)
-      (l: vlabel X) s im s' om:
+      (l : vlabel X) s im s' om :
   input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s, im) (s', om) ->
   (s i = s' i \/
    exists li, (l = existT i li) /\
@@ -1014,10 +1014,10 @@ Proof.
     by state_update_simpl.
 Qed.
 
-Lemma input_valid_transition_project_any {V} (i: V)
-      {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
+Lemma input_valid_transition_project_any {V} (i : V)
+      {message} `{EqDecision V} {IM : V -> VLSM message} {constraint}
       (X := composite_vlsm IM constraint)
-      (l: vlabel X) s im s' om:
+      (l : vlabel X) s im s' om :
   input_valid_transition X l (s, im) (s', om) ->
   (s i = s' i \/
    exists li, (l = existT i li) /\
@@ -1036,10 +1036,10 @@ Qed.
   components.
 *)
 Lemma can_emit_composite_project
-  {message} `{EqDecision V} {IM: V -> VLSM message} {constraint}
+  {message} `{EqDecision V} {IM : V -> VLSM message} {constraint}
   (X := composite_vlsm IM constraint)
   (m : message)
-  (Hemit: can_emit (pre_loaded_with_all_messages_vlsm X) m)
+  (Hemit : can_emit (pre_loaded_with_all_messages_vlsm X) m)
   : exists (j : V), can_emit (pre_loaded_with_all_messages_vlsm (IM j)) m.
 Proof.
   apply can_emit_iff in Hemit.
@@ -1208,11 +1208,11 @@ Proof.
   destruct ai; simpl in *.
   match goal with
   |- context [let (_, _) := let (_, _) := ?t in _ in _] =>
-    destruct t eqn : eq_trans'
+    destruct t eqn: eq_trans'
   end.
   match goal with
   |- context [let (_, _) := let (_, _) := ?t in _ in _] =>
-    destruct t eqn : eq_trans
+    destruct t eqn: eq_trans
   end.
   inversion Hpr; subst.
   split.
@@ -1255,7 +1255,7 @@ Proof.
   destruct ai.
   match goal with
   |- context [let (_, _) := let (_, _) := ?t in _ in _] =>
-    destruct t eqn : eq_trans
+    destruct t eqn: eq_trans
   end.
   simpl in *.
   unfold vtransition in eq_trans.
@@ -1284,8 +1284,8 @@ Proof.
   - by simpl; itauto.
   - simpl in *.
     rewrite (composite_apply_plan_app IM).
-    destruct (composite_apply_plan IM s a) as (tra, sa) eqn : eq_a; simpl in *.
-    destruct (composite_apply_plan IM sa [x]) as (trx, sx) eqn : eq_x; simpl in *.
+    destruct (composite_apply_plan IM s a) as (tra, sa) eqn: eq_a; simpl in *.
+    destruct (composite_apply_plan IM sa [x]) as (trx, sx) eqn: eq_x; simpl in *.
 
     unfold a_indices in Hdif.
     rewrite map_app in Hdif.
@@ -1372,14 +1372,14 @@ Proof.
       rewrite !apply_plan_app.
       simpl in *.
       destruct (apply_plan Free s' a)
-        as (tra', sa') eqn : eq_as'.
+        as (tra', sa') eqn: eq_as'.
       destruct (apply_plan Free s a)
-        as (tra, sa) eqn : eq_as.
+        as (tra, sa) eqn: eq_as.
       simpl in *.
       destruct (apply_plan Free sa [x])
-        as (trx, sx) eqn : eq_xsa.
+        as (trx, sx) eqn: eq_xsa.
       destruct (apply_plan Free sa' [x])
-        as (trx', sx') eqn : eq_xsa'.
+        as (trx', sx') eqn: eq_xsa'.
       simpl in *.
       destruct (decide (i = (projT1 (label_a x)))).
       * by rewrite e.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1111,8 +1111,7 @@ Proof.
   intro m. simpl. unfold composite_initial_message_prop.
   apply
     (Decision_iff
-      (P := List.Exists (fun i => vinitial_message_prop (IM i) m) (enum index))
-    ).
+      (P := List.Exists (fun i => vinitial_message_prop (IM i) m) (enum index))).
   - rewrite <- exists_finite.
     split; intros [i Hm]; exists i.
     + by exists (exist _ _ Hm).

--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -571,7 +571,7 @@ Inductive rec_obs : State -> Observation -> Prop :=
 Equations rec_obs_fn (s : State) : listset Observation by wf (sizeState s) lt :=
 | {| obs := [] |} => ∅
 | {| obs := o :: os; adr := a |} =>
-  {[o]} ∪ rec_obs_fn (state (message o)) ∪ rec_obs_fn {| obs := os; adr := a |}.
+  {[ o ]} ∪ rec_obs_fn (state (message o)) ∪ rec_obs_fn {| obs := os; adr := a |}.
 Next Obligation.
 Proof. by intros [? []] os a _; unfold sizeState; cbn; lia. Qed.
 Next Obligation.

--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -117,7 +117,7 @@ Definition addObservation' (ob : Observation) (obs : list Observation) : list Ob
 
 Lemma addObservation'_ind (P : list Observation -> Prop)
   (Hempty : P [])
-  (Hadd : forall ob obs, P obs -> P (addObservation' ob obs)):
+  (Hadd : forall ob obs, P obs -> P (addObservation' ob obs)) :
   forall obs, P obs.
 Proof.
   exact (list_ind P Hempty Hadd).
@@ -125,7 +125,7 @@ Qed.
 
 Lemma addObservation'_rec (P : list Observation -> Set)
   (Hempty : P [])
-  (Hadd : forall ob obs, P obs -> P (addObservation' ob obs)):
+  (Hadd : forall ob obs, P obs -> P (addObservation' ob obs)) :
   forall obs, P obs.
 Proof.
   exact (list_rec P Hempty Hadd).
@@ -133,7 +133,7 @@ Defined.
 
 Lemma addObservation'_rect (P : list Observation -> Type)
   (Hempty : P [])
-  (Hadd : forall ob obs, P obs -> P (addObservation' ob obs)):
+  (Hadd : forall ob obs, P obs -> P (addObservation' ob obs)) :
   forall obs, P obs.
 Proof.
   exact (list_rect P Hempty Hadd).
@@ -150,7 +150,7 @@ Notation "s <+> ob" := (addObservation ob s) (left associativity, at level 50).
 *)
 Lemma addObservation_ind (P : State -> Prop)
   (Hempty : forall a, P (MkState [] a))
-  (Hadd : forall ob s, P s -> P (addObservation ob s)):
+  (Hadd : forall ob s, P s -> P (addObservation ob s)) :
   forall obs, P obs.
 Proof.
   intros [obs a].
@@ -160,7 +160,7 @@ Qed.
 
 Lemma addObservation_rec (P : State -> Set)
   (Hempty : forall a, P (MkState [] a))
-  (Hadd : forall ob s, P s -> P (s <+> ob)):
+  (Hadd : forall ob s, P s -> P (s <+> ob)) :
   forall obs, P obs.
 Proof.
   intros [obs a].
@@ -170,7 +170,7 @@ Defined.
 
 Lemma addObservation_rect (P : State -> Type)
   (Hempty : forall a, P (MkState [] a))
-  (Hadd : forall ob s, P s -> P (addObservation ob s)):
+  (Hadd : forall ob s, P s -> P (addObservation ob s)) :
   forall obs, P obs.
 Proof.
   intros [obs a].

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -2206,8 +2206,8 @@ Proof.
     Forall (fun item =>
       ELMO_equivocating_validators (lift_to_composite_state ELMOComponent s i_m (destination item))
         ⊆
-      ELMO_equivocating_validators s ∪ {[idx i_m]}
-      ) tr_m).
+      ELMO_equivocating_validators s ∪ {[idx i_m]})
+        tr_m).
   {
     assert (Hall_reachable :
       Forall (fun item =>
@@ -2353,8 +2353,8 @@ Proof.
   cut
     (input_valid_transition ELMOProtocol (existT i_m Send)
       (lift_to_composite_state ELMOComponent s i_m (state m), None)
-      (lift_to_composite_state ELMOComponent s i_m (state m <+> MkObservation Send m), Some m)
-    ); [by apply input_valid_transition_out |].
+      (lift_to_composite_state ELMOComponent s i_m (state m <+> MkObservation Send m), Some m))
+    ; [by apply input_valid_transition_out |].
   repeat split.
   - by apply finite_valid_trace_from_to_last_pstate in Htr_m_lift.
   - by apply option_valid_message_None.

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -1952,7 +1952,7 @@ Lemma ELMO_equivocating_validators_step_update_Receive
   ELMOComponentRAMTransition i Receive (sigma i) s' m ->
     ELMO_equivocating_validators (state_update ELMOComponent sigma i s')
       ⊆
-    ELMO_equivocating_validators sigma ∪ {[adr (state m)]}.
+    ELMO_equivocating_validators sigma ∪ {[ adr (state m) ]}.
 Proof.
   intros Hsigma Ht.
   assert (Hte : input_valid_transition ReachELMO
@@ -2005,13 +2005,13 @@ Lemma ELMO_update_state_with_initial
   (s : composite_state ELMOComponent)
   (Hs : valid_state_prop ELMOProtocol s)
   (i : index)
-  (Heqv : (sum_weights (ELMO_equivocating_validators s ∪ {[idx i]}) <= threshold)%R)
+  (Heqv : (sum_weights (ELMO_equivocating_validators s ∪ {[ idx i ]}) <= threshold)%R)
   (si : State)
   (Hsi : vinitial_state_prop (ELMOComponent i) si) :
     valid_state_prop ELMOProtocol (state_update ELMOComponent s i si) /\
     ELMO_equivocating_validators (state_update ELMOComponent s i si)
       ⊆
-    ELMO_equivocating_validators s ∪ {[idx i]}.
+    ELMO_equivocating_validators s ∪ {[ idx i ]}.
 Proof.
   assert (Hincl : VLSM_incl ELMOProtocol ReachELMO) by apply constraint_preloaded_free_incl.
   assert (Htr_min := ELMO_state_to_minimal_equivocation_trace_valid _ Hs).
@@ -2046,11 +2046,11 @@ Proof.
     by rewrite state_update_twice_neq.
   }
   cut (ELMO_equivocating_validators (state_update ELMOComponent sf i si) ⊆
-        ELMO_equivocating_validators sf ∪ {[idx i]}).
+        ELMO_equivocating_validators sf ∪ {[ idx i ]}).
   {
     intro Hsfisi_eqvs'.
     assert (Hsfisi_eqvs :
-      ELMO_equivocating_validators (state_update ELMOComponent sf i si) ⊆ s_eqvs ∪ {[idx i]}).
+      ELMO_equivocating_validators (state_update ELMOComponent sf i si) ⊆ s_eqvs ∪ {[ idx i ]}).
     {
       etransitivity; [done |].
       by apply union_subseteq; split; [apply union_subseteq_l' | apply union_subseteq_r'].
@@ -2160,7 +2160,7 @@ Proof.
   apply ELMO_msg_valid_full_has_sender in ELMO_mv_msg_valid_full0 as Hsender.
   destruct Hsender as [i_m Hsender].
   assert (Heqv :
-    (sum_weights (ELMO_equivocating_validators s ∪ {[idx i_m]}) <= threshold)%R).
+    (sum_weights (ELMO_equivocating_validators s ∪ {[ idx i_m ]}) <= threshold)%R).
   {
     etransitivity; [| apply Hc].
     apply sum_weights_subseteq; [by apply NoDup_elements.. |].
@@ -2206,7 +2206,7 @@ Proof.
     Forall (fun item =>
       ELMO_equivocating_validators (lift_to_composite_state ELMOComponent s i_m (destination item))
         ⊆
-      ELMO_equivocating_validators s ∪ {[idx i_m]})
+      ELMO_equivocating_validators s ∪ {[ idx i_m ]})
         tr_m).
   {
     assert (Hall_reachable :
@@ -2251,7 +2251,7 @@ Proof.
     constructor; [| by constructor].
     assert (Hsis0_eqvs :
       ELMO_equivocating_validators (state_update ELMOComponent s i_m s0)
-        ⊆ ELMO_equivocating_validators s ∪ {[adr (state m)]}).
+        ⊆ ELMO_equivocating_validators s ∪ {[ adr (state m) ]}).
     {
       apply valid_trace_get_last in Htr_m as <-.
       destruct_list_last tr tr' lst Heq; [done |].
@@ -2265,14 +2265,14 @@ Proof.
     destruct (Ht) as [(_ & _ & H_v) H_t];
       inversion H_v as [? ? [] |]; subst; inversion H_t; subst; cycle 1.
     - transitivity (ELMO_equivocating_validators (state_update ELMOComponent s i_m s0)
-        ∪ {[adr (state m)]}).
+        ∪ {[ adr (state m) ]}).
       + by eapply union_subseteq_l', ELMO_equivocating_validators_step_update_Send;
           [| by constructor; state_update_simpl].
       + by apply union_subseteq; split; [| apply union_subseteq_r'].
     - destruct (decide (adr (state m) = adr (state m0))) as [Hmm0 | Hnmm0].
       {
         transitivity (ELMO_equivocating_validators (state_update ELMOComponent s i_m s0)
-          ∪ {[adr (state m)]}).
+          ∪ {[ adr (state m) ]}).
         - rewrite Hmm0.
           by eapply ELMO_equivocating_validators_step_update_Receive;
             [| constructor; state_update_simpl].
@@ -2281,7 +2281,7 @@ Proof.
       assert (Hm0_obs : m0 ∈ messages (s i)) by (apply Hlast_obs; left; done).
       destruct (decide (i_m = i)); cycle 1.
       + transitivity (ELMO_equivocating_validators (state_update ELMOComponent s i_m s0)
-          ∪ {[adr (state m)]});
+          ∪ {[ adr (state m) ]});
           [| by apply union_subseteq; split; [| by apply union_subseteq_r']].
         eapply union_subseteq_l', ELMO_equivocating_validators_step_update_Receive_already_Observed;
           [done | | by constructor; state_update_simpl].

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -2709,7 +2709,7 @@ Proof.
 Qed.
 
 Lemma component_reflects_composite_messages_step_update
-  (i : index) (l : Label) (sigma : composite_state ELMOComponent) (s' : State) (m : Message ) :
+  (i : index) (l : Label) (sigma : composite_state ELMOComponent) (s' : State) (m : Message) :
   ELMOComponentRAMTransition i l (sigma i) s' m ->
   component_reflects_composite_messages sigma i ->
   component_reflects_composite_messages (state_update ELMOComponent sigma i s') i.

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -83,7 +83,7 @@ Lemma full_node_reachable_messages_ind
                  (Hfull : full_node s msg)
                  (IH : forall m, m ∈ messages s -> P s m),
     P (s <+> MkObservation l msg) msg)
-  (Hprev : forall s ob m (IH: P s m), P (s <+> ob) m)
+  (Hprev : forall s ob m (IH : P s m), P (s <+> ob) m)
   :
   forall s, UMO_reachable full_node s ->
   forall m, m ∈ messages s -> P s m.
@@ -243,11 +243,11 @@ Inductive ELMO_msg_valid_full : Message -> Prop :=
 | MVF_nil :
     forall m : Message,
       obs (state m) = [] -> MessageHasSender m -> ELMO_msg_valid_full m
-| MVF_send:
+| MVF_send :
     forall m,
       ELMO_msg_valid_full m ->
       ELMO_msg_valid_full (m <*> MkObservation Send m)
-| MVF_recv:
+| MVF_recv :
     forall m mo,
       full_node (state m) mo ->
       no_self_equiv (state m) mo ->
@@ -430,7 +430,7 @@ Proof.
   by inversion Hv; subst; inversion Ht.
 Qed.
 
-Lemma ELMO_transition_inj:
+Lemma ELMO_transition_inj :
   forall l (s : State) (om : option Message) (s' : State) (om' : option Message),
     input_valid_transition Ri l (s, om) (s', om') ->
   forall l0 s0 om0 om'0,
@@ -558,7 +558,7 @@ Proof.
     by exists l0; apply (unfold_robs _ _ Hs); right; exists m.
 Qed.
 
-Lemma full_node_messages_iff_rec_obs:
+Lemma full_node_messages_iff_rec_obs :
   forall (s : State), UMO_reachable full_node s ->
   forall (m : Message),
     m ∈ messages s <-> (exists l, rec_obs s (MkObservation l m)).
@@ -2503,8 +2503,8 @@ Lemma all_intermediary_transitions_are_receive
   (Hsigma : composite_ram_state_prop ELMOComponent sigma)
   (Hcomponent : sigma i = si)
   (Hspecial : component_reflects_composite sigma i)
-  (tr_m: list transition_item)
-  (Htr_m: finite_valid_trace_from_to
+  (tr_m : list transition_item)
+  (Htr_m : finite_valid_trace_from_to
           (pre_loaded_with_all_messages_vlsm (ELMOComponent i_m))
           (sigma i_m) (state m) tr_m)
   : Forall (fun item : transition_item => l item = Receive) tr_m.
@@ -2549,16 +2549,16 @@ Proof.
 Qed.
 
 Lemma lift_receive_trace
-  (sigma: composite_state ELMOComponent)
-  (Hsigma: valid_state_prop ELMOProtocol sigma)
-  (m: Message)
-  (i_m: index)
-  (tr_m: list transition_item)
-  (Htr_m:
+  (sigma : composite_state ELMOComponent)
+  (Hsigma : valid_state_prop ELMOProtocol sigma)
+  (m : Message)
+  (i_m : index)
+  (tr_m : list transition_item)
+  (Htr_m :
     finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm (ELMOComponent i_m))
       (sigma i_m) (state m) tr_m)
-  (Htr_m_receive: Forall (fun item : transition_item => l item = Receive) tr_m)
-  (Htr_m_inputs_in_sigma:
+  (Htr_m_receive : Forall (fun item : transition_item => l item = Receive) tr_m)
+  (Htr_m_inputs_in_sigma :
     forall (item : transition_item) (msg : Message),
       item ∈ tr_m -> input item = Some msg ->
       composite_has_been_directly_observed ELMOComponent sigma msg) :
@@ -2813,7 +2813,7 @@ Qed.
 *)
 Lemma reflecting_composite_for_reachable_component
   (i : index) (si : vstate (ELMOComponent i))
-  (Hreachable : ram_state_prop (ELMOComponent i) si):
+  (Hreachable : ram_state_prop (ELMOComponent i) si) :
   exists s : vstate ELMOProtocol,
     s i = si
     /\ valid_state_prop ELMOProtocol s

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -1609,8 +1609,8 @@ Proof.
         [contradict Hnot_sent |]; exists k.
   - destruct Hequiv as [m Hadr [i_rec Hrecv] Hnot_sent].
     unfold ELMO_global_equivocators.
-    exists m;split;[done|].
-    split;[|done].
+    exists m; split; [done|].
+    split; [|done].
     exists i_rec.
     by apply full_node_messages_iff_rec_obs, received_in_messages.
 Qed.
@@ -1664,7 +1664,7 @@ Proof.
       destruct Hobs as [k Hobs]; exists k.
     + by apply elem_of_messages.
     + assert (m' ∈ messages (s k)) by (eapply elem_of_messages; done).
-      enough (m <hb m') by (eapply messages_hb_transitive;done).
+      enough (m <hb m') by (eapply messages_hb_transitive; done).
       revert Hdepth; apply (tc_congruence (fun m=>m)).
       unfold msg_dep_rel, compose, immediate_dependency.
       by intros x y Hdep; apply elem_of_list_to_set in Hdep.
@@ -1683,8 +1683,8 @@ Proof.
   apply Morphisms_Prop.ex_iff_morphism; intro m.
   assert (forall k : index, UMO_reachable full_node (s k))
     by (intro; eapply ELMO_full_node_reachable, valid_state_project_preloaded_to_preloaded; done).
-  setoid_rewrite <- full_node_messages_iff_rec_obs;[| done].
-  setoid_rewrite <- ELMO_CHBO_in_messages;[| done].
+  setoid_rewrite <- full_node_messages_iff_rec_obs; [| done].
+  setoid_rewrite <- ELMO_CHBO_in_messages; [| done].
   (* firstorder works here but is slow *)
   by split; intros []; constructor; [cbv; f_equal | .. | apply Some_inj |]; itauto.
 Qed.

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -147,7 +147,7 @@ Proof.
     by apply reach_init.
   - destruct Ht as [(_ & _ & Hvalid) Ht]; cbn in Ht, Hvalid.
     rewrite VM_transition_is_UMO in Ht.
-    destruct l, om; injection Ht as [= <- <-]; [| done..|].
+    destruct l, om; injection Ht as [= <- <-]; [| done.. |].
     + apply VM_enforces_full_node in Hvalid.
       by apply reach_recv.
     + by apply reach_send.
@@ -259,14 +259,14 @@ Lemma ELMO_msg_valid_full_to_reach (m : Message) :
   UMO_reachable (fun s m => full_node s m /\ no_self_equiv s m) (state m).
 Proof.
   by induction 1; destruct m as [ms]; cbn in *;
-    [replace ms with (MkState [] (adr ms)) by (apply eq_State; done) |..];
+    [replace ms with (MkState [] (adr ms)) by (apply eq_State; done) | ..];
     constructor.
 Qed.
 
 Lemma ELMO_msg_valid_full_has_sender (m : Message) :
   ELMO_msg_valid_full m -> MessageHasSender m.
 Proof.
-  by induction 1; [done |..]; destruct IHELMO_msg_valid_full; econstructor.
+  by induction 1; [done | ..]; destruct IHELMO_msg_valid_full; econstructor.
 Qed.
 
 #[local] Instance ELMO_local_equivocation : BasicEquivocation State Address Ca threshold :=
@@ -336,7 +336,7 @@ Proof.
   constructor 1 with sentMessages; constructor.
   - by intros [] []; cbn in *; subst; cbn; apply not_elem_of_nil.
   - intros l s im s' om [(Hvsp & Hovmp & Hv) Ht] m; cbn in *.
-    destruct l, im; cbn in *; [| by exfalso; inversion Hv..|];
+    destruct l, im; cbn in *; [| by exfalso; inversion Hv.. |];
     inversion_clear Ht; destruct s; cbn.
     + by rewrite decide_False; cbn; firstorder congruence.
     + rewrite decide_True by done; cbn.
@@ -619,7 +619,7 @@ Proof.
   apply local_equivocators_simple_addObservation
     in Ha as [| (<- & _ & m & Hm & Hincomp)]; [done |]; cbn in *.
   destruct Hincomp as [Hadr []].
-  by apply self_messages_sent in Hm; [constructor |..].
+  by apply self_messages_sent in Hm; [constructor | ..].
 Qed.
 
 (**
@@ -820,7 +820,7 @@ Proof.
   intros [Hs _]%ELMO_reachable_view.
   induction Hs as [| | ? ? Hvalid].
   - by inversion 1.
-  - by intros m [->|Hm%IHHs]%elem_of_messages_addObservation; apply submseteq_cons.
+  - by intros m [-> | Hm%IHHs]%elem_of_messages_addObservation; apply submseteq_cons.
   - intros m Hm.
     apply submseteq_cons; change (full_node s m).
     apply elem_of_messages_addObservation in Hm as [-> | Hm].
@@ -1223,7 +1223,7 @@ Qed.
 Proof.
   constructor.
   - by typeclasses eauto.
-  - by intros [[| [[] ?] ?] ?] *; [inversion 1 |..];
+  - by intros [[| [[] ?] ?] ?] *; [inversion 1 | ..];
       intro Hitem; apply elem_of_list_singleton in Hitem;
       inversion_clear Hitem.
   - by apply ELMOComponent_state_destructor_input_valid_transition.
@@ -1609,8 +1609,8 @@ Proof.
         [contradict Hnot_sent |]; exists k.
   - destruct Hequiv as [m Hadr [i_rec Hrecv] Hnot_sent].
     unfold ELMO_global_equivocators.
-    exists m; split; [done|].
-    split; [|done].
+    exists m; split; [done |].
+    split; [| done].
     exists i_rec.
     by apply full_node_messages_iff_rec_obs, received_in_messages.
 Qed.
@@ -1660,7 +1660,7 @@ Lemma ELMO_CHBO_in_messages :
     exists (k : index), m ∈ messages (s k).
 Proof.
   intros s Hs m; split.
-  - intros [Hobs|m' Hobs Hdepth];
+  - intros [Hobs | m' Hobs Hdepth];
       destruct Hobs as [k Hobs]; exists k.
     + by apply elem_of_messages.
     + assert (m' ∈ messages (s k)) by (eapply elem_of_messages; done).
@@ -1698,7 +1698,7 @@ Proof.
   rewrite ELMO_global_equivocators_iff_msg_dep_equivocation by done.
   rewrite <- global_equivocators_simple_iff_full_node_equivocation by done.
   pose proof @ELMOComponent_message_dependencies_full_node_condition.
-  by rewrite full_node_is_globally_equivocating_iff; [| typeclasses eauto |..].
+  by rewrite full_node_is_globally_equivocating_iff; [| typeclasses eauto | ..].
 Qed.
 
 (**
@@ -1850,7 +1850,7 @@ Proof.
   inversion Ht as [| ? ? ? [(Hsi & _ & Hvi) Hti]]; inversion Hvi; inversion Hti; subst.
   destruct (decide (a = idx i)); subst; [done |].
   intros [ges_m ges_adr ges_recv ges_not_sent].
-  econstructor; [done |..].
+  econstructor; [done | ..].
   - destruct ges_recv as [j Hrcv]; exists j.
     destruct (decide (j = i)); subst; state_update_simpl; [| done].
     by cbn; rewrite decide_False by auto.
@@ -1891,13 +1891,13 @@ Proof.
         destruct (decide (j = i)); subst; state_update_simpl; [| done].
         by cbn; rewrite decide_False by auto.
   - intros [[ges_m ges_adr ges_recv ges_not_sent] | [-> Hnsnd]].
-    + econstructor; [done |..].
+    + econstructor; [done | ..].
       * destruct ges_recv as [j Hrcv]; exists j.
         destruct (decide (j = i)); subst; state_update_simpl; [| done].
         by cbn; rewrite decide_True, map_cons by done; right.
       * intros [j Hsnd]; apply ges_not_sent; exists j.
         by destruct (decide (j = i)); subst; state_update_simpl.
-    + econstructor; [done |..].
+    + econstructor; [done | ..].
       * by exists i; state_update_simpl; left.
       * intros [j Hsnd]; apply Hnsnd; exists j.
         destruct (decide (j = i)); subst; state_update_simpl; [| done].
@@ -2082,7 +2082,7 @@ Proof.
   assert (Hpre_tisi : input_valid_transition ReachELMO (existT j lj)
     (state_update ELMOComponent s i si, iom) (state_update ELMOComponent sf i si, oom)).
   {
-    repeat split; [done |..| done].
+    repeat split; [done | .. | done].
     - by apply any_message_is_valid_in_preloaded.
     - by cbn; state_update_simpl.
   }
@@ -2154,7 +2154,7 @@ Proof.
   {
     apply valid_state_prop_iff; right.
     by exists (existT i Receive), (s, Some m), None; repeat split;
-      [| apply any_message_is_valid_in_preloaded |..].
+      [| apply any_message_is_valid_in_preloaded | ..].
   }
   pose (H_rcv := Hrcv); destruct H_rcv.
   apply ELMO_msg_valid_full_has_sender in ELMO_mv_msg_valid_full0 as Hsender.
@@ -2331,7 +2331,7 @@ Proof.
     rewrite Forall_singleton in H_lst_msg_valid.
     rewrite Forall_singleton in Hsf_bounded_eqv.
     setoid_rewrite map_app; cbn.
-    eapply extend_right_finite_trace_from_to; [by apply IHHtr_m| cbn].
+    eapply extend_right_finite_trace_from_to; [by apply IHHtr_m | cbn].
     destruct Ht0 as [(Hs0 &  _ & Hv0) Ht0].
     repeat split.
     - by eapply finite_valid_trace_from_to_last_pstate, IHHtr_m.
@@ -2456,10 +2456,10 @@ Proof.
   assert (i <> i_m) by (contradict Hadr_neq; congruence).
   apply valid_state_project_preloaded with (i := i_m) in Hsigma as Hsi_m.
   assert (adr (sigma i_m) = idx i_m) by (apply ELMO_reachable_adr; done).
-  destruct (ELMO_unique_trace_segments i_m (sigma i_m) (state m)) as [tr []]; [..| by eexists].
+  destruct (ELMO_unique_trace_segments i_m (sigma i_m) (state m)) as [tr []]; [.. | by eexists].
   - destruct Ht as [(Hsi & _ & Hv) _]; inversion Hv; subst.
     by clear Hsi_m; destruct m; eapply receivable_messages_reachable.
-  - destruct (H_not_i_paused i_m) as [Hinit | (sim & lst_im & Hsnd)]; [done |..].
+  - destruct (H_not_i_paused i_m) as [Hinit | (sim & lst_im & Hsnd)]; [done | ..].
     + replace (sigma i_m) with (MkState [] (adr (state m)));
         [by specialize (state_suffix_empty_minimum (state m)); itauto |].
       by apply eq_State; [| cbn; congruence].
@@ -2487,7 +2487,7 @@ Proof.
       * eapply was_sent_before_characterization_1 in Hbefore; [by rewrite Hsnd; itauto |].
         eapply ELMO_reachable_view with (i := i_m).
         destruct Ht as [(Hsi & _ & Hv) _]; inversion Hv; subst.
-        by clear Hsi_m; destruct m; eapply receivable_messages_reachable; [congruence |..].
+        by clear Hsi_m; destruct m; eapply receivable_messages_reachable; [congruence | ..].
 Qed.
 
 Lemma all_intermediary_transitions_are_receive
@@ -2521,7 +2521,7 @@ Proof.
   eapply ELMOComponent_sentMessages_of_ram_trace in Hitem as Hm0; [| done..].
   eapply reachable_sent_messages_adr in Hm0 as Hm0_adr;
     [| by eapply finite_valid_trace_from_to_last_pstate].
-  exists (MkMessage s_m0); [by congruence |..].
+  exists (MkMessage s_m0); [by congruence | ..].
   - exists i.
     assert (Hm : MkMessage s_m0 ∈ messages (sigma i)).
     {
@@ -2590,7 +2590,7 @@ Proof.
     by (eapply Htr_m_inputs_in_sigma;
       [apply elem_of_app; right; apply elem_of_list_singleton |]; done).
   edestruct IHHtr_m as [Htr Hall];
-    [..| split; [eapply finite_valid_trace_from_to_app; [by apply Htr |] |]].
+    [.. | split; [eapply finite_valid_trace_from_to_app; [by apply Htr |] |]].
   - done.
   - intros item msg Hitem Hmsg.
     by eapply Htr_m_inputs_in_sigma; [apply elem_of_app; left |].
@@ -2599,7 +2599,7 @@ Proof.
   - apply finite_valid_trace_from_add_last; [| done].
     apply first_transition_valid; cbn.
     apply finite_valid_trace_from_to_last_pstate in Htr as Hsigma'.
-    repeat split; cbn; [done |..].
+    repeat split; cbn; [done | ..].
     + by eapply composite_directly_observed_valid; cycle 1.
     + by constructor; state_update_simpl.
     + eapply
@@ -2675,7 +2675,7 @@ Proof.
     composite_has_been_directly_observed ELMOComponent sigma msg).
   {
     intros item msg Hitem Hinput.
-    destruct Ht as [(Hsi & _ & Hv) _]; inversion Hv as [? ? []|]; subst.
+    destruct Ht as [(Hsi & _ & Hv) _]; inversion Hv as [? ? [] |]; subst.
     cut (has_been_received (ELMOComponent i_m) (state m) msg).
     {
       cbn; intro Hmsg.
@@ -2697,7 +2697,7 @@ Proof.
     + intros m0; split; [| by eexists].
       intros [j Hm0]; destruct (decide (i_m = j)); subst; state_update_simpl;
         [| by apply Hspecial; eexists].
-      destruct Ht as [(_ & _ & Hv) _]; inversion Hv as [? ? []|]; subst.
+      destruct Ht as [(_ & _ & Hv) _]; inversion Hv as [? ? [] |]; subst.
       by eapply elem_of_submseteq; [| done].
     + intros a; state_update_simpl.
       by transitivity (global_equivocators_simple sigma a); [apply Heqv | apply Hspecial].
@@ -2830,9 +2830,9 @@ Proof.
   - unfold initial_state_prop in Hs; cbn in Hs.
     apply UMOComponent_initial_state_spec in Hs as ->.
     exists (` (composite_s0 ELMOComponent)).
-    unfold composite_s0; cbn; split_and!; [done |..].
+    unfold composite_s0; cbn; split_and!; [done | ..].
     + by apply initial_state_is_valid.
-    + repeat split; cbn; [..| by inversion 1].
+    + repeat split; cbn; [.. | by inversion 1].
       * by intros [j Hj].
       * by inversion 1.
       * by intros []; itauto.
@@ -2862,14 +2862,14 @@ Proof.
         subst sigma'; state_update_simpl.
         unfold local_equivocators_full; cbn; rewrite lefo_alt; cbn.
         by split; [right | intros [|]; [destruct_and! |]].
-      * intros [? <- ]; esplit; [done |..].
+      * intros [? <- ]; esplit; [done | ..].
         -- destruct ges_recv as [j Hrecv].
            destruct (decide (i = j)); subst; subst sigma'; state_update_simpl; [| by eexists].
            by cbn in Hrecv; rewrite decide_False in Hrecv by itauto; exists j.
         -- intros [j Hsent]; apply ges_not_sent; exists j.
            destruct (decide (i = j)); subst; subst sigma'; state_update_simpl; [| done].
            by eapply has_been_sent_step_update; [| right].
-      * intros []; esplit; [done |..].
+      * intros []; esplit; [done | ..].
         -- destruct ges_recv as [j Hrecv]; exists j.
            destruct (decide (i = j)); subst; subst sigma'; state_update_simpl; [| done].
            by eapply has_been_received_step_update; [| right].
@@ -2979,7 +2979,7 @@ Proof.
     assert (ELMOComponentRAMTransition i Receive (sigma' i) (sigma i <+> MkObservation Receive m) m).
     {
       subst sigma'; state_update_simpl; rewrite Heqi.
-      constructor; repeat split; [..| done].
+      constructor; repeat split; [.. | done].
       - by eapply valid_state_project_preloaded.
       - by apply any_message_is_valid_in_preloaded.
     }

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -1570,7 +1570,7 @@ Qed.
 
 Lemma ELMO_state_to_minimal_equivocation_trace_equivocation_monotonic :
   forall (s : composite_state ELMOComponent) (Hs : composite_ram_state_prop ELMOComponent s),
-  forall (is : composite_state ELMOComponent) (tr :list (composite_transition_item ELMOComponent)),
+  forall (is : composite_state ELMOComponent) (tr : list (composite_transition_item ELMOComponent)),
   ELMO_state_to_minimal_equivocation_trace s Hs = (is, tr) ->
   forall (pre suf : list (composite_transition_item ELMOComponent))
     (item : composite_transition_item ELMOComponent),

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -652,7 +652,7 @@ Proof.
 Qed.
 
 Lemma local_equivocators_full_nondecreasing (s : State) l om s' om' :
-  vtransition Ri l (s,om) = (s',om') ->
+  vtransition Ri l (s, om) = (s', om') ->
   (forall a, local_equivocators_full s a ->
              local_equivocators_full s' a).
 Proof.
@@ -2987,7 +2987,7 @@ Proof.
     + intros k Hk.
       subst sigma'.
       destruct (decide (k = i_m)); subst; state_update_simpl; [| by apply Hchi_send; itauto].
-      by constructor 2; eexists _,_.
+      by constructor 2; eexists _, _.
     + by etransitivity; [| eapply input_valid_transition_in_futures].
     + by subst sigma'; rewrite <- Heqi; state_update_simpl.
     + split; [| by eexists]; intros [j Hj].

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -570,7 +570,7 @@ Proof.
       setoid_rewrite rec_obs_addObservation_iff; cbn.
     split.
     + by intros [<- | [l0]]; eauto.
-    + by intros [l0 [ | [[= _] | [->]]]]; eauto using full_node_rebase_rec_obs.
+    + by intros [l0 [| [[= _] | [->]]]]; eauto using full_node_rebase_rec_obs.
 Qed.
 
 (**
@@ -1202,7 +1202,7 @@ Proof.
   intros s' Hs'; split; intro Hs''.
   - by cbn in Hs''; apply UMOComponent_initial_state_spec in Hs'' as ->.
   - apply ELMO_reachable_adr in Hs'.
-    by destruct s' as [[| [[] ]] adr]; cbn in *; [| done..].
+    by destruct s' as [[| [[]]] adr]; cbn in *; [| done..].
 Qed.
 
 Lemma ELMOComponent_state_destructor_input_valid_transition :
@@ -1627,7 +1627,7 @@ Lemma global_equivocators_simple_iff_full_node_equivocation :
 Proof.
   split.
   - by intros [? [?%Some_inj]]; econstructor.
-  - by intros [? <- ]; econstructor.
+  - by intros [? <-]; econstructor.
 Qed.
 
 (**
@@ -1779,7 +1779,7 @@ Proof.
     split; [| by apply Htr_min]; clear Htr_min.
     apply (extend_right_finite_trace_from_to _ IHHtr).
     destruct Ht as [(Hs_pre & _ & [Hv _]) Ht].
-    repeat split; [| | done | | done ].
+    repeat split; [| | done | | done].
     + by apply valid_trace_last_pstate in IHHtr.
     + by destruct iom; [apply Hmsg_valid | apply option_valid_message_None].
     + destruct l as [i []]; [| done].
@@ -2862,7 +2862,7 @@ Proof.
         subst sigma'; state_update_simpl.
         unfold local_equivocators_full; cbn; rewrite lefo_alt; cbn.
         by split; [right | intros [|]; [destruct_and! |]].
-      * intros [? <- ]; esplit; [done | ..].
+      * intros [? <-]; esplit; [done | ..].
         -- destruct ges_recv as [j Hrecv].
            destruct (decide (i = j)); subst; subst sigma'; state_update_simpl; [| by eexists].
            by cbn in Hrecv; rewrite decide_False in Hrecv by itauto; exists j.
@@ -3013,7 +3013,7 @@ Proof.
         -- intros Heqv.
            destruct (decide (a = adr (state m))); [by subst |].
            eapply local_equivocators_full_step_update in Heqv; [| by constructor].
-           by destruct Heqv as [| [-> ]].
+           by destruct Heqv as [| [->]].
 Qed.
 
 (** Every [ELMOComponent] is a validator for [ELMOProtocol]. *)

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -298,7 +298,7 @@ Proof.
     apply (Hv k suffix). rewrite lastn_cons.
     by case_decide; [lia |].
   - apply (Hv (1 + length (obs (state m))) (obs (state m))).
-    by rewrite lastn_ge; cbn; [| lia ].
+    by rewrite lastn_ge; cbn; [| lia].
 Qed.
 
 Lemma MO_msg_valid_alt_Receive_conv :

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -1188,8 +1188,8 @@ Record incomparable_state (s1 s2 : State) : Prop :=
 
 Lemma rec_obs_send_inv
   (Q : State -> Observation -> Prop) s ob
-  (Hnew: Q s (MkObservation Send (MkMessage s)))
-  (Hprev: rec_obs s ob -> Q s ob) :
+  (Hnew : Q s (MkObservation Send (MkMessage s)))
+  (Hprev : rec_obs s ob -> Q s ob) :
   rec_obs (s <+> MkObservation Send (MkMessage s)) ob -> Q s ob.
 Proof.
   by inversion 1; (replace s with s0 in *; [auto | apply eq_State]).
@@ -1197,9 +1197,9 @@ Qed.
 
 Lemma rec_obs_recv_inv
   (Q : State -> Message -> Observation -> Prop) s m ob
-  (Hnew: Q s m (MkObservation Receive m))
-  (Hprev: rec_obs s ob -> Q s m ob)
-  (Hrecv: rec_obs (state m) ob -> Q s m ob) :
+  (Hnew : Q s m (MkObservation Receive m))
+  (Hprev : rec_obs s ob -> Q s m ob)
+  (Hrecv : rec_obs (state m) ob -> Q s m ob) :
   rec_obs (s <+> MkObservation Receive m) ob -> Q s m ob.
 Proof.
   by inversion 1; (replace s with s0 in *; [auto | apply eq_State]).

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -709,7 +709,7 @@ Proof.
   intros s Hs.
   apply valid_state_has_trace in Hs as (is & tr & Htr).
   apply finite_valid_trace_init_to_state2trace_Ui_inv in Htr as Heqtr; subst.
-  replace (``(vs0 Ri)) with is; [done|].
+  replace (``(vs0 Ri)) with is; [done |].
   by apply vs0_uniqueness, Htr.
 Qed.
 
@@ -1039,7 +1039,7 @@ Lemma state_suffix_totally_orders_sent_messages_Ui' :
 Proof.
   intros s m1 m2 Hvsp Hin1 Hin2.
   by eapply state_suffix_totally_orders_sent_messages_Ri';
-    [apply UMO_reachable_Ui |..].
+    [apply UMO_reachable_Ui | ..].
 Qed.
 
 (** ** Observability
@@ -1686,7 +1686,7 @@ Proof.
     rewrite (IHis' (state_update U us i' (MkState [] (idx i'))) m i).
     + by state_update_simpl.
     + by apply valid_state_prop_state_update_init.
-    + erewrite adr_of_sentMessages, adr_of_valid_state_Ri; [done | ..| done].
+    + erewrite adr_of_sentMessages, adr_of_valid_state_Ri; [done | .. | done].
       * by rewrite <- Hidx; apply Hvsp'.
       * by eapply UMO_reachable_Ri, Hvsp'.
     + intros j Hnin. destruct (decide (i' = j)); subst.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -657,7 +657,7 @@ Proof.
   split; [| done].
   revert Htr.
   unfold pre_vlsm;clear.
-  destruct vlsm as (T,M).
+  destruct vlsm as (T, M).
   by apply VLSM_incl_finite_valid_trace_init_to, vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
@@ -682,7 +682,7 @@ Proof.
   spec Hsm; [| done].
   revert Htr.
   unfold pre_vlsm;clear.
-  destruct vlsm as (T,M).
+  destruct vlsm as (T, M).
   by apply VLSM_incl_finite_valid_trace_init_to, vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
@@ -812,7 +812,7 @@ Lemma sent_messages_proper
 Proof.
   unfold sent_messages. rewrite exists_proj1_sig.
   specialize (proper_sent s Hs m) as Hbs.
-  unfold has_been_sent_prop,all_traces_have_message_prop in Hbs.
+  unfold has_been_sent_prop, all_traces_have_message_prop in Hbs.
   rewrite Hbs.
   symmetry.
   by apply has_been_sent_consistency.
@@ -833,7 +833,7 @@ Lemma received_messages_proper
 Proof.
   unfold received_messages. rewrite exists_proj1_sig.
   specialize (proper_received s Hs m) as Hbs.
-  unfold has_been_received_prop,all_traces_have_message_prop in Hbs.
+  unfold has_been_received_prop, all_traces_have_message_prop in Hbs.
   rewrite Hbs.
   symmetry.
   by apply has_been_received_consistency.
@@ -998,7 +998,7 @@ Qed.
 
 Lemma oracle_step_property_from_trace:
      forall l s im s' om,
-       input_valid_transition (pre_loaded_with_all_messages_vlsm vlsm) l (s,im) (s',om) ->
+       input_valid_transition (pre_loaded_with_all_messages_vlsm vlsm) l (s, im) (s', om) ->
        forall msg, oracle s' msg
                    <-> (selector msg {| l:=l; input:=im; destination:=s'; output:=om |}
                         \/ oracle s msg).
@@ -1129,7 +1129,7 @@ Proof.
   destruct (input item) as [m|] eqn:Heqm; [| done].
   elim (selected_message_exists_in_all_traces_initial_state _ _ Hs (field_selector input) m).
   apply has_been_received_consistency; [done | by apply initial_state_is_valid|].
-  eexists _,_, Htr.
+  eexists _, _, Htr.
   apply Exists_exists. exists item. split; [| done].
   by apply elem_of_list_In.
 Qed.
@@ -1532,7 +1532,7 @@ Proof.
   destruct Htr as [Htr _].
   eapply valid_trace_forget_last, input_valid_transition_to in Htr; [| done].
   cbn in Hz; rewrite Hz in Htr.
-  by eexists _,_,_.
+  by eexists _, _, _.
 Qed.
 
 Lemma preloaded_sent_can_emit
@@ -1998,7 +1998,7 @@ Proof.
   apply pre_loaded_with_all_messages_projection_input_valid_transition_eq
     with (j := i) in Ht; [| done]; cbn in Ht.
   specialize (can_emit_signed i m).
-  spec can_emit_signed; [by eexists _,_,_ |].
+  spec can_emit_signed; [by eexists _, _, _ |].
   unfold channel_authenticated_message in can_emit_signed.
   destruct (sender m) as [v|] eqn: Hsender; [| by inversion can_emit_signed].
   apply Some_inj in can_emit_signed.
@@ -2200,7 +2200,7 @@ Proof.
   eapply VLSM_incl_input_valid_transition in Ht; cbn in Ht;
     [| by apply constraint_preloaded_free_incl].
   eapply (VLSM_projection_input_valid_transition (preloaded_component_projection IM i))
-    in Ht; [by eexists _,_ |].
+    in Ht; [by eexists _, _ |].
   by apply (composite_project_label_eq IM).
 Qed.
 
@@ -2604,7 +2604,7 @@ Qed.
 (** A sent message cannot have been previously sent or received. *)
 Definition cannot_resend_message_stepwise_prop : Prop :=
   forall l s oim s' m,
-    input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s,oim) (s',Some m) ->
+    input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s, oim) (s', Some m) ->
     ~has_been_sent X s m /\ ~has_been_received X s' m.
 
 Lemma cannot_resend_received_message_in_future
@@ -2630,7 +2630,7 @@ Context
   (Hno_resend : cannot_resend_message_stepwise_prop).
 
 Lemma input_valid_transition_received_not_resent l s m s' om'
-  (Ht : input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s,Some m) (s', om'))
+  (Ht : input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s, Some m) (s', om'))
   : om' <> Some m.
 Proof.
   destruct om' as [m'|]; [| by congruence].
@@ -2642,7 +2642,7 @@ Proof.
   apply proj1 in Htr as Hlst. apply finite_valid_trace_from_to_last_pstate in Hlst.
   apply proper_received; [done |].
   apply has_been_received_consistency; [done | done |].
-  exists _,_,Htr.
+  exists _, _, Htr.
   by apply Exists_app; right; apply Exists_cons; left.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -15,8 +15,8 @@ From VLSM.Core Require Export ReachableThreshold.
   and limit equivocation by means of a composition constraint.
 *)
 
-Lemma exists_proj1_sig {A: Type} (P: A -> Prop) (a: A):
-  (exists xP: {x | P x}, proj1_sig xP = a) <-> P a.
+Lemma exists_proj1_sig {A : Type} (P : A -> Prop) (a : A) :
+  (exists xP : {x | P x}, proj1_sig xP = a) <-> P a.
 Proof.
   split.
   - by intros [[x Hx] [= ->]].
@@ -77,7 +77,7 @@ Proof.
 Qed.
 
 Lemma incl_equivocating_validators_equivocation_fault
-  `{Heqv: BasicEquivocation st validator }
+  `{Heqv : BasicEquivocation st validator }
   `{EqDecision validator}
   : forall s1 s2,
     equivocating_validators s1 ⊆ equivocating_validators s2 ->
@@ -235,7 +235,7 @@ Definition specialized_selected_message_exists_in_some_traces
   (Htr : finite_valid_trace_init_to X start s tr),
   trace_has_message message_selector m tr.
 
-Definition selected_message_exists_in_some_preloaded_traces: forall
+Definition selected_message_exists_in_some_preloaded_traces : forall
   (message_selector : message -> transition_item -> Prop)
   (s : state)
   (m : message),
@@ -585,7 +585,7 @@ Qed.
 (** Reverse implication for 'selected_messages_consistency_prop' always holds. *)
 Lemma consistency_from_valid_state_proj2
   (s : state)
-  (Hs: valid_state_prop pre_vlsm s)
+  (Hs : valid_state_prop pre_vlsm s)
   (m : message)
   (selector : message -> transition_item -> Prop)
   (Hall : selected_message_exists_in_all_preloaded_traces selector s m)
@@ -687,11 +687,11 @@ Proof.
 Qed.
 
 Lemma has_been_sent_consistency_proper_not_sent
-  (has_been_sent: state_message_oracle)
-  (has_been_sent_dec: RelDecision has_been_sent)
+  (has_been_sent : state_message_oracle)
+  (has_been_sent_dec : RelDecision has_been_sent)
   (s : state)
   (m : message)
-  (proper_sent: has_been_sent_prop has_been_sent s m)
+  (proper_sent : has_been_sent_prop has_been_sent s m)
   (has_not_been_sent
     := fun (s : state) (m : message) => ~ has_been_sent s m)
   (Hconsistency : selected_messages_consistency_prop (field_selector output) s m)
@@ -710,7 +710,7 @@ Definition has_been_received_stepwise_prop
 
 Class HasBeenReceivedCapability : Type :=
 {
-  has_been_received: state_message_oracle;
+  has_been_received : state_message_oracle;
   has_been_received_dec :> RelDecision has_been_received;
   has_been_received_stepwise_props :
     has_been_received_stepwise_prop has_been_received;
@@ -772,11 +772,11 @@ Proof.
 Qed.
 
 Lemma has_been_received_consistency_proper_not_received
-  (has_been_received: state_message_oracle)
-  (has_been_received_dec: RelDecision has_been_received)
+  (has_been_received : state_message_oracle)
+  (has_been_received_dec : RelDecision has_been_received)
   (s : state)
   (m : message)
-  (proper_received: has_been_received_prop has_been_received s m)
+  (proper_received : has_been_received_prop has_been_received s m)
   (has_not_been_received
     := fun (s : state) (m : message) => ~ has_been_received s m)
   (Hconsistency : selected_messages_consistency_prop (field_selector input) s m)
@@ -870,7 +870,7 @@ Section sec_trace_from_stepwise.
 
 Context
   (message : Type)
-  (vlsm: VLSM message)
+  (vlsm : VLSM message)
   (selector : message -> transition_item -> Prop)
   (oracle : state_message_oracle vlsm)
   (oracle_props : oracle_stepwise_props selector oracle)
@@ -911,7 +911,7 @@ Proof.
 Qed.
 
 Lemma selected_messages_consistency_prop_from_stepwise
-    (oracle_dec: RelDecision oracle)
+    (oracle_dec : RelDecision oracle)
     (s : state)
     (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s)
     (m : message)
@@ -926,8 +926,8 @@ Proof.
     by elim (Hsm _ _ Htr).
 Qed.
 
-Lemma in_futures_preserving_oracle_from_stepwise:
-  forall (s1 s2: state)
+Lemma in_futures_preserving_oracle_from_stepwise :
+  forall (s1 s2 : state)
     (Hfutures : in_futures (pre_loaded_with_all_messages_vlsm vlsm) s1 s2)
     (m : message),
     oracle s1 m -> oracle  s2 m.
@@ -949,19 +949,19 @@ Section sec_stepwise_from_trace.
 
 Context
   (message : Type)
-  (vlsm: VLSM message)
-  (selector: message -> transition_item -> Prop)
-  (oracle: state_message_oracle vlsm)
-  (oracle_dec: RelDecision oracle)
-  (Horacle_all_have:
-     forall s (Hs: valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s) m,
+  (vlsm : VLSM message)
+  (selector : message -> transition_item -> Prop)
+  (oracle : state_message_oracle vlsm)
+  (oracle_dec : RelDecision oracle)
+  (Horacle_all_have :
+     forall s (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s) m,
       all_traces_have_message_prop vlsm selector oracle s m)
-  (Hnot_oracle_none_have:
-     forall s (Hs: valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s) m,
+  (Hnot_oracle_none_have :
+     forall s (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s) m,
        no_traces_have_message_prop vlsm selector (fun m s => ~ oracle m s) s m).
 
-Lemma oracle_no_inits_from_trace:
-  forall (s: vstate vlsm), initial_state_prop (VLSMMachine := vmachine vlsm) s ->
+Lemma oracle_no_inits_from_trace :
+  forall (s : vstate vlsm), initial_state_prop (VLSMMachine := vmachine vlsm) s ->
                            forall m, ~ oracle s m.
 Proof.
   intros s Hinit m Horacle.
@@ -973,7 +973,7 @@ Proof.
   by split; [constructor |].
 Qed.
 
-Lemma examine_one_trace:
+Lemma examine_one_trace :
   forall is s tr,
     finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm vlsm) is s tr ->
   forall m,
@@ -996,7 +996,7 @@ Proof.
     by exists is, tr, Htr.
 Qed.
 
-Lemma oracle_step_property_from_trace:
+Lemma oracle_step_property_from_trace :
      forall l s im s' om,
        input_valid_transition (pre_loaded_with_all_messages_vlsm vlsm) l (s, im) (s', om) ->
        forall msg, oracle s' msg
@@ -1045,10 +1045,10 @@ End sec_stepwise_from_trace.
 
 Lemma preloaded_has_been_sent_stepwise_props
       [message : Type]
-      (vlsm: VLSM message)
+      (vlsm : VLSM message)
       `{HasBeenSentCapability message vlsm}
       (seed : message -> Prop)
-      (X := pre_loaded_vlsm vlsm seed):
+      (X := pre_loaded_vlsm vlsm seed) :
   has_been_sent_stepwise_prop (vlsm := X) (has_been_sent vlsm).
 Proof.
   by destruct (has_been_sent_stepwise_props vlsm).
@@ -1056,9 +1056,9 @@ Qed.
 
 #[export] Instance preloaded_HasBeenSentCapability
       [message : Type]
-      (vlsm: VLSM message)
+      (vlsm : VLSM message)
       `{HasBeenSentCapability message vlsm}
-      (seed : message -> Prop):
+      (seed : message -> Prop) :
   HasBeenSentCapability (pre_loaded_vlsm vlsm seed).
 Proof.
   econstructor.
@@ -1067,7 +1067,7 @@ Proof.
 Defined.
 
 Lemma has_been_sent_examine_one_trace
-  `{HasBeenSentCapability message vlsm}:
+  `{HasBeenSentCapability message vlsm} :
   forall is s tr,
     finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm vlsm) is s tr ->
   forall m,
@@ -1082,10 +1082,10 @@ Qed.
 
 Lemma preloaded_has_been_received_stepwise_props
       {message : Type}
-      (vlsm: VLSM message)
+      (vlsm : VLSM message)
       `{HasBeenReceivedCapability message vlsm}
       (seed : message -> Prop)
-      (X := pre_loaded_vlsm vlsm seed):
+      (X := pre_loaded_vlsm vlsm seed) :
   has_been_received_stepwise_prop (vlsm := X) (has_been_received vlsm).
 Proof.
   by destruct (has_been_received_stepwise_props vlsm).
@@ -1093,9 +1093,9 @@ Qed.
 
 #[export] Instance preloaded_HasBeenReceivedCapability
       {message : Type}
-      (vlsm: VLSM message)
+      (vlsm : VLSM message)
       `{HasBeenReceivedCapability message vlsm}
-      (seed : message -> Prop):
+      (seed : message -> Prop) :
   HasBeenReceivedCapability (pre_loaded_vlsm vlsm seed).
 Proof.
   econstructor.
@@ -1104,7 +1104,7 @@ Proof.
 Defined.
 
 Lemma has_been_received_examine_one_trace
-  `{HasBeenReceivedCapability message vlsm}:
+  `{HasBeenReceivedCapability message vlsm} :
   forall is s tr,
     finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm vlsm) is s tr ->
   forall m,
@@ -1146,7 +1146,7 @@ Qed.
 
 Class HasBeenDirectlyObservedCapability {message} (vlsm : VLSM message) : Type :=
 {
-  has_been_directly_observed: state_message_oracle vlsm;
+  has_been_directly_observed : state_message_oracle vlsm;
   has_been_directly_observed_dec :> RelDecision has_been_directly_observed;
   has_been_directly_observed_stepwise_props :
     oracle_stepwise_props item_sends_or_receives has_been_directly_observed;
@@ -1171,7 +1171,7 @@ Definition has_been_directly_observed_step_update `{HasBeenDirectlyObservedCapab
 
 Lemma proper_directly_observed
   {message} (vlsm : VLSM message) `{HasBeenDirectlyObservedCapability message vlsm} :
-  forall (s: state),
+  forall (s : state),
     valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s ->
     forall m,
       all_traces_have_message_prop vlsm item_sends_or_receives (has_been_directly_observed vlsm) s m.
@@ -1182,7 +1182,7 @@ Qed.
 
 Lemma proper_not_directly_observed
   `(vlsm : VLSM message) `{HasBeenDirectlyObservedCapability message vlsm} :
-  forall (s: state),
+  forall (s : state),
     valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s ->
     forall m,
       no_traces_have_message_prop vlsm item_sends_or_receives
@@ -1193,7 +1193,7 @@ Proof.
 Qed.
 
 Lemma has_been_directly_observed_examine_one_trace
-  {message} (vlsm : VLSM message) `{HasBeenDirectlyObservedCapability message vlsm}:
+  {message} (vlsm : VLSM message) `{HasBeenDirectlyObservedCapability message vlsm} :
   forall is s tr,
     finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm vlsm) is s tr ->
   forall m,
@@ -1519,7 +1519,7 @@ Lemma sent_can_emit
   can_emit X m.
 Proof.
   apply valid_state_has_trace in Hs as (is & tr & Htr).
-  assert (Hpre_tr: finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm X) is s tr).
+  assert (Hpre_tr : finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm X) is s tr).
   {
     by clear -Htr; destruct X;
       eapply VLSM_incl_finite_valid_trace_init_to;
@@ -1627,9 +1627,9 @@ Context
 Section sec_stepwise_props.
 
 Context
-  [message_selectors: forall i : index, message -> vtransition_item (IM i) -> Prop]
-  [oracles: forall i, state_message_oracle (IM i)]
-  (stepwise_props: forall i, oracle_stepwise_props (message_selectors i) (oracles i))
+  [message_selectors : forall i : index, message -> vtransition_item (IM i) -> Prop]
+  [oracles : forall i, state_message_oracle (IM i)]
+  (stepwise_props : forall i, oracle_stepwise_props (message_selectors i) (oracles i))
   .
 
 Definition composite_message_selector : message -> composite_transition_item IM -> Prop.
@@ -2648,10 +2648,10 @@ Qed.
 
 Lemma lift_preloaded_trace_to_seeded
   (P : message -> Prop)
-  (tr: list transition_item)
-  (Htrm: trace_received_not_sent_before_or_after_invariant tr P)
-  (is: state)
-  (Htr: finite_valid_trace PreX is tr)
+  (tr : list transition_item)
+  (Htrm : trace_received_not_sent_before_or_after_invariant tr P)
+  (is : state)
+  (Htr : finite_valid_trace PreX is tr)
   : finite_valid_trace (pre_loaded_vlsm X P) is tr.
 Proof.
   unfold trace_received_not_sent_before_or_after_invariant in Htrm.
@@ -2703,9 +2703,9 @@ Qed.
 
 Lemma lift_preloaded_state_to_seeded
   (P : message -> Prop)
-  (s: state)
-  (Hequiv_s: state_received_not_sent_invariant s P)
-  (Hs: valid_state_prop PreX s)
+  (s : state)
+  (Hequiv_s : state_received_not_sent_invariant s P)
+  (Hs : valid_state_prop PreX s)
   : valid_state_prop (pre_loaded_vlsm X P) s.
 Proof.
   apply valid_state_has_trace in Hs as Htr.
@@ -2721,7 +2721,7 @@ Qed.
 Lemma lift_generated_to_seeded
   (P : message -> Prop)
   (s : state)
-  (Hequiv_s: state_received_not_sent_invariant s P)
+  (Hequiv_s : state_received_not_sent_invariant s P)
   (m : message)
   (Hgen : can_produce PreX s m)
   : can_produce (pre_loaded_vlsm X P) s m.
@@ -2819,7 +2819,7 @@ Context
   `{HasBeenReceivedCapability message X}
 .
 
-Lemma has_been_received_in_state s1 m:
+Lemma has_been_received_in_state s1 m :
   valid_state_prop X s1 ->
   has_been_received X s1 m ->
   exists (s0 : state) (item : transition_item) (tr : list transition_item),
@@ -2853,7 +2853,7 @@ Proof.
   by split; [| apply  Htr2].
 Qed.
 
-Lemma has_been_received_in_state_preloaded s1 m:
+Lemma has_been_received_in_state_preloaded s1 m :
   valid_state_prop (pre_loaded_with_all_messages_vlsm X) s1 ->
   has_been_received X s1 m ->
   exists (s0 : state) (item : transition_item) (tr : list transition_item),

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -15,8 +15,8 @@ From VLSM.Core Require Export ReachableThreshold.
   and limit equivocation by means of a composition constraint.
 *)
 
-Lemma exists_proj1_sig {A:Type} (P:A -> Prop) (a:A):
-  (exists xP:{x | P x}, proj1_sig xP = a) <-> P a.
+Lemma exists_proj1_sig {A: Type} (P: A -> Prop) (a: A):
+  (exists xP: {x | P x}, proj1_sig xP = a) <-> P a.
 Proof.
   split.
   - by intros [[x Hx] [= ->]].
@@ -1126,7 +1126,7 @@ Lemma trace_to_initial_state_has_no_inputs
   : forall item, In item tr -> input item = None.
 Proof.
   intros item Hitem.
-  destruct (input item) as [m |] eqn:Heqm; [| done].
+  destruct (input item) as [m |] eqn: Heqm; [| done].
   elim (selected_message_exists_in_all_traces_initial_state _ _ Hs (field_selector input) m).
   apply has_been_received_consistency; [done | by apply initial_state_is_valid |].
   eexists _, _, Htr.
@@ -1171,7 +1171,7 @@ Definition has_been_directly_observed_step_update `{HasBeenDirectlyObservedCapab
 
 Lemma proper_directly_observed
   {message} (vlsm : VLSM message) `{HasBeenDirectlyObservedCapability message vlsm} :
-  forall (s:state),
+  forall (s: state),
     valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s ->
     forall m,
       all_traces_have_message_prop vlsm item_sends_or_receives (has_been_directly_observed vlsm) s m.
@@ -1182,7 +1182,7 @@ Qed.
 
 Lemma proper_not_directly_observed
   `(vlsm : VLSM message) `{HasBeenDirectlyObservedCapability message vlsm} :
-  forall (s:state),
+  forall (s: state),
     valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s ->
     forall m,
       no_traces_have_message_prop vlsm item_sends_or_receives
@@ -2847,7 +2847,7 @@ Proof.
   rewrite Heqtr in Hfptf.
   apply (finite_valid_trace_from_to_app_split X) in Hfptf.
   destruct Hfptf as [Htr1 Htr2].
-  destruct tritem eqn:Heqtritem.
+  destruct tritem eqn: Heqtritem.
   simpl in Hintritem. subst input.
   eexists. eexists. eexists.
   by split; [| apply  Htr2].
@@ -2879,7 +2879,7 @@ Proof.
   rewrite Heqtr in Hfptf.
   apply (finite_valid_trace_from_to_app_split (pre_loaded_with_all_messages_vlsm X)) in Hfptf.
   destruct Hfptf as [Htr1 Htr2].
-  destruct tritem eqn:Heqtritem.
+  destruct tritem eqn: Heqtritem.
   simpl in Hintritem. subst input.
   eexists. eexists. eexists.
   by split; [| apply  Htr2].

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -431,7 +431,7 @@ Proof.
   - rewrite Exists_nil.
     by itauto.
   - rewrite Exists_cons, IHHtr.
-    apply (Horacle.(oracle_step_update _ _)) with (msg:=m) in Ht.
+    apply (Horacle.(oracle_step_update _ _)) with (msg := m) in Ht.
     by itauto.
 Qed.
 
@@ -961,7 +961,7 @@ Context
        no_traces_have_message_prop vlsm selector (fun m s => ~ oracle m s) s m).
 
 Lemma oracle_no_inits_from_trace:
-  forall (s: vstate vlsm), initial_state_prop (VLSMMachine:=vmachine vlsm) s ->
+  forall (s: vstate vlsm), initial_state_prop (VLSMMachine := vmachine vlsm) s ->
                            forall m, ~ oracle s m.
 Proof.
   intros s Hinit m Horacle.
@@ -1000,13 +1000,13 @@ Lemma oracle_step_property_from_trace:
      forall l s im s' om,
        input_valid_transition (pre_loaded_with_all_messages_vlsm vlsm) l (s, im) (s', om) ->
        forall msg, oracle s' msg
-                   <-> (selector msg {| l:=l; input:=im; destination:=s'; output:=om |}
+                   <-> (selector msg {| l := l; input := im; destination := s'; output := om |}
                         \/ oracle s msg).
 Proof.
   intros l s im s' om Htrans msg.
   rename Htrans into Htrans'.
   pose proof Htrans' as [[Hproto_s [Hproto_m Hvalid]] Htrans].
-  set (preloaded:= pre_loaded_with_all_messages_vlsm vlsm) in * |- *.
+  set (preloaded := pre_loaded_with_all_messages_vlsm vlsm) in * |- *.
   pose proof (valid_state_has_trace _ _ Hproto_s)
     as [is [tr [Htr Hinit]]].
   pose proof (Htr' := extend_right_finite_trace_from_to _ Htr Htrans').
@@ -1049,7 +1049,7 @@ Lemma preloaded_has_been_sent_stepwise_props
       `{HasBeenSentCapability message vlsm}
       (seed : message -> Prop)
       (X := pre_loaded_vlsm vlsm seed):
-  has_been_sent_stepwise_prop (vlsm:=X) (has_been_sent vlsm).
+  has_been_sent_stepwise_prop (vlsm := X) (has_been_sent vlsm).
 Proof.
   by destruct (has_been_sent_stepwise_props vlsm).
 Qed.
@@ -1086,7 +1086,7 @@ Lemma preloaded_has_been_received_stepwise_props
       `{HasBeenReceivedCapability message vlsm}
       (seed : message -> Prop)
       (X := pre_loaded_vlsm vlsm seed):
-  has_been_received_stepwise_prop (vlsm:=X) (has_been_received vlsm).
+  has_been_received_stepwise_prop (vlsm := X) (has_been_received vlsm).
 Proof.
   by destruct (has_been_received_stepwise_props vlsm).
 Qed.
@@ -1636,7 +1636,7 @@ Definition composite_message_selector : message -> composite_transition_item IM 
 Proof.
   intros msg [[i li] input s output].
   apply (message_selectors i msg).
-  exact {|l:=li; input:=input; destination:=s i; output:=output|}.
+  exact {|l := li; input := input; destination := s i; output := output|}.
 Defined.
 
 Definition composite_oracle : composite_state IM -> message -> Prop :=
@@ -1645,7 +1645,7 @@ Definition composite_oracle : composite_state IM -> message -> Prop :=
 Lemma composite_stepwise_props
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
-  : oracle_stepwise_props (vlsm:=X) composite_message_selector composite_oracle.
+  : oracle_stepwise_props (vlsm := X) composite_message_selector composite_oracle.
 Proof.
   split.
   - (* initial states not claim *)
@@ -1664,7 +1664,7 @@ Proof.
       by destruct Hproto as [|(lj & Hlj & _)]; [left | right; congruence].
     }
     apply input_valid_transition_preloaded_project_active in Hproto; simpl in Hproto.
-    apply (oracle_step_update (stepwise_props i)) with (msg:=msg) in Hproto.
+    apply (oracle_step_update (stepwise_props i)) with (msg := msg) in Hproto.
     split.
     + intros [j Hj].
       destruct (Hsj j) as [Hunchanged|Hji].
@@ -1737,7 +1737,7 @@ Definition composite_has_been_sent
 Lemma composite_has_been_sent_dec : RelDecision composite_has_been_sent.
 Proof.
   intros s m.
-  apply (Decision_iff (P:=List.Exists (fun i => has_been_sent (IM i) (s i) m) (enum index))).
+  apply (Decision_iff (P := List.Exists (fun i => has_been_sent (IM i) (s i) m) (enum index))).
   - by rewrite Exists_finite.
   - by typeclasses eauto.
 Qed.
@@ -1745,7 +1745,7 @@ Qed.
 Lemma composite_has_been_sent_stepwise_props
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
-  : has_been_sent_stepwise_prop (vlsm:=X) composite_has_been_sent.
+  : has_been_sent_stepwise_prop (vlsm := X) composite_has_been_sent.
 Proof.
   unfold has_been_sent_stepwise_props.
   pose proof (composite_stepwise_props (fun i => has_been_sent_stepwise_props (IM i)))
@@ -1789,7 +1789,7 @@ Definition composite_has_been_received
 Lemma composite_has_been_received_dec : RelDecision composite_has_been_received.
 Proof.
   intros s m.
-  apply (Decision_iff (P:=List.Exists (fun i => has_been_received (IM i) (s i) m) (enum index))).
+  apply (Decision_iff (P := List.Exists (fun i => has_been_received (IM i) (s i) m) (enum index))).
   - by rewrite Exists_finite.
   - by typeclasses eauto.
 Qed.
@@ -1797,7 +1797,7 @@ Qed.
 Lemma composite_has_been_received_stepwise_props
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
-  : has_been_received_stepwise_prop (vlsm:=X) composite_has_been_received.
+  : has_been_received_stepwise_prop (vlsm := X) composite_has_been_received.
 Proof.
   unfold has_been_received_stepwise_props.
   pose proof (composite_stepwise_props (fun i => has_been_received_stepwise_props (IM i)))
@@ -1825,7 +1825,7 @@ Lemma preloaded_composite_has_been_received_stepwise_props
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (seed : message -> Prop)
   (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
-  : has_been_received_stepwise_prop (vlsm:=X) composite_has_been_received.
+  : has_been_received_stepwise_prop (vlsm := X) composite_has_been_received.
 Proof.
   unfold has_been_received_stepwise_props.
   specialize (composite_stepwise_props (fun i => has_been_received_stepwise_props (IM i)))
@@ -1869,7 +1869,7 @@ Qed.
 Lemma composite_has_been_directly_observed_stepwise_props
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
-  : oracle_stepwise_props (vlsm:=X) item_sends_or_receives composite_has_been_directly_observed.
+  : oracle_stepwise_props (vlsm := X) item_sends_or_receives composite_has_been_directly_observed.
 Proof.
   pose proof (composite_stepwise_props
                 (fun i => (has_been_directly_observed_stepwise_props (IM i))))

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -606,7 +606,7 @@ Lemma has_been_sent_consistency
 Proof.
   split; [| by apply consistency_from_valid_state_proj2].
   intro Hsome.
-  destruct (decide (has_been_sent s m)) as [Hsm|Hsm].
+  destruct (decide (has_been_sent s m)) as [Hsm | Hsm].
   - by apply proper_sent in Hsm.
   - apply proper_not_sent in Hsm; [| done].
     destruct Hsome as [is [tr [Htr Hmsg]]].
@@ -764,7 +764,7 @@ Lemma has_been_received_consistency
 Proof.
   split; [| by apply consistency_from_valid_state_proj2].
   intro Hsome.
-  destruct (decide (has_been_received s m)) as [Hsm|Hsm];
+  destruct (decide (has_been_received s m)) as [Hsm | Hsm];
     [by apply proper_received in Hsm |].
   apply proper_not_received in Hsm; [| done].
   destruct Hsome as [is [tr [Htr Hsome]]].
@@ -919,7 +919,7 @@ Lemma selected_messages_consistency_prop_from_stepwise
 Proof.
   split; [| by apply consistency_from_valid_state_proj2].
   intro Hsome.
-  destruct (decide (oracle s m)) as [Hsm|Hsm].
+  destruct (decide (oracle s m)) as [Hsm | Hsm].
   - by apply prove_all_have_message_from_stepwise in Hsm.
   - apply prove_none_have_message_from_stepwise in Hsm; [| done].
     destruct Hsome as [is [tr [Htr Hmsg]]].
@@ -1126,9 +1126,9 @@ Lemma trace_to_initial_state_has_no_inputs
   : forall item, In item tr -> input item = None.
 Proof.
   intros item Hitem.
-  destruct (input item) as [m|] eqn:Heqm; [| done].
+  destruct (input item) as [m |] eqn:Heqm; [| done].
   elim (selected_message_exists_in_all_traces_initial_state _ _ Hs (field_selector input) m).
-  apply has_been_received_consistency; [done | by apply initial_state_is_valid|].
+  apply has_been_received_consistency; [done | by apply initial_state_is_valid |].
   eexists _, _, Htr.
   apply Exists_exists. exists item. split; [| done].
   by apply elem_of_list_In.
@@ -1315,7 +1315,7 @@ Lemma has_been_directly_observed_consistency
 Proof.
   split; [| by apply consistency_from_valid_state_proj2].
   intro Hsome.
-  destruct (decide (has_been_directly_observed vlsm s m)) as [Hsm|Hsm].
+  destruct (decide (has_been_directly_observed vlsm s m)) as [Hsm | Hsm].
   - by apply proper_directly_observed in Hsm.
   - apply proper_not_directly_observed in Hsm; [| done].
     destruct Hsome as [is [tr [Htr Hmsg]]].
@@ -1636,7 +1636,7 @@ Definition composite_message_selector : message -> composite_transition_item IM 
 Proof.
   intros msg [[i li] input s output].
   apply (message_selectors i msg).
-  exact {|l := li; input := input; destination := s i; output := output|}.
+  exact {| l := li; input := input; destination := s i; output := output |}.
 Defined.
 
 Definition composite_oracle : composite_state IM -> message -> Prop :=
@@ -1661,13 +1661,13 @@ Proof.
     {
       intro j.
       apply (input_valid_transition_preloaded_project_any j) in Hproto.
-      by destruct Hproto as [|(lj & Hlj & _)]; [left | right; congruence].
+      by destruct Hproto as [| (lj & Hlj & _)]; [left | right; congruence].
     }
     apply input_valid_transition_preloaded_project_active in Hproto; simpl in Hproto.
     apply (oracle_step_update (stepwise_props i)) with (msg := msg) in Hproto.
     split.
     + intros [j Hj].
-      destruct (Hsj j) as [Hunchanged|Hji].
+      destruct (Hsj j) as [Hunchanged | Hji].
       * by right; exists j; rewrite Hunchanged.
       * subst j.
         apply Hproto in Hj.
@@ -1675,7 +1675,7 @@ Proof.
     + intros [Hnow | [j Hbefore]].
       * by exists i; apply Hproto; left.
       * exists j.
-        destruct (Hsj j) as [Hunchanged| ->].
+        destruct (Hsj j) as [Hunchanged | ->].
         -- by rewrite <- Hunchanged.
         -- by apply Hproto; right.
 Qed.
@@ -1718,7 +1718,7 @@ Proof.
   apply proj1, finite_valid_trace_from_to_app_split, proj2 in Htr.
   rewrite finite_trace_last_is_last in Htr.
   destruct itemX, l; cbn in *.
-  by split_and!; [| exists suf |..].
+  by split_and!; [| exists suf | ..].
 Qed.
 
 End sec_stepwise_props.
@@ -2000,7 +2000,7 @@ Proof.
   specialize (can_emit_signed i m).
   spec can_emit_signed; [by eexists _, _, _ |].
   unfold channel_authenticated_message in can_emit_signed.
-  destruct (sender m) as [v|] eqn: Hsender; [| by inversion can_emit_signed].
+  destruct (sender m) as [v |] eqn: Hsender; [| by inversion can_emit_signed].
   apply Some_inj in can_emit_signed.
   by exists v; subst; unfold can_emit; eauto.
 Qed.
@@ -2363,7 +2363,7 @@ Lemma composite_has_been_directly_observed_sent_received_iff
     composite_has_been_sent IM s m \/ composite_has_been_received IM s m.
 Proof.
   split.
-  - by intros [i [Hs|Hr]]; [left | right]; exists i.
+  - by intros [i [Hs | Hr]]; [left | right]; exists i.
   - by intros [[i Hs] | [i Hr]]; exists i; [left | right].
 Qed.
 
@@ -2573,12 +2573,12 @@ Proof.
     split; [done |].
     intro Hbsm. elim Hnbsm.
     apply proper_sent; [done |].
-    by apply has_been_sent_consistency; [..|exists is, tr, Htr].
+    by apply has_been_sent_consistency; [.. | exists is, tr, Htr].
   - split.
     + apply proper_received; [done |].
-      by apply has_been_received_consistency; [..|exists is, tr, Htr].
+      by apply has_been_received_consistency; [.. | exists is, tr, Htr].
     + intro Hbsm. elim Hnbsm.
-      by apply proper_sent in Hbsm; [eapply Hbsm|].
+      by apply proper_sent in Hbsm; [eapply Hbsm |].
 Qed.
 
 Definition state_received_not_sent_invariant
@@ -2633,7 +2633,7 @@ Lemma input_valid_transition_received_not_resent l s m s' om'
   (Ht : input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s, Some m) (s', om'))
   : om' <> Some m.
 Proof.
-  destruct om' as [m'|]; [| by congruence].
+  destruct om' as [m' |]; [| by congruence].
   intro Heq. inversion Heq. subst m'. clear Heq.
   destruct (Hno_resend _ _ _ _ _ Ht) as [_ Hnbr_m].
   elim Hnbr_m. clear Hnbr_m.
@@ -2685,7 +2685,7 @@ Proof.
       produced in a valid (by IHHtr) trace.
       If m was not sent during tr,
     *)
-    assert (Decision (trace_has_message (field_selector output) m tr)) as [Hsent|Hnot_sent].
+    assert (Decision (trace_has_message (field_selector output) m tr)) as [Hsent | Hnot_sent].
     apply (@Exists_dec _). intros. apply decide_eq.
     + by eapply valid_trace_output_is_valid.
     + apply initial_message_is_valid.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -126,7 +126,7 @@ Definition equivocation_in_trace
     (suffix : list transition_item),
     tr = prefix ++ item :: suffix
     /\ input item = Some msg
-    /\ ~trace_has_message (field_selector output) msg prefix.
+    /\ ~ trace_has_message (field_selector output) msg prefix.
 
 Instance equivocation_in_trace_dec
   `{EqDecision message}
@@ -135,7 +135,7 @@ Proof.
   intros msg tr.
   apply @Decision_iff with
     (List.Exists (fun d => match d with (prefix, item, _) =>
-      input item = Some msg /\ ~trace_has_message (field_selector output) msg prefix
+      input item = Some msg /\ ~ trace_has_message (field_selector output) msg prefix
     end) (one_element_decompositions tr)).
   - rewrite Exists_exists.  split.
     + intros [((prefix, item), suffix) [Hitem Heqv]].
@@ -175,7 +175,7 @@ Lemma equivocation_in_trace_last_char
   (item : vtransition_item vlsm)
   : equivocation_in_trace msg (tr ++ [item]) <->
     equivocation_in_trace msg tr \/
-    input item = Some msg /\ ~trace_has_message (field_selector output) msg tr.
+    input item = Some msg /\ ~ trace_has_message (field_selector output) msg tr.
 Proof.
   split.
   - intros [prefix [item' [suffix [Heq_tr_item' [Hinput Hnoutput]]]]].
@@ -253,7 +253,7 @@ Definition specialized_selected_message_exists_in_no_trace
   (start : state)
   (tr : list transition_item)
   (Htr : finite_valid_trace_init_to X start s tr),
-  ~trace_has_message message_selector m tr.
+  ~ trace_has_message message_selector m tr.
 
 Definition selected_message_exists_in_no_preloaded_trace :=
   specialized_selected_message_exists_in_no_trace pre_vlsm.
@@ -450,7 +450,7 @@ Lemma oracle_initial_trace_update
     oracle s m <-> trace_has_message selector m tr.
 Proof.
   rewrite (oracle_partial_trace_update Horacle) by apply Htr.
-  assert (~oracle s0 m) by (eapply oracle_no_inits, Htr; done).
+  assert (~ oracle s0 m) by (eapply oracle_no_inits, Htr; done).
   by itauto.
 Qed.
 
@@ -897,7 +897,7 @@ Lemma prove_none_have_message_from_stepwise :
   forall (s : state)
          (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s)
          (m : message),
-    no_traces_have_message_prop vlsm selector (fun s m => ~oracle s m) s m.
+    no_traces_have_message_prop vlsm selector (fun s m => ~ oracle s m) s m.
 Proof.
   intros s Hproto m.
   split.
@@ -958,11 +958,11 @@ Context
       all_traces_have_message_prop vlsm selector oracle s m)
   (Hnot_oracle_none_have:
      forall s (Hs: valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s) m,
-       no_traces_have_message_prop vlsm selector (fun m s => ~oracle m s) s m).
+       no_traces_have_message_prop vlsm selector (fun m s => ~ oracle m s) s m).
 
 Lemma oracle_no_inits_from_trace:
   forall (s: vstate vlsm), initial_state_prop (VLSMMachine:=vmachine vlsm) s ->
-                           forall m, ~oracle s m.
+                           forall m, ~ oracle s m.
 Proof.
   intros s Hinit m Horacle.
   assert (Hproto : valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s)
@@ -1186,7 +1186,7 @@ Lemma proper_not_directly_observed
     valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s ->
     forall m,
       no_traces_have_message_prop vlsm item_sends_or_receives
-                                  (fun s m => ~has_been_directly_observed vlsm s m) s m.
+                                  (fun s m => ~ has_been_directly_observed vlsm s m) s m.
 Proof.
   by apply proper_not_oracle_holds, oracle_trace_props_from_stepwise,
     has_been_directly_observed_stepwise_props.
@@ -1919,7 +1919,7 @@ Definition sender_safety_prop : Prop :=
   (Hsender : sender m = Some v),
   forall (j : index)
          (Hdif : j <> A v),
-         ~can_emit (pre_loaded_with_all_messages_vlsm (IM j)) m.
+         ~ can_emit (pre_loaded_with_all_messages_vlsm (IM j)) m.
 
 (**
   An alternative, possibly friendlier, formulation. Note that it is
@@ -1979,7 +1979,7 @@ Definition sender_nontriviality_prop : Prop :=
   sender m = Some v.
 
 Definition no_initial_messages_in_IM_prop : Prop :=
-  forall i m, ~vinitial_message_prop (IM i) m.
+  forall i m, ~ vinitial_message_prop (IM i) m.
 
 Lemma composite_no_initial_valid_messages_emitted_by_sender
     (can_emit_signed : channel_authentication_prop)
@@ -2605,7 +2605,7 @@ Qed.
 Definition cannot_resend_message_stepwise_prop : Prop :=
   forall l s oim s' m,
     input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s, oim) (s', Some m) ->
-    ~has_been_sent X s m /\ ~has_been_received X s' m.
+    ~ has_been_sent X s m /\ ~ has_been_received X s' m.
 
 Lemma cannot_resend_received_message_in_future
   (Hno_resend : cannot_resend_message_stepwise_prop)

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -656,7 +656,7 @@ Proof.
   exists is, tr.
   split; [| done].
   revert Htr.
-  unfold pre_vlsm;clear.
+  unfold pre_vlsm; clear.
   destruct vlsm as (T, M).
   by apply VLSM_incl_finite_valid_trace_init_to, vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
@@ -681,7 +681,7 @@ Proof.
   specialize (Hsm is tr).
   spec Hsm; [| done].
   revert Htr.
-  unfold pre_vlsm;clear.
+  unfold pre_vlsm; clear.
   destruct vlsm as (T, M).
   by apply VLSM_incl_finite_valid_trace_init_to, vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
@@ -967,9 +967,9 @@ Proof.
   intros s Hinit m Horacle.
   assert (Hproto : valid_state_prop (pre_loaded_with_all_messages_vlsm vlsm) s)
     by (apply initial_state_is_valid; done).
-  apply Horacle_all_have in Horacle;[| done].
+  apply Horacle_all_have in Horacle; [| done].
   specialize (Horacle s nil).
-  eapply Exists_nil;apply Horacle;clear Horacle.
+  eapply Exists_nil; apply Horacle; clear Horacle.
   by split; [constructor |].
 Qed.
 
@@ -1636,7 +1636,7 @@ Definition composite_message_selector : message -> composite_transition_item IM 
 Proof.
   intros msg [[i li] input s output].
   apply (message_selectors i msg).
-  exact {|l:=li;input:=input;destination:=s i;output:=output|}.
+  exact {|l:=li; input:=input; destination:=s i; output:=output|}.
 Defined.
 
 Definition composite_oracle : composite_state IM -> message -> Prop :=
@@ -1663,7 +1663,7 @@ Proof.
       apply (input_valid_transition_preloaded_project_any j) in Hproto.
       by destruct Hproto as [|(lj & Hlj & _)]; [left | right; congruence].
     }
-    apply input_valid_transition_preloaded_project_active in Hproto;simpl in Hproto.
+    apply input_valid_transition_preloaded_project_active in Hproto; simpl in Hproto.
     apply (oracle_step_update (stepwise_props i)) with (msg:=msg) in Hproto.
     split.
     + intros [j Hj].
@@ -2660,7 +2660,7 @@ Proof.
   - rapply @finite_valid_trace_from_empty.
     by apply initial_state_is_valid.
   - assert (trace_received_not_sent_before_or_after_invariant tr P) as Htrm'.
-    { intros m [Hrecv Hsend]. apply (Htrm m);clear Htrm.
+    { intros m [Hrecv Hsend]. apply (Htrm m); clear Htrm.
       split; [by apply Exists_app; left |].
       contradict Hsend.
       unfold trace_has_message in Hsend.
@@ -2669,7 +2669,7 @@ Proof.
       cut (oom <> Some m); [by itauto |].
       intros ->.
       cut (has_been_received X sf m); [by apply (Hno_resend _ _ _ _ _ Hx) |].
-      apply (has_been_received_step_update Hx);right.
+      apply (has_been_received_step_update Hx); right.
       erewrite oracle_partial_trace_update.
       - by left.
       - by apply has_been_received_stepwise_props.
@@ -2677,7 +2677,7 @@ Proof.
     }
     specialize (IHHtr Htrm').
     apply (extend_right_finite_trace_from _ IHHtr).
-    repeat split;try apply Hx;
+    repeat split; try apply Hx;
     [by apply finite_valid_trace_last_pstate |].
     destruct iom as [m |]; [| by apply option_valid_message_None].
     (*
@@ -2692,12 +2692,12 @@ Proof.
       right. apply Htrm.
       split.
       * by apply Exists_app; right; apply Exists_cons; left.
-      * intro Hsent;destruct Hnot_sent.
+      * intro Hsent; destruct Hnot_sent.
         unfold trace_has_message in Hsent.
         rewrite Exists_app, Exists_cons, Exists_nil in Hsent.
         destruct Hsent as [Hsent | [[= ->] | []]]; [done | exfalso].
         apply Hno_resend in Hx as Hx'.
-        apply (proj2 Hx');clear Hx'.
+        apply (proj2 Hx'); clear Hx'.
         by rewrite (has_been_received_step_update Hx); left.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -228,7 +228,7 @@ Context
   .
 
 Lemma equivocators_composition_for_directly_observed_index_incl_embedding
-  (s: state)
+  (s : state)
   : VLSM_embedding
     (equivocators_composition_for_directly_observed IM indices1 s)
     (equivocators_composition_for_directly_observed IM indices2 s)
@@ -414,7 +414,7 @@ Proof.
 Qed.
 
 #[local] Lemma fixed_input_valid_transition_sub_projection_helper
-  (Hs_pr: valid_state_prop (equivocators_composition_for_sent IM equivocators base_s)
+  (Hs_pr : valid_state_prop (equivocators_composition_for_sent IM equivocators base_s)
     (composite_state_sub_projection IM (elements equivocators) s))
   l
   (e : sub_index_prop (elements equivocators) (projT1 l))
@@ -446,7 +446,7 @@ Qed.
 
 (** See the lemma [fixed_output_has_strong_fixed_equivocation] below. *)
 #[local] Lemma fixed_output_has_strong_fixed_equivocation_helper
-  (Hs_pr: valid_state_prop (equivocators_composition_for_sent IM equivocators base_s)
+  (Hs_pr : valid_state_prop (equivocators_composition_for_sent IM equivocators base_s)
     (composite_state_sub_projection IM (elements equivocators) s))
   sf
   (Hfuture : in_futures PreFree sf base_s)
@@ -486,9 +486,9 @@ End sec_fixed_finite_valid_trace_sub_projection_helper_lemmas.
 *)
 Lemma fixed_finite_valid_trace_sub_projection_helper
   si s tr
-  (Htr: finite_valid_trace_init_to Fixed si s tr)
+  (Htr : finite_valid_trace_init_to Fixed si s tr)
   base_s
-  (Hfuture: in_futures PreFree s base_s)
+  (Hfuture : in_futures PreFree s base_s)
   : finite_valid_trace_from_to (equivocators_composition_for_sent IM equivocators base_s)
     (composite_state_sub_projection IM (elements equivocators) si)
     (composite_state_sub_projection IM (elements equivocators) s)
@@ -576,7 +576,7 @@ Qed.
 Lemma fixed_directly_observed_has_strong_fixed_equivocation f
   (Hf : valid_state_prop Fixed f)
   m
-  (Hobs: composite_has_been_directly_observed IM f m)
+  (Hobs : composite_has_been_directly_observed IM f m)
   : strong_fixed_equivocation IM equivocators f m.
 Proof.
   apply (VLSM_incl_valid_state Fixed_incl_Preloaded) in Hf as Hfuture.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -457,7 +457,7 @@ Proof.
   destruct (decide (projT1 l ∈ elements equivocators)).
   - apply
       (fixed_input_valid_transition_sub_projection_helper Hs_pr _ e) in Ht.
-    by right; eexists _,_,_.
+    by right; eexists _, _, _.
   - left.
     exists (projT1 l). split; [done |].
     apply (VLSM_projection_in_futures
@@ -515,7 +515,7 @@ Proof.
     split; cycle 1.
     + intros m Hobs.
       eapply @has_been_directly_observed_step_update with (msg := m) (vlsm := Free) in Hpre_t.
-      apply composite_has_been_directly_observed_free_iff,Hpre_t in Hobs.
+      apply composite_has_been_directly_observed_free_iff, Hpre_t in Hobs.
       destruct Hobs as [Hitem | Hobs]
       ; [| by apply composite_has_been_directly_observed_free_iff, Htr_obs in Hobs].
       apply valid_trace_last_pstate in Htr.
@@ -595,9 +595,9 @@ Proof.
   destruct Hsf as [tr Htr].
   apply finite_valid_trace_from_to_complete_left in Htr as [is [trs [Htr Hs]]].
   apply fixed_finite_valid_trace_sub_projection in Htr as Hpr_tr.
-  apply proj1, finite_valid_trace_from_to_app_split,proj1, valid_trace_forget_last in Htr.
+  apply proj1, finite_valid_trace_from_to_app_split, proj1, valid_trace_forget_last in Htr.
   rewrite (finite_trace_sub_projection_app IM (elements equivocators)) in Hpr_tr.
-  apply proj1, finite_valid_trace_from_to_app_split,proj1, valid_trace_last_pstate in Hpr_tr.
+  apply proj1, finite_valid_trace_from_to_app_split, proj1, valid_trace_last_pstate in Hpr_tr.
   subst s. simpl.
   by rewrite <- (finite_trace_sub_projection_last_state IM _ _ _ _ Htr).
 Qed.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -184,7 +184,7 @@ Qed.
 Lemma strong_fixed_equivocation_subsumption s m
   : strong_fixed_equivocation s m -> fixed_equivocation s m.
 Proof.
-  intros [Hobs | Hemit]; [left|right].
+  intros [Hobs | Hemit]; [left | right].
   - by apply sent_by_non_equivocating_are_directly_observed.
   - revert Hemit. apply VLSM_incl_can_emit.
     by apply Equivocators_Strong_Fixed_incl.
@@ -582,7 +582,7 @@ Proof.
   apply (VLSM_incl_valid_state Fixed_incl_Preloaded) in Hf as Hfuture.
   apply in_futures_refl in Hfuture.
   apply valid_state_has_trace in Hf as [is [tr Htr]].
-  eapply fixed_finite_valid_trace_sub_projection_helper in Htr as Htr_pr; [|done].
+  eapply fixed_finite_valid_trace_sub_projection_helper in Htr as Htr_pr; [| done].
   by apply Htr_pr.
 Qed.
 
@@ -833,7 +833,7 @@ Proof.
     intros s om [Hv Hc].
     split.
     + by cbn; rewrite lift_sub_state_to_neq.
-    + destruct om as [m|]; [| done].
+    + destruct om as [m |]; [| done].
       by apply lift_sub_state_to_strong_fixed_equivocation.
   - intros [i liX] lY.
     unfold remove_equivocating_state_project;
@@ -931,7 +931,7 @@ Proof.
     + destruct Hv as [_ [_ [Hv _]]]; revert Hv; destruct l as (i, li).
       destruct_dec_sig i j Hj Heq; subst i; cbn; unfold sub_IM; cbn.
       by rewrite lift_sub_state_to_eq with (Hi := Hj).
-    + destruct om as [m|]; [| done]; cbn.
+    + destruct om as [m |]; [| done]; cbn.
       destruct Hv as (_ & Hm & _).
       apply emitted_messages_are_valid_iff in Hm.
       destruct Hm as [[Hinit | Hobs] | Hemit].

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -1053,10 +1053,10 @@ Context
   (non_equivocators := list_to_set (enum index) ∖ equivocators)
   (Free := free_composite_vlsm IM)
   (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
-  (FixedNonEquivocating:= pre_induced_sub_projection IM (elements non_equivocators)
+  (FixedNonEquivocating := pre_induced_sub_projection IM (elements non_equivocators)
                                 (fixed_equivocation_constraint IM equivocators))
   (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
-  (StrongFixedNonEquivocating:= pre_induced_sub_projection IM (elements non_equivocators)
+  (StrongFixedNonEquivocating := pre_induced_sub_projection IM (elements non_equivocators)
                                 (strong_fixed_equivocation_constraint IM equivocators))
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
   .

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -768,7 +768,7 @@ Lemma lift_sub_state_to_sent_by_non_equivocating_iff s eqv_is m
   : sent_by_non_equivocating IM equivocators s m <->
     sent_by_non_equivocating IM equivocators (lift_sub_state_to IM (elements equivocators) s eqv_is) m.
 Proof.
-  by split; intros [i [Hi Hsent]]; exists i; split; [done | | done | ]
+  by split; intros [i [Hi Hsent]]; exists i; split; [done | | done |]
   ; revert Hsent; rewrite lift_sub_state_to_neq.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation/FullNode.v
+++ b/theories/VLSM/Core/Equivocation/FullNode.v
@@ -113,7 +113,7 @@ Lemma full_node_condition_for_admissible_equivocators_subsumption
       full_node_condition_for_admissible_equivocators
       full_node_condition_for_admissible_equivocators_alt.
 Proof.
-  intros l (s, [m|]) [Hs [_ [_ Hc]]]; [| done].
+  intros l (s, [m |]) [Hs [_ [_ Hc]]]; [| done].
   destruct Hc as [Hno_equiv | Hfull]; [by left |].
   right.
   destruct Hfull as [i [Hi Hfull]].

--- a/theories/VLSM/Core/Equivocation/FullNode.v
+++ b/theories/VLSM/Core/Equivocation/FullNode.v
@@ -89,8 +89,8 @@ Definition full_node_condition_for_admissible_equivocators_alt
 Lemma node_generated_without_further_equivocation_weaken
   (i : index)
   (Hno_resend : cannot_resend_message_stepwise_prop (IM i))
-  (s: composite_state IM)
-  (Hs: valid_state_prop
+  (s : composite_state IM)
+  (Hs : valid_state_prop
      (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)) s)
   (m : message)
   (Hsmi : node_generated_without_further_equivocation s m i)

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -188,7 +188,7 @@ Context
   (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
   (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
-  (Hlimited : (sum_weights equivocators <= threshold)%R )
+  (Hlimited : (sum_weights equivocators <= threshold)%R)
   (sender : message -> option index)
   (Hsender_safety : sender_safety_alt_prop IM (fun i => i) sender)
   `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -222,7 +222,7 @@ Proof.
   destruct Hvs' as [m0 [Hsender0 [pre [item [suf [Heqtr [Hm0 Heqv]]]]]]].
   rewrite Heqtr in Htr.
   destruct Htr as [Htr Hinit].
-  change (pre ++ item::suf) with (pre ++ [item] ++ suf) in Htr.
+  change (pre ++ item:: suf) with (pre ++ [item] ++ suf) in Htr.
   apply (finite_valid_trace_from_to_app_split StrongFixed) in Htr.
   destruct Htr as [Hpre Hitem].
   apply (VLSM_incl_finite_valid_trace_from_to StrongFixedinclPreFree) in Hpre as Hpre_pre.

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -222,7 +222,7 @@ Proof.
   destruct Hvs' as [m0 [Hsender0 [pre [item [suf [Heqtr [Hm0 Heqv]]]]]]].
   rewrite Heqtr in Htr.
   destruct Htr as [Htr Hinit].
-  change (pre ++ item:: suf) with (pre ++ [item] ++ suf) in Htr.
+  change (pre ++ item :: suf) with (pre ++ [item] ++ suf) in Htr.
   apply (finite_valid_trace_from_to_app_split StrongFixed) in Htr.
   destruct Htr as [Hpre Hitem].
   apply (VLSM_incl_finite_valid_trace_from_to StrongFixedinclPreFree) in Hpre as Hpre_pre.

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -68,7 +68,7 @@ Proof.
     as [[[is His] ->] | (l & [s' om'] & om & [(_ & _ & _ & Hv) Ht])]; simpl.
   - exists ∅.
     + by intros v Hv; contradict Hv; apply Hno_initial_equivocation.
-    + rewrite sum_weights_empty; [|done].
+    + rewrite sum_weights_empty; [| done].
       by apply (rt_positive (H6 := H6)).
   - by cbv in Hv, Ht; rewrite Ht in Hv.
 Qed.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -212,7 +212,7 @@ Proof.
   - cut (valid_message_prop (equivocators_composition_for_sent IM equivocators s) dm).
     {
       intro Hsent_comp; apply emitted_messages_are_valid_iff in Hsent_comp
-        as [[[sub_j [[_im Him] Heqim]] | ] | ]
+        as [[[sub_j [[_im Him] Heqim]] |] |]
       ; [| by left | by right].
       destruct_dec_sig sub_j j Hj Heqsub_j; subst.
       clear -Him no_initial_messages_in_IM; contradict Him.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -41,12 +41,12 @@ Definition msg_dep_fixed_set_equivocation_vlsm : VLSM message :=
   composite_vlsm IM msg_dep_fixed_set_equivocation_constraint.
 
 Lemma messages_with_valid_dependences_can_be_emitted s dm
-  (Hdepm:
+  (Hdepm :
     forall dm0, msg_dep_rel message_dependencies dm0 dm ->
     valid_message_prop (equivocators_composition_for_sent IM equivocators s) dm0)
-  (dm_i: index)
-  (Hdm_i: dm_i ∈ equivocators)
-  (Hemitted: can_emit (pre_loaded_with_all_messages_vlsm (IM dm_i)) dm)
+  (dm_i : index)
+  (Hdm_i : dm_i ∈ equivocators)
+  (Hemitted : can_emit (pre_loaded_with_all_messages_vlsm (IM dm_i)) dm)
   : can_emit (equivocators_composition_for_sent IM equivocators s) dm.
 Proof.
   eapply sub_valid_preloaded_lifts_can_be_emitted, message_dependencies_are_sufficient.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -160,7 +160,7 @@ Proof.
   apply can_emit_iff.
   apply (VLSM_projection_input_valid_transition
     (single_equivocator_projection s i Hi)) with (lY := li) in HtX
-  ; [by eexists _,_,_ |].
+  ; [by eexists _, _, _ |].
   unfold sub_label_element_project; cbn.
   by rewrite decide_True_pi with eq_refl.
 Qed.

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -134,7 +134,7 @@ Context
 
 Definition not_directly_observed_happens_before_dependencies (s : composite_state IM) (m : message)
   : Cm :=
-  filter (fun dm => ~composite_has_been_directly_observed IM s dm) (full_message_dependencies m).
+  filter (fun dm => ~ composite_has_been_directly_observed IM s dm) (full_message_dependencies m).
 
 Definition msg_dep_coequivocating_senders (s : composite_state IM) (m : message)
   : Cv :=

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -480,7 +480,7 @@ Lemma msg_dep_fixed_limited_equivocation_witnessed
         (type Limited) (composite_type IM) Datatypes.id original_state
         tr).
 Proof.
-  repeat split; [..| by apply Htr].
+  repeat split; [.. | by apply Htr].
   - by eapply coeqv_limited_equivocation_state_not_heavy,
             finite_valid_trace_last_pstate, Htr.
   - apply valid_trace_add_default_last in Htr.
@@ -520,7 +520,7 @@ Proof.
         intro; rewrite !elem_of_elements.
         by destruct iom as [im |]; [apply union_subseteq_l |].
       * destruct iom as [im |]
-        ; [apply option_valid_message_Some|apply option_valid_message_None].
+        ; [apply option_valid_message_Some | apply option_valid_message_None].
         destruct (decide (composite_has_been_directly_observed IM (original_state s) im))
               as [Hobs | Hnobs].
         -- eapply composite_directly_observed_valid; [| done].

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -59,7 +59,7 @@ Context
   `{HasBeenSentCapability message X}
   `{HasBeenDirectlyObservedCapability message X}
   (Henforced : forall l s om, input_valid (pre_loaded_with_all_messages_vlsm X) l (s, om) ->
-    no_equivocations X l (s,om))
+    no_equivocations X l (s, om))
   .
 
 (**
@@ -81,7 +81,7 @@ Proof.
 Qed.
 
 Lemma directly_observed_were_sent_preserved l s im s' om:
-  input_valid_transition X l (s,im) (s',om) ->
+  input_valid_transition X l (s, im) (s', om) ->
   directly_observed_were_sent s ->
   directly_observed_were_sent s'.
 Proof.

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -55,7 +55,7 @@ Section sec_no_equivocation_invariants.
 
 Context
   message
-  (X: VLSM message)
+  (X : VLSM message)
   `{HasBeenSentCapability message X}
   `{HasBeenDirectlyObservedCapability message X}
   (Henforced : forall l s om, input_valid (pre_loaded_with_all_messages_vlsm X) l (s, om) ->
@@ -69,10 +69,10 @@ Context
   the same state, too.
 *)
 
-Definition directly_observed_were_sent (s: state) : Prop :=
+Definition directly_observed_were_sent (s : state) : Prop :=
   forall msg, has_been_directly_observed X s msg -> has_been_sent X s msg.
 
-Lemma directly_observed_were_sent_initial s:
+Lemma directly_observed_were_sent_initial s :
   vinitial_state_prop X s ->
   directly_observed_were_sent s.
 Proof.
@@ -80,7 +80,7 @@ Proof.
   by apply has_been_directly_observed_no_inits in Hsend.
 Qed.
 
-Lemma directly_observed_were_sent_preserved l s im s' om:
+Lemma directly_observed_were_sent_preserved l s im s' om :
   input_valid_transition X l (s, im) (s', om) ->
   directly_observed_were_sent s ->
   directly_observed_were_sent s'.
@@ -206,13 +206,13 @@ Section sec_composite_no_equivocation_invariants.
 Context
   `{forall i, HasBeenReceivedCapability (IM i)}
   (X := composite_vlsm IM constraint)
-  (Hsubsumed: preloaded_constraint_subsumption IM constraint composite_no_equivocations)
+  (Hsubsumed : preloaded_constraint_subsumption IM constraint composite_no_equivocations)
   .
 
-Definition composite_directly_observed_were_sent (s: state) : Prop :=
+Definition composite_directly_observed_were_sent (s : state) : Prop :=
   forall msg, composite_has_been_directly_observed IM s msg -> composite_has_been_sent IM s msg.
 
-Lemma composite_directly_observed_were_sent_invariant s:
+Lemma composite_directly_observed_were_sent_invariant s :
   valid_state_prop X s ->
   composite_directly_observed_were_sent s.
 Proof.

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -93,7 +93,7 @@ Proof.
   specialize (Henforced l s (Some msg)).
   rewrite (has_been_sent_step_update Hptrans).
   destruct Hptrans as [Hv _].
-  destruct Hobs as [[Hin|Hout]|Hobs]; subst.
+  destruct Hobs as [[Hin | Hout] | Hobs]; subst.
   - (* by [no_equivocations], the incoming message [im] was previously sent *)
     specialize (Henforced Hv).
     by destruct Henforced; [right |].
@@ -220,7 +220,7 @@ Proof.
   rewrite composite_has_been_directly_observed_sent_received_iff.
   intros Hobs.
   cut (has_been_sent X s m); [done |].
-  apply (directly_observed_were_sent_invariant message X); [|done ..].
+  apply (directly_observed_were_sent_invariant message X); [| done ..].
   by intros l s0 om; apply Hsubsumed.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -43,7 +43,7 @@ Definition item_equivocating_in_trace
   (item : composite_transition_item IM)
   (tr : list (composite_transition_item IM))
   : Prop
-  := from_option (fun m => ~trace_has_message (field_selector output) m tr) False (input item).
+  := from_option (fun m => ~ trace_has_message (field_selector output) m tr) False (input item).
 
 #[local] Instance item_equivocating_in_trace_dec : RelDecision item_equivocating_in_trace.
 Proof.
@@ -154,7 +154,7 @@ Definition is_equivocating_tracewise
   exists prefix elem suffix (lprefix := finite_trace_last is prefix),
   tr = prefix ++ elem :: suffix
   /\ input elem = Some m
-  /\ ~has_been_sent (IM j) (lprefix j) m.
+  /\ ~ has_been_sent (IM j) (lprefix j) m.
 
 (**
   A possibly friendlier version using a previously defined primitive.

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -235,7 +235,7 @@ Proof.
   destruct Heqv as [m [Hv [prefix [item [suffix [Heq Heqv]]]]]].
   exists m. split; [done |]. exists prefix.
   destruct_list_last suffix suffix' item' Heqsuffix.
-  { exfalso. subst. apply app_inj_tail,proj2 in Heq. subst item. apply proj1 in Heqv. simpl in Heqv.
+  { exfalso. subst. apply app_inj_tail, proj2 in Heq. subst item. apply proj1 in Heqv. simpl in Heqv.
     subst om. simpl in n. congruence. }
   exists item, suffix'. split; [| done].
   replace (prefix ++ item :: suffix' ++ [item']) with ((prefix ++ item :: suffix') ++ [item']) in Heq.
@@ -275,7 +275,7 @@ Proof.
   subst.
   clear -Hnbs_m Htr.
   apply preloaded_finite_valid_trace_init_to_projection with (j := A v) in Htr as Htrv.
-  apply proj1, finite_valid_trace_from_to_app_split,proj1
+  apply proj1, finite_valid_trace_from_to_app_split, proj1
     , preloaded_finite_valid_trace_from_to_projection with (j := A v)
     , finite_valid_trace_from_to_last in Htr.
   rewrite (VLSMTotalProjection.VLSM_projection_finite_trace_project_app

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -238,7 +238,7 @@ Lemma equivocating_validators_witness_last_char
     (exists m, om = Some m /\
      exists v, sender m = Some v /\
      v ∉ equivocating_validators s /\
-     equivocating_validators s' ≡@{Cv} {[ v ]} ∪ (equivocating_validators s) /\
+     equivocating_validators s' ≡@{Cv} {[v]} ∪ (equivocating_validators s) /\
      forall (is : composite_state IM) (tr : list transition_item),
         finite_valid_trace_init_to PreFree is s tr ->
         trace_witnessing_equivocation_prop is tr ->
@@ -417,7 +417,7 @@ Lemma strong_trace_witnessing_equivocation_prop_extend_neq
   (Hwneq: ¬ trace_has_message (field_selector output) msg tr)
   v
   (Hsender: sender msg = Some v)
-  (Hneq: equivocating_validators (destination item) ≡@{Cv} {[ v ]} ∪ (equivocating_validators s))
+  (Hneq: equivocating_validators (destination item) ≡@{Cv} {[v]} ∪ (equivocating_validators s))
   : strong_trace_witnessing_equivocation_prop is (tr ++ [item]).
 Proof.
   intros prefix suffix Heq_tr''_item.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -238,7 +238,7 @@ Lemma equivocating_validators_witness_last_char
     (exists m, om = Some m /\
      exists v, sender m = Some v /\
      v ∉ equivocating_validators s /\
-     equivocating_validators s' ≡@{Cv} {[v]} ∪ (equivocating_validators s) /\
+     equivocating_validators s' ≡@{Cv} {[ v ]} ∪ (equivocating_validators s) /\
      forall (is : composite_state IM) (tr : list transition_item),
         finite_valid_trace_init_to PreFree is s tr ->
         trace_witnessing_equivocation_prop is tr ->
@@ -416,7 +416,7 @@ Lemma strong_trace_witnessing_equivocation_prop_extend_neq
   (Hwneq : ¬ trace_has_message (field_selector output) msg tr)
   v
   (Hsender : sender msg = Some v)
-  (Hneq : equivocating_validators (destination item) ≡@{Cv} {[v]} ∪ (equivocating_validators s))
+  (Hneq : equivocating_validators (destination item) ≡@{Cv} {[ v ]} ∪ (equivocating_validators s))
   : strong_trace_witnessing_equivocation_prop is (tr ++ [item]).
 Proof.
   intros prefix suffix Heq_tr''_item.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -252,7 +252,7 @@ Proof.
     in Hwitness as Hincl
   ; [| by split].
   remember (finite_trace_last is tr) as s.
-  destruct (option_bind _ _ sender om) as [v |] eqn:Heq_v.
+  destruct (option_bind _ _ sender om) as [v |] eqn: Heq_v.
   - destruct om as [m |]; [| by inversion Heq_v]. simpl in Heq_v.
     destruct (decide (set_eq (elements (equivocating_validators s)) (elements (equivocating_validators s')))).
     + apply set_eq_fin_set in s0; left; split; [done |].
@@ -762,7 +762,7 @@ Proof.
     spec Heqv; [by apply app_nil_r |].
     destruct iom as [im |]; [| by repeat split; auto using option_valid_message_None].
     apply Free_has_sender in Hiom as _Hsender.
-    destruct (sender im) as [v |] eqn:Hsender; [| by congruence].
+    destruct (sender im) as [v |] eqn: Hsender; [| by congruence].
     clear _Hsender.
     specialize (Heqv v).
     rewrite finite_trace_last_is_last in Heqv.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -242,8 +242,7 @@ Lemma equivocating_validators_witness_last_char
      forall (is : composite_state IM) (tr : list transition_item),
         finite_valid_trace_init_to PreFree is s tr ->
         trace_witnessing_equivocation_prop is tr ->
-        ~ trace_has_message (field_selector output) m tr
-    ).
+        ~ trace_has_message (field_selector output) m tr).
 Proof.
   destruct Htr_item as [Htr Hinit].
   apply finite_valid_trace_from_to_app_split in Htr.
@@ -390,8 +389,8 @@ Proof.
           apply valid_trace_last_pstate in Htr' as Htr'_lst.
           destruct
             (has_been_sent_consistency Free
-              _ Htr'_lst m
-            ) as [Hconsistency _].
+              _ Htr'_lst m)
+            as [Hconsistency _].
           spec Hconsistency; [by exists is, tr', Htr' |].
           by specialize (Hconsistency is' tr'' Htr'').
         }

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -101,7 +101,7 @@ Proof.
   rewrite <- elem_of_elements.
   replace (elements (equivocating_validators s)) with (@nil validator).
   simpl.
-  split; [by inversion 1|].
+  split; [by inversion 1 |].
   intros [m [_ Hmsg]].
   - by elim (no_equivocation_in_empty_trace PreFree m).
   - by symmetry; apply elements_empty_iff, equivocating_validators_empty_in_initial_state.
@@ -186,7 +186,7 @@ Proof.
   destruct (transition_is_equivocating_tracewise_char IM A sender  _ _ _ _ _ Ht _ Hv)
     as [| Hom];
     [by contradict Hnv; apply equivocating_validators_is_equivocating_tracewise_iff |].
-  destruct om as [m|]; simpl in Hom; [| by congruence].
+  destruct om as [m |]; simpl in Hom; [| by congruence].
   exists m; split_and!; [done.. |].
   intros is tr [Htr Hinit] Hwitness.
   specialize (extend_right_finite_trace_from_to _ Htr Ht) as Htr'.
@@ -253,8 +253,8 @@ Proof.
     in Hwitness as Hincl
   ; [| by split].
   remember (finite_trace_last is tr) as s.
-  destruct (option_bind _ _ sender om) as [v|] eqn:Heq_v.
-  - destruct om as [m|]; [| by inversion Heq_v]. simpl in Heq_v.
+  destruct (option_bind _ _ sender om) as [v |] eqn:Heq_v.
+  - destruct om as [m |]; [| by inversion Heq_v]. simpl in Heq_v.
     destruct (decide (set_eq (elements (equivocating_validators s)) (elements (equivocating_validators s')))).
     + apply set_eq_fin_set in s0; left; split; [done |].
       by apply
@@ -268,14 +268,14 @@ Proof.
       {
         setoid_rewrite <- elem_of_elements.
         apply Exists_exists.
-        apply neg_Forall_Exists_neg; [intro; apply elem_of_list_dec|].
+        apply neg_Forall_Exists_neg; [intro; apply elem_of_list_dec |].
         intro all. elim n.
         split; [| by rewrite Forall_forall in all].
         by unfold set_eq, subseteq, list_subseteq; setoid_rewrite elem_of_elements.
       }
       destruct Hv as [v' [Heqv Hneqv]].
       apply Honly_v in Heqv as Heq_v'.
-      destruct Heq_v' as [|[_m [Heq_m [Heq_v' Hweqv]]]]; [by subst |].
+      destruct Heq_v' as [| [_m [Heq_m [Heq_v' Hweqv]]]]; [by subst |].
       inversion Heq_m. subst _m. clear Heq_m.
       assert (v' = v) by congruence. subst v'. clear Heq_v'.
       split; [done |]. split; [| by subst].
@@ -286,7 +286,7 @@ Proof.
         [by right | left].
         apply elem_of_singleton.
         by apply Honly_v in Hv';
-          destruct Hv' as [|[_m [Heq_m [Heq_v' _]]]]; [by subst |]; congruence.
+          destruct Hv' as [| [_m [Heq_m [Heq_v' _]]]]; [by subst |]; congruence.
       * by apply elem_of_union in Hv' as [Heq_v' | Hs'0]
         ; [by apply elem_of_singleton in Heq_v'; subst v' | by apply Hincl].
   - left; split.
@@ -522,7 +522,7 @@ Proof.
       as [[Heq Hwitness'] | [msg [Heq_om [v [Hsender [Hnv Hneq]]]]]].
     + specialize (IHn (length tr')).
       rewrite app_length in Hn. simpl in Hn.
-      spec IHn; [lia|].
+      spec IHn; [lia |].
       specialize (IHn is tr').
       spec IHn; [by subst m; setoid_rewrite Heq |].
       specialize (IHn eq_refl).
@@ -763,7 +763,7 @@ Proof.
     spec Heqv; [by apply app_nil_r |].
     destruct iom as [im |]; [| by repeat split; auto using option_valid_message_None].
     apply Free_has_sender in Hiom as _Hsender.
-    destruct (sender im) as [v|] eqn:Hsender; [| by congruence].
+    destruct (sender im) as [v |] eqn:Hsender; [| by congruence].
     clear _Hsender.
     specialize (Heqv v).
     rewrite finite_trace_last_is_last in Heqv.

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -138,9 +138,9 @@ Qed.
   [trace_witnessing_equivocation_prop]erty.
 *)
 Lemma input_valid_transition_reflects_trace_witnessing_equivocation_prop
-  (is s: composite_state IM)
-  (tr: list (composite_transition_item IM))
-  (Htr: finite_valid_trace_init_to PreFree is s tr)
+  (is s : composite_state IM)
+  (tr : list (composite_transition_item IM))
+  (Htr : finite_valid_trace_init_to PreFree is s tr)
   (item : composite_transition_item IM)
   (Hwitness : trace_witnessing_equivocation_prop is (tr ++ [item]))
   (s' := destination item)
@@ -353,13 +353,13 @@ Qed.
 Lemma strong_trace_witnessing_equivocation_prop_extend_eq
   s
   is tr'
-  (Htr': finite_valid_trace_init_to PreFree is s tr')
+  (Htr' : finite_valid_trace_init_to PreFree is s tr')
   is' tr''
-  (Htr'': finite_valid_trace_init_to PreFree is' s tr'')
+  (Htr'' : finite_valid_trace_init_to PreFree is' s tr'')
   (Hprefix : strong_trace_witnessing_equivocation_prop is' tr'')
   item
   (Hwitness : trace_witnessing_equivocation_prop is (tr' ++ [item]))
-  (Heq: equivocating_validators s ≡@{Cv} equivocating_validators (destination item))
+  (Heq : equivocating_validators s ≡@{Cv} equivocating_validators (destination item))
   : strong_trace_witnessing_equivocation_prop is' (tr'' ++ [item]).
 Proof.
   intros prefix suffix Heq_tr''_item.
@@ -408,15 +408,15 @@ Qed.
 Lemma strong_trace_witnessing_equivocation_prop_extend_neq
   s
   is tr
-  (Htr: finite_valid_trace_init_to PreFree is s tr)
+  (Htr : finite_valid_trace_init_to PreFree is s tr)
   (Hprefix : strong_trace_witnessing_equivocation_prop is tr)
   item
   msg
   (Hmsg : input item = Some msg)
-  (Hwneq: ¬ trace_has_message (field_selector output) msg tr)
+  (Hwneq : ¬ trace_has_message (field_selector output) msg tr)
   v
-  (Hsender: sender msg = Some v)
-  (Hneq: equivocating_validators (destination item) ≡@{Cv} {[v]} ∪ (equivocating_validators s))
+  (Hsender : sender msg = Some v)
+  (Hneq : equivocating_validators (destination item) ≡@{Cv} {[v]} ∪ (equivocating_validators s))
   : strong_trace_witnessing_equivocation_prop is (tr ++ [item]).
 Proof.
   intros prefix suffix Heq_tr''_item.
@@ -671,9 +671,9 @@ Definition equivocating_validators_fixed_equivocation_constraint
 Lemma equivocators_can_emit_free m
   (Hmsg : valid_message_prop Free m)
   v
-  (Hsender: sender m = Some v)
+  (Hsender : sender m = Some v)
   sf
-  (Hequivocating_v: v ∈ equivocating_validators sf)
+  (Hequivocating_v : v ∈ equivocating_validators sf)
   l s
   (Hv : composite_valid IM l (s, Some m))
   : can_emit
@@ -723,7 +723,7 @@ Qed.
 
 Lemma strong_witness_has_fixed_equivocation is s tr
   (Htr : finite_valid_trace_init_to (free_composite_vlsm IM) is s tr)
-  (Heqv: strong_trace_witnessing_equivocation_prop (Cv := Ci) IM threshold Datatypes.id sender is tr)
+  (Heqv : strong_trace_witnessing_equivocation_prop (Cv := Ci) IM threshold Datatypes.id sender is tr)
   : finite_valid_trace_init_to (fixed_equivocation_vlsm_composition IM
       (equivocating_validators s)) is s tr.
 Proof.

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -143,7 +143,7 @@ Proof.
   apply valid_state_has_trace in Hpr_is as [is' [tr_is Hpr_is]].
   exists is', (tr_is ++ (VLSM_weak_embedding_finite_trace_project Hsimul tr)).
   destruct Hpr_is as [Hpr_is His'].
-  repeat split; [| done|].
+  repeat split; [| done |].
   - by eapply (finite_valid_trace_from_to_app (pre_loaded_with_all_messages_vlsm Y)).
   - apply Exists_app. right.
     apply Exists_exists in Hm as [item [Hitem Hm]].
@@ -425,7 +425,7 @@ Context
 Lemma can_emit_projection
   : can_emit PreFree m -> can_emit (pre_loaded_with_all_messages_vlsm (IM j)) m.
 Proof.
-  destruct (sender m) as [v|] eqn:Hsender; simpl in Hj; [| by congruence].
+  destruct (sender m) as [v |] eqn:Hsender; simpl in Hj; [| by congruence].
   apply Some_inj in Hj.
   specialize (Hsender_safety _ _ Hsender).
   intros [(s0, om0) [(i, li) [s1 Hemitted]]].

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -428,7 +428,7 @@ Proof.
   destruct (sender m) as [v|] eqn:Hsender; simpl in Hj; [| by congruence].
   apply Some_inj in Hj.
   specialize (Hsender_safety _ _ Hsender).
-  intros [(s0,om0) [(i, li) [s1 Hemitted]]].
+  intros [(s0, om0) [(i, li) [s1 Hemitted]]].
   specialize (preloaded_component_projection IM i) as Hproj.
   specialize (VLSM_projection_input_valid_transition Hproj (existT i li) li)
     as Htransition.
@@ -437,9 +437,9 @@ Proof.
   remember (s0 i) as s0i. clear s0 Heqs0i.
   remember (s1 i) as s1i. clear s1 Heqs1i.
   specialize (Hsender_safety i).
-  spec Hsender_safety; [by eexists _,_, _ |].
+  spec Hsender_safety; [by eexists _, _, _ |].
   rewrite Hsender_safety in Hj; subst.
-  by eexists _,_, _.
+  by eexists _, _, _.
 Qed.
 
 End sec_sender_safety_can_emit_projection.

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -425,7 +425,7 @@ Context
 Lemma can_emit_projection
   : can_emit PreFree m -> can_emit (pre_loaded_with_all_messages_vlsm (IM j)) m.
 Proof.
-  destruct (sender m) as [v |] eqn:Hsender; simpl in Hj; [| by congruence].
+  destruct (sender m) as [v |] eqn: Hsender; simpl in Hj; [| by congruence].
   apply Some_inj in Hj.
   specialize (Hsender_safety _ _ Hsender).
   intros [(s0, om0) [(i, li) [s1 Hemitted]]].

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -152,7 +152,7 @@ Proof.
   intro Hsi. elim Hi. clear Hi. unfold is_singleton_state in *.
   simpl in *.
   destruct l as (j, lj).
-  destruct (vtransition (equivocator_IM j) lj (s0 j, iom)) as (sj', om') eqn:Htj.
+  destruct (vtransition (equivocator_IM j) lj (s0 j, iom)) as (sj', om') eqn: Htj.
   inversion Ht. subst. clear Ht.
   destruct (decide (i = j)); subst; state_update_simpl; [| done].
   by revert Hsi; apply equivocator_transition_reflects_singleton_state with iom oom lj.
@@ -188,7 +188,7 @@ Proof.
     cbn -[composite_transition].
     match goal with
       |- context [composite_transition equivocator_IM l ?som] =>
-      destruct (composite_transition equivocator_IM l som) eqn:Htrans
+      destruct (composite_transition equivocator_IM l som) eqn: Htrans
     end.
     apply equivocators_transition_cannot_decrease_state_size with (eqv := eqv) in Htrans.
     by cbn in *; lia.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -190,7 +190,7 @@ Proof.
       |- context [composite_transition equivocator_IM l ?som] =>
       destruct (composite_transition equivocator_IM l som) eqn:Htrans
     end.
-    apply equivocators_transition_cannot_decrease_state_size with (eqv:=eqv) in Htrans.
+    apply equivocators_transition_cannot_decrease_state_size with (eqv := eqv) in Htrans.
     by cbn in *; lia.
 Qed.
 

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -137,11 +137,11 @@ End sec_equivocating_indices_BasicEquivocation.
 *)
 Lemma equivocators_transition_preserves_equivocating_indices
   (index_listing : list index)
-  (s: composite_state equivocator_IM)
-  (iom oom: option message)
-  (l: composite_label equivocator_IM)
-  (s0: composite_state equivocator_IM)
-  (Ht: composite_transition equivocator_IM l (s0, iom) = (s, oom))
+  (s : composite_state equivocator_IM)
+  (iom oom : option message)
+  (l : composite_label equivocator_IM)
+  (s0 : composite_state equivocator_IM)
+  (Ht : composite_transition equivocator_IM l (s0, iom) = (s, oom))
   : equivocating_indices index_listing s0 ⊆ equivocating_indices index_listing s.
 Proof.
   intros i Hi.
@@ -160,7 +160,7 @@ Qed.
 
 Lemma equivocators_transition_cannot_decrease_state_size
   l s iom s' oom
-  (Ht: composite_transition equivocator_IM l (s, iom) = (s', oom))
+  (Ht : composite_transition equivocator_IM l (s, iom) = (s', oom))
   : forall eqv, equivocator_state_n (s eqv) <= equivocator_state_n (s' eqv).
 Proof.
   intro eqv.
@@ -463,7 +463,7 @@ Qed.
 Lemma equivocator_descriptors_update_twice
   (s : equivocator_descriptors)
   (i : index)
-  (si si': MachineDescriptor (IM i))
+  (si si' : MachineDescriptor (IM i))
   : equivocator_descriptors_update (equivocator_descriptors_update s i si) i si'
   = equivocator_descriptors_update s i si'.
 Proof.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -89,7 +89,7 @@ Proof.
   unfold eq_rect_r, eq_rect in Hpr; simpl in Hpr.
   match type of Hpr with
     (match ?exp with _ => _ end = _)
-    => destruct exp as [(oitemx, deqv')|] eqn: Hitem_pr; [| by congruence]
+    => destruct exp as [(oitemx, deqv') |] eqn: Hitem_pr; [| by congruence]
   end.
   simpl in Ht.
   destruct item. simpl in *. destruct l as (i, li). simpl in *.
@@ -266,7 +266,7 @@ Lemma exists_equivocators_transition_item_project
       ,
         proper_equivocator_descriptors equivocators' s
         /\ equivocators_transition_item_project equivocators item = Some
-          (Some ({| l := lx; input := input item; output := output item; destination := sx|}),
+          (Some ({| l := lx; input := input item; output := output item; destination := sx |}),
             equivocators').
 Proof.
   specialize
@@ -345,12 +345,12 @@ Proof.
   unfold equivocators_transition_item_project.
   rewrite Hoitemi. clear Hoitemi.
   destruct item. simpl in *. destruct l as (i, li). simpl in *.
-  destruct oitemi as [itemi'|]; eexists _; eexists _; (split; [done |])
+  destruct oitemi as [itemi' |]; eexists _; eexists _; (split; [done |])
   ; [| split; [done |]]
   ; [ destruct Hitemx as [[Hex Hli] [Hinputi [Houtputi [Hdestinationi Hdescriptori]]]]
-  ; rewrite Hli; subst; split; [ repeat split|]
+  ; rewrite Hli; subst; split; [ repeat split |]
     |]
-  ; [by exists Hex | apply equivocator_descriptors_update_eq |..]
+  ; [by exists Hex | apply equivocator_descriptors_update_eq | ..]
   ; intros
   ; match type of Ht with
     | (let (_, _) := ?t in _ ) = _ =>
@@ -453,7 +453,7 @@ Proof.
       (IM (projT1 (l item)))
       (composite_transition_item_projection equivocator_IM item)
       (eqv_descriptors (projT1 (l item))))
-    as [([itemi|], descriptori)|] eqn:Hpr_itemi
+    as [([itemi |], descriptori) |] eqn:Hpr_itemi
   ; [| by congruence..].
   inversion Hpr_item. subst. clear Hpr_item. simpl.
   repeat split.
@@ -509,24 +509,24 @@ Proof.
       as pr_tr.
     split.
     + intro Htr.
-      destruct pr_itrX_tr as [(tr1, e1)|] ; [| by inversion Htr].
+      destruct pr_itrX_tr as [(tr1, e1) |] ; [| by inversion Htr].
       specialize (IHtr tr1 e1). apply proj1 in IHtr. specialize (IHtr eq_refl).
       destruct IHtr as [trX [Hpr_tr Htr1]].
       rewrite Hpr_tr in *. rewrite Htr1 in *.
       simpl in Htr. simpl.
       destruct (equivocators_transition_item_project e1 a)
-        as [(oitem, eqv_descriptors'')|] eqn: Ha; [| by congruence].
+        as [(oitem, eqv_descriptors'') |] eqn: Ha; [| by congruence].
       by destruct oitem; inversion Htr; eexists _.
     + intros [trX [Htr HtrX']].
       subst trX'.
-      destruct pr_tr as [(tr1, e1)|]; [| by inversion Htr].
+      destruct pr_tr as [(tr1, e1) |]; [| by inversion Htr].
       specialize (IHtr (tr1 ++ itrX) e1). apply proj2 in IHtr.
       rewrite IHtr by (eexists _; done).
       simpl in *.
       destruct (equivocators_transition_item_project e1 a)
-        as [(oitem, odescriptor)|] eqn:Ha
+        as [(oitem, odescriptor) |] eqn:Ha
       ; [| done].
-      by destruct oitem as [item'|]; inversion Htr.
+      by destruct oitem as [item' |]; inversion Htr.
 Qed.
 
 Lemma equivocators_trace_project_folder_additive
@@ -577,7 +577,7 @@ Proof.
   match goal with
   |- fold_right _ ?r _ = _ <-> _ => remember r as r_sufX
   end.
-  destruct r_sufX as [(sufX, eqv_descriptors')|]
+  destruct r_sufX as [(sufX, eqv_descriptors') |]
   ; [
     | by rewrite equivocators_trace_project_fold_None; split;
       [intro contra; congruence | intros [preX [sufX [eqv_descriptors' [contra _]]]]; congruence]
@@ -620,9 +620,9 @@ Proof.
       as (trX' & xX & eqv_descriptors' & Hpr_x & Hpr_tr & Heq).
     simpl in Hpr_x.
     destruct (equivocators_transition_item_project eqv_descriptors x)
-      as [(ox, descriptorx)|] eqn:Hpr_x_item
+      as [(ox, descriptorx) |] eqn:Hpr_x_item
     ; [| by congruence].
-    destruct xX as [|xX _empty].
+    destruct xX as [| xX _empty].
     + destruct ox; [by congruence |].
       inversion Hpr_x. subst. clear Hpr_x.
       rewrite app_nil_r in  Heq. subst trX'.
@@ -672,7 +672,7 @@ Lemma equivocators_trace_project_app_inv
     tr = pre ++ suf.
 Proof.
   intro Hpr_tr.
-  destruct sufX as [|itemX sufX].
+  destruct sufX as [| itemX sufX].
   - rewrite app_nil_r in Hpr_tr.
     exists tr, [], eqv_descriptors.
     by rewrite app_nil_r.
@@ -708,14 +708,14 @@ Lemma equivocators_trace_project_preserves_equivocating_indices
 Proof.
   generalize dependent trX. generalize dependent descriptors.
   induction Htr using finite_valid_trace_from_to_rev_ind; [by inversion 2 |].
-  set (x := {|l := l|}).
+  set (x := {| l := l |}).
   intros.
   apply equivocators_trace_project_app_iff in Hproject_tr.
   destruct Hproject_tr as [preX [sufX [descriptors' [Hproject_x [Hproject_tr _]]]]].
   simpl in Hproject_x.
   destruct
     (equivocators_transition_item_project descriptors x)
-    as [(oitemx, _descriptors')|] eqn: Hpr_x ; [| by congruence].
+    as [(oitemx, _descriptors') |] eqn: Hpr_x ; [| by congruence].
   assert (_descriptors' = descriptors') as -> by (destruct oitemx; congruence).
   clear Hproject_x trX sufX.
 
@@ -752,7 +752,7 @@ Proof.
   generalize dependent descriptors.
   generalize dependent s.
   induction tr using rev_ind; intros.
-  - by inversion Hproject_tr; subst; destruct (idescriptors eqv); simpl; [|lia].
+  - by inversion Hproject_tr; subst; destruct (idescriptors eqv); simpl; [| lia].
   - apply finite_valid_trace_from_to_last in Htr as Heq_s.
     rewrite finite_trace_last_is_last in Heq_s. subst s.
     apply finite_valid_trace_from_to_app_split in Htr.
@@ -817,7 +817,7 @@ Proof.
   intros eqv Heqv. specialize (Hincl eqv Heqv).
   apply set_union_iff in Hincl.
   clear Heqv.
-  destruct Hincl as [|Heqv]; [done |].
+  destruct Hincl as [| Heqv]; [done |].
   specialize (Hdescriptors eqv).
   apply elem_of_list_filter in Heqv.
   destruct Heqv as [Heqv Hin].
@@ -854,7 +854,7 @@ Proof.
   - unfold equivocators_trace_project in Hproject_tr.
     rewrite fold_right_app in Hproject_tr.
     match type of Hproject_tr with
-    | fold_right _ ?i _ = _ => destruct i as [(projectx, final_descriptors')|] eqn:Hproject_x
+    | fold_right _ ?i _ = _ => destruct i as [(projectx, final_descriptors') |] eqn:Hproject_x
     end
     ; [| by rewrite equivocators_trace_project_fold_None in Hproject_tr; inversion Hproject_tr].
     apply equivocators_trace_project_folder_additive_iff in Hproject_tr.
@@ -869,7 +869,7 @@ Proof.
     { clear - Hproject_x Hproject_xi.
       simpl in *.
       destruct (equivocators_transition_item_project final_descriptors x)
-        as [(ox, final')|] eqn:Hpr_item_x
+        as [(ox, final') |] eqn:Hpr_item_x
       ; [| by congruence].
       unfold equivocators_transition_item_project in Hpr_item_x.
       destruct (decide (i = projT1 (l x))).
@@ -879,9 +879,9 @@ Proof.
         simpl in Hproject_xi.
         subst eqv_final.
         destruct (equivocator_vlsm_transition_item_project _ _ _)
-          as [(oitem', descriptor')|] eqn:Heqpr_item_x
+          as [(oitem', descriptor') |] eqn:Heqpr_item_x
         ; [| done].
-        destruct oitem' as [item'|]
+        destruct oitem' as [item' |]
         ; inversion Hproject_xi; subst descriptor' project_xi; clear Hproject_xi
         ; inversion Hpr_item_x; subst; clear Hpr_item_x
         ; inversion Hproject_x; subst; clear Hproject_x
@@ -904,9 +904,9 @@ Proof.
         inversion Hproject_xi. subst. clear Hproject_xi.
         destruct
           (equivocator_vlsm_transition_item_project _ _ _)
-          as [(oitem', descriptor')|] eqn:Heqpr_item_x
+          as [(oitem', descriptor') |] eqn:Heqpr_item_x
         ; [| done].
-        destruct oitem' as [item'|]
+        destruct oitem' as [item' |]
         ; inversion Hpr_item_x; subst; clear Hpr_item_x
         ; inversion Hproject_x; subst; clear Hproject_x
         ; state_update_simpl
@@ -944,7 +944,7 @@ Proof.
   simpl in Hproject_x.
   destruct
     (equivocators_transition_item_project descriptors x)
-    as [(oitemx, _descriptors')|] eqn: Hpr_x; [| by congruence].
+    as [(oitemx, _descriptors') |] eqn: Hpr_x; [| by congruence].
   assert (_descriptors' = descriptors') as -> by (destruct oitemx; congruence).
   clear Hproject_x trX sufX.
   destruct Hx as [(_ & _  & Hv & _) Ht].
@@ -993,14 +993,14 @@ Proof.
   destruct Hproperx as [Hproper' [Heq_final_descriptors' [Heq_ltr [Hex_new Hx]]]].
   specialize (IHtr _ Hproper').
   destruct IHtr as [trX' [initial_descriptors [Htr_project [Hproper_initial Hlst]]]].
-  destruct oitem as [item|].
+  destruct oitem as [item |].
   - simpl in Hitemx. destruct Hitemx as [Hl [Hinput [Houtput [Hdestination _]]]].
     specialize (Hx _ eq_refl).
     destruct Hx as [Hvx Htx].
     exists (trX' ++ [item]), initial_descriptors. subst foldx.
     by erewrite equivocators_trace_project_folder_additive, !finite_trace_last_is_last.
   - exists trX', initial_descriptors.
-    subst; split_and!; [done ..|].
+    subst; split_and!; [done .. |].
     by rewrite finite_trace_last_is_last; congruence.
 Qed.
 
@@ -1047,9 +1047,9 @@ Proof.
   | fold_right _ ?f _ = _ => remember f as project_x
   end.
   simpl in Heqproject_x.
-  destruct project_x as [(x', x_descriptors)|]
+  destruct project_x as [(x', x_descriptors) |]
   ; [| by rewrite equivocators_trace_project_fold_None in Hproject; congruence].
-  destruct (equivocators_transition_item_project final_descriptors x) as [(oitem', ditem')|]
+  destruct (equivocators_transition_item_project final_descriptors x) as [(oitem', ditem') |]
     eqn:Hproject_x
   ; [| by congruence].
   apply (equivocators_trace_project_folder_additive_iff tr x' x_descriptors initial_descriptors trX)
@@ -1066,11 +1066,11 @@ Proof.
   | context [equivocator_vlsm_transition_item_project ?X ?i ?c] =>
       remember (equivocator_vlsm_transition_item_project X i c)  as projecti
   end.
-  destruct projecti as [(oitem'', ditem'')|]; [| by congruence].
+  destruct projecti as [(oitem'', ditem'') |]; [| by congruence].
   unfold equivocator_vlsm_transition_item_project in Heqprojecti.
   unfold final_state in *. clear final_state.
   rewrite finite_trace_last_is_last. simpl.
-  destruct (final_descriptors (projT1 l)) as [sn| j] eqn:Hfinali.
+  destruct (final_descriptors (projT1 l)) as [sn | j] eqn:Hfinali.
   - inversion Heqprojecti. subst. clear Heqprojecti.
     inversion Hproject_x. subst; clear Hproject_x.
     inversion Heqproject_x. subst. clear Heqproject_x.
@@ -1096,7 +1096,7 @@ Proof.
     destruct (equivocator_transition _ _ _) as (si', om') eqn:Ht'.
     inversion Ht. subst om'. clear Ht.
     replace (s i) with si' in * by (subst; state_update_simpl; done).
-    destruct (equivocator_state_project si' j) as [si'j|] eqn:Hj; [| done].
+    destruct (equivocator_state_project si' j) as [si'j |] eqn:Hj; [| done].
     by destruct li as [ndi | idi li | idi li]
     ; destruct (decide _)
     ; inversion Heqprojecti; subst; clear Heqprojecti
@@ -1282,10 +1282,10 @@ Proof.
     exists initial_descriptors.
     split; [done |].
     specialize (Hpr_app initial_descriptors final_descriptors).
-    destruct oitem as [item|].
+    destruct oitem as [item |].
     + exists (trX ++ [item]).
       destruct HtrX as [HtrX HinitX].
-      repeat split; [..| done].
+      repeat split; [.. | done].
       * apply (Hpr_app (trX ++ [item])).
         exists trX, [item], final_descriptors'.
         by rewrite Hpr_x.
@@ -1344,7 +1344,7 @@ Proof.
   - intros Hpr_tr.
     case_decide; [| by congruence].
     destruct (equivocators_trace_project final_descriptors trX)
-      as [(_trY, initial_descriptors)|] eqn:Htr_project
+      as [(_trY, initial_descriptors) |] eqn:Htr_project
     ; [| by congruence].
     by inversion Hpr_tr; subst _trY; clear Hpr_tr; eauto.
   - intros [Hnot_equiv [initial_descriptors [Hpr_tr Hpr_s]]].
@@ -1476,20 +1476,20 @@ Proof.
   rewrite IHtr.
   f_equal.
   inversion Hpre_x. subst.
-  destruct Ht as [[_ [_ [Hv _]]] Ht]. destruct l as (i, [sn|ji li|ji li])
+  destruct Ht as [[_ [_ [Hv _]]] Ht]. destruct l as (i, [sn | ji li | ji li])
   ; unfold equivocators_total_trace_project; cbn in *
   ; unfold equivocators_transition_item_project; cbn in *
   ; rewrite !equivocator_state_project_zero.
   - inversion_clear Ht.
     rewrite decide_False; [done |].
     by state_update_simpl; cbn.
-  - destruct (equivocator_state_project _ _) as [s_i|]; [| done].
+  - destruct (equivocator_state_project _ _) as [s_i |]; [| done].
     destruct (vtransition _ _ _) as (si', _om').
     inversion_clear Ht. state_update_simpl.
-    destruct ji as [|ji].
+    destruct ji as [| ji].
     + by rewrite decide_True.
     + by rewrite decide_False.
-  - destruct (equivocator_state_project _ _) as [s_i|]; [| done].
+  - destruct (equivocator_state_project _ _) as [s_i |]; [| done].
     destruct (vtransition _ _ _) as (si', _om').
     inversion_clear Ht.
     by state_update_simpl; cbn; rewrite decide_False.
@@ -1578,7 +1578,7 @@ Proof.
   unfold equivocators_trace_project in Hpr_item. unfold sub_IM in *.
   simpl in *.
   destruct (equivocators_transition_item_project IM final_descriptors item)
-    as [(ox, final')|] eqn:Hpr_item_x
+    as [(ox, final') |] eqn:Hpr_item_x
   ; [| by congruence].
   unfold equivocators_transition_item_project in Hpr_item_x.
   unfold composite_transition_item_projection in Hpr_item_x.
@@ -1586,7 +1586,7 @@ Proof.
     (composite_transition_item_projection_from_eq (equivocator_IM IM) item
       (projT1 (l item)) eq_refl) (final_descriptors (projT1 (l item))))
     as pr_item_x.
-  destruct pr_item_x as [(oitem', descriptor')|]; [| by congruence].
+  destruct pr_item_x as [(oitem', descriptor') |]; [| by congruence].
 
   unfold composite_transition_item_projection_from_eq in Heqpr_item_x.
   unfold eq_rect_r in Heqpr_item_x.
@@ -1613,7 +1613,7 @@ Proof.
     simpl in Hpr_sub_item.
     split.
     + extensionality i.
-      destruct oitem' as [item'|]
+      destruct oitem' as [item' |]
       ; inversion Hpr_sub_item; subst; clear Hpr_sub_item
       ; inversion Hpr_item_x; subst; clear Hpr_item_x
       ; inversion Hpr_item; subst; clear Hpr_item
@@ -1633,7 +1633,7 @@ Proof.
         simpl in e. replace e with (eq_refl (projT1 (l item))); [done |].
         by apply Eqdep_dec.UIP_dec.
       * by rewrite! equivocator_descriptors_update_neq; [| | intros ->].
-    + destruct oitem' as [item'|]
+    + destruct oitem' as [item' |]
       ; inversion Hpr_sub_item; subst; clear Hpr_sub_item
       ; inversion Hpr_item_x; subst; clear Hpr_item_x
       ; inversion Hpr_item; subst; clear Hpr_item
@@ -1663,7 +1663,7 @@ Proof.
       ; inversion Hpr_item_x; subst; clear Hpr_item_x
       ; inversion Hpr_item; subst; clear Hpr_item
       ; state_update_simpl.
-    + destruct oitem' as [item'|]
+    + destruct oitem' as [item' |]
       ; inversion Hpr_item_x; subst; clear Hpr_item_x
       ; inversion Hpr_item; subst; clear Hpr_item
       ; simpl; [| done].
@@ -1695,7 +1695,7 @@ Proof.
   - unfold equivocators_trace_project in Hproject_tr.
     rewrite fold_right_app in Hproject_tr.
     match type of Hproject_tr with
-    | fold_right _ ?i _ = _ => destruct i as [(projectx, final_descriptors')|] eqn:Hproject_x
+    | fold_right _ ?i _ = _ => destruct i as [(projectx, final_descriptors') |] eqn:Hproject_x
     end
     ; [| by rewrite equivocators_trace_project_fold_None in Hproject_tr; inversion Hproject_tr].
     apply equivocators_trace_project_folder_additive_iff in Hproject_tr.
@@ -1738,7 +1738,7 @@ Lemma seeded_equivocators_initial_message
   (Hem : vinitial_message_prop SeededXE m)
   : vinitial_message_prop SeededX m.
 Proof.
-  destruct Hem as [[eqv [emi Hem]]|Hseed].
+  destruct Hem as [[eqv [emi Hem]] | Hseed].
   - by left; exists eqv, emi.
   - by right.
 Qed.
@@ -1832,7 +1832,7 @@ Proof.
     assert (Hlst_trX' : valid_state_prop SeededX (finite_trace_last
       (equivocators_state_project sub_IM initial_descriptors is) trX')).
     { by apply (finite_valid_trace_last_pstate SeededX) in HtrX'. }
-    destruct oitem as [item|]; inversion _Hprojectx; subst lstX; clear _Hprojectx
+    destruct oitem as [item |]; inversion _Hprojectx; subst lstX; clear _Hprojectx
     ; [| by constructor].
     simpl in Hitemx. destruct Hitemx as [Hl [Hinput [Houtput [Hdestination _]]]].
     specialize (Hx _ eq_refl).
@@ -1908,7 +1908,7 @@ Lemma SeededXE_SeededX_vlsm_partial_projection
   : VLSM_partial_projection SeededXE SeededX
       (equivocators_partial_trace_project sub_IM final_descriptors).
 Proof.
-  split; [split|].
+  split; [split |].
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
     assert
       (HPreFree_pre_tr : finite_valid_trace_from SubPreFreeE s_pre (pre ++ tr)).
@@ -1962,7 +1962,7 @@ Lemma equivocators_no_equivocations_vlsm_X_vlsm_partial_projection
   : VLSM_partial_projection equivocators_no_equivocations_vlsm Free
       (equivocators_partial_trace_project IM final_descriptors).
 Proof.
-  split; [split|].
+  split; [split |].
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
     assert
       (HPreFree_pre_tr : finite_valid_trace_from PreFreeE s_pre (pre ++ tr)).
@@ -2006,7 +2006,7 @@ Proof.
       unfold equivocators_no_equivocations_constraint.
       intros [Hno_equiv _].
       split; [| done ].
-      destruct om as [m|]; [| done].
+      destruct om as [m |]; [| done].
       left. destruct Hno_equiv as [Hno_equiv | Hfalse]; [| done].
       destruct Hno_equiv as [eqv Hno_equiv].
       by exists (dexist eqv (SubProjectionTraces.free_sub_free_index_obligation_1 eqv)).
@@ -2046,7 +2046,7 @@ Proof.
         composite_label_sub_projection_option,
         pre_VLSM_embedding_transition_item_project.
       simpl.
-      case_decide as Hla; [|contradict Hla; apply elem_of_enum].
+      case_decide as Hla; [| contradict Hla; apply elem_of_enum].
       f_equal; [| done].
       destruct a, l as (i, li); cbn; f_equal.
       unfold composite_label_sub_projection;
@@ -2085,7 +2085,7 @@ Proof.
       with (EquivocatorsComposition.equivocators_state_project IM initial_descriptors s)
       in HtrX'
     ; [replace (VLSM_embedding_finite_trace_project _ _) with trX
-      in HtrX'|]
+      in HtrX' |]
     ; [done | | done].
     clear.
     induction trX; [done |].
@@ -2093,7 +2093,7 @@ Proof.
     unfold pre_VLSM_projection_transition_item_project,
       composite_label_sub_projection_option.
     simpl.
-    case_decide as Hla; [|contradict Hla; apply elem_of_enum].
+    case_decide as Hla; [| contradict Hla; apply elem_of_enum].
     cbn; f_equal; [| done].
     by destruct a, l as [i li].
 Qed.
@@ -2143,15 +2143,15 @@ Lemma PreFreeE_Free_vlsm_projection_type
 Proof.
   apply basic_VLSM_projection_type.
   intros l Hl s om s' om' [[_ [_ [Hv _]]] Ht].
-  destruct l as [i [sn| ji li| ji li]]; cbn in Hv, Ht.
+  destruct l as [i [sn | ji li | ji li]]; cbn in Hv, Ht.
   - inversion_clear Ht. unfold equivocators_total_state_project.
     by state_update_simpl.
   - simpl in Hl. destruct ji as [| ji]; [by inversion Hl |]. clear Hl.
-    destruct (equivocator_state_project _ _) as [si|]; [| done].
+    destruct (equivocator_state_project _ _) as [si |]; [| done].
     destruct (vtransition _ _ _) as (si', _om').
     inversion_clear Ht.  unfold equivocators_total_state_project.
     by state_update_simpl.
-  - destruct (equivocator_state_project _ _) as [si|]; [| done].
+  - destruct (equivocator_state_project _ _) as [si |]; [| done].
     destruct (vtransition _ _ _) as (si', _om').
     inversion_clear Ht.  unfold equivocators_total_state_project.
     by state_update_simpl.
@@ -2161,7 +2161,7 @@ Lemma equivocators_no_equivocations_vlsm_X_vlsm_projection
   : VLSM_projection equivocators_no_equivocations_vlsm Free
       (equivocators_total_label_project IM) (equivocators_total_state_project IM).
 Proof.
-  constructor; [constructor|].
+  constructor; [constructor |].
   - intros * Htr. apply PreFreeE_Free_vlsm_projection_type.
     apply VLSM_incl_finite_valid_trace_from; [| done].
     by apply equivocators_no_equivocations_vlsm_incl_PreFree.
@@ -2191,7 +2191,7 @@ Lemma preloaded_equivocators_no_equivocations_vlsm_X_vlsm_projection
   : VLSM_projection PreFreeE PreFree
       (equivocators_total_label_project IM) (equivocators_total_state_project IM).
 Proof.
-  constructor; [constructor; intros|].
+  constructor; [constructor; intros |].
   - by apply PreFreeE_Free_vlsm_projection_type.
   - intros * Htr.
     specialize (VLSM_partial_projection_finite_valid_trace

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -353,7 +353,7 @@ Proof.
   ; [by exists Hex | apply equivocator_descriptors_update_eq | ..]
   ; intros
   ; match type of Ht with
-    | (let (_, _) := ?t in _ ) = _ =>
+    | (let (_, _) := ?t in _) = _ =>
       destruct t as (si', om') eqn:Ht'
     end
   ; inversion Ht; subst; clear Ht
@@ -692,7 +692,7 @@ Lemma equivocators_trace_project_preserves_equivocating_indices
   (trX : list (composite_transition_item IM))
   (is s : composite_state equivocator_IM)
   (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm
-          (free_composite_vlsm equivocator_IM)) is s tr )
+          (free_composite_vlsm equivocator_IM)) is s tr)
   (Hdescriptors : proper_equivocator_descriptors descriptors s)
   (Hproject_tr : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   :
@@ -741,7 +741,7 @@ Lemma equivocators_trace_project_from_state_descriptors
   (trX : list (composite_transition_item IM))
   (is s : composite_state equivocator_IM)
   (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm
-          (free_composite_vlsm equivocator_IM)) is s tr )
+          (free_composite_vlsm equivocator_IM)) is s tr)
   (Hdescriptors : proper_equivocator_descriptors descriptors s)
   (Hproject_tr : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   : forall eqv, previous_state_descriptor_prop (IM eqv) (descriptors eqv) (is eqv) (idescriptors eqv).
@@ -797,7 +797,7 @@ Lemma equivocators_trace_project_preserves_equivocating_indices_final
   (trX : list (composite_transition_item IM))
   (is s : composite_state equivocator_IM)
   (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm
-          (free_composite_vlsm equivocator_IM)) is s tr )
+          (free_composite_vlsm equivocator_IM)) is s tr)
   (Hdescriptors : not_equivocating_equivocator_descriptors IM descriptors s)
   (Hproject_tr : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   :

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -146,8 +146,8 @@ Proof.
     specialize
       (equivocators_vlsm_transition_item_project_zero_descriptor (IM (projT1 (l item)))
         (composite_transition_item_projection equivocator_IM item)
-        (s (projT1 (l item)))
-      ) as Hpr_item.
+        (s (projT1 (l item))))
+      as Hpr_item.
     remember (composite_transition_item_projection equivocator_IM item) as pr_item.
     spec Hpr_item.
     {
@@ -232,8 +232,8 @@ Proof.
     (no_equivocating_equivocator_transition_item_project (IM i)
       (composite_transition_item_projection equivocator_IM item)
       Hdest_i
-      (s i)
-    ) as Heqv_pr.
+      (s i))
+    as Heqv_pr.
   destruct item, l. simpl in Ht, Hv. simpl in i. subst i.
   specialize (Heqv_pr Hv).
   spec Heqv_pr.
@@ -274,8 +274,8 @@ Proof.
       (IM (projT1 (l item)))
       (composite_transition_item_projection equivocator_IM item)
       (s (projT1 (l item)))
-      Hs
-    ) as Hproject.
+      Hs)
+    as Hproject.
   spec Hproject; [by rewrite (sigT_eta (l item)) in Hv |].
   spec Hproject; [by apply composite_transition_project_active in Ht |].
   destruct Hproject as [Heqv' [eqv [Heqv Hproject]]].
@@ -810,8 +810,8 @@ Proof.
   apply not_equivocating_equivocator_descriptors_proper in Hdescriptors as Hproper.
   specialize
     (equivocators_trace_project_preserves_equivocating_indices _ _ _ _ _ _
-      Htr Hproper Hproject_tr
-    ) as Hincl.
+      Htr Hproper Hproject_tr)
+    as Hincl.
   intros eqv Heqv. specialize (Hincl eqv Heqv).
   apply set_union_iff in Hincl.
   clear Heqv.
@@ -1011,8 +1011,8 @@ Lemma equivocators_trace_project_zero_descriptors
 Proof.
   specialize
     (preloaded_equivocators_valid_trace_from_project
-      (zero_descriptor IM) is tr
-    ) as Hproject.
+      (zero_descriptor IM) is tr)
+    as Hproject.
   simpl in Hproject. spec Hproject; [by apply zero_descriptor_proper |].
   specialize (Hproject Htr).
   destruct Hproject as [trX [initial_descriptors [Hproject _]]].
@@ -1123,8 +1123,7 @@ Lemma preloaded_equivocators_valid_trace_project_proper_initial
 Proof.
   destruct
     (preloaded_equivocators_valid_trace_from_project
-      final_descriptors is tr Hproper Htr
-    )
+      final_descriptors is tr Hproper Htr)
     as [_trX [_initial_descriptors [_Hproject [Hiproper _]]]].
   rewrite Hproject in _Hproject.
   by inversion _Hproject; subst.
@@ -1395,12 +1394,12 @@ Proof.
   apply not_equivocating_equivocator_descriptors_proper in Hnot_equiv as Hproper.
   specialize
     (preloaded_equivocators_valid_trace_project_proper_initial _ _ Htr
-      _ _ _ Htr_project Hproper
-    ) as Hinitial_descriptors.
+      _ _ _ Htr_project Hproper)
+    as Hinitial_descriptors.
   destruct
     (preloaded_equivocators_valid_trace_from_project
-      _ _ _ Hinitial_descriptors Hpre
-    ) as [preX [pre_descriptors [Hpre_project [Hpre_desciptors Hs_project]]]].
+      _ _ _ Hinitial_descriptors Hpre)
+    as [preX [pre_descriptors [Hpre_project [Hpre_desciptors Hs_project]]]].
   exists (equivocators_state_project pre_descriptors s_pre), preX.
   split; [| done].
   apply construct_equivocators_partial_trace_project.
@@ -1647,8 +1646,7 @@ Proof.
           (sub_index_prop selection)
           (sub_index_prop_dec selection)
           (fun n => vlabel (IM n))
-          (projT1 (l item)) (l item') (l item') _Hl Hl
-        ).
+          (projT1 (l item)) (l item') (l item') _Hl Hl).
   - simpl in Hpr_sub_item. unfold final_sub_descriptors in *.
     inversion Hpr_sub_item. subst. clear Hpr_sub_item.
     split.
@@ -1705,8 +1703,7 @@ Proof.
       [Hproject_sub_x [Htr_subX' Heqtr_subX]]]]].
     specialize
       (equivocators_trace_project_finite_trace_sub_projection_item_commute
-        x _ _ _ Hproject_x _ _ Hproject_sub_x
-      )
+        x _ _ _ Hproject_x _ _ Hproject_sub_x)
       as Hfinal_sub'.
 
     destruct Hfinal_sub' as [Hfinal_sub' Hpr_sub_x].
@@ -1991,8 +1988,7 @@ Proof.
             (SubProjectionTraces.sub_IM equivocator_IM (enum index))
             (free_constraint _)))
         (composite_state_sub_projection equivocator_IM (finite.enum index) s)
-        (VLSM_embedding_finite_trace_project Hproj tr)
-    ).
+        (VLSM_embedding_finite_trace_project Hproj tr)).
     { revert Htr.
       apply VLSM_incl_finite_valid_trace.
       clear.
@@ -2016,8 +2012,7 @@ Proof.
         (enum index)
         (fun m => False)
         _ _ Htr'
-        (free_sub_free_equivocator_descriptors final_descriptors)
-        )
+        (free_sub_free_equivocator_descriptors final_descriptors))
       as Hproject.
     spec Hproject.
     {
@@ -2053,8 +2048,7 @@ Proof.
         (@dec_sig_sigT_eq _ _
           (sub_index_prop_dec (enum index))
           (fun n => vlabel (EquivocatorsComposition.equivocator_IM IM n))
-          i li li
-        ).
+          i li li).
     }
     destruct Hcommute as [Heq_initial Heq_trX].
     subst.
@@ -2126,8 +2120,8 @@ Proof.
   apply not_equivocating_equivocator_descriptors_proper in Hproper.
   destruct
     (preloaded_equivocators_valid_trace_from_project _
-      _ _ _ Hproper HPreFree_tr
-    ) as [trX [initial_descriptors [Htr_project [Hinitial_desciptors Hfinal_project]]]].
+      _ _ _ Hproper HPreFree_tr)
+    as [trX [initial_descriptors [Htr_project [Hinitial_desciptors Hfinal_project]]]].
   eexists. eexists. eexists. eexists. split; [done |]. split; [by apply Hinitial_desciptors |].
   split; [by apply Htr_project |]. split; [by apply Hfinal_project |].
   apply valid_trace_add_default_last.
@@ -2172,8 +2166,8 @@ Proof.
     specialize
      (VLSM_partial_projection_finite_valid_trace
       (equivocators_no_equivocations_vlsm_X_vlsm_partial_projection (zero_descriptor IM))
-       sX trX (equivocators_total_state_project IM sX) (equivocators_total_trace_project IM trX)
-     ) as Hsim.
+       sX trX (equivocators_total_state_project IM sX) (equivocators_total_trace_project IM trX))
+     as Hsim.
     spec Hsim.
     { simpl. rewrite decide_True by apply zero_descriptor_not_equivocating.
       by rewrite (equivocators_total_trace_project_characterization IM (proj1 Hpre_tr)).

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -97,7 +97,7 @@ Proof.
     as (si', om') eqn:Htei.
   inversion Ht. subst. clear Ht.
   replace idescriptors with (equivocator_descriptors_update descriptors i deqv')
-    by (destruct oitemx;congruence);clear oitem Hpr.
+    by (destruct oitemx; congruence); clear oitem Hpr.
   intros eqv Heqv. apply set_union_iff in Heqv. apply set_union_iff.
   destruct (decide (eqv = i)).
   - subst i.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -708,7 +708,7 @@ Lemma equivocators_trace_project_preserves_equivocating_indices
 Proof.
   generalize dependent trX. generalize dependent descriptors.
   induction Htr using finite_valid_trace_from_to_rev_ind; [by inversion 2 |].
-  set (x:={|l:=l|}).
+  set (x := {|l := l|}).
   intros.
   apply equivocators_trace_project_app_iff in Hproject_tr.
   destruct Hproject_tr as [preX [sufX [descriptors' [Hproject_x [Hproject_tr _]]]]].

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -437,7 +437,7 @@ Proof.
 Qed.
 
 Lemma equivocators_transition_item_project_inv_characterization
-  (eqv_descriptors eqv_descriptors': equivocator_descriptors)
+  (eqv_descriptors eqv_descriptors' : equivocator_descriptors)
   (item : composite_transition_item equivocator_IM)
   (itemx : composite_transition_item IM)
   (Hpr_item : equivocators_transition_item_project eqv_descriptors item =
@@ -465,7 +465,7 @@ Qed.
 
 Definition equivocators_trace_project_folder
   (item : composite_transition_item equivocator_IM)
-  (result: option (list (composite_transition_item IM) * equivocator_descriptors))
+  (result : option (list (composite_transition_item IM) * equivocator_descriptors))
   : option (list (composite_transition_item IM) * equivocator_descriptors)
   :=
   match result with
@@ -1030,7 +1030,7 @@ Lemma preloaded_equivocators_valid_trace_project_inv
   (Htr : finite_valid_trace PreFreeE is tr)
   (trX : list (composite_transition_item IM))
   (initial_descriptors : equivocator_descriptors)
-  (Hproject: equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors))
+  (Hproject : equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors))
   (Hproper : proper_equivocator_descriptors initial_descriptors is)
   : proper_equivocator_descriptors final_descriptors final_state.
 Proof.
@@ -1117,7 +1117,7 @@ Lemma preloaded_equivocators_valid_trace_project_proper_initial
   (final_descriptors : equivocator_descriptors)
   (trX : list (composite_transition_item IM))
   (initial_descriptors : equivocator_descriptors)
-  (Hproject: equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors))
+  (Hproject : equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors))
   (Hproper : proper_equivocator_descriptors final_descriptors final_state)
   : proper_equivocator_descriptors initial_descriptors is.
 Proof.
@@ -1130,15 +1130,15 @@ Proof.
 Qed.
 
 Lemma equivocators_trace_project_output_reflecting_inv
-  (is: composite_state equivocator_IM)
-  (tr: list (composite_transition_item equivocator_IM))
+  (is : composite_state equivocator_IM)
+  (tr : list (composite_transition_item equivocator_IM))
   (Htr : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm
            (free_composite_vlsm equivocator_IM)) is tr)
   (m : message)
   (Hbbs : Exists (field_selector output m) tr)
   : exists
     (final_descriptors initial_descriptors : equivocator_descriptors)
-    (trX: list (composite_transition_item IM)),
+    (trX : list (composite_transition_item IM)),
     not_equivocating_equivocator_descriptors IM final_descriptors (finite_trace_last is tr) /\
     equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors) /\
     Exists (field_selector output m) trX.
@@ -1192,15 +1192,15 @@ Proof.
 Qed.
 
 Lemma equivocators_trace_project_output_reflecting_iff
-  (is: composite_state equivocator_IM)
-  (tr: list (composite_transition_item equivocator_IM))
-  (Htr: finite_valid_trace_from (pre_loaded_with_all_messages_vlsm
+  (is : composite_state equivocator_IM)
+  (tr : list (composite_transition_item equivocator_IM))
+  (Htr : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm
           (free_composite_vlsm equivocator_IM)) is tr)
   (m : message)
   : Exists (field_selector output m) tr
   <-> exists
     (final_descriptors initial_descriptors : equivocator_descriptors)
-    (trX: list (composite_transition_item IM)),
+    (trX : list (composite_transition_item IM)),
     not_equivocating_equivocator_descriptors IM final_descriptors (finite_trace_last is tr) /\
     equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors) /\
     Exists (field_selector output m) trX.
@@ -1557,14 +1557,14 @@ Context
   two ways lead to the same result.
 *)
 Lemma equivocators_trace_project_finite_trace_sub_projection_item_commute
-  (item: composite_transition_item (equivocator_IM IM))
-  (final_descriptors' final_descriptors: equivocator_descriptors IM)
+  (item : composite_transition_item (equivocator_IM IM))
+  (final_descriptors' final_descriptors : equivocator_descriptors IM)
   (final_sub_descriptors := fun i : sub_index selection => final_descriptors (` i))
-  (pr_item: list (composite_transition_item IM))
+  (pr_item : list (composite_transition_item IM))
   (Hpr_item : equivocators_trace_project IM final_descriptors [item] =
                 Some (pr_item, final_descriptors'))
-  (pr_sub_item: list (composite_transition_item (sub_IM IM selection)))
-  (final_sub_descriptors': equivocator_descriptors (sub_IM IM selection))
+  (pr_sub_item : list (composite_transition_item (sub_IM IM selection)))
+  (final_sub_descriptors' : equivocator_descriptors (sub_IM IM selection))
   (Hpr_sub_item :
     equivocators_trace_project (sub_IM IM selection) final_sub_descriptors
       (finite_trace_sub_projection (equivocator_IM IM) selection [item]) =

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -347,8 +347,8 @@ Proof.
   destruct item. simpl in *. destruct l as (i, li). simpl in *.
   destruct oitemi as [itemi' |]; eexists _; eexists _; (split; [done |])
   ; [| split; [done |]]
-  ; [ destruct Hitemx as [[Hex Hli] [Hinputi [Houtputi [Hdestinationi Hdescriptori]]]]
-  ; rewrite Hli; subst; split; [ repeat split |]
+  ; [destruct Hitemx as [[Hex Hli] [Hinputi [Houtputi [Hdestinationi Hdescriptori]]]]
+  ; rewrite Hli; subst; split; [repeat split |]
     |]
   ; [by exists Hex | apply equivocator_descriptors_update_eq | ..]
   ; intros
@@ -2003,7 +2003,7 @@ Proof.
       unfold free_sub_free_constraint, lift_sub_label, free_sub_free_state, free_sub_free_index.
       unfold equivocators_no_equivocations_constraint.
       intros [Hno_equiv _].
-      split; [| done ].
+      split; [| done].
       destruct om as [m |]; [| done].
       left. destruct Hno_equiv as [Hno_equiv | Hfalse]; [| done].
       destruct Hno_equiv as [eqv Hno_equiv].

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -94,7 +94,7 @@ Proof.
   simpl in Ht.
   destruct item. simpl in *. destruct l as (i, li). simpl in *.
   destruct (vtransition (equivocator_IM i) li (s i, input))
-    as (si', om') eqn:Htei.
+    as (si', om') eqn: Htei.
   inversion Ht. subst. clear Ht.
   replace idescriptors with (equivocator_descriptors_update descriptors i deqv')
     by (destruct oitemx; congruence); clear oitem Hpr.
@@ -156,7 +156,7 @@ Proof.
       destruct l as (i, li).
       unfold projT1 .
       match type of Ht with
-      | (let (_, _) := ?t in _) = _ => destruct t as (si', om') eqn:Hti
+      | (let (_, _) := ?t in _) = _ => destruct t as (si', om') eqn: Hti
       end.
       inversion Ht; subst; cbn.
       by state_update_simpl.
@@ -238,7 +238,7 @@ Proof.
   specialize (Heqv_pr Hv).
   spec Heqv_pr.
   { simpl. unfold eq_rect_r. simpl.
-    destruct (vtransition (equivocator_IM x) v (s x, input)) eqn:Hti.
+    destruct (vtransition (equivocator_IM x) v (s x, input)) eqn: Hti.
     clear -Ht Hti; inversion Ht; subst.
     by state_update_simpl.
   }
@@ -354,7 +354,7 @@ Proof.
   ; intros
   ; match type of Ht with
     | (let (_, _) := ?t in _) = _ =>
-      destruct t as (si', om') eqn:Ht'
+      destruct t as (si', om') eqn: Ht'
     end
   ; inversion Ht; subst; clear Ht
   ; rewrite state_update_eq in Hchar
@@ -453,7 +453,7 @@ Proof.
       (IM (projT1 (l item)))
       (composite_transition_item_projection equivocator_IM item)
       (eqv_descriptors (projT1 (l item))))
-    as [([itemi |], descriptori) |] eqn:Hpr_itemi
+    as [([itemi |], descriptori) |] eqn: Hpr_itemi
   ; [| by congruence..].
   inversion Hpr_item. subst. clear Hpr_item. simpl.
   repeat split.
@@ -524,7 +524,7 @@ Proof.
       rewrite IHtr by (eexists _; done).
       simpl in *.
       destruct (equivocators_transition_item_project e1 a)
-        as [(oitem, odescriptor) |] eqn:Ha
+        as [(oitem, odescriptor) |] eqn: Ha
       ; [| done].
       by destruct oitem as [item' |]; inversion Htr.
 Qed.
@@ -618,7 +618,7 @@ Proof.
       as (trX' & xX & eqv_descriptors' & Hpr_x & Hpr_tr & Heq).
     simpl in Hpr_x.
     destruct (equivocators_transition_item_project eqv_descriptors x)
-      as [(ox, descriptorx) |] eqn:Hpr_x_item
+      as [(ox, descriptorx) |] eqn: Hpr_x_item
     ; [| by congruence].
     destruct xX as [| xX _empty].
     + destruct ox; [by congruence |].
@@ -783,9 +783,9 @@ Proof.
     destruct l as (i, li). simpl in *.
     destruct (decide (i = eqv)).
     + subst. specialize (His_tr eqv). specialize (Htr_x eqv).
-      destruct (descriptors eqv) eqn:Hvin_desc_eqv;
+      destruct (descriptors eqv) eqn: Hvin_desc_eqv;
         [by simpl in Hex_new; rewrite Hex_new in Hex_new' |].
-      destruct (final_descriptors' eqv) eqn:Hfin_desc_eqv'.
+      destruct (final_descriptors' eqv) eqn: Hfin_desc_eqv'.
       * by simpl in Hex_new, Hex_new'; rewrite Hex_new'; simpl;  lia.
       * by destruct (idescriptors eqv); simpl in *; lia.
     + by rewrite Heq_final_descriptors' in Hex_new'; state_update_simpl.
@@ -852,7 +852,7 @@ Proof.
   - unfold equivocators_trace_project in Hproject_tr.
     rewrite fold_right_app in Hproject_tr.
     match type of Hproject_tr with
-    | fold_right _ ?i _ = _ => destruct i as [(projectx, final_descriptors') |] eqn:Hproject_x
+    | fold_right _ ?i _ = _ => destruct i as [(projectx, final_descriptors') |] eqn: Hproject_x
     end
     ; [| by rewrite equivocators_trace_project_fold_None in Hproject_tr; inversion Hproject_tr].
     apply equivocators_trace_project_folder_additive_iff in Hproject_tr.
@@ -867,7 +867,7 @@ Proof.
     { clear - Hproject_x Hproject_xi.
       simpl in *.
       destruct (equivocators_transition_item_project final_descriptors x)
-        as [(ox, final') |] eqn:Hpr_item_x
+        as [(ox, final') |] eqn: Hpr_item_x
       ; [| by congruence].
       unfold equivocators_transition_item_project in Hpr_item_x.
       destruct (decide (i = projT1 (l x))).
@@ -877,7 +877,7 @@ Proof.
         simpl in Hproject_xi.
         subst eqv_final.
         destruct (equivocator_vlsm_transition_item_project _ _ _)
-          as [(oitem', descriptor') |] eqn:Heqpr_item_x
+          as [(oitem', descriptor') |] eqn: Heqpr_item_x
         ; [| done].
         destruct oitem' as [item' |]
         ; inversion Hproject_xi; subst descriptor' project_xi; clear Hproject_xi
@@ -902,7 +902,7 @@ Proof.
         inversion Hproject_xi. subst. clear Hproject_xi.
         destruct
           (equivocator_vlsm_transition_item_project _ _ _)
-          as [(oitem', descriptor') |] eqn:Heqpr_item_x
+          as [(oitem', descriptor') |] eqn: Heqpr_item_x
         ; [| done].
         destruct oitem' as [item' |]
         ; inversion Hpr_item_x; subst; clear Hpr_item_x
@@ -1048,7 +1048,7 @@ Proof.
   destruct project_x as [(x', x_descriptors) |]
   ; [| by rewrite equivocators_trace_project_fold_None in Hproject; congruence].
   destruct (equivocators_transition_item_project final_descriptors x) as [(oitem', ditem') |]
-    eqn:Hproject_x
+    eqn: Hproject_x
   ; [| by congruence].
   apply (equivocators_trace_project_folder_additive_iff tr x' x_descriptors initial_descriptors trX)
   in Hproject.
@@ -1068,7 +1068,7 @@ Proof.
   unfold equivocator_vlsm_transition_item_project in Heqprojecti.
   unfold final_state in *. clear final_state.
   rewrite finite_trace_last_is_last. simpl.
-  destruct (final_descriptors (projT1 l)) as [sn | j] eqn:Hfinali.
+  destruct (final_descriptors (projT1 l)) as [sn | j] eqn: Hfinali.
   - inversion Heqprojecti. subst. clear Heqprojecti.
     inversion Hproject_x. subst; clear Hproject_x.
     inversion Heqproject_x. subst. clear Heqproject_x.
@@ -1091,10 +1091,10 @@ Proof.
     unfold projT1, projT2 in Heqprojecti.
     destruct Ht as [Hv Ht].
     cbn in Ht.
-    destruct (equivocator_transition _ _ _) as (si', om') eqn:Ht'.
+    destruct (equivocator_transition _ _ _) as (si', om') eqn: Ht'.
     inversion Ht. subst om'. clear Ht.
     replace (s i) with si' in * by (subst; state_update_simpl; done).
-    destruct (equivocator_state_project si' j) as [si'j |] eqn:Hj; [| done].
+    destruct (equivocator_state_project si' j) as [si'j |] eqn: Hj; [| done].
     by destruct li as [ndi | idi li | idi li]
     ; destruct (decide _)
     ; inversion Heqprojecti; subst; clear Heqprojecti
@@ -1341,7 +1341,7 @@ Proof.
   - intros Hpr_tr.
     case_decide; [| by congruence].
     destruct (equivocators_trace_project final_descriptors trX)
-      as [(_trY, initial_descriptors) |] eqn:Htr_project
+      as [(_trY, initial_descriptors) |] eqn: Htr_project
     ; [| by congruence].
     by inversion Hpr_tr; subst _trY; clear Hpr_tr; eauto.
   - intros [Hnot_equiv [initial_descriptors [Hpr_tr Hpr_s]]].
@@ -1575,7 +1575,7 @@ Proof.
   unfold equivocators_trace_project in Hpr_item. unfold sub_IM in *.
   simpl in *.
   destruct (equivocators_transition_item_project IM final_descriptors item)
-    as [(ox, final') |] eqn:Hpr_item_x
+    as [(ox, final') |] eqn: Hpr_item_x
   ; [| by congruence].
   unfold equivocators_transition_item_project in Hpr_item_x.
   unfold composite_transition_item_projection in Hpr_item_x.
@@ -1691,7 +1691,7 @@ Proof.
   - unfold equivocators_trace_project in Hproject_tr.
     rewrite fold_right_app in Hproject_tr.
     match type of Hproject_tr with
-    | fold_right _ ?i _ = _ => destruct i as [(projectx, final_descriptors') |] eqn:Hproject_x
+    | fold_right _ ?i _ = _ => destruct i as [(projectx, final_descriptors') |] eqn: Hproject_x
     end
     ; [| by rewrite equivocators_trace_project_fold_None in Hproject_tr; inversion Hproject_tr].
     apply equivocators_trace_project_folder_additive_iff in Hproject_tr.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -509,7 +509,7 @@ Proof.
       as pr_tr.
     split.
     + intro Htr.
-      destruct pr_itrX_tr as [(tr1,e1)|] ; [| by inversion Htr].
+      destruct pr_itrX_tr as [(tr1, e1)|] ; [| by inversion Htr].
       specialize (IHtr tr1 e1). apply proj1 in IHtr. specialize (IHtr eq_refl).
       destruct IHtr as [trX [Hpr_tr Htr1]].
       rewrite Hpr_tr in *. rewrite Htr1 in *.
@@ -854,7 +854,7 @@ Proof.
   - unfold equivocators_trace_project in Hproject_tr.
     rewrite fold_right_app in Hproject_tr.
     match type of Hproject_tr with
-    | fold_right _ ?i _ = _ => destruct i as [(projectx,final_descriptors')|] eqn:Hproject_x
+    | fold_right _ ?i _ = _ => destruct i as [(projectx, final_descriptors')|] eqn:Hproject_x
     end
     ; [| by rewrite equivocators_trace_project_fold_None in Hproject_tr; inversion Hproject_tr].
     apply equivocators_trace_project_folder_additive_iff in Hproject_tr.
@@ -1085,7 +1085,7 @@ Proof.
       simpl in Ht. unfold vtransition in Ht. simpl in Ht.
       destruct l as (i, li).
       match type of Ht with
-      | (let (_,_) := ?t in _) = _ => destruct t as (si', om')
+      | (let (_, _) := ?t in _) = _ => destruct t as (si', om')
       end.
       inversion Ht. subst. simpl in n.
       by state_update_simpl.
@@ -1159,7 +1159,7 @@ Proof.
   destruct Hex as [eqv_final [eqv_init [Heqv_init [Heqv_final [trXi [Hprojecti Hex]]]]]].
   specialize (VLSM_projection_finite_trace_last
     (preloaded_component_projection equivocator_IM i) _ _ Htr) as Hlst.
-  simpl in Hlst,Heqv_final. rewrite <- Hlst in Heqv_final. clear Hlst.
+  simpl in Hlst, Heqv_final. rewrite <- Hlst in Heqv_final. clear Hlst.
   match type of Heqv_final with
   | existing_descriptor _ _ (?l i) => remember l as final
   end.
@@ -1339,7 +1339,7 @@ Lemma equivocators_partial_trace_project_characterization
       equivocators_trace_project final_descriptors trX = Some (trY, initial_descriptors) /\
       equivocators_state_project initial_descriptors sX = sY.
 Proof.
-  unfold partial_trace_project,equivocators_partial_trace_project.
+  unfold partial_trace_project, equivocators_partial_trace_project.
   split.
   - intros Hpr_tr.
     case_decide; [| by congruence].
@@ -1695,7 +1695,7 @@ Proof.
   - unfold equivocators_trace_project in Hproject_tr.
     rewrite fold_right_app in Hproject_tr.
     match type of Hproject_tr with
-    | fold_right _ ?i _ = _ => destruct i as [(projectx,final_descriptors')|] eqn:Hproject_x
+    | fold_right _ ?i _ = _ => destruct i as [(projectx, final_descriptors')|] eqn:Hproject_x
     end
     ; [| by rewrite equivocators_trace_project_fold_None in Hproject_tr; inversion Hproject_tr].
     apply equivocators_trace_project_folder_additive_iff in Hproject_tr.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -578,10 +578,8 @@ Proof.
   |- fold_right _ ?r _ = _ <-> _ => remember r as r_sufX
   end.
   destruct r_sufX as [(sufX, eqv_descriptors') |]
-  ; [
-    | by rewrite equivocators_trace_project_fold_None; split;
-      [intro contra; congruence | intros [preX [sufX [eqv_descriptors' [contra _]]]]; congruence]
-    ].
+  ; [| by rewrite equivocators_trace_project_fold_None; split;
+      [intro contra; congruence | intros [preX [sufX [eqv_descriptors' [contra _]]]]; congruence]].
   rewrite (equivocators_trace_project_folder_additive_iff
     pre sufX eqv_descriptors' ieqv_descriptors trX).
   split.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -341,8 +341,7 @@ Proof.
   intros [Hproper Hfixed].
   specialize
     (preloaded_equivocators_valid_trace_project_proper_initial IM
-      _ _ Htr _ _ _ HtrX Hproper
-    )
+      _ _ Htr _ _ _ HtrX Hproper)
     as Hiproper.
   split; [done |].
   intros i Hi. specialize (Hfixed i Hi).
@@ -923,14 +922,14 @@ Proof.
   }
   specialize
     (equivocators_trace_project_preserves_proper_fixed_equivocator_descriptors _ _ Hsufpre
-      final_descriptors eqv_item _ Hpr_suf Hproper
-    ) as Hproper_item.
+      final_descriptors eqv_item _ Hpr_suf Hproper)
+    as Hproper_item.
   destruct Hproper_item as [Hproper_item Hproper_fixed_item].
   specialize (Hproper_fixed_item _ Hno_equiv_item).
   specialize
     (no_equivocating_equivocators_transition_item_project IM eqv_item item
-      Hproper_fixed_item
-    ) as Hex.
+      Hproper_fixed_item)
+    as Hex.
   spec Hex.
   {
     apply (not_equivocating_index_has_singleton_state _ (elements equivocating));
@@ -1127,16 +1126,15 @@ Proof.
   specialize
     (finite_valid_trace_sub_projection (equivocator_IM IM) (elements equivocating)
       (equivocators_fixed_equivocations_constraint IM (elements equivocating))
-      (composite_has_been_directly_observed IM sX)
-    ) as Hproject.
+      (composite_has_been_directly_observed IM sX))
+    as Hproject.
   specialize (Hproject is tr).
   spec Hproject.
   { subst sX.
     rewrite <- (valid_trace_get_last Htr) in Hdescriptors |- *.
     apply
       (equivocators_trace_sub_item_input_is_seeded_or_sub_previously_sent
-        _ _ (valid_trace_forget_last Htr) descriptors Hdescriptors
-      ).
+        _ _ (valid_trace_forget_last Htr) descriptors Hdescriptors).
   }
   specialize (Hproject (valid_trace_forget_last Htr)).
 
@@ -1165,8 +1163,8 @@ Proof.
   destruct
     (equivocator_vlsm_transition_item_project (IM (projT1 (l item)))
       (composite_transition_item_projection (equivocator_IM IM) item)
-      (item_descriptors (projT1 (l item)))
-    ) as [(o, deqv') |]
+      (item_descriptors (projT1 (l item))))
+    as [(o, deqv') |]
     ; [| by congruence].
   destruct o as [item' |]; [| by congruence].
   inversion Hpr_item. subst output_itemX pre_descriptors. clear Hpr_item deqv'.
@@ -1178,8 +1176,8 @@ Proof.
   specialize
     (projection_has_not_been_directly_observed_is_equivocating _ _ (valid_trace_forget_last Htr)
       _ Hdescriptors
-      _ n item
-    ) as Hitem_equivocating.
+      _ n item)
+    as Hitem_equivocating.
   clear Hdescriptors n.
   spec Hitem_equivocating; [by rewrite Heqtr, !elem_of_app, elem_of_cons; auto |].
   specialize (Hitem_equivocating Houtput_select).
@@ -1199,8 +1197,8 @@ Proof.
       (composite_state_sub_projection (equivocator_IM IM) (elements equivocating) is)
       (finite_trace_sub_projection (equivocator_IM IM) (elements equivocating) tr)
       Hproject
-      (fun i => final_descriptors_m (proj1_sig i))
-    ) as Hsub_project.
+      (fun i => final_descriptors_m (proj1_sig i)))
+    as Hsub_project.
   simpl in Hsub_project.
   spec Hsub_project.
   {
@@ -1233,8 +1231,7 @@ Proof.
   destruct
     (equivocators_trace_project_finite_trace_sub_projection_commute IM (elements equivocating)
       final_descriptors_m initial_descriptors_m initial_descriptors' tr trXm trX'
-      Hproject_trXm Hpr_tr'
-    )
+      Hproject_trXm Hpr_tr')
     as [_ HeqtrX].
   clear Hproject_trXm Hpr_tr'.
 
@@ -1242,8 +1239,8 @@ Proof.
 
   remember
     (equivocators_state_project (sub_IM IM (elements equivocating)) initial_descriptors'
-      (composite_state_sub_projection (equivocator_IM IM) (elements equivocating) is)
-    ) as isX. clear HeqisX.
+      (composite_state_sub_projection (equivocator_IM IM) (elements equivocating) is))
+    as isX. clear HeqisX.
   eapply can_emit_from_valid_trace; [done |].
 
   subst.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -632,7 +632,7 @@ Proof.
   }
 
   assert (HtrX_Pre : finite_valid_trace (pre_loaded_with_all_messages_vlsm Free)
-                      (equivocators_state_project IM initial_descriptors is) trX ).
+                      (equivocators_state_project IM initial_descriptors is) trX).
   {
     revert HtrX_Free; apply VLSM_incl_finite_valid_trace.
     by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -499,7 +499,7 @@ Proof.
     specialize (equivocators_trace_project_preserves_proper_fixed_equivocator_descriptors
       _ _ (proj1 Htr'pre) _ _ _ Htr_project Hproper')
       as Hproper_initial.
-    destruct oitem as [item|].
+    destruct oitem as [item |].
     +  simpl in Hitemx. destruct Hitemx as [Hl [Hinput [Houtput [Hdestination _]]]].
       specialize (Hx _ eq_refl).
       destruct Hx as [Hvx Htx].
@@ -691,7 +691,7 @@ Proof.
   specialize (Heqv_descriptors'' _ Hitem_not_equiv).
   simpl in *.
   destruct (equivocators_transition_item_project IM eqv_descriptors'' item)
-    as [(o, odescriptor)|] eqn:Hpr
+    as [(o, odescriptor) |] eqn:Hpr
   ; [| by congruence].
   destruct item. simpl in *.
   apply first_transition_valid in Hpre_item_free. simpl in Hpre_item_free.
@@ -775,7 +775,7 @@ Proof.
   apply finite_valid_trace_from_app_iff in Htr as Hpre. destruct Hpre as [Hpre _].
   apply finite_valid_trace_from_app_iff in Hpre. destruct Hpre as [Hpre Hivt].
   apply first_transition_valid in Hivt.
-  destruct (composite_has_been_directly_observed_dec IM lst_trX m) as [|Heqv]
+  destruct (composite_has_been_directly_observed_dec IM lst_trX m) as [| Heqv]
   ; [by left | right].
   assert (Hsuf_free : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE)
     (finite_trace_last is pre) ([item] ++ suf)).
@@ -794,7 +794,7 @@ Proof.
   destruct Hivt as [[_ [_ [_ [[Hc _] Hfixed]]]] Ht].
   simpl in Ht, Hfixed. rewrite Ht in Hfixed. simpl in Hfixed.
   clear Ht.
-  destruct Hc as [Hc | Hinit]; [|done ].
+  destruct Hc as [Hc | Hinit]; [| done ].
   assert (Hpre_free : finite_valid_trace FreeE is pre).
   {
     split; [| done].
@@ -1166,9 +1166,9 @@ Proof.
     (equivocator_vlsm_transition_item_project (IM (projT1 (l item)))
       (composite_transition_item_projection (equivocator_IM IM) item)
       (item_descriptors (projT1 (l item)))
-    ) as [(o, deqv')|]
+    ) as [(o, deqv') |]
     ; [| by congruence].
-  destruct o as [item'|]; [| by congruence].
+  destruct o as [item' |]; [| by congruence].
   inversion Hpr_item. subst output_itemX pre_descriptors. clear Hpr_item deqv'.
   simpl in Houtput_select.
 
@@ -1287,7 +1287,7 @@ Lemma fixed_equivocators_vlsm_partial_projection
   (final_descriptors : equivocator_descriptors IM)
   : VLSM_partial_projection XE X (equivocators_partial_trace_project IM final_descriptors).
 Proof.
-  split; [split|].
+  split; [split |].
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
     assert (HPreFree_pre_tr :
       finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE) s_pre (pre ++ tr)).
@@ -1313,7 +1313,7 @@ Qed.
 Lemma fixed_equivocators_vlsm_projection
   : VLSM_projection XE X (equivocators_total_label_project IM) (equivocators_total_state_project IM).
 Proof.
-  constructor; [constructor|]; intros sX trX HtrX.
+  constructor; [constructor |]; intros sX trX HtrX.
   - apply PreFreeE_Free_vlsm_projection_type.
     apply VLSM_incl_finite_valid_trace_from; [| done].
     by apply equivocators_fixed_equivocations_vlsm_incl_PreFree.
@@ -1363,7 +1363,7 @@ Lemma strong_constraint_subsumption_fixed_all
     (equivocators_no_equivocations_constraint IM)
     (equivocators_fixed_equivocations_constraint IM (enum index)).
 Proof.
-  by split; [|intro; intros; apply elem_of_enum].
+  by split; [| intro; intros; apply elem_of_enum].
 Qed.
 
 Lemma strong_constraint_subsumption_all_fixed

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -386,7 +386,7 @@ Definition constraint_has_been_sent_prop
     (descriptors : equivocator_descriptors IM)
     (Hdescriptors : proper_fixed_equivocator_descriptors descriptors s)
     (sX := equivocators_state_project IM descriptors s)
-    (m: message)
+    (m : message)
     (Hm : has_been_sent FreeE s m)
     l,
   constraint l (sX, Some m).
@@ -606,17 +606,17 @@ Qed.
   in any projection of the final state.
 *)
 Lemma not_equivocating_sent_message_has_been_directly_observed_in_projection
-  (is: vstate XE)
-  (tr: list (composite_transition_item (equivocator_IM IM)))
-  (Htr: finite_valid_trace XE is tr)
+  (is : vstate XE)
+  (tr : list (composite_transition_item (equivocator_IM IM)))
+  (Htr : finite_valid_trace XE is tr)
   (lst := finite_trace_last is tr)
-  (item: transition_item)
-  (Hitem: item ∈ tr)
-  (Hitem_not_equiv: projT1 (l item) ∉ equivocating)
-  (m: message)
-  (Hm: field_selector output m item)
-  (descriptors: equivocator_descriptors IM)
-  (Hdescriptors: proper_fixed_equivocator_descriptors descriptors lst)
+  (item : transition_item)
+  (Hitem : item ∈ tr)
+  (Hitem_not_equiv : projT1 (l item) ∉ equivocating)
+  (m : message)
+  (Hm : field_selector output m item)
+  (descriptors : equivocator_descriptors IM)
+  (Hdescriptors : proper_fixed_equivocator_descriptors descriptors lst)
   : has_been_directly_observed Free (equivocators_state_project IM descriptors lst) m.
 Proof.
   destruct (free_equivocators_valid_trace_project descriptors is tr Hdescriptors Htr)
@@ -740,8 +740,8 @@ Lemma equivocators_trace_sub_item_input_is_seeded_or_sub_previously_sent
   (tr : list (vtransition_item XE))
   (s := finite_trace_last is tr)
   (Htr : finite_valid_trace XE is tr)
-  (descriptors: equivocator_descriptors IM)
-  (Hproper: proper_fixed_equivocator_descriptors descriptors s)
+  (descriptors : equivocator_descriptors IM)
+  (Hproper : proper_fixed_equivocator_descriptors descriptors s)
   (lst_trX := equivocators_state_project IM descriptors s)
   : trace_sub_item_input_is_seeded_or_sub_previously_sent
     (equivocator_IM IM) (elements equivocating)
@@ -877,19 +877,19 @@ Qed.
   in any projection.
 *)
 Lemma equivocator_vlsm_trace_project_reflect_non_equivocating
-  (is: composite_state (equivocator_IM IM))
-  (tr: list (composite_transition_item (equivocator_IM IM)))
-  (Htr: finite_valid_trace XE is tr)
-  (m: message)
-  (final_descriptors: equivocator_descriptors IM)
-  (Hproper: proper_fixed_equivocator_descriptors final_descriptors (finite_trace_last is tr))
-  (trX: list (composite_transition_item IM))
-  (initial_descriptors: equivocator_descriptors IM)
-  (Htr_project: equivocators_trace_project IM final_descriptors tr = Some (trX, initial_descriptors))
-  (item: composite_transition_item (equivocator_IM IM))
-  (Hitem: item ∈ tr)
-  (Houtput: output item = Some m)
-  (Hno_equiv_item: projT1 (l item) ∉ equivocating)
+  (is : composite_state (equivocator_IM IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
+  (Htr : finite_valid_trace XE is tr)
+  (m : message)
+  (final_descriptors : equivocator_descriptors IM)
+  (Hproper : proper_fixed_equivocator_descriptors final_descriptors (finite_trace_last is tr))
+  (trX : list (composite_transition_item IM))
+  (initial_descriptors : equivocator_descriptors IM)
+  (Htr_project : equivocators_trace_project IM final_descriptors tr = Some (trX, initial_descriptors))
+  (item : composite_transition_item (equivocator_IM IM))
+  (Hitem : item ∈ tr)
+  (Houtput : output item = Some m)
+  (Hno_equiv_item : projT1 (l item) ∉ equivocating)
   : trace_has_message (field_selector output) m trX.
 Proof.
   apply elem_of_list_split in Hitem.
@@ -952,15 +952,15 @@ Qed.
   one of the nodes allowed to equivocate.
 *)
 Lemma projection_has_not_been_directly_observed_is_equivocating
-  (is: composite_state (equivocator_IM IM))
-  (tr: list (composite_transition_item (equivocator_IM IM)))
-  (Htr: finite_valid_trace XE is tr)
+  (is : composite_state (equivocator_IM IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
+  (Htr : finite_valid_trace XE is tr)
   (s := @finite_trace_last _ (composite_type (equivocator_IM IM)) is tr)
-  (descriptors: equivocator_descriptors IM)
-  (Hproper: proper_fixed_equivocator_descriptors descriptors s)
+  (descriptors : equivocator_descriptors IM)
+  (Hproper : proper_fixed_equivocator_descriptors descriptors s)
   (sX := equivocators_state_project IM descriptors s)
-  (m: message)
-  (Hno: ~ composite_has_been_directly_observed IM sX m)
+  (m : message)
+  (Hno : ~ composite_has_been_directly_observed IM sX m)
   : forall item : composite_transition_item (equivocator_IM IM),
       item ∈ tr -> output item = Some m -> projT1 (l item) ∈ equivocating.
 Proof.
@@ -1264,7 +1264,7 @@ Theorem fixed_equivocators_valid_trace_project
   (is : composite_state (equivocator_IM IM))
   (tr : list (composite_transition_item (equivocator_IM IM)))
   (final_state := finite_trace_last is tr)
-  (Hproper: proper_fixed_equivocator_descriptors final_descriptors final_state)
+  (Hproper : proper_fixed_equivocator_descriptors final_descriptors final_state)
   (Htr : finite_valid_trace XE is tr)
   : exists
     (trX : list (composite_transition_item IM))

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -571,7 +571,7 @@ Proof.
           valid_state_prop (pre_loaded_with_all_messages_vlsm FreeE) (finite_trace_last is tr'))
             by (apply finite_valid_trace_last_pstate, Htr'pre).
         apply proper_sent; [done |].
-        apply has_been_sent_consistency; [typeclasses eauto | done | ].
+        apply has_been_sent_consistency; [typeclasses eauto | done |].
         by exists is, tr', (valid_trace_add_default_last Htr'pre).
     + exists trX'. exists initial_descriptors. subst foldx. split; [done |].
       split; [by apply Htr_project |].
@@ -794,7 +794,7 @@ Proof.
   destruct Hivt as [[_ [_ [_ [[Hc _] Hfixed]]]] Ht].
   simpl in Ht, Hfixed. rewrite Ht in Hfixed. simpl in Hfixed.
   clear Ht.
-  destruct Hc as [Hc | Hinit]; [| done ].
+  destruct Hc as [Hc | Hinit]; [| done].
   assert (Hpre_free : finite_valid_trace FreeE is pre).
   {
     split; [| done].
@@ -1025,7 +1025,7 @@ Proof.
     split; [| done].
     destruct om; [| done].
     simpl in Hc. simpl.
-    destruct Hc as [Hc | Hc ]
+    destruct Hc as [Hc | Hc]
     ; [| by right; apply Hseed12].
     left.
     destruct Hc as [subi Hibs].

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -75,7 +75,7 @@ Proof.
   split; [| by apply elem_of_enum].
   cbn in Ht.
   destruct l as (eqv, leqv).
-  destruct (equivocator_transition _ _ _) as (si', _om') eqn:Hti.
+  destruct (equivocator_transition _ _ _) as (si', _om') eqn: Hti.
   inversion Ht. subst. clear Ht.
   destruct (decide (i = eqv)); subst; state_update_simpl; [| done].
   by apply (zero_descriptor_transition_reflects_equivocating_state (IM eqv) _ _ _ _ _ Hti _ Hzero Hi).
@@ -690,14 +690,14 @@ Proof.
   specialize (Heqv_descriptors'' _ Hitem_not_equiv).
   simpl in *.
   destruct (equivocators_transition_item_project IM eqv_descriptors'' item)
-    as [(o, odescriptor) |] eqn:Hpr
+    as [(o, odescriptor) |] eqn: Hpr
   ; [| by congruence].
   destruct item. simpl in *.
   apply first_transition_valid in Hpre_item_free. simpl in Hpre_item_free.
   destruct Hpre_item_free as [[_ [_ [Hv _]]] Ht].
   destruct l. simpl in *. unfold vtransition in Ht. simpl in Ht.
   match type of Ht with
-  | (let (_, _) := ?t in _) = _ => destruct t as (si', om') eqn:Hti
+  | (let (_, _) := ?t in _) = _ => destruct t as (si', om') eqn: Hti
   end.
   inversion Ht; subst; clear Ht.
   state_update_simpl.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -528,7 +528,7 @@ Proof.
       simpl in Hl. subst.
       simpl in Hc.
       destruct Hc as [[Hno_equiv _] _].
-      simpl in Htx,Hvx,Hstate_project.
+      simpl in Htx, Hvx, Hstate_project.
       rewrite Hstate_project in Hvx, Htx.
       destruct input as [input |]; [| by repeat split;
         [| apply option_valid_message_None | | apply HconstraintNone |]].
@@ -911,7 +911,7 @@ Proof.
   destruct Htr as [Hpre Hsuf].
   apply finite_valid_trace_from_app_iff in Hpre.
   destruct Hpre as [_ Hitem].
-  rewrite app_assoc,finite_trace_last_app in Hproper.
+  rewrite app_assoc, finite_trace_last_app in Hproper.
   rewrite finite_trace_last_is_last in Hsuf, Hproper.
   assert (Hsufpre :
     finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE) (destination item) suf).

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -45,7 +45,7 @@ Context {message : Type}
   .
 
 Lemma no_initial_messages_in_sub_IM
-  : forall i m, ~vinitial_message_prop (sub_IM IM (elements equivocating) i) m.
+  : forall i m, ~ vinitial_message_prop (sub_IM IM (elements equivocating) i) m.
 Proof.
   intros [i Hi] m Hinit.
   by apply (no_initial_messages_in_IM i m).

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -127,7 +127,7 @@ Proof.
       apply (VLSM_incl_valid_state HinclE) in Heqv_state_s.
       revert Heqv_state_s.
       by apply (VLSM_projection_valid_state (preloaded_component_projection (equivocator_IM IM) i)).
-  - destruct (composite_transition _ _ _) as (s', om') eqn:Ht'.
+  - destruct (composite_transition _ _ _) as (s', om') eqn: Ht'.
     apply
       (equivocating_transition_preserves_fixed_equivocation
         IM (elements equivocating) _ _ _ _ _ Ht' Hlift_s).
@@ -250,7 +250,7 @@ Proof.
       split; [by split |].
       apply (VLSM_eq_valid_state HeqXE) in Hs.
       apply valid_state_has_fixed_equivocation in Hs.
-      destruct (composite_transition _ _ _) as (s', om') eqn:Ht.
+      destruct (composite_transition _ _ _) as (s', om') eqn: Ht.
       by apply
         (equivocating_transition_preserves_fixed_equivocation
           IM (elements equivocating) _ _ _ _ _ Ht Hs).
@@ -366,7 +366,7 @@ Proof.
       destruct Hom as [Hom | Hinitial]; [by left | exfalso].
       by apply no_initial_messages_in_XE in Hinitial.
     + apply valid_state_has_fixed_equivocation in Hes.
-      destruct (composite_transition _ _ _) as (es', om') eqn:Het.
+      destruct (composite_transition _ _ _) as (es', om') eqn: Het.
       simpl.
       by apply
         (zero_descriptor_transition_preserves_fixed_equivocation
@@ -432,7 +432,7 @@ Proof.
       destruct Hom as [Hom | Hinitial]; [by left | exfalso].
       by apply no_initial_messages_in_XE in Hinitial.
     + apply valid_state_has_fixed_equivocation in Hes.
-      destruct (composite_transition _ _ _) as (es', om') eqn:Het.
+      destruct (composite_transition _ _ _) as (es', om') eqn: Het.
       simpl.
       by apply
         (zero_descriptor_transition_preserves_fixed_equivocation

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -197,7 +197,7 @@ Proof.
   specialize (vlsm_is_pre_loaded_with_False X) as HeqX.
   specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM (elements equivocating)) as HinclE.
   intro; intros.
-  destruct iom as [im|]; swap 1 2; [|destruct HcX as [Hsent | Hemitted]].
+  destruct iom as [im |]; swap 1 2; [| destruct HcX as [Hsent | Hemitted]].
   - exists [], eqv_state_s.
     by split; [constructor | eauto].
   - exists []. exists eqv_state_s.
@@ -263,7 +263,7 @@ Proof.
       apply (VLSM_eq_valid_state HeqXE) in Hstate_valid.
       apply (VLSM_eq_valid_state HeqX) in HtrX.
       intros m Hsent.
-      apply (VLSM_incl_valid_message (VLSM_eq_proj1 HeqXE)); [by left|].
+      apply (VLSM_incl_valid_message (VLSM_eq_proj1 HeqXE)); [by left |].
       by apply (fixed_equivocating_messages_sent_by_non_equivocating_are_valid eqv_state_s).
     }
     specialize (Hreplay eqv_state_s).
@@ -347,7 +347,7 @@ Proof.
   *)
   assert (no_initial_messages_in_XE :
     forall m, ~ vinitial_message_prop (pre_loaded_vlsm XE (fun _ => False)) m).
-  { intros m [[i [[mi Hmi] Him]]|Hseeded]; [| done].
+  { intros m [[i [[mi Hmi] Him]] | Hseeded]; [| done].
     by elim (no_initial_messages_in_IM i mi).
   }
   specialize (vlsm_is_pre_loaded_with_False X) as HeqX.
@@ -364,7 +364,7 @@ Proof.
     apply (VLSM_eq_valid_state HeqXE) in Hes.
     split.
     + split; [| done].  destruct om as [im |]; [| done].
-      destruct Hom as [Hom|Hinitial]; [by left | exfalso].
+      destruct Hom as [Hom | Hinitial]; [by left | exfalso].
       by apply no_initial_messages_in_XE in Hinitial.
     + apply valid_state_has_fixed_equivocation in Hes.
       destruct (composite_transition _ _ _) as (es', om') eqn:Het.
@@ -411,7 +411,7 @@ Proof.
   assert (no_initial_messages_in_XE :
     forall m, ~ vinitial_message_prop (pre_loaded_vlsm XE (fun _ => False)) m).
   {
-    intros m [[i [[mi Hmi] Him]]|Hseeded]; [| done].
+    intros m [[i [[mi Hmi] Him]] | Hseeded]; [| done].
     by elim (no_initial_messages_in_IM i mi).
   }
   specialize (vlsm_is_pre_loaded_with_False X) as HeqX.
@@ -431,7 +431,7 @@ Proof.
     apply (VLSM_eq_valid_state HeqXE) in Hes.
     split.
     + split; [| done]. destruct om as [im |]; [| done].
-      destruct Hom as [Hom|Hinitial]; [by left | exfalso].
+      destruct Hom as [Hom | Hinitial]; [by left | exfalso].
       by apply no_initial_messages_in_XE in Hinitial.
     + apply valid_state_has_fixed_equivocation in Hes.
       destruct (composite_transition _ _ _) as (es', om') eqn:Het.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -281,7 +281,7 @@ Proof.
     apply valid_trace_forget_last in Him_etr.
     specialize (Hreplay _ _ Him_etr).
     apply valid_trace_add_default_last in Hreplay.
-    eexists _,_; split; [done |].
+    eexists _, _; split; [done |].
     (*
       Having verified the validity part of the conclusion, now we only
       need to show two projection properties, and the no message-equivocation
@@ -320,7 +320,7 @@ Proof.
       rewrite finite_trace_last_is_last.
       rewrite finite_trace_last_output_is_last in Him_output.
       replace (output _) with (Some im) in Ht.
-      by eexists _,_.
+      by eexists _, _.
 Qed.
 
 (** ** The main result

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -111,8 +111,7 @@ Proof.
       by specialize
         (VLSM_weak_embedding_has_been_sent
           (PreFreeSubE_PreFreeE_weak_embedding IM _ _ Heqv_state_s)
-          _ Hs m
-          ).
+          _ Hs m).
     + destruct Hseed as [i [Hi Hsent]].
       simpl.
       exists i.
@@ -371,8 +370,7 @@ Proof.
       simpl.
       by apply
         (zero_descriptor_transition_preserves_fixed_equivocation
-          IM (elements equivocating) _ _ _ _ _ Het Hes li
-        ).
+          IM (elements equivocating) _ _ _ _ _ Het Hes li).
   - by apply fixed_equivocation_has_replayable_message_prop.
 Qed.
 
@@ -438,8 +436,7 @@ Proof.
       simpl.
       by apply
         (zero_descriptor_transition_preserves_fixed_equivocation
-          IM [] _ _ _ _ _ Het Hes li
-        ).
+          IM [] _ _ _ _ _ Het Hes li).
   - clear isX sX trX HtrX. intro; intros.
     specialize (equivocators_fixed_equivocations_vlsm_incl_PreFree IM []) as HinclE.
     destruct iom as [im |]; [| by exists [], eqv_state_s; split; constructor].

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
@@ -103,7 +103,7 @@ Lemma limited_equivocators_finite_valid_trace_init_to_rev
 Proof.
   destruct HtrX as (equivocating & Hlimited & HtrX).
   eapply VLSM_incl_finite_valid_trace, valid_trace_add_default_last in HtrX
-  ; [| by eapply VLSM_eq_proj1,Fixed_eq_StrongFixed].
+  ; [| by eapply VLSM_eq_proj1, Fixed_eq_StrongFixed].
   eapply fixed_equivocators_finite_valid_trace_init_to_rev in HtrX
     as (is & s & tr & His & Hs & Htr & Hptr & Houtput); [| done].
   exists is, s, tr; split_and?; try itauto.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
@@ -342,7 +342,7 @@ Lemma limited_equivocators_vlsm_partial_projection
   : VLSM_partial_projection equivocators_limited_equivocations_vlsm Limited
       (equivocators_partial_trace_project IM final_descriptors).
 Proof.
-  split; [split|].
+  split; [split |].
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
     assert (HPreFree_pre_tr :
       finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE) s_pre (pre ++ tr)).
@@ -371,7 +371,7 @@ Lemma limited_equivocators_vlsm_projection
   : VLSM_projection equivocators_limited_equivocations_vlsm Limited
     (equivocators_total_label_project IM) (equivocators_total_state_project IM).
 Proof.
-  constructor; [constructor|]; intros ? *.
+  constructor; [constructor |]; intros ? *.
   - intros HtrX. apply PreFreeE_Free_vlsm_projection_type.
     revert HtrX. apply VLSM_incl_finite_valid_trace_from.
     by apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
@@ -21,9 +21,9 @@ Lemma equivocator_initial_state_project
   {message}
   (X : VLSM message)
   (es : vstate (equivocator_vlsm X))
-  (eqv_descriptor: MachineDescriptor X)
-  (Heqv: proper_descriptor X eqv_descriptor es)
-  (Hes: vinitial_state_prop (equivocator_vlsm X) es):
+  (eqv_descriptor : MachineDescriptor X)
+  (Heqv : proper_descriptor X eqv_descriptor es)
+  (Hes : vinitial_state_prop (equivocator_vlsm X) es) :
   vinitial_state_prop X (equivocator_state_descriptor_project es eqv_descriptor).
 Proof.
   destruct eqv_descriptor; [done |].
@@ -38,8 +38,8 @@ Lemma composite_equivocators_initial_state_project
   (IM : index -> VLSM message)
   (es : composite_state (equivocator_IM IM))
   (eqv_descriptors : equivocator_descriptors IM)
-  {eqv_constraint: composite_constraint (equivocator_IM IM)}
-  {constraint: composite_constraint IM}
+  {eqv_constraint : composite_constraint (equivocator_IM IM)}
+  {constraint : composite_constraint IM}
   (Heqv : proper_equivocator_descriptors IM eqv_descriptors es)
   (Hes : vinitial_state_prop (composite_vlsm (equivocator_IM IM) eqv_constraint) es)
   : vinitial_state_prop (composite_vlsm IM constraint)
@@ -208,7 +208,7 @@ Lemma equivocators_limited_valid_trace_projects_to_fixed_limited_equivocation
   (is : composite_state equivocator_IM)
   (tr : list (composite_transition_item equivocator_IM))
   (final_state := finite_trace_last is tr)
-  (Hproper: not_equivocating_equivocator_descriptors IM final_descriptors final_state)
+  (Hproper : not_equivocating_equivocator_descriptors IM final_descriptors final_state)
   (Htr : finite_valid_trace equivocators_limited_equivocations_vlsm is tr)
   : exists
     (trX : list (composite_transition_item IM))
@@ -263,7 +263,7 @@ Lemma equivocators_limited_valid_trace_projects_to_annotated_limited_equivocatio
   (is : composite_state equivocator_IM)
   (tr : list (composite_transition_item equivocator_IM))
   (final_state := finite_trace_last is tr)
-  (Hproper: not_equivocating_equivocator_descriptors IM final_descriptors final_state)
+  (Hproper : not_equivocating_equivocator_descriptors IM final_descriptors final_state)
   (Htr : finite_valid_trace equivocators_limited_equivocations_vlsm is tr)
   : exists
     (trX : list (composite_transition_item IM))
@@ -310,7 +310,7 @@ Lemma limited_equivocators_valid_trace_project
   (is : composite_state equivocator_IM)
   (tr : list (composite_transition_item equivocator_IM))
   (final_state := finite_trace_last is tr)
-  (Hproper: not_equivocating_equivocator_descriptors IM final_descriptors final_state)
+  (Hproper : not_equivocating_equivocator_descriptors IM final_descriptors final_state)
   (Htr : finite_valid_trace equivocators_limited_equivocations_vlsm is tr)
   : exists
     (trX : list (composite_transition_item IM))

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -168,7 +168,7 @@ Proof.
       | _ =>  full_replay_state i
       end)).
   {
-    intros Hcut; specialize (Hcut _ (incl_refl _) ltac: (apply NoDup_enum)).
+    intros Hcut; specialize (Hcut _ (incl_refl _) ltac : (apply NoDup_enum)).
     unfold replayed_initial_state_from, composite_apply_plan.
     rewrite _apply_plan_last; extensionality i.
     specialize (Hcut i); unfold composite_apply_plan in Hcut; unfold spawn_initial_state
@@ -212,8 +212,8 @@ Qed.
   the projection of the replaying of an initial state is empty.
 *)
 Lemma equivocators_trace_project_replayed_initial_state_from full_replay_state is
-  (eqv_descriptors: equivocator_descriptors)
-  (Heqv_descriptors: not_equivocating_equivocator_descriptors IM eqv_descriptors full_replay_state)
+  (eqv_descriptors : equivocator_descriptors)
+  (Heqv_descriptors : not_equivocating_equivocator_descriptors IM eqv_descriptors full_replay_state)
   : equivocators_trace_project eqv_descriptors
       (replayed_initial_state_from full_replay_state is) =
     Some ([], eqv_descriptors).
@@ -281,8 +281,8 @@ Proof.
 Qed.
 
 Lemma equivocator_state_descriptor_project_replayed_initial_state_from_left full_replay_state is
-  (eqv_descriptors: equivocator_descriptors)
-  (Heqv_descriptors: not_equivocating_equivocator_descriptors IM eqv_descriptors full_replay_state)
+  (eqv_descriptors : equivocator_descriptors)
+  (Heqv_descriptors : not_equivocating_equivocator_descriptors IM eqv_descriptors full_replay_state)
   (lst := finite_trace_last full_replay_state (replayed_initial_state_from full_replay_state is))
   : forall i,
     equivocator_state_descriptor_project (lst i) (eqv_descriptors i) =
@@ -340,8 +340,8 @@ Proof.
 Qed.
 
 Lemma equivocator_state_descriptor_project_replayed_trace_from_left full_replay_state is tr
-  (eqv_descriptors: equivocator_descriptors)
-  (Heqv_descriptors: not_equivocating_equivocator_descriptors IM eqv_descriptors full_replay_state)
+  (eqv_descriptors : equivocator_descriptors)
+  (Heqv_descriptors : not_equivocating_equivocator_descriptors IM eqv_descriptors full_replay_state)
   (lst := finite_trace_last full_replay_state (replayed_trace_from full_replay_state is tr))
   : forall i,
     equivocator_state_descriptor_project (lst i) (eqv_descriptors i) =
@@ -368,8 +368,8 @@ Proof.
 Qed.
 
 Lemma equivocators_trace_project_replayed_trace_from_left full_replay_state is tr
-  (eqv_descriptors: equivocator_descriptors)
-  (Heqv_descriptors: not_equivocating_equivocator_descriptors IM eqv_descriptors full_replay_state)
+  (eqv_descriptors : equivocator_descriptors)
+  (Heqv_descriptors : not_equivocating_equivocator_descriptors IM eqv_descriptors full_replay_state)
   : equivocators_trace_project eqv_descriptors
       (replayed_trace_from full_replay_state is tr) =
     Some ([], eqv_descriptors).
@@ -439,7 +439,7 @@ Lemma lift_equivocators_sub_transition
   (full_replay_state : composite_state equivocator_IM)
   l s om s' om'
   (Hv : composite_valid sub_equivocator_IM l (s, om))
-  (Ht: composite_transition sub_equivocator_IM l (s, om) = (s', om'))
+  (Ht : composite_transition sub_equivocator_IM l (s, om) = (s', om'))
   : composite_transition equivocator_IM (lift_equivocators_sub_label_to full_replay_state  l)
       (lift_equivocators_sub_state_to full_replay_state s, om) =
       (lift_equivocators_sub_state_to full_replay_state s', om').

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -168,7 +168,7 @@ Proof.
       | _ =>  full_replay_state i
       end)).
   {
-    intros Hcut; specialize (Hcut _ (incl_refl _) ltac : (apply NoDup_enum)).
+    intros Hcut; specialize (Hcut _ (incl_refl _) ltac:(apply NoDup_enum)).
     unfold replayed_initial_state_from, composite_apply_plan.
     rewrite _apply_plan_last; extensionality i.
     specialize (Hcut i); unfold composite_apply_plan in Hcut; unfold spawn_initial_state

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -166,8 +166,7 @@ Proof.
         if (decide (eqv ∈ l)) then equivocator_state_append (full_replay_state i) (is eqv)
         else full_replay_state i
       | _ =>  full_replay_state i
-      end
-    )).
+      end)).
   {
     intros Hcut; specialize (Hcut _ (incl_refl _) ltac:(apply NoDup_enum)).
     unfold replayed_initial_state_from, composite_apply_plan.
@@ -430,8 +429,8 @@ Proof.
   specialize
     (equivocator_state_append_valid (IM i) li
       (s (dexist i Hi)) om
-      (full_replay_state i) Hv
-    ) as Hlift.
+      (full_replay_state i) Hv)
+    as Hlift.
   cbn.
   by rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi).
 Qed.
@@ -451,8 +450,8 @@ Proof.
     (equivocator_state_append_transition (IM i) li
       (s (dexist i Hi)) om
       (s' (dexist i Hi)) om'
-      (full_replay_state i) Hv
-    ) as Hlift.
+      (full_replay_state i) Hv)
+    as Hlift.
   cbn in Ht.
   destruct (equivocator_transition _ _ _) as (_si', _om').
   inversion Ht; subst s' om'; clear Ht.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -168,7 +168,7 @@ Proof.
       | _ =>  full_replay_state i
       end)).
   {
-    intros Hcut; specialize (Hcut _ (incl_refl _) ltac:(apply NoDup_enum)).
+    intros Hcut; specialize (Hcut _ (incl_refl _) ltac: (apply NoDup_enum)).
     unfold replayed_initial_state_from, composite_apply_plan.
     rewrite _apply_plan_last; extensionality i.
     specialize (Hcut i); unfold composite_apply_plan in Hcut; unfold spawn_initial_state
@@ -227,8 +227,8 @@ Proof.
   subst plan.
   induction l using rev_ind; [split; simpl; [done | lia] |].
   rewrite map_app, (composite_apply_plan_app equivocator_IM).
-  destruct (composite_apply_plan _ _ _) as (litems, lfinal) eqn:Hplanl.
-  destruct (composite_apply_plan _ lfinal _) as (aitems, afinal) eqn:Hplana.
+  destruct (composite_apply_plan _ _ _) as (litems, lfinal) eqn: Hplanl.
+  destruct (composite_apply_plan _ lfinal _) as (aitems, afinal) eqn: Hplana.
   simpl in *.
   inversion_clear Hplana.
   split.
@@ -237,7 +237,7 @@ Proof.
     repeat split; [| by apply IHl].
     specialize (Heqv_descriptors (` x)).
     unfold existing_descriptor in Heqv_descriptors.
-    destruct (eqv_descriptors (` x)) eqn:Heqv_x; [done |].
+    destruct (eqv_descriptors (` x)) eqn: Heqv_x; [done |].
     destruct Heqv_descriptors as [s_x_n Heqv_descriptors].
     apply equivocator_state_project_Some_rev in Heqv_descriptors as Hltn.
     apply proj2 in IHl.
@@ -267,8 +267,8 @@ Proof.
   rewrite map_app, (composite_apply_plan_app equivocator_IM).
   specialize (composite_apply_plan_last equivocator_IM full_replay_state
     (map (initial_new_machine_transition_item is) l)) as Hlst.
-  destruct (composite_apply_plan _ _ _) as (litems, lfinal) eqn:Hplanl.
-  destruct (composite_apply_plan _ lfinal _) as (aitems, afinal) eqn:Hplana.
+  destruct (composite_apply_plan _ _ _) as (litems, lfinal) eqn: Hplanl.
+  destruct (composite_apply_plan _ lfinal _) as (aitems, afinal) eqn: Hplana.
   inversion_clear Hplana.
   simpl in *.
   rewrite finite_trace_last_is_last. simpl.
@@ -390,7 +390,7 @@ Proof.
   subst sub_i.
   specialize (Heqv_descriptors i).
   unfold existing_descriptor in Heqv_descriptors.
-  destruct (eqv_descriptors _) eqn:Heqv_l; [done |].
+  destruct (eqv_descriptors _) eqn: Heqv_l; [done |].
   destruct Heqv_descriptors as [s_l_n Hs_l_n].
   apply equivocator_state_project_Some_rev in Hs_l_n as Hltn.
   specialize (lift_equivocators_sub_state_to_size full_replay_state destination i)

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -60,7 +60,7 @@ Proof.
     by apply lift_sub_valid, Hv.
   - by intros [_ Ht]; revert Ht; apply lift_sub_transition.
   - by intros; apply (lift_sub_state_initial equivocator_IM).
-  - intros; destruct HmX as [Hinit|Hseeded]; [| by apply Hseed].
+  - intros; destruct HmX as [Hinit | Hseeded]; [| by apply Hseed].
     apply initial_message_is_valid.
     destruct Hinit as [i Him].
     by exists (proj1_sig i).
@@ -116,7 +116,7 @@ Lemma lift_equivocators_sub_state_to_size
 Proof.
   intro i.
   unfold lift_equivocators_sub_state_to.
-  destruct (decide _); [|lia].
+  destruct (decide _); [| lia].
   by rewrite equivocator_state_append_size; lia.
 Qed.
 
@@ -247,7 +247,7 @@ Proof.
     unfold equivocator_vlsm_transition_item_project. rewrite Heqv_x.
     simpl; equivocator_state_update_simpl.
     rewrite decide_False by lia.
-    destruct_equivocator_state_project (lfinal (` x)) n lfinal_x_n Hltn'; [|lia].
+    destruct_equivocator_state_project (lfinal (` x)) n lfinal_x_n Hltn'; [| lia].
     by equivocator_state_update_simpl.
   - intro i. apply proj2 in IHl. specialize (IHl i).
     by destruct (decide (i = `x)); subst; equivocator_state_update_simpl; [lia |].
@@ -276,7 +276,7 @@ Proof.
   intros i j Hj.
   destruct (decide (`x = i)); subst; equivocator_state_update_simpl; [| by auto].
   specialize (IHl (` x) j Hj).
-  destruct_equivocator_state_project (full_replay_state (` x)) j s_x_j Hltj; [|lia].
+  destruct_equivocator_state_project (full_replay_state (` x)) j s_x_j Hltj; [| lia].
   rewrite equivocator_state_extend_project_1; [done |].
   by apply equivocator_state_project_Some_rev in IHl as Hltj'.
 Qed.
@@ -292,7 +292,7 @@ Proof.
   intro i. specialize (Heqv_descriptors i).
   unfold equivocator_state_descriptor_project.
   unfold existing_descriptor in Heqv_descriptors.
-  destruct (eqv_descriptors i) as [sn|ji]; [done |].
+  destruct (eqv_descriptors i) as [sn | ji]; [done |].
   destruct Heqv_descriptors as [full_i_ji Hpr_ji].
   apply equivocator_state_project_Some_rev in Hpr_ji as Hltji.
   subst lst.
@@ -351,7 +351,7 @@ Proof.
   intro i. specialize (Heqv_descriptors i).
   unfold equivocator_state_descriptor_project.
   unfold existing_descriptor in Heqv_descriptors.
-  destruct (eqv_descriptors i) as [sn|ji]; [done |].
+  destruct (eqv_descriptors i) as [sn | ji]; [done |].
   destruct Heqv_descriptors as [full_i_ji Hpr_ji].
   apply equivocator_state_project_Some_rev in Hpr_ji as Hltji.
   subst lst.
@@ -401,10 +401,10 @@ Proof.
   simpl.
   destruct_equivocator_state_project
     (lift_equivocators_sub_state_to full_replay_state destination i) n
-    lift_n Hlt_n; [|lia].
+    lift_n Hlt_n; [| lia].
   rewrite (lift_equivocators_sub_state_to_sub) with (Hi := Hi).
   rewrite equivocator_state_append_lst.
-  by destruct li as [sn_d| id li| id li]; simpl
+  by destruct li as [sn_d | id li | id li]; simpl
   ; rewrite !decide_False by lia
   ; equivocator_state_update_simpl.
 Qed.
@@ -648,7 +648,7 @@ Proof.
   left. exists i.
   simpl. rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi).
   subst. unfold SubProjectionTraces.sub_IM in Hsent. cbn in Hsent |-*.
-  apply equivocator_state_append_sent_right; [..|done].
+  apply equivocator_state_append_sent_right; [.. | done].
   - by apply Hfull_replay_state_pr.
   - by apply (Hs_pr (dexist i Hi) Hs).
 Qed.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -234,7 +234,7 @@ Proof.
   inversion_clear Hplana.
   split.
   - apply equivocators_trace_project_app_iff.
-    exists [],[],eqv_descriptors.
+    exists [], [], eqv_descriptors.
     repeat split; [| by apply IHl].
     specialize (Heqv_descriptors (` x)).
     unfold existing_descriptor in Heqv_descriptors.
@@ -376,17 +376,17 @@ Lemma equivocators_trace_project_replayed_trace_from_left full_replay_state is t
     Some ([], eqv_descriptors).
 Proof.
   apply equivocators_trace_project_app_iff.
-  exists [],[],eqv_descriptors.
+  exists [], [], eqv_descriptors.
   repeat split; [| by apply equivocators_trace_project_replayed_initial_state_from].
   induction tr using rev_ind; [done |].
   unfold pre_VLSM_embedding_finite_trace_project.
   rewrite map_app.
   apply equivocators_trace_project_app_iff.
-  exists [],[], eqv_descriptors.
+  exists [], [], eqv_descriptors.
   repeat split; [| done].
   clear IHtr.
   destruct x. simpl.
-  destruct l as (sub_i,li).
+  destruct l as (sub_i, li).
   destruct_dec_sig sub_i i Hi Heqsub_i.
   subst sub_i.
   specialize (Heqv_descriptors i).

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -204,7 +204,7 @@ Proof.
     + case_decide.
       * rewrite decide_True; rewrite ?elem_of_app; itauto.
       * rewrite decide_False; [done |].
-        intros [Hin | Hx]%elem_of_app; [ done |].
+        intros [Hin | Hx]%elem_of_app; [done |].
         by rewrite elem_of_list_singleton, dsig_eq in Hx.
 Qed.
 

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -126,9 +126,9 @@ Proof.
     }
     by apply functional_extensionality_dep_good; subst.
   - destruct IHHtrX1 as [eqv_state_is [Hstate_start_project [eqv_state_s
-      [Hstate_final_project [eqv_state_tr [Hstate_project [Hstate_trace _ ]]]]]]].
+      [Hstate_final_project [eqv_state_tr [Hstate_project [Hstate_trace _]]]]]]].
     destruct IHHtrX2 as [eqv_msg_is [Hmsg_start_project [eqv_msg_s [_
-      [eqv_msg_tr [Hmsg_project [Hmsg_trace Hfinal_msg ]]]]]]].
+      [eqv_msg_tr [Hmsg_project [Hmsg_trace Hfinal_msg]]]]]]].
     exists eqv_state_is. split; [done |].
     apply valid_trace_last_pstate in Hstate_trace as Hstate_valid.
     destruct Ht as [[Hs [Hiom [Hv Hc]]] Ht].

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -280,8 +280,7 @@ Lemma replayed_trace_from_valid_equivocating
 Proof.
   apply
     (sub_replayed_trace_from_valid_equivocating IM seed
-      (enum index) _ Hfull_replay_state
-    ).
+      (enum index) _ Hfull_replay_state).
   pose (Hproj := preloaded_sub_composition_all_embedding (equivocator_IM IM)
     (no_equivocations_additional_constraint_with_pre_loaded (equivocator_IM IM)
     (free_constraint _) seed) seed).
@@ -331,8 +330,7 @@ Proof.
     apply valid_trace_forget_last in Hmsg_trace.
     specialize
       (replayed_trace_from_valid_equivocating
-       _ Hstate_valid _ _ Hmsg_trace
-      )
+       _ Hstate_valid _ _ Hmsg_trace)
       as Hmsg_trace_full_replay.
     remember (all_equivocating_replayed_trace_from _ _ _ ) as emsg_tr.
     apply valid_trace_add_default_last in Hmsg_trace_full_replay.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -137,7 +137,7 @@ Proof.
       as Hreplay.
     spec Hreplay.
     { clear -Heqiom Hfinal_msg.
-      destruct iom as [im|]; [| done].
+      destruct iom as [im |]; [| done].
       unfold empty_initial_message_or_final_output in Heqiom.
       destruct_list_last iom_tr iom_tr' item Heqiom_tr.
       - by right.
@@ -211,7 +211,7 @@ Proof.
     }
     clear Happ_extend.
     apply valid_trace_last_pstate in Happ.
-    repeat split; [done |..| done].
+    repeat split; [done | .. | done].
     + destruct iom as [im |]; [| by apply option_valid_message_None].
       destruct Hbs_iom as [Hbs_iom | Hseeded].
       * by apply (preloaded_composite_sent_valid (equivocator_IM IM) _ _ _ Happ _ Hbs_iom).
@@ -316,12 +316,12 @@ Lemma seeded_equivocators_finite_valid_trace_init_to_rev
 Proof.
   apply
     (generalized_equivocators_finite_valid_trace_init_to_rev IM)
-  ; [..| done].
+  ; [.. | done].
   - intro; intros. split; [| done].
     destruct om; [| done].
-    destruct Hom as [Hsent|Hinitial]; [by left |].
+    destruct Hom as [Hsent | Hinitial]; [by left |].
     right.
-    destruct Hinitial as [[i [[mi Hmi] Him]]|Hseeded]; [exfalso | done].
+    destruct Hinitial as [[i [[mi Hmi] Him]] | Hseeded]; [exfalso | done].
     by elim (no_initial_messages_in_IM i mi).
   - clear isX sX trX HtrX.
     intro; intros.
@@ -421,7 +421,7 @@ Proof.
   clear.
   intros l (s, om) Hc.
   split; [| done].
-  destruct om as [m|]; [| done].
+  destruct om as [m |]; [| done].
   by apply proj1 in Hc.
 Qed.
 

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -76,14 +76,14 @@ Definition replayable_message_prop : Prop :=
   forall si s tr
     (HtrX : finite_valid_trace_init_to CX si s tr)
     eqv_state_s
-    (Hstate_valid: valid_state_prop CE eqv_state_s)
+    (Hstate_valid : valid_state_prop CE eqv_state_s)
     (Hstate_final_project : equivocators_total_state_project IM eqv_state_s = s)
     eqv_msg_is eqv_msg_s eqv_msg_tr
     (Hmsg_trace : finite_valid_trace_init_to CE eqv_msg_is eqv_msg_s eqv_msg_tr)
     iom
     (Hfinal_msg : last_in_trace_except_from (vinitial_message_prop CE) eqv_msg_tr iom)
     l
-    (HcX: constraintX l (s, iom)),
+    (HcX : constraintX l (s, iom)),
     exists eqv_msg_tr lst_msg_tr,
       finite_valid_trace_from_to CE eqv_state_s lst_msg_tr eqv_msg_tr /\
       equivocators_total_trace_project IM eqv_msg_tr = [] /\

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -332,7 +332,7 @@ Proof.
       (replayed_trace_from_valid_equivocating
        _ Hstate_valid _ _ Hmsg_trace)
       as Hmsg_trace_full_replay.
-    remember (all_equivocating_replayed_trace_from _ _ _ ) as emsg_tr.
+    remember (all_equivocating_replayed_trace_from _ _ _) as emsg_tr.
     apply valid_trace_add_default_last in Hmsg_trace_full_replay.
     eexists _, _; split; [done |].
     subst.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -157,7 +157,7 @@ Proof.
       (@existT _ (fun i : index => vlabel (equivocator_IM IM i)) eqv (ContinueWith 0 li))
       as el.
     destruct (vtransition CE el (es, iom))
-      as (es', om') eqn:Hesom'.
+      as (es', om') eqn: Hesom'.
     specialize (Happ_extend  el iom es' om').
     apply valid_trace_get_last in Happ as Heqes.
     assert (Hes_pr_i : forall i, equivocators_total_state_project IM es i = s i)
@@ -170,7 +170,7 @@ Proof.
     cbn in Hesom', Hes_pr_eqv.
     rewrite Hes_pr_eqv in Hesom'.
     cbn in Ht.
-    destruct (vtransition _ _ _) as (si', _om) eqn:Hteqv.
+    destruct (vtransition _ _ _) as (si', _om) eqn: Hteqv.
     inversion Ht. subst sf _om. clear Ht.
     inversion Hesom'. subst es' om'. clear Hesom'.
     match type of Happ_extend with

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -336,7 +336,7 @@ Proof.
       as Hmsg_trace_full_replay.
     remember (all_equivocating_replayed_trace_from _ _ _ ) as emsg_tr.
     apply valid_trace_add_default_last in Hmsg_trace_full_replay.
-    eexists _,_; split; [done |].
+    eexists _, _; split; [done |].
     subst.
     unfold all_equivocating_replayed_trace_from.
     rewrite

--- a/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
@@ -36,7 +36,7 @@ Lemma equivocator_state_append_valid l s om base_s
       (equivocator_state_append base_s s, om).
 Proof.
   by destruct l; cbn; [done | ..]
-  ; (destruct (equivocator_state_project s n) as [sn |] eqn:Hn; [| done])
+  ; (destruct (equivocator_state_project s n) as [sn |] eqn: Hn; [| done])
   ; rewrite (equivocator_state_append_project_2 _ base_s s _ n eq_refl)
   ; rewrite Hn.
 Qed.
@@ -49,10 +49,10 @@ Lemma equivocator_state_append_transition l s om s' om' base_s
 Proof.
   destruct l; cbn; intros Hv Ht
   ; [by inversion_clear Ht; f_equal; apply equivocator_state_append_extend_commute | ..]
-  ; (destruct (equivocator_state_project s n) as [sn |] eqn:Hn; [| done])
+  ; (destruct (equivocator_state_project s n) as [sn |] eqn: Hn; [| done])
   ;  rewrite (equivocator_state_append_project_2 _ base_s s _ n eq_refl)
   ;  rewrite Hn
-  ;  destruct (vtransition _ _ _) as (sn', _om') eqn:Hti
+  ;  destruct (vtransition _ _ _) as (sn', _om') eqn: Hti
   ;  inversion_clear Ht; f_equal.
   - by apply equivocator_state_append_update_commute.
   - by apply equivocator_state_append_extend_commute.

--- a/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
@@ -35,8 +35,8 @@ Lemma equivocator_state_append_valid l s om base_s
       (equivocator_state_append_label base_s l)
       (equivocator_state_append base_s s, om).
 Proof.
-  by destruct l; cbn; [done |..]
-  ; (destruct (equivocator_state_project s n) as [sn|] eqn:Hn; [| done])
+  by destruct l; cbn; [done | ..]
+  ; (destruct (equivocator_state_project s n) as [sn |] eqn:Hn; [| done])
   ; rewrite (equivocator_state_append_project_2 _ base_s s _ n eq_refl)
   ; rewrite Hn.
 Qed.
@@ -49,7 +49,7 @@ Lemma equivocator_state_append_transition l s om s' om' base_s
 Proof.
   destruct l; cbn; intros Hv Ht
   ; [by inversion_clear Ht; f_equal; apply equivocator_state_append_extend_commute | ..]
-  ; (destruct (equivocator_state_project s n) as [sn|] eqn:Hn; [| done])
+  ; (destruct (equivocator_state_project s n) as [sn |] eqn:Hn; [| done])
   ;  rewrite (equivocator_state_append_project_2 _ base_s s _ n eq_refl)
   ;  rewrite Hn
   ;  destruct (vtransition _ _ _) as (sn', _om') eqn:Hti

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -137,7 +137,7 @@ Proof.
   by rewrite !fin_to_nat_to_fin.
 Qed.
 
-#[local] Lemma equivocator_state_project_None s i (Hi : ~i < equivocator_state_n s)
+#[local] Lemma equivocator_state_project_None s i (Hi : ~ i < equivocator_state_n s)
   : equivocator_state_project s i = None.
 Proof.
   unfold equivocator_state_project.
@@ -151,7 +151,7 @@ Proof.
 Qed.
 
 Lemma equivocator_state_project_None_rev s i
-  : equivocator_state_project s i = None -> ~i < equivocator_state_n s.
+  : equivocator_state_project s i = None -> ~ i < equivocator_state_n s.
 Proof.
   unfold equivocator_state_project.
   by case_decide; [congruence | intro; lia].

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -132,7 +132,7 @@ Definition equivocator_state_project
   : equivocator_state_project s i = Some (equivocator_state_s s (nat_to_fin Hi)).
 Proof.
   unfold equivocator_state_project.
-  case_decide; [|lia].
+  case_decide; [| lia].
   f_equal. apply equivocator_state_eq.
   by rewrite !fin_to_nat_to_fin.
 Qed.
@@ -158,7 +158,7 @@ Proof.
 Qed.
 
 #[local] Ltac destruct_equivocator_state_project' es i si Hi Hpr :=
-  destruct (equivocator_state_project es i) as [si|] eqn:Hpr
+  destruct (equivocator_state_project es i) as [si |] eqn:Hpr
   ; [ specialize (equivocator_state_project_Some_rev _ _ _ Hpr) as Hi
     | specialize (equivocator_state_project_None_rev _ _ Hpr) as Hi ].
 
@@ -182,8 +182,8 @@ Proof.
     specialize (Hext (equivocator_state_last es2)) as Hlst_es2.
     clear Hext.
     symmetry in Hlst_es1.
-    destruct_equivocator_state_project es1 (equivocator_state_last es1) lst1 Hi1; [|lia].
-    destruct_equivocator_state_project es2 (equivocator_state_last es2) lst2 Hi2; [|lia].
+    destruct_equivocator_state_project es1 (equivocator_state_last es1) lst1 Hi1; [| lia].
+    destruct_equivocator_state_project es2 (equivocator_state_last es2) lst2 Hi2; [| lia].
     apply equivocator_state_project_Some_rev in Hlst_es1.
     apply equivocator_state_project_Some_rev in Hlst_es2.
     lia.
@@ -240,7 +240,7 @@ Lemma equivocator_state_update_project_eq bs i si j
   : equivocator_state_project (equivocator_state_update bs i si) j = Some si.
 Proof.
   pose proof (equivocator_state_update_size bs i si) as Heq.
-  destruct_equivocator_state_project' (equivocator_state_update bs i si) j sj Hi' Hpr ; [|lia].
+  destruct_equivocator_state_project' (equivocator_state_update bs i si) j sj Hi' Hpr ; [| lia].
   rewrite <- Hpr.
   rewrite (equivocator_state_project_Some _ _ Hi').
   f_equal; subst; clear; simpl.
@@ -352,7 +352,7 @@ Qed.
   let Hni := fresh "Hni" in
   let Hni' := fresh "Hni" in
   destruct (decide (i < equivocator_state_n es)) as [Hi | Hni]
-  ; [|destruct (decide (i = equivocator_state_n es)) as [Hi | Hni']]
+  ; [| destruct (decide (i = equivocator_state_n es)) as [Hi | Hni']]
   ; [| | assert (Hi : equivocator_state_n es < i) by lia]
   ; [ specialize (equivocator_state_extend_project_1 es s i Hi) as Hpr
     | specialize (equivocator_state_extend_project_2 es s i Hi) as Hpr
@@ -445,8 +445,8 @@ Qed.
 
 #[local] Ltac destruct_equivocator_state_append_project' es es' i Hi k Hk Hpr :=
   let Hi' := fresh "Hi" in
-  destruct (decide (i < equivocator_state_n es)) as [Hi| Hi']; swap 1 2;
-  [ destruct (decide (i < equivocator_state_n es + equivocator_state_n es')) as [Hi|Hi];
+  destruct (decide (i < equivocator_state_n es)) as [Hi | Hi']; swap 1 2;
+  [ destruct (decide (i < equivocator_state_n es + equivocator_state_n es')) as [Hi | Hi];
     swap 1 2;
     [ specialize (equivocator_state_append_project_3 es es' i Hi) as Hpr
     | apply not_lt_plus_dec in Hi' as [k Hk];
@@ -498,7 +498,7 @@ Proof.
       ; [done | done |].
       by rewrite equivocator_state_append_size; lia.
     + rewrite !equivocator_state_extend_project_1
-      ; [rewrite equivocator_state_append_project_2 with (k := k)|lia|]
+      ; [rewrite equivocator_state_append_project_2 with (k := k) | lia |]
       ; [done | done |].
       by rewrite equivocator_state_append_size; lia.
   - rewrite equivocator_state_extend_project_1.
@@ -670,7 +670,7 @@ Arguments equivocator_state_extend {_ _} _ _ : assert.
 Arguments equivocator_state_append {_ _} _ _ : assert.
 
 Ltac destruct_equivocator_state_project' es i si Hi Hpr :=
-  destruct (equivocator_state_project es i) as [si|] eqn:Hpr
+  destruct (equivocator_state_project es i) as [si |] eqn:Hpr
   ; [ specialize (equivocator_state_project_Some_rev _ _ _ _ Hpr) as Hi
     | specialize (equivocator_state_project_None_rev _ _ _ Hpr) as Hi ].
 
@@ -700,7 +700,7 @@ Ltac destruct_equivocator_state_extend_project' es s i Hi Hpr :=
   let Hni := fresh "Hni" in
   let Hni' := fresh "Hni" in
   destruct (decide (i < equivocator_state_n es)) as [Hi | Hni]
-  ; [|destruct (decide (i = equivocator_state_n es)) as [Hi | Hni']]
+  ; [| destruct (decide (i = equivocator_state_n es)) as [Hi | Hni']]
   ; [| | assert (Hi : equivocator_state_n es < i) by lia]
   ; [ specialize (equivocator_state_extend_project_1 _ es s i Hi) as Hpr
     | specialize (equivocator_state_extend_project_2 _ es s i Hi) as Hpr
@@ -868,7 +868,7 @@ Lemma equivocator_transition_no_equivocation_zero_descriptor
 Proof.
   unfold is_singleton_state in Hs'.
   destruct l as [sn | ei l | ei l]
-  ; [ inversion Ht; subst; rewrite equivocator_state_extend_size in Hs'; cbv in Hs'; lia|..]
+  ; [ inversion Ht; subst; rewrite equivocator_state_extend_size in Hs'; cbv in Hs'; lia | ..]
   ; cbn in Hv, Ht;  destruct_equivocator_state_project s ei sei Hei; [| done | | done]
   ; destruct (vtransition _ _ _) as (si', om')
   ; inversion Ht; subst; equivocator_state_update_simpl.
@@ -888,8 +888,8 @@ Lemma equivocator_transition_reflects_singleton_state
   : is_singleton_state X s' -> is_singleton_state X s.
 Proof.
   unfold is_singleton_state.
-  by destruct l as [sn| ei l| ei l]; cbn in Ht
-  ; [inversion Ht; rewrite equivocator_state_extend_size; cbv; lia| ..]
+  by destruct l as [sn | ei l | ei l]; cbn in Ht
+  ; [inversion Ht; rewrite equivocator_state_extend_size; cbv; lia | ..]
   ; destruct (equivocator_state_project _ _)
   ; [| by inversion Ht | | by inversion Ht]
   ; destruct (vtransition _ _ _) as (si', om')
@@ -904,8 +904,8 @@ Lemma equivocator_transition_cannot_decrease_state_size
   : equivocator_state_n s <= equivocator_state_n s'.
 Proof.
   specialize (equivocator_state_extend_size X s) as Hex_size.
-  destruct l as [sn| ei l| ei l]
-  ; [inversion Ht; rewrite Hex_size; lia|..]
+  destruct l as [sn | ei l | ei l]
+  ; [inversion Ht; rewrite Hex_size; lia | ..]
   ; cbn in Ht
   ; destruct (equivocator_state_project _ _)
   ; [| by inversion Ht; lia | | by inversion Ht; lia]
@@ -975,14 +975,14 @@ Proof.
       destruction tactic for a valid equivocator transition
       vtransition equivocator_vlsm l (s, om) = (s', om')
     *)
-    destruct l as [sn|i l|i l]
+    destruct l as [sn | i l | i l]
     ; [ inversion_clear Ht; split; [by apply option_valid_message_None |]
       ; intros
       ; destruct_equivocator_state_extend_project s sn i Hi
       ; [ by apply IHHbs1 in H
       | inversion H; subst; apply initial_state_is_valid; apply Hv
       | done]
-      |..]
+      | ..]
     ; cbn in Hv, Ht
     ; destruct_equivocator_state_project' s i si Hi Hpr; [| done | | done]
     ; destruct (vtransition _ _ _) as (si', _om') eqn:Hti
@@ -1198,8 +1198,8 @@ Proof.
   destruct (vtransition _ _ _) as (si', _om') eqn:Hti.
   inversion Ht; subst s' _om'. clear Ht.
   simpl.
-  destruct_equivocator_state_update_project s ieqvi si' ni Hni' Hini; [lia..|].
-  by destruct_equivocator_state_project s ni sni Hni''; [|lia].
+  destruct_equivocator_state_update_project s ieqvi si' ni Hni' Hini; [lia.. |].
+  by destruct_equivocator_state_project s ni sni Hni''; [| lia].
 Qed.
 
 Lemma existing_false_label_equivocator_state_project_same

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -158,7 +158,7 @@ Proof.
 Qed.
 
 #[local] Ltac destruct_equivocator_state_project' es i si Hi Hpr :=
-  destruct (equivocator_state_project es i) as [si |] eqn:Hpr
+  destruct (equivocator_state_project es i) as [si |] eqn: Hpr
   ; [specialize (equivocator_state_project_Some_rev _ _ _ Hpr) as Hi
     | specialize (equivocator_state_project_None_rev _ _ Hpr) as Hi].
 
@@ -667,7 +667,7 @@ Arguments equivocator_state_extend {_ _} _ _ : assert.
 Arguments equivocator_state_append {_ _} _ _ : assert.
 
 Ltac destruct_equivocator_state_project' es i si Hi Hpr :=
-  destruct (equivocator_state_project es i) as [si |] eqn:Hpr
+  destruct (equivocator_state_project es i) as [si |] eqn: Hpr
   ; [specialize (equivocator_state_project_Some_rev _ _ _ _ Hpr) as Hi
     | specialize (equivocator_state_project_None_rev _ _ _ Hpr) as Hi].
 
@@ -981,7 +981,7 @@ Proof.
       | ..]
     ; cbn in Hv, Ht
     ; destruct_equivocator_state_project' s i si Hi Hpr; [| done | | done]
-    ; destruct (vtransition _ _ _) as (si', _om') eqn:Hti
+    ; destruct (vtransition _ _ _) as (si', _om') eqn: Hti
     ; inversion Ht; subst s' _om'; clear Ht
 
     (* I wish I could solve this goal, then apply the composed tactic for the remaining two goals. *)
@@ -1156,7 +1156,7 @@ Lemma existing_true_label_equivocator_state_project_not_last
 Proof.
   cbn in Ht.
   rewrite Hsi in Ht.
-  destruct (vtransition _ _ _) as (si', _om') eqn:Hti.
+  destruct (vtransition _ _ _) as (si', _om') eqn: Hti.
   inversion Ht; subst s' _om'. clear Ht.
   simpl.
   by destruct_equivocator_state_extend_project s si' ni Hni'; [| lia..].
@@ -1191,7 +1191,7 @@ Lemma existing_false_label_equivocator_state_project_not_same
   = equivocator_state_descriptor_project s (Existing ni).
 Proof.
   cbn in Ht. rewrite Hsi in Ht.
-  destruct (vtransition _ _ _) as (si', _om') eqn:Hti.
+  destruct (vtransition _ _ _) as (si', _om') eqn: Hti.
   inversion Ht; subst s' _om'. clear Ht.
   simpl.
   destruct_equivocator_state_update_project s ieqvi si' ni Hni' Hini; [lia.. |].

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -654,15 +654,15 @@ Ltac equivocator_state_update_simpl :=
   autounfold with state_update in *;
   autorewrite with equivocator_state_update state_update in *.
 
-Arguments Spawn {_ _} _: assert.
-Arguments ContinueWith {_ _} _ _: assert.
-Arguments ForkWith {_ _} _ _: assert.
-Arguments equivocator_state_n {_ _} _: assert.
-Arguments equivocator_state_last {_ _} _: assert.
-Arguments equivocator_state_zero {_ _} _: assert.
-Arguments equivocator_state_s {_ _} _ _: assert.
-Arguments equivocator_state_project {_ _} _ _: assert.
-Arguments equivocator_state_update {_ _} _ _ _: assert.
+Arguments Spawn {_ _} _ : assert.
+Arguments ContinueWith {_ _} _ _ : assert.
+Arguments ForkWith {_ _} _ _ : assert.
+Arguments equivocator_state_n {_ _} _ : assert.
+Arguments equivocator_state_last {_ _} _ : assert.
+Arguments equivocator_state_zero {_ _} _ : assert.
+Arguments equivocator_state_s {_ _} _ _ : assert.
+Arguments equivocator_state_project {_ _} _ _ : assert.
+Arguments equivocator_state_update {_ _} _ _ _ : assert.
 Arguments equivocator_state_extend {_ _} _ _ : assert.
 Arguments equivocator_state_append {_ _} _ _ : assert.
 
@@ -854,11 +854,11 @@ Proof. by destruct d. Qed.
   the descriptor of the label of the transition must be Existing 0 false
 *)
 Lemma equivocator_transition_no_equivocation_zero_descriptor
-  (iom oom: option message)
-  (l: vlabel equivocator_vlsm)
-  (s s': vstate equivocator_vlsm)
-  (Hv: vvalid equivocator_vlsm l (s, iom))
-  (Ht: vtransition equivocator_vlsm l (s, iom) = (s', oom))
+  (iom oom : option message)
+  (l : vlabel equivocator_vlsm)
+  (s s' : vstate equivocator_vlsm)
+  (Hv : vvalid equivocator_vlsm l (s, iom))
+  (Ht : vtransition equivocator_vlsm l (s, iom) = (s', oom))
   (Hs' : is_singleton_state X s')
   : exists li, l = ContinueWith 0 li.
 Proof.
@@ -877,10 +877,10 @@ Qed.
   the state prior to the transition has no equivocation as well.
 *)
 Lemma equivocator_transition_reflects_singleton_state
-  (iom oom: option message)
-  (l: vlabel equivocator_vlsm)
-  (s s': vstate equivocator_vlsm)
-  (Ht: equivocator_transition X l (s, iom) = (s', oom))
+  (iom oom : option message)
+  (l : vlabel equivocator_vlsm)
+  (s s' : vstate equivocator_vlsm)
+  (Ht : equivocator_transition X l (s, iom) = (s', oom))
   : is_singleton_state X s' -> is_singleton_state X s.
 Proof.
   unfold is_singleton_state.
@@ -893,10 +893,10 @@ Proof.
 Qed.
 
 Lemma equivocator_transition_cannot_decrease_state_size
-  (iom oom: option message)
-  (l: vlabel equivocator_vlsm)
-  (s s': vstate equivocator_vlsm)
-  (Ht: equivocator_transition X l (s, iom) = (s', oom))
+  (iom oom : option message)
+  (l : vlabel equivocator_vlsm)
+  (s s' : vstate equivocator_vlsm)
+  (Ht : equivocator_transition X l (s, iom) = (s', oom))
   : equivocator_state_n s <= equivocator_state_n s'.
 Proof.
   specialize (equivocator_state_extend_size X s) as Hex_size.
@@ -912,10 +912,10 @@ Proof.
 Qed.
 
 Lemma equivocator_transition_preserves_equivocating_state
-  (iom oom: option message)
-  (l: vlabel equivocator_vlsm)
-  (s s': vstate equivocator_vlsm)
-  (Ht: equivocator_transition X l (s, iom) = (s', oom))
+  (iom oom : option message)
+  (l : vlabel equivocator_vlsm)
+  (s s' : vstate equivocator_vlsm)
+  (Ht : equivocator_transition X l (s, iom) = (s', oom))
   : is_equivocating_state X s -> is_equivocating_state X s'.
 Proof.
   intros Hs Hs'. elim Hs. clear Hs. revert Ht Hs' .
@@ -923,10 +923,10 @@ Proof.
 Qed.
 
 Lemma zero_descriptor_transition_reflects_equivocating_state
-  (iom oom: option message)
-  (l: vlabel equivocator_vlsm)
-  (s s': vstate equivocator_vlsm)
-  (Ht: equivocator_transition X l (s, iom) = (s', oom))
+  (iom oom : option message)
+  (l : vlabel equivocator_vlsm)
+  (s s' : vstate equivocator_vlsm)
+  (Ht : equivocator_transition X l (s, iom) = (s', oom))
   li
   (Hzero : l = ContinueWith 0 li)
   : is_equivocating_state X s' -> is_equivocating_state X s.
@@ -1219,7 +1219,7 @@ Qed.
 
 End sec_equivocator_vlsm_valid_state_projections.
 
-Arguments NewMachine {_ _} _: assert.
+Arguments NewMachine {_ _} _ : assert.
 Arguments Existing {_ _} _ : assert.
 Arguments equivocator_label_descriptor {_ _} _ : assert.
-Arguments equivocator_state_descriptor_project {_ _} _ _: assert.
+Arguments equivocator_state_descriptor_project {_ _} _ _ : assert.

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -275,8 +275,7 @@ Qed.
   ; destruct (decide (j < equivocator_state_n es)) as [Hj | Hj]
   ; [ destruct (decide (i = j)) as [Hij | Hij]
     ; [ specialize (equivocator_state_update_project_eq es i s j Hj Hij) as Hpr
-      | specialize (equivocator_state_update_project_neq es i s j Hij) as Hpr
-      ]
+      | specialize (equivocator_state_update_project_neq es i s j Hij) as Hpr]
     | specialize (equivocator_state_project_None (equivocator_state_update es i s) j Hj) as Hpr]
   ; rewrite Hpr in *
   ; clear Hsize.
@@ -450,10 +449,8 @@ Qed.
     swap 1 2;
     [ specialize (equivocator_state_append_project_3 es es' i Hi) as Hpr
     | apply not_lt_plus_dec in Hi' as [k Hk];
-      specialize (equivocator_state_append_project_2 es es' i k (eq_sym Hk)) as Hpr
-    ]
-  | specialize (equivocator_state_append_project_1 es es' i Hi) as Hpr
-  ]
+      specialize (equivocator_state_append_project_2 es es' i k (eq_sym Hk)) as Hpr]
+  | specialize (equivocator_state_append_project_1 es es' i Hi) as Hpr]
   ; rewrite Hpr in *
   .
 
@@ -686,8 +683,7 @@ Ltac destruct_equivocator_state_update_project' es i s j Hj Hij Hpr :=
   ; [ specialize (equivocator_state_project_None _ (equivocator_state_update es i s) j Hj) as Hpr
     | destruct (decide (i = j)) as [Hij | Hij]
     ; [ specialize (equivocator_state_update_project_eq _ es i s j Hj Hij) as Hpr
-      | specialize (equivocator_state_update_project_neq _ es i s j Hij) as Hpr
-      ]]
+      | specialize (equivocator_state_update_project_neq _ es i s j Hij) as Hpr]]
   ; rewrite Hpr in *
   ; clear Hsize.
 

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -159,8 +159,8 @@ Qed.
 
 #[local] Ltac destruct_equivocator_state_project' es i si Hi Hpr :=
   destruct (equivocator_state_project es i) as [si |] eqn:Hpr
-  ; [ specialize (equivocator_state_project_Some_rev _ _ _ Hpr) as Hi
-    | specialize (equivocator_state_project_None_rev _ _ Hpr) as Hi ].
+  ; [specialize (equivocator_state_project_Some_rev _ _ _ Hpr) as Hi
+    | specialize (equivocator_state_project_None_rev _ _ Hpr) as Hi].
 
 #[local] Ltac destruct_equivocator_state_project es i si Hi :=
   let Hpr := fresh "Hpr" in
@@ -273,8 +273,8 @@ Qed.
   let Hsize := fresh "Hsize" in
   pose proof (equivocator_state_update_size es i s) as Hsize
   ; destruct (decide (j < equivocator_state_n es)) as [Hj | Hj]
-  ; [ destruct (decide (i = j)) as [Hij | Hij]
-    ; [ specialize (equivocator_state_update_project_eq es i s j Hj Hij) as Hpr
+  ; [destruct (decide (i = j)) as [Hij | Hij]
+    ; [specialize (equivocator_state_update_project_eq es i s j Hj Hij) as Hpr
       | specialize (equivocator_state_update_project_neq es i s j Hij) as Hpr]
     | specialize (equivocator_state_project_None (equivocator_state_update es i s) j Hj) as Hpr]
   ; rewrite Hpr in *
@@ -353,7 +353,7 @@ Qed.
   destruct (decide (i < equivocator_state_n es)) as [Hi | Hni]
   ; [| destruct (decide (i = equivocator_state_n es)) as [Hi | Hni']]
   ; [| | assert (Hi : equivocator_state_n es < i) by lia]
-  ; [ specialize (equivocator_state_extend_project_1 es s i Hi) as Hpr
+  ; [specialize (equivocator_state_extend_project_1 es s i Hi) as Hpr
     | specialize (equivocator_state_extend_project_2 es s i Hi) as Hpr
     | specialize (equivocator_state_extend_project_3 es s i Hi) as Hpr]
   ; rewrite Hpr in *.
@@ -445,9 +445,9 @@ Qed.
 #[local] Ltac destruct_equivocator_state_append_project' es es' i Hi k Hk Hpr :=
   let Hi' := fresh "Hi" in
   destruct (decide (i < equivocator_state_n es)) as [Hi | Hi']; swap 1 2;
-  [ destruct (decide (i < equivocator_state_n es + equivocator_state_n es')) as [Hi | Hi];
+  [destruct (decide (i < equivocator_state_n es + equivocator_state_n es')) as [Hi | Hi];
     swap 1 2;
-    [ specialize (equivocator_state_append_project_3 es es' i Hi) as Hpr
+    [specialize (equivocator_state_append_project_3 es es' i Hi) as Hpr
     | apply not_lt_plus_dec in Hi' as [k Hk];
       specialize (equivocator_state_append_project_2 es es' i k (eq_sym Hk)) as Hpr]
   | specialize (equivocator_state_append_project_1 es es' i Hi) as Hpr]
@@ -668,8 +668,8 @@ Arguments equivocator_state_append {_ _} _ _ : assert.
 
 Ltac destruct_equivocator_state_project' es i si Hi Hpr :=
   destruct (equivocator_state_project es i) as [si |] eqn:Hpr
-  ; [ specialize (equivocator_state_project_Some_rev _ _ _ _ Hpr) as Hi
-    | specialize (equivocator_state_project_None_rev _ _ _ Hpr) as Hi ].
+  ; [specialize (equivocator_state_project_Some_rev _ _ _ _ Hpr) as Hi
+    | specialize (equivocator_state_project_None_rev _ _ _ Hpr) as Hi].
 
 Ltac destruct_equivocator_state_project es i si Hi :=
   let Hpr := fresh "Hpr" in
@@ -680,9 +680,9 @@ Ltac destruct_equivocator_state_update_project' es i s j Hj Hij Hpr :=
   let Hsize := fresh "Hsize" in
   pose proof (equivocator_state_update_size _ es i s) as Hsize
   ; destruct (decide (j < equivocator_state_n es)) as [Hj | Hj]; swap 1 2
-  ; [ specialize (equivocator_state_project_None _ (equivocator_state_update es i s) j Hj) as Hpr
+  ; [specialize (equivocator_state_project_None _ (equivocator_state_update es i s) j Hj) as Hpr
     | destruct (decide (i = j)) as [Hij | Hij]
-    ; [ specialize (equivocator_state_update_project_eq _ es i s j Hj Hij) as Hpr
+    ; [specialize (equivocator_state_update_project_eq _ es i s j Hj Hij) as Hpr
       | specialize (equivocator_state_update_project_neq _ es i s j Hij) as Hpr]]
   ; rewrite Hpr in *
   ; clear Hsize.
@@ -698,7 +698,7 @@ Ltac destruct_equivocator_state_extend_project' es s i Hi Hpr :=
   destruct (decide (i < equivocator_state_n es)) as [Hi | Hni]
   ; [| destruct (decide (i = equivocator_state_n es)) as [Hi | Hni']]
   ; [| | assert (Hi : equivocator_state_n es < i) by lia]
-  ; [ specialize (equivocator_state_extend_project_1 _ es s i Hi) as Hpr
+  ; [specialize (equivocator_state_extend_project_1 _ es s i Hi) as Hpr
     | specialize (equivocator_state_extend_project_2 _ es s i Hi) as Hpr
     | specialize (equivocator_state_extend_project_3 _ es s i Hi) as Hpr]
   ; rewrite Hpr in *.
@@ -864,7 +864,7 @@ Lemma equivocator_transition_no_equivocation_zero_descriptor
 Proof.
   unfold is_singleton_state in Hs'.
   destruct l as [sn | ei l | ei l]
-  ; [ inversion Ht; subst; rewrite equivocator_state_extend_size in Hs'; cbv in Hs'; lia | ..]
+  ; [inversion Ht; subst; rewrite equivocator_state_extend_size in Hs'; cbv in Hs'; lia | ..]
   ; cbn in Hv, Ht;  destruct_equivocator_state_project s ei sei Hei; [| done | | done]
   ; destruct (vtransition _ _ _) as (si', om')
   ; inversion Ht; subst; equivocator_state_update_simpl.
@@ -972,10 +972,10 @@ Proof.
       vtransition equivocator_vlsm l (s, om) = (s', om')
     *)
     destruct l as [sn | i l | i l]
-    ; [ inversion_clear Ht; split; [by apply option_valid_message_None |]
+    ; [inversion_clear Ht; split; [by apply option_valid_message_None |]
       ; intros
       ; destruct_equivocator_state_extend_project s sn i Hi
-      ; [ by apply IHHbs1 in H
+      ; [by apply IHHbs1 in H
       | inversion H; subst; apply initial_state_is_valid; apply Hv
       | done]
       | ..]

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -501,8 +501,7 @@ Definition equivocator_vlsm_trace_project
         | Some (None, odescriptor) => Some (r, odescriptor)
         | Some (Some item', odescriptor) => Some (item' :: r, odescriptor)
         end
-      end
-    )
+      end)
     (Some ([], descriptor))
     tr.
 

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -126,7 +126,7 @@ Qed.
 Lemma equivocator_transition_item_project_inv_none
   (item : vtransition_item equivocator_vlsm)
   (descriptor : MachineDescriptor)
-  (Hitem: equivocator_vlsm_transition_item_project item descriptor = None)
+  (Hitem : equivocator_vlsm_transition_item_project item descriptor = None)
   : exists (i : nat),
     descriptor = Existing i /\
     equivocator_state_project (destination item) i = None.
@@ -607,14 +607,14 @@ Qed.
 (** Next we prove some inversion properties for [equivocator_vlsm_transition_item_project]. *)
 Lemma equivocator_valid_transition_project_inv2
   (l : vlabel equivocator_vlsm)
-  (s' s: vstate equivocator_vlsm)
+  (s' s : vstate equivocator_vlsm)
   (iom oom : option message)
-  (Hv: vvalid equivocator_vlsm l (s', iom))
-  (Ht: vtransition equivocator_vlsm l (s', iom) = (s, oom))
+  (Hv : vvalid equivocator_vlsm l (s', iom))
+  (Ht : vtransition equivocator_vlsm l (s', iom) = (s, oom))
   (item := {| l := l; input := iom; destination := s; output := oom |})
   (di di' : MachineDescriptor)
   (item' : vtransition_item X)
-  (Hitem: equivocator_vlsm_transition_item_project item di = Some (Some item', di'))
+  (Hitem : equivocator_vlsm_transition_item_project item di = Some (Some item', di'))
   : exists (i : nat), di = Existing i /\
     exists sx, equivocator_state_project s i = Some sx /\
     exists (i' : nat), di' = Existing i' /\
@@ -651,11 +651,11 @@ Lemma equivocator_valid_transition_project_inv3
   (l : vlabel equivocator_vlsm)
   (s s' : vstate equivocator_vlsm)
   (iom oom : option message)
-  (Hv: vvalid equivocator_vlsm l (s', iom))
-  (Ht: vtransition equivocator_vlsm l (s', iom) = (s, oom))
+  (Hv : vvalid equivocator_vlsm l (s', iom))
+  (Ht : vtransition equivocator_vlsm l (s', iom) = (s, oom))
   (item := {| l := l; input := iom; destination := s; output := oom |})
   (di di' : MachineDescriptor)
-  (Hitem: equivocator_vlsm_transition_item_project item di = Some (None, di'))
+  (Hitem : equivocator_vlsm_transition_item_project item di = Some (None, di'))
   : match di with
     | NewMachine sn => di' = di
     | Existing i =>
@@ -715,8 +715,8 @@ Lemma equivocator_valid_transition_project_inv4
   (l : vlabel equivocator_vlsm)
   (s s' : vstate equivocator_vlsm)
   (iom oom : option message)
-  (Hv: vvalid equivocator_vlsm l (s', iom))
-  (Ht: vtransition equivocator_vlsm l (s', iom) = (s, oom))
+  (Hv : vvalid equivocator_vlsm l (s', iom))
+  (Ht : vtransition equivocator_vlsm l (s', iom) = (s, oom))
   (i' : nat)
   si'
   (Hi' : equivocator_state_project s' i' = Some si')
@@ -757,7 +757,7 @@ Lemma equivocator_valid_transition_project_inv5_new_machine
   (l : vlabel equivocator_vlsm)
   (s s' : vstate equivocator_vlsm)
   (iom oom : option message)
-  (Ht: vtransition equivocator_vlsm l (s', iom) = (s, oom))
+  (Ht : vtransition equivocator_vlsm l (s', iom) = (s, oom))
   (item := {| l := l; input := iom; destination := s; output := oom |})
   (sn : state)
   (Hnew : l = Spawn sn)
@@ -777,8 +777,8 @@ Lemma equivocator_valid_transition_project_inv5
   (l : vlabel equivocator_vlsm)
   (s s' : vstate equivocator_vlsm)
   (iom oom : option message)
-  (Hv: vvalid equivocator_vlsm l (s', iom))
-  (Ht: vtransition equivocator_vlsm l (s', iom) = (s, oom))
+  (Hv : vvalid equivocator_vlsm l (s', iom))
+  (Ht : vtransition equivocator_vlsm l (s', iom) = (s, oom))
   (item := {| l := l; input := iom; destination := s; output := oom |})
   (_i : nat)
   (Hsndl : equivocator_label_descriptor l = Existing _i)
@@ -979,11 +979,11 @@ Qed.
   machine descriptor is valid for the last state of the trace argument.
 *)
 Lemma equivocator_vlsm_trace_project_inv
-  (tr: list transition_item)
+  (tr : list transition_item)
   (Hntr : tr <> [])
-  (j: nat)
-  (HtrX: is_Some (equivocator_vlsm_trace_project tr (Existing j)))
-  (is: state)
+  (j : nat)
+  (HtrX : is_Some (equivocator_vlsm_trace_project tr (Existing j)))
+  (is : state)
   : exists sj, equivocator_state_project (finite_trace_last is tr) j = Some sj.
 Proof.
   apply exists_last in Hntr.
@@ -1048,14 +1048,14 @@ Qed.
 
 (** An inversion lemma about projections of a valid trace. *)
 Lemma preloaded_equivocator_vlsm_valid_trace_project_inv2
-  (is fs: state)
-  (tr: list transition_item)
+  (is fs : state)
+  (tr : list transition_item)
   (Hntr : tr <> [])
-  (Htr: finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm equivocator_vlsm) is fs tr)
+  (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm equivocator_vlsm) is fs tr)
   (j : nat)
   (di : MachineDescriptor)
-  (trX: list (vtransition_item X))
-  (HtrX: equivocator_vlsm_trace_project tr (Existing j) = Some (trX, di))
+  (trX : list (vtransition_item X))
+  (HtrX : equivocator_vlsm_trace_project tr (Existing j) = Some (trX, di))
   : exists fsj, equivocator_state_project fs j = Some fsj /\
     match di with
     | NewMachine sn =>

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -1073,7 +1073,7 @@ Proof.
   spec Hj; [done |].
   specialize (Hj is) as [fsj Hfsj].
   replace (finite_trace_last _ _) with fs in Hfsj
-    by (symmetry;apply (valid_trace_get_last Htr)).
+    by (symmetry; apply (valid_trace_get_last Htr)).
   exists fsj. split; [done |].
   specialize
     (preloaded_equivocator_vlsm_trace_project_valid _ _ _ Htr _ _ Hfsj)

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -104,8 +104,8 @@ Lemma equivocator_vlsm_transition_item_project_some_inj
 Proof.
   destruct item.
   destruct l as [sn | j ls | j l2]; cbn in HitemX, HitemX'
-  ; destruct (equivocator_state_project _ i) as [si |] eqn:Hsi; [| done | | done | | done]
-  ; destruct (equivocator_state_project _ i') as [si' |] eqn:Hsi'; [| done | | done | | done]
+  ; destruct (equivocator_state_project _ i) as [si |] eqn: Hsi; [| done | | done | | done]
+  ; destruct (equivocator_state_project _ i') as [si' |] eqn: Hsi'; [| done | | done | | done]
   ; case_decide; [done | done | | done | | done]; subst
   ; case_decide; [| done | | done]; subst.
   - assert (si = si') by congruence; subst si'.
@@ -144,7 +144,7 @@ Lemma equivocator_transition_item_project_proper
   (Hproper : proper_descriptor X descriptor (destination item))
   : is_Some (equivocator_vlsm_transition_item_project item descriptor).
 Proof.
-  destruct (equivocator_vlsm_transition_item_project _ _) as [x |] eqn:contra
+  destruct (equivocator_vlsm_transition_item_project _ _) as [x |] eqn: contra
   ; [by eexists |].
   apply equivocator_transition_item_project_inv_none in contra.
   destruct contra as [id [Heqd Hd]].
@@ -231,7 +231,7 @@ Proof.
   destruct l as [sn | i l | i l]
   ; [by inversion Hs | ..]
   ; cbn in Hv, Ht
-  ; destruct (equivocator_state_project _ _) as [si |] eqn:Hpr; [| done | | done]
+  ; destruct (equivocator_state_project _ _) as [si |] eqn: Hpr; [| done | | done]
   ; split; [done | | done |]
   ; destruct (vtransition _ _ _) as (si', om'); inversion_clear Ht.
   - exists (Existing i).
@@ -313,7 +313,7 @@ Lemma equivocator_transition_item_project_proper_characterization
       end.
 Proof.
   destruct item. simpl. simpl in Hproper.
-  destruct descriptor eqn:Heqvi; cbn.
+  destruct descriptor eqn: Heqvi; cbn.
   - by eexists None, _.
   - destruct l as [nsi | ieqvi li | ieqvi li]
     ; destruct Hproper as [destn Hpr]; rewrite Hpr
@@ -347,7 +347,7 @@ Proof.
       split; [repeat split |].
       intros.
       cbn in Hv.
-      destruct (equivocator_state_project s n) as [sn |] eqn:Hpri
+      destruct (equivocator_state_project s n) as [sn |] eqn: Hpri
       ; [| done].
       split; [by eexists |].
       split; [lia |].
@@ -361,7 +361,7 @@ Proof.
     + split; [done |].
       intros.
       cbn in Hv.
-      destruct (equivocator_state_project s ieqvi) as [sieqvi |] eqn:Hpri
+      destruct (equivocator_state_project s ieqvi) as [sieqvi |] eqn: Hpri
       ; [| done].
       cut (proper_descriptor X (Existing n) s).
       { intro Hproper. split_and!; [done | lia |].
@@ -379,7 +379,7 @@ Proof.
       intros.
       cbn in Hv.
       simpl.
-      destruct (equivocator_state_project s ieqvi) as [sieqvi |] eqn:Hpri
+      destruct (equivocator_state_project s ieqvi) as [sieqvi |] eqn: Hpri
       ; [| done].
       split; [by eexists |].
       specialize (existing_true_label_equivocator_transition_size X Ht _ Hpri) as Ht_size.
@@ -399,7 +399,7 @@ Proof.
     + split; [done |].
       intros.
       cbn in Hv.
-      destruct (equivocator_state_project s ieqvi) as [sieqvi |] eqn:Hpri
+      destruct (equivocator_state_project s ieqvi) as [sieqvi |] eqn: Hpri
       ; [| done].
       cut (proper_descriptor X (Existing n) s).
       { intro Hproper. split_and!; [done | lia |].
@@ -445,7 +445,7 @@ Proof.
       ; destruct Heqv as [Heqv | Heqv]; done
       |])
   ; cbn in Hv
-  ; (destruct (equivocator_state_project s j) as [sj |] eqn:Hsj; [| done]).
+  ; (destruct (equivocator_state_project s j) as [sj |] eqn: Hsj; [| done]).
   - specialize (existing_false_label_equivocator_transition_size X Ht _ Hsj) as Ht_size.
     intros [Heqv | Heqv]; [clear -Ht_size Heqv; cbv in *; lia |].
     right.
@@ -536,11 +536,11 @@ Lemma equivocator_vlsm_trace_project_cons
 Proof.
   simpl in Hproject.
   destruct (equivocator_vlsm_trace_project bsuffix dlast) as [(suffix, dmiddle) |]
-    eqn:Hsuffix
+    eqn: Hsuffix
   ; [| by congruence].
   exists dmiddle.
   destruct (equivocator_vlsm_transition_item_project bprefix dmiddle) as [[[prefix |] i] |]
-    eqn:Hprefix
+    eqn: Hprefix
   ; inversion Hproject; subst; clear Hproject.
   - by exists [prefix], suffix; cbn; rewrite Hprefix.
   - by exists []; exists tr; cbn; rewrite Hprefix.
@@ -596,7 +596,7 @@ Proof.
   - by inversion Hprefix; subst.
   - simpl in Hprefix.
     destruct (equivocator_vlsm_trace_project bprefix dmiddle) as [(prefix', dstart') |]
-      eqn:Hprefix'
+      eqn: Hprefix'
     ; [| by congruence].
     specialize (IHbprefix prefix' dstart' eq_refl).
     simpl. rewrite IHbprefix.
@@ -626,15 +626,15 @@ Proof.
   destruct di as [sn | i]; [by simpl in Hitem; congruence |].
   eexists _; split; [done |].
   simpl in Hitem.
-  destruct (equivocator_state_project s i) as [si |] eqn:Heqsi; [| done].
+  destruct (equivocator_state_project s i) as [si |] eqn: Heqsi; [| done].
   eexists; split; [done |].
   destruct l as [sn | j lx | j lx]; [by destruct (decide _) | ..]
   ; cbn in Hv
-  ; (destruct (equivocator_state_project s' j) as [s'j |] eqn:Heqs'j; [| done])
+  ; (destruct (equivocator_state_project s' j) as [s'j |] eqn: Heqs'j; [| done])
   ; (destruct (decide _); [| done])
   ; inversion Hitem; subst; simpl; repeat split; eexists _; repeat split; exists s'j
   ; (repeat split; [done.. |])
-  ; destruct (vtransition X _ _) as (s'j', _oom) eqn:Hti.
+  ; destruct (vtransition X _ _) as (s'j', _oom) eqn: Hti.
   - specialize (existing_false_label_equivocator_state_project_same X Ht _ Heqs'j _ _ Hti)
       as [Heq_oom Heqs'j'].
     by subst; simpl; rewrite Heqsi.
@@ -672,7 +672,7 @@ Lemma equivocator_valid_transition_project_inv3
 Proof.
   destruct di as [si | i]; [by inversion Hitem |].
   subst item. simpl in Hitem.
-  destruct (equivocator_state_project s i) as [si |] eqn:Heqsi; [| done].
+  destruct (equivocator_state_project s i) as [si |] eqn: Heqsi; [| done].
   destruct l as [sn | id lx | id lx]; destruct (decide _); inversion Hitem; subst.
   - inversion Ht; subst.
     split_and!; [done | done | apply Hv | done | | apply Hv].
@@ -688,7 +688,7 @@ Proof.
     by destruct_equivocator_state_project s' i s'i Hi; [subst | lia].
   - eexists; split; [done |].
     cbn in Hv.
-    destruct (equivocator_state_project s' id) as [s'id |] eqn:Hpr; [| done].
+    destruct (equivocator_state_project s' id) as [s'id |] eqn: Hpr; [| done].
     specialize (existing_false_label_equivocator_state_project_not_same X Ht _ Hpr i) as Hn.
     simpl in Hn. rewrite Heqsi in Hn.
     specialize (existing_false_label_equivocator_transition_size X Ht _ Hpr) as Ht_size.
@@ -700,7 +700,7 @@ Proof.
     by simpl in Hn; subst.
   - eexists; split; [done |].
     cbn in Hv.
-    destruct (equivocator_state_project s' id) as [s'id |] eqn:Hpr; [| done].
+    destruct (equivocator_state_project s' id) as [s'id |] eqn: Hpr; [| done].
     specialize (existing_true_label_equivocator_state_project_not_last X Ht _ Hpr i) as Hn.
     simpl in Hn. rewrite Heqsi in Hn.
     specialize (existing_true_label_equivocator_transition_size X Ht _ Hpr) as Ht_size.
@@ -736,14 +736,14 @@ Proof.
     exists None.
     rewrite decide_False ; [done |].
     by rewrite equivocator_state_extend_lst; lia.
-  - cbn in Hv. destruct (equivocator_state_project s' j) as [s'j |] eqn:Heqs'j
+  - cbn in Hv. destruct (equivocator_state_project s' j) as [s'j |] eqn: Heqs'j
     ; [| done].
     specialize (existing_false_label_equivocator_transition_size X Ht _ Heqs'j) as Ht_size.
     apply equivocator_state_project_Some_rev in Hi' as Hlti'.
     destruct_equivocator_state_project s i' si Hlti; [| lia].
     eexists; split; [done |].
     by destruct (decide _); subst; eexists _.
-  - cbn in Hv. destruct (equivocator_state_project s' j) as [s'j |] eqn:Heqs'j
+  - cbn in Hv. destruct (equivocator_state_project s' j) as [s'j |] eqn: Heqs'j
     ; [| done].
     specialize (existing_true_label_equivocator_transition_size X Ht _ Heqs'j) as Ht_size.
     apply equivocator_state_project_Some_rev in Hi' as Hlti'.
@@ -788,11 +788,11 @@ Lemma equivocator_valid_transition_project_inv5
 Proof.
   destruct l as [sn | _i' lx | _i' lx]; simpl in Hsndl; inversion Hsndl; subst
   ; cbn in Hv
-  ; (destruct (equivocator_state_project s' _i) as [s'i |] eqn:Heqs'i; [| done]).
+  ; (destruct (equivocator_state_project s' _i) as [s'i |] eqn: Heqs'i; [| done]).
   - specialize (existing_false_label_equivocator_transition_size X Ht _ Heqs'i) as Ht_size.
     specialize (existing_false_label_equivocator_state_project_same X Ht _ Heqs'i) as Ht_pr.
     simpl in Ht_pr.
-    destruct (vtransition X _ _) as (si', _oom) eqn:Hti.
+    destruct (vtransition X _ _) as (si', _oom) eqn: Hti.
     specialize (Ht_pr _ _ eq_refl) as [Heq_oom Heqsi'].
     exists _i.
     simpl.
@@ -804,7 +804,7 @@ Proof.
     specialize (existing_true_label_equivocator_state_project_last X Ht _ Heqs'i) as Ht_pr.
     cbn in Ht. rewrite Heqs'i in Ht.
     simpl in Ht_pr.
-    destruct (vtransition X _ _) as (si', _oom) eqn:Hti.
+    destruct (vtransition X _ _) as (si', _oom) eqn: Hti.
     specialize (Ht_pr _ _ eq_refl) as [Heq_oom Heqsi'].
     exists (equivocator_state_n s').
     simpl.
@@ -872,7 +872,7 @@ Proof.
     }
     simpl in Hchar1. rewrite Heqsi in Hchar1.
     destruct Hchar1 as [[Hex Hl] [Heqiom [Hoom [Hsi Hdl]]]]. subst.
-    destruct (equivocator_label_descriptor l) as [sn | i'] eqn:Hd; simpl in Hchar2.
+    destruct (equivocator_label_descriptor l) as [sn | i'] eqn: Hd; simpl in Hchar2.
     + specialize (Hchar2 _ eq_refl) as [HvX HtX].
       split; [apply Hproper' |].
       destruct itemX. simpl in *.
@@ -997,7 +997,7 @@ Proof.
   simpl in *.
   destruct (equivocator_vlsm_transition_item_project x dj)
     as [(_x, _dmiddle) |]
-    eqn:Hx'
+    eqn: Hx'
   ; [| by congruence].
   destruct _x as [itemx |]; inversion Hx; subst lx _dmiddle; clear Hx.
   - subst. destruct x. unfold equivocator_vlsm_transition_item_project in Hx'.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -432,7 +432,7 @@ Proof.
     (equivocator_transition_item_project_proper_characterization item _ Hproper)
     as Hchar.
   destruct item. simpl in *.
-  destruct Hchar as [_oitemx [_deqv' [_Hpr [Hchar1 Hchar2]]] ].
+  destruct Hchar as [_oitemx [_deqv' [_Hpr [Hchar1 Hchar2]]]].
   rewrite Hproject in _Hpr. inversion _Hpr. subst _oitemx _deqv'. clear _Hpr.
   specialize (Hchar2 _ Hv Ht).
   destruct Hchar2 as [Hdeqv' Hchar2].

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -51,11 +51,11 @@ Definition equivocator_vlsm_transition_item_project
           else Some (None, Existing j)
         | ForkWith i lx =>
             if (decide (j = equivocator_state_last s)) then (* this is the copy *)
-              Some (Some {| l := lx; input := im; output := om; destination := sj|}, Existing i)
+              Some (Some {| l := lx; input := im; output := om; destination := sj |}, Existing i)
             else Some (None, Existing j)
         | ContinueWith i lx =>
           if decide (i = j) then
-              Some ( Some {| l := lx; input := im; output := om; destination := sj|}, Existing i)
+              Some ( Some {| l := lx; input := im; output := om; destination := sj |}, Existing i)
             else Some (None, Existing j)
         end
       end
@@ -81,7 +81,7 @@ Proof.
     rewrite decide_False by (cbv; lia).
     by eexists.
   - by destruct (decide _); subst; eexists.
-  - destruct (equivocator_state_project s n) as [si|]; [| done].
+  - destruct (equivocator_state_project s n) as [si |]; [| done].
     destruct (vtransition _ _ _) as (si', om').
     inversion_clear Ht.
     rewrite equivocator_state_extend_lst.
@@ -103,9 +103,9 @@ Lemma equivocator_vlsm_transition_item_project_some_inj
   : i = i' /\ itemX = itemX' /\ odescriptor = odescriptor'.
 Proof.
   destruct item.
-  destruct l as [sn| j ls| j l2]; cbn in HitemX, HitemX'
-  ; destruct (equivocator_state_project _ i) as [si|] eqn:Hsi; [| done | | done | | done]
-  ; destruct (equivocator_state_project _ i') as [si'|] eqn:Hsi'; [| done | | done | | done]
+  destruct l as [sn | j ls | j l2]; cbn in HitemX, HitemX'
+  ; destruct (equivocator_state_project _ i) as [si |] eqn:Hsi; [| done | | done | | done]
+  ; destruct (equivocator_state_project _ i') as [si' |] eqn:Hsi'; [| done | | done | | done]
   ; case_decide; [done | done | | done | | done]; subst
   ; case_decide; [| done | | done]; subst.
   - assert (si = si') by congruence; subst si'.
@@ -144,7 +144,7 @@ Lemma equivocator_transition_item_project_proper
   (Hproper : proper_descriptor X descriptor (destination item))
   : is_Some (equivocator_vlsm_transition_item_project item descriptor).
 Proof.
-  destruct (equivocator_vlsm_transition_item_project _ _) as [x|] eqn:contra
+  destruct (equivocator_vlsm_transition_item_project _ _) as [x |] eqn:contra
   ; [by eexists |].
   apply equivocator_transition_item_project_inv_none in contra.
   destruct contra as [id [Heqd Hd]].
@@ -228,10 +228,10 @@ Lemma exists_equivocator_transition_item_project
             |}, equivocator_label_descriptor (l item)).
 Proof.
   destruct item. simpl in *.
-  destruct l as [sn| i l| i l]
+  destruct l as [sn | i l | i l]
   ; [by inversion Hs | ..]
   ; cbn in Hv, Ht
-  ; destruct (equivocator_state_project _ _) as [si|] eqn:Hpr; [| done | | done]
+  ; destruct (equivocator_state_project _ _) as [si |] eqn:Hpr; [| done | | done]
   ; split; [done | | done |]
   ; destruct (vtransition _ _ _) as (si', om'); inversion_clear Ht.
   - exists (Existing i).
@@ -240,7 +240,7 @@ Proof.
     by rewrite equivocator_state_update_project_eq, decide_True.
   - exists (Existing (equivocator_state_n s)); cbn.
     destruct_equivocator_state_extend_project s si' (equivocator_state_n s) Hn
-    ; [lia| |lia]; cbn.
+    ; [lia | | lia]; cbn.
     by rewrite (equivocator_state_last_n _ s), decide_True.
 Qed.
 
@@ -315,7 +315,7 @@ Proof.
   destruct item. simpl. simpl in Hproper.
   destruct descriptor eqn:Heqvi; cbn.
   - by eexists None, _.
-  - destruct l as [nsi| ieqvi li| ieqvi li]
+  - destruct l as [nsi | ieqvi li | ieqvi li]
     ; destruct Hproper as [destn Hpr]; rewrite Hpr
     ; case_decide; subst
     ; eexists _, _; split; try done.
@@ -324,7 +324,7 @@ Proof.
       split; [by apply Hv |].
       specialize (new_machine_label_equivocator_transition_size X Ht) as Ht_size.
       specialize (equivocator_state_last_n X destination) as Hlst_size.
-      split; [lia|].
+      split; [lia |].
       rewrite <-
         (new_machine_label_equivocator_state_project_last X Ht).
       simpl.
@@ -344,13 +344,13 @@ Proof.
       specialize (equivocator_state_last_n X destination) as Hlst_size.
       by destruct_equivocator_state_project s n _sn Hn'; [eexists | lia].
     + simpl.
-      split; [repeat split|].
+      split; [repeat split |].
       intros.
       cbn in Hv.
-      destruct (equivocator_state_project s n) as [sn|] eqn:Hpri
+      destruct (equivocator_state_project s n) as [sn |] eqn:Hpri
       ; [| done].
       split; [by eexists |].
-      split; [lia|].
+      split; [lia |].
       intros. subst sx. simpl.
       split; [done |].
       destruct (vtransition _ _ _) as (si', _output).
@@ -361,7 +361,7 @@ Proof.
     + split; [done |].
       intros.
       cbn in Hv.
-      destruct (equivocator_state_project s ieqvi) as [sieqvi|] eqn:Hpri
+      destruct (equivocator_state_project s ieqvi) as [sieqvi |] eqn:Hpri
       ; [| done].
       cut (proper_descriptor X (Existing n) s).
       { intro Hproper. split_and!; [done | lia |].
@@ -379,14 +379,14 @@ Proof.
       intros.
       cbn in Hv.
       simpl.
-      destruct (equivocator_state_project s ieqvi) as [sieqvi|] eqn:Hpri
+      destruct (equivocator_state_project s ieqvi) as [sieqvi |] eqn:Hpri
       ; [| done].
       split; [by eexists |].
       specialize (existing_true_label_equivocator_transition_size X Ht _ Hpri) as Ht_size.
       specialize (equivocator_state_last_n X destination) as Hlst_size.
       specialize (existing_true_label_equivocator_state_project_last X Ht _ Hpri) as Ht_pr.
       apply equivocator_state_project_Some_rev in Hpri as Hlt.
-      split; [lia|].
+      split; [lia |].
       simpl in *.
       intros. subst  sx.
       rewrite Hpri in *.
@@ -399,7 +399,7 @@ Proof.
     + split; [done |].
       intros.
       cbn in Hv.
-      destruct (equivocator_state_project s ieqvi) as [sieqvi|] eqn:Hpri
+      destruct (equivocator_state_project s ieqvi) as [sieqvi |] eqn:Hpri
       ; [| done].
       cut (proper_descriptor X (Existing n) s).
       { intro Hproper. split_and!; [done | lia |].
@@ -436,21 +436,21 @@ Proof.
   rewrite Hproject in _Hpr. inversion _Hpr. subst _oitemx _deqv'. clear _Hpr.
   specialize (Hchar2 _ Hv Ht).
   destruct Hchar2 as [Hdeqv' Hchar2].
-  destruct l as [sn| j l| j l]; simpl in *
-  ; [left; inversion_clear Ht;  cbv; lia| ..]
+  destruct l as [sn | j l | j l]; simpl in *
+  ; [left; inversion_clear Ht;  cbv; lia | ..]
   ; (destruct oitem as [itemx |]
     ; [intros Heqv; left; destruct itemx; destruct Hchar1
         as [[_ Hl] [Hinput [Houtput [Hdest Heq_deqv']]]]
       ; subst; apply (equivocator_transition_preserves_equivocating_state X _ _ _ _ _ Ht)
-      ; destruct Heqv as [Heqv|Heqv]; done
+      ; destruct Heqv as [Heqv | Heqv]; done
       |])
   ; cbn in Hv
-  ; (destruct (equivocator_state_project s j) as [sj|] eqn:Hsj; [| done]).
+  ; (destruct (equivocator_state_project s j) as [sj |] eqn:Hsj; [| done]).
   - specialize (existing_false_label_equivocator_transition_size X Ht _ Hsj) as Ht_size.
-    intros [Heqv | Heqv]; [clear -Ht_size Heqv; cbv in *; lia|].
+    intros [Heqv | Heqv]; [clear -Ht_size Heqv; cbv in *; lia |].
     right.
     unfold equivocator_vlsm_transition_item_project in Hproject.
-    destruct descriptor as [|deqvi]; [done |].
+    destruct descriptor as [| deqvi]; [done |].
     destruct (equivocator_state_project destination deqvi); [| done].
     case_decide; [by congruence |].
     by inversion Hproject; subst; inversion Heqv.
@@ -536,11 +536,11 @@ Lemma equivocator_vlsm_trace_project_cons
     tr = prefix ++ suffix.
 Proof.
   simpl in Hproject.
-  destruct (equivocator_vlsm_trace_project bsuffix dlast) as [(suffix, dmiddle)|]
+  destruct (equivocator_vlsm_trace_project bsuffix dlast) as [(suffix, dmiddle) |]
     eqn:Hsuffix
   ; [| by congruence].
   exists dmiddle.
-  destruct (equivocator_vlsm_transition_item_project bprefix dmiddle) as [[[prefix|] i]|]
+  destruct (equivocator_vlsm_transition_item_project bprefix dmiddle) as [[[prefix |] i] |]
     eqn:Hprefix
   ; inversion Hproject; subst; clear Hproject.
   - by exists [prefix], suffix; cbn; rewrite Hprefix.
@@ -574,9 +574,9 @@ Proof.
     + simpl. rewrite Hprefix.
       simpl in Ha.
       destruct (equivocator_vlsm_transition_item_project a da)
-        as [(oitem', i)|]
+        as [(oitem', i) |]
       ; [| by congruence].
-      by destruct oitem' as [item'|]; inversion Ha; subst.
+      by destruct oitem' as [item' |]; inversion Ha; subst.
     + by subst; rewrite app_assoc.
 Qed.
 
@@ -596,7 +596,7 @@ Proof.
   induction bprefix; intros.
   - by inversion Hprefix; subst.
   - simpl in Hprefix.
-    destruct (equivocator_vlsm_trace_project bprefix dmiddle) as [(prefix', dstart')|]
+    destruct (equivocator_vlsm_trace_project bprefix dmiddle) as [(prefix', dstart') |]
       eqn:Hprefix'
     ; [| by congruence].
     specialize (IHbprefix prefix' dstart' eq_refl).
@@ -627,14 +627,14 @@ Proof.
   destruct di as [sn | i]; [by simpl in Hitem; congruence |].
   eexists _; split; [done |].
   simpl in Hitem.
-  destruct (equivocator_state_project s i) as [si|] eqn:Heqsi; [| done].
+  destruct (equivocator_state_project s i) as [si |] eqn:Heqsi; [| done].
   eexists; split; [done |].
-  destruct l as [sn| j lx| j lx]; [by destruct (decide _) |..]
+  destruct l as [sn | j lx | j lx]; [by destruct (decide _) | ..]
   ; cbn in Hv
-  ; (destruct (equivocator_state_project s' j) as [s'j|] eqn:Heqs'j; [| done])
+  ; (destruct (equivocator_state_project s' j) as [s'j |] eqn:Heqs'j; [| done])
   ; (destruct (decide _); [| done])
   ; inversion Hitem; subst; simpl; repeat split; eexists _; repeat split; exists s'j
-  ; (repeat split; [done..|])
+  ; (repeat split; [done.. |])
   ; destruct (vtransition X _ _) as (s'j', _oom) eqn:Hti.
   - specialize (existing_false_label_equivocator_state_project_same X Ht _ Heqs'j _ _ Hti)
       as [Heq_oom Heqs'j'].
@@ -671,10 +671,10 @@ Lemma equivocator_valid_transition_project_inv3
       end
     end.
 Proof.
-  destruct di as [si | i]; [by inversion Hitem|].
+  destruct di as [si | i]; [by inversion Hitem |].
   subst item. simpl in Hitem.
-  destruct (equivocator_state_project s i) as [si|] eqn:Heqsi; [| done].
-  destruct l as [sn|id lx|id lx]; destruct (decide _); inversion Hitem; subst.
+  destruct (equivocator_state_project s i) as [si |] eqn:Heqsi; [| done].
+  destruct l as [sn | id lx | id lx]; destruct (decide _); inversion Hitem; subst.
   - inversion Ht; subst.
     split_and!; [done | done | apply Hv | done | | apply Hv].
     by rewrite equivocator_state_extend_lst, equivocator_state_extend_project_2 in Heqsi.
@@ -684,31 +684,31 @@ Proof.
     specialize (new_machine_label_equivocator_transition_size X Ht) as Ht_size.
     specialize (equivocator_state_last_n X s) as Hs_lst.
     apply equivocator_state_project_Some_rev in Heqsi.
-    spec Hn; [lia|].
+    spec Hn; [lia |].
     simpl in Hn.
     by destruct_equivocator_state_project s' i s'i Hi; [subst | lia].
   - eexists; split; [done |].
     cbn in Hv.
-    destruct (equivocator_state_project s' id) as [s'id|] eqn:Hpr; [| done].
+    destruct (equivocator_state_project s' id) as [s'id |] eqn:Hpr; [| done].
     specialize (existing_false_label_equivocator_state_project_not_same X Ht _ Hpr i) as Hn.
     simpl in Hn. rewrite Heqsi in Hn.
     specialize (existing_false_label_equivocator_transition_size X Ht _ Hpr) as Ht_size.
     specialize (equivocator_state_last_n X s) as Hs_lst.
     apply equivocator_state_project_Some_rev in Heqsi.
-    spec Hn; [lia|].
+    spec Hn; [lia |].
     specialize (Hn n).
-    destruct_equivocator_state_project s' i s'i Hi; [|lia].
+    destruct_equivocator_state_project s' i s'i Hi; [| lia].
     by simpl in Hn; subst.
   - eexists; split; [done |].
     cbn in Hv.
-    destruct (equivocator_state_project s' id) as [s'id|] eqn:Hpr; [| done].
+    destruct (equivocator_state_project s' id) as [s'id |] eqn:Hpr; [| done].
     specialize (existing_true_label_equivocator_state_project_not_last X Ht _ Hpr i) as Hn.
     simpl in Hn. rewrite Heqsi in Hn.
     specialize (existing_true_label_equivocator_transition_size X Ht _ Hpr) as Ht_size.
     specialize (equivocator_state_last_n X s) as Hs_lst.
     apply equivocator_state_project_Some_rev in Heqsi.
-    spec Hn; [lia|].
-    destruct_equivocator_state_project s' i s'i Hi; [|lia].
+    spec Hn; [lia |].
+    destruct_equivocator_state_project s' i s'i Hi; [| lia].
     by simpl in Hn; subst.
 Qed.
 
@@ -737,20 +737,20 @@ Proof.
     exists None.
     rewrite decide_False ; [done |].
     by rewrite equivocator_state_extend_lst; lia.
-  - cbn in Hv. destruct (equivocator_state_project s' j) as [s'j|] eqn:Heqs'j
+  - cbn in Hv. destruct (equivocator_state_project s' j) as [s'j |] eqn:Heqs'j
     ; [| done].
     specialize (existing_false_label_equivocator_transition_size X Ht _ Heqs'j) as Ht_size.
     apply equivocator_state_project_Some_rev in Hi' as Hlti'.
-    destruct_equivocator_state_project s i' si Hlti; [|lia].
+    destruct_equivocator_state_project s i' si Hlti; [| lia].
     eexists; split; [done |].
     by destruct (decide _); subst; eexists _.
-  - cbn in Hv. destruct (equivocator_state_project s' j) as [s'j|] eqn:Heqs'j
+  - cbn in Hv. destruct (equivocator_state_project s' j) as [s'j |] eqn:Heqs'j
     ; [| done].
     specialize (existing_true_label_equivocator_transition_size X Ht _ Heqs'j) as Ht_size.
     apply equivocator_state_project_Some_rev in Hi' as Hlti'.
-    destruct_equivocator_state_project s i' si Hlti; [|lia].
+    destruct_equivocator_state_project s i' si Hlti; [| lia].
     eexists; split; [done |].
-    rewrite decide_False; [by eexists _|].
+    rewrite decide_False; [by eexists _ |].
     by specialize (equivocator_state_last_n X s); lia.
 Qed.
 
@@ -787,9 +787,9 @@ Lemma equivocator_valid_transition_project_inv5
     exists (itemx : vtransition_item X),
     equivocator_vlsm_transition_item_project item (Existing i) = Some (Some itemx, Existing _i).
 Proof.
-  destruct l as [sn| _i' lx| _i' lx]; simpl in Hsndl; inversion Hsndl; subst
+  destruct l as [sn | _i' lx | _i' lx]; simpl in Hsndl; inversion Hsndl; subst
   ; cbn in Hv
-  ; (destruct (equivocator_state_project s' _i) as [s'i|] eqn:Heqs'i; [| done]).
+  ; (destruct (equivocator_state_project s' _i) as [s'i |] eqn:Heqs'i; [| done]).
   - specialize (existing_false_label_equivocator_transition_size X Ht _ Heqs'i) as Ht_size.
     specialize (existing_false_label_equivocator_state_project_same X Ht _ Heqs'i) as Ht_pr.
     simpl in Ht_pr.
@@ -798,7 +798,7 @@ Proof.
     exists _i.
     simpl.
     apply equivocator_state_project_Some_rev in Heqs'i as Hlti.
-    destruct_equivocator_state_project s _i si Hi; [|lia].
+    destruct_equivocator_state_project s _i si Hi; [| lia].
     simpl in Heqsi'. subst si.
     by rewrite decide_True; eauto.
   - specialize (existing_true_label_equivocator_transition_size X Ht _ Heqs'i) as Ht_size.
@@ -809,7 +809,7 @@ Proof.
     specialize (Ht_pr _ _ eq_refl) as [Heq_oom Heqsi'].
     exists (equivocator_state_n s').
     simpl.
-    destruct_equivocator_state_project s (equivocator_state_n s') s_lst Hlst; [|lia].
+    destruct_equivocator_state_project s (equivocator_state_n s') s_lst Hlst; [| lia].
     simpl in Heqsi'. subst s_lst. eexists; split; [done |].
     specialize (equivocator_state_last_n X s) as Hs_lst.
     rewrite decide_True by lia.
@@ -854,7 +854,7 @@ Proof.
     unfold equivocator_vlsm_trace_project.
     rewrite foldr_app. replace (foldr _ _ tl) with (Some (tlX, di')).
     simpl.
-    destruct di' as [sn| i]; [by eexists _, _ |].
+    destruct di' as [sn | i]; [by eexists _, _ |].
     destruct Hdi as [si [Heqsi HltX]].
     specialize (equivocator_transition_item_project_proper_characterization item (Existing i))
       as Hchar.
@@ -863,7 +863,7 @@ Proof.
     rewrite Hitem_pr.
     subst item.
     specialize (Hchar2 _ Hv Ht) as [Hproper' [Hprevious Hchar2]].
-    destruct oitem as [itemX|]; eexists _, _; split; [done | | done |].
+    destruct oitem as [itemX |]; eexists _, _; split; [done | | done |].
     2: { simpl in *. rewrite Heqsi in Hchar2.
          destruct descriptor' as [sn | i']; simpl in Hchar2.
          - by subst si.
@@ -875,11 +875,11 @@ Proof.
     destruct Hchar1 as [[Hex Hl] [Heqiom [Hoom [Hsi Hdl]]]]. subst.
     destruct (equivocator_label_descriptor l) as [sn | i'] eqn:Hd; simpl in Hchar2.
     + specialize (Hchar2 _ eq_refl) as [HvX HtX].
-      split; [apply Hproper'|].
+      split; [apply Hproper' |].
       destruct itemX. simpl in *.
       rewrite Heqsi in Hitem_pr. subst.
       apply (finite_valid_trace_from_to_extend (pre_loaded_vlsm X seed)); [done |].
-      repeat split; [..| done | done].
+      repeat split; [.. | done | done].
       * by apply initial_state_is_valid.
       * by apply preloaded_with_equivocator_state_project_valid_message.
     + destruct Hproper' as [s'i' Heqs'i']; rewrite Heqs'i' in *.
@@ -889,7 +889,7 @@ Proof.
       destruct itemX. simpl in *.
       subst.
       apply (finite_valid_trace_from_to_extend (pre_loaded_vlsm X seed)); [done |].
-      repeat split; [..| done | done].
+      repeat split; [.. | done | done].
       * by eapply preloaded_with_equivocator_state_project_valid_state.
       * by apply preloaded_with_equivocator_state_project_valid_message.
 Qed.
@@ -919,7 +919,7 @@ Proof.
   specialize (preloaded_with_equivocator_vlsm_trace_project_valid _ _ _ _ Hbtr _ _ Hj)
     as [tr [di [Hbtr_pr Hdi]]].
   eexists _, _; split; [done |].
-  destruct di as [sn|i].
+  destruct di as [sn | i].
   - destruct Hdi as [Hsn Htr].
     split; [done |].
     apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj2
@@ -962,7 +962,7 @@ Proof.
   specialize (preloaded_with_equivocator_vlsm_trace_project_valid _ _ _ _ Hbtr _ _ Hj)
     as [tr [di [Hbtr_pr Hdi]]].
   eexists _, _; split; [done |].
-  destruct di as [sn|i].
+  destruct di as [sn | i].
   - destruct Hdi as [Hsn Htr].
     split; [done |].
     apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj2
@@ -997,16 +997,16 @@ Proof.
   remember (Existing j) as dj.
   simpl in *.
   destruct (equivocator_vlsm_transition_item_project x dj)
-    as [(_x, _dmiddle)|]
+    as [(_x, _dmiddle) |]
     eqn:Hx'
   ; [| by congruence].
-  destruct _x as [itemx|]; inversion Hx; subst lx _dmiddle; clear Hx.
+  destruct _x as [itemx |]; inversion Hx; subst lx _dmiddle; clear Hx.
   - subst. destruct x. unfold equivocator_vlsm_transition_item_project in Hx'.
     simpl.
-    destruct (equivocator_state_project destination j); [|congruence].
+    destruct (equivocator_state_project destination j); [| congruence].
     by eexists.
   - subst. destruct x. simpl in *.
-    destruct (equivocator_state_project destination j); [|congruence].
+    destruct (equivocator_state_project destination j); [| congruence].
     by eexists.
 Qed.
 
@@ -1042,7 +1042,7 @@ Proof.
     rewrite Htr.
     destruct Hitem as [oitem Hoitem].
     rewrite Hoitem.
-    destruct oitem as [itemx|].
+    destruct oitem as [itemx |].
     + by exists (itemx :: tr).
     + by exists tr.
 Qed.
@@ -1098,17 +1098,17 @@ Lemma equivocator_zero_projection
 Proof.
   apply basic_VLSM_strong_projection; intro; intros.
   - by destruct lX as [sn | [| i] lX | [| i] lX]; inversion H; subst.
-  - destruct lX as [sn| [|i] lX | [|i] lX]; inversion H; subst.
+  - destruct lX as [sn | [| i] lX | [| i] lX]; inversion H; subst.
     cbn in H0.
     rewrite equivocator_state_project_zero in H0.
     by destruct (vtransition _ _ _); inversion_clear H0.
   - unfold equivocator_label_zero_project in H.
-    destruct lX as [sn| [|i] lX | [|i] lX]; inversion H; subst; cbn in H0.
+    destruct lX as [sn | [| i] lX | [| i] lX]; inversion H; subst; cbn in H0.
     + by inversion H0.
-    + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _)|]; inversion H0.
+    + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _) |]; inversion H0.
     + rewrite equivocator_state_project_zero in H0.
       by destruct (vtransition _ _ _); inversion_clear H0.
-    + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _)|];
+    + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _) |];
         inversion_clear H0.
   - by apply H.
   - by apply equivocator_state_project_valid_message.
@@ -1121,17 +1121,17 @@ Lemma preloaded_equivocator_zero_projection :
 Proof.
   apply basic_VLSM_projection_preloaded; intro; intros.
   - by destruct lX as [sn | [| i] lX | [| i] lX]; inversion H; subst.
-  - destruct lX as [sn| [|i] lX | [|i] lX]; inversion H; subst.
+  - destruct lX as [sn | [| i] lX | [| i] lX]; inversion H; subst.
     cbn in H0. rewrite equivocator_state_project_zero in H0.
     by destruct (vtransition _ _ _); inversion_clear H0.
   - unfold equivocator_label_zero_project in H.
-    destruct lX as [sn| [|i] lX | [|i] lX]; inversion H; subst; cbn in H0.
+    destruct lX as [sn | [| i] lX | [| i] lX]; inversion H; subst; cbn in H0.
     + by inversion H0.
-    + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _)|];
+    + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _) |];
         inversion_clear H0.
     + by rewrite equivocator_state_project_zero in H0; destruct (vtransition _ _ _);
         inversion_clear H0.
-    + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _)|];
+    + by destruct (equivocator_state_project _ _); [destruct (vtransition _ _ _) |];
         inversion_clear H0.
   - apply H.
 Qed.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -863,7 +863,7 @@ Proof.
     rewrite Hitem_pr.
     subst item.
     specialize (Hchar2 _ Hv Ht) as [Hproper' [Hprevious Hchar2]].
-    destruct oitem as [itemX|]; eexists _,_; split; [done | | done |].
+    destruct oitem as [itemX|]; eexists _, _; split; [done | | done |].
     2: { simpl in *. rewrite Heqsi in Hchar2.
          destruct descriptor' as [sn | i']; simpl in Hchar2.
          - by subst si.
@@ -918,7 +918,7 @@ Proof.
     (VLSM_eq_proj1 (vlsm_is_pre_loaded_with_False equivocator_vlsm))) in Hbtr.
   specialize (preloaded_with_equivocator_vlsm_trace_project_valid _ _ _ _ Hbtr _ _ Hj)
     as [tr [di [Hbtr_pr Hdi]]].
-  eexists _,_; split; [done |].
+  eexists _, _; split; [done |].
   destruct di as [sn|i].
   - destruct Hdi as [Hsn Htr].
     split; [done |].
@@ -961,7 +961,7 @@ Proof.
     (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True equivocator_vlsm))) in Hbtr.
   specialize (preloaded_with_equivocator_vlsm_trace_project_valid _ _ _ _ Hbtr _ _ Hj)
     as [tr [di [Hbtr_pr Hdi]]].
-  eexists _,_; split; [done |].
+  eexists _, _; split; [done |].
   destruct di as [sn|i].
   - destruct Hdi as [Hsn Htr].
     split; [done |].

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -55,7 +55,7 @@ Definition equivocator_vlsm_transition_item_project
             else Some (None, Existing j)
         | ContinueWith i lx =>
           if decide (i = j) then
-              Some ( Some {| l := lx; input := im; output := om; destination := sj |}, Existing i)
+              Some (Some {| l := lx; input := im; output := om; destination := sj |}, Existing i)
             else Some (None, Existing j)
         end
       end

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -223,8 +223,8 @@ Context
   selector
   (Hselector_io :
     forall l1 l2 s1 s2 im om m,
-      selector m  {| l:= l1; input := im; destination := s1; output := om |} <->
-      selector m  {| l:= l2; input := im; destination := s2; output := om |})
+      selector m  {| l := l1; input := im; destination := s1; output := om |} <->
+      selector m  {| l := l2; input := im; destination := s2; output := om |})
   oracle
   (Hdec : RelDecision oracle)
   (Hstepwise : oracle_stepwise_props (vlsm := X) selector oracle).

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -46,7 +46,7 @@ Proof.
       eqn: Htr; [| by congruence].
     specialize (IHtr trX').
     destruct (equivocator_vlsm_transition_item_project _ a i') as [[[item' |] i''] |]
-      eqn:Hitem'
+      eqn: Hitem'
     ; inversion HtrX; subst; clear HtrX.
     + apply equivocator_transition_item_project_inv_messages in Hitem'.
       destruct Hitem' as [_ [_ [_ [_ Ha]]]].
@@ -196,7 +196,7 @@ Lemma equivocator_vlsm_trace_project_output_reflecting_inv
 Proof.
   apply Exists_exists in Hbbs.
   destruct Hbbs as [item [Hin Houtput]].
-  destruct (equivocator_label_descriptor (l item)) as [sn | i] eqn:Hsndl.
+  destruct (equivocator_label_descriptor (l item)) as [sn | i] eqn: Hsndl.
   - destruct item. destruct l; inversion Hsndl.
     subst. simpl in *.
     by destruct (preloaded_equivocator_vlsm_trace_project_valid_item_new_machine
@@ -305,8 +305,8 @@ Proof.
         rewrite equivocator_state_extend_project_1; [done |].
         by apply equivocator_state_project_Some_rev in Hsins.
     + cbn in Hv.
-      destruct (equivocator_state_project s idesc) as [sidesc |] eqn:Hidesc; [| done].
-      destruct (vtransition X l (sidesc, im)) as (sidesc', om') eqn:Htx.
+      destruct (equivocator_state_project s idesc) as [sidesc |] eqn: Hidesc; [| done].
+      destruct (vtransition X l (sidesc, im)) as (sidesc', om') eqn: Htx.
       specialize
         (oracle_step_update l sidesc im sidesc' om').
       spec oracle_step_update.
@@ -363,8 +363,8 @@ Proof.
               destruct_equivocator_state_project s' ins _sins Hins; [| lia].
               cbn in Hnot_same; congruence.
     + cbn in Hv.
-      destruct (equivocator_state_project s idesc) as [sidesc |] eqn:Hidesc; [| done].
-      destruct (vtransition X l (sidesc, im)) as (sidesc', om') eqn:Htx.
+      destruct (equivocator_state_project s idesc) as [sidesc |] eqn: Hidesc; [| done].
+      destruct (vtransition X l (sidesc, im)) as (sidesc', om') eqn: Htx.
       specialize
         (oracle_step_update l sidesc im sidesc' om').
       spec oracle_step_update.

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -42,10 +42,10 @@ Proof.
   induction tr; intros.
   - by inversion HtrX; subst; inversion Hjbs.
   - simpl in HtrX.
-    destruct (equivocator_vlsm_trace_project _ tr j) as [(trX', i')|]
+    destruct (equivocator_vlsm_trace_project _ tr j) as [(trX', i') |]
       eqn: Htr; [| by congruence].
     specialize (IHtr trX').
-    destruct (equivocator_vlsm_transition_item_project _ a i') as [[[item'|] i'']|]
+    destruct (equivocator_vlsm_transition_item_project _ a i') as [[[item' |] i''] |]
       eqn:Hitem'
     ; inversion HtrX; subst; clear HtrX.
     + apply equivocator_transition_item_project_inv_messages in Hitem'.
@@ -133,7 +133,7 @@ Proof.
   destruct
     (preloaded_equivocator_vlsm_trace_project_valid_inv _ _ _ Htl _ _ Hi)
     as [suffix Hsuffix].
-  exists itemx. split; [eexists; apply Hitemx|].
+  exists itemx. split; [eexists; apply Hitemx |].
   remember (Existing i) as dsuffix.
   remember {| input := iom |} as bitem.
   specialize (equivocator_vlsm_trace_project_app_inv
@@ -305,7 +305,7 @@ Proof.
         rewrite equivocator_state_extend_project_1; [done |].
         by apply equivocator_state_project_Some_rev in Hsins.
     + cbn in Hv.
-      destruct (equivocator_state_project s idesc) as [sidesc|] eqn:Hidesc; [| done].
+      destruct (equivocator_state_project s idesc) as [sidesc |] eqn:Hidesc; [| done].
       destruct (vtransition X l (sidesc, im)) as (sidesc', om') eqn:Htx.
       specialize
         (oracle_step_update l sidesc im sidesc' om').
@@ -333,9 +333,9 @@ Proof.
            by left; revert H; apply Hselector_io.
         -- right. exists i, s'i. split; [| done].
            specialize (Hnot_same i).
-           spec Hnot_same; [lia|]. specialize (Hnot_same n).
+           spec Hnot_same; [lia |]. specialize (Hnot_same n).
            simpl in Hnot_same. rewrite Hs'i in Hnot_same.
-           destruct_equivocator_state_project s i si Hlti'; [|lia].
+           destruct_equivocator_state_project s i si Hlti'; [| lia].
            by cbn in Hnot_same; congruence.
       * apply proj2 in oracle_step_update.
         apply equivocator_state_project_Some_rev in Hidesc as Hltidesc.
@@ -345,7 +345,7 @@ Proof.
            specialize (oracle_step_update (or_introl Heq_im)).
            exists idesc, sidesc'.
            simpl in Hsame.
-           destruct_equivocator_state_project  s' idesc _sidesc' Hlst; [|lia].
+           destruct_equivocator_state_project  s' idesc _sidesc' Hlst; [| lia].
            simpl in Hsame.
            by subst.
         -- apply equivocator_state_project_Some_rev in Hsins as Hltins.
@@ -355,15 +355,15 @@ Proof.
               specialize (oracle_step_update (or_intror Hbri)).
               exists ins, sidesc'. split; [| done].
               simpl in Hsame.
-              by destruct_equivocator_state_project s' ins _sidesc' Hins; [subst |lia].
+              by destruct_equivocator_state_project s' ins _sidesc' Hins; [subst | lia].
            ++ exists ins, sins. split; [| done].
-              specialize (Hnot_same ins). spec Hnot_same; [lia|].
+              specialize (Hnot_same ins). spec Hnot_same; [lia |].
               specialize (Hnot_same n).
               simpl in Hnot_same. rewrite Hsins in Hnot_same.
-              destruct_equivocator_state_project s' ins _sins Hins; [|lia].
+              destruct_equivocator_state_project s' ins _sins Hins; [| lia].
               cbn in Hnot_same; congruence.
     + cbn in Hv.
-      destruct (equivocator_state_project s idesc) as [sidesc|] eqn:Hidesc; [| done].
+      destruct (equivocator_state_project s idesc) as [sidesc |] eqn:Hidesc; [| done].
       destruct (vtransition X l (sidesc, im)) as (sidesc', om') eqn:Htx.
       specialize
         (oracle_step_update l sidesc im sidesc' om').
@@ -391,9 +391,9 @@ Proof.
            by left; revert H; apply Hselector_io.
         -- right. exists i, s'i. split; [| done].
            specialize (Hnot_last i).
-           spec Hnot_last; [lia|].
+           spec Hnot_last; [lia |].
            simpl in Hnot_last. rewrite Hs'i in Hnot_last.
-           destruct_equivocator_state_project s i si Hlti'; [|lia].
+           destruct_equivocator_state_project s i si Hlti'; [| lia].
            by cbn in Hnot_last; congruence.
       * apply proj2 in oracle_step_update.
         intros [Heq_im | [ins [sins [Hsins Hbri]]]].
@@ -402,13 +402,13 @@ Proof.
            specialize (oracle_step_update (or_introl Heq_im)).
            exists (equivocator_state_n s), sidesc'.
            simpl in Hlast.
-           destruct_equivocator_state_project  s' (equivocator_state_n s) _sidesc' Hlst; [|lia].
+           destruct_equivocator_state_project  s' (equivocator_state_n s) _sidesc' Hlst; [| lia].
            by subst.
         -- apply equivocator_state_project_Some_rev in Hsins as Hltins.
-           specialize (Hnot_last ins). spec Hnot_last; [lia|].
+           specialize (Hnot_last ins). spec Hnot_last; [lia |].
            simpl in Hnot_last. rewrite Hsins in Hnot_last.
            exists ins, sins. split; [| done].
-           destruct_equivocator_state_project s' ins _sins Hltins'; [|lia].
+           destruct_equivocator_state_project s' ins _sins Hltins'; [| lia].
            by cbn in Hnot_last; congruence.
 Qed.
 

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -329,7 +329,7 @@ Proof.
         -- subst i. simpl in Hsame. rewrite Hs'i in Hsame.
            simpl in Hsame. subst s'i.
            apply oracle_step_update in Hbri.
-           destruct Hbri as [H | Hbri]; [| by right; eexists _,_].
+           destruct Hbri as [H | Hbri]; [| by right; eexists _, _].
            by left; revert H; apply Hselector_io.
         -- right. exists i, s'i. split; [| done].
            specialize (Hnot_same i).
@@ -387,7 +387,7 @@ Proof.
         -- subst i. simpl in Hlast. rewrite Hs'i in Hlast.
            simpl in Hlast. subst s'i.
            apply oracle_step_update in Hbri.
-           destruct Hbri as [H | Hbri]; [| by right; eexists _,_].
+           destruct Hbri as [H | Hbri]; [| by right; eexists _, _].
            by left; revert H; apply Hselector_io.
         -- right. exists i, s'i. split; [| done].
            specialize (Hnot_last i).

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -30,12 +30,12 @@ Context
   the original trace must do so too.
 *)
 Lemma equivocator_vlsm_trace_project_output_reflecting
-  (tr: list (vtransition_item equivocator_vlsm))
-  (trX: list (vtransition_item X))
+  (tr : list (vtransition_item equivocator_vlsm))
+  (trX : list (vtransition_item X))
   (j i : MachineDescriptor)
-  (HtrX: equivocator_vlsm_trace_project _ tr j = Some (trX, i))
+  (HtrX : equivocator_vlsm_trace_project _ tr j = Some (trX, i))
   (m : message)
-  (Hjbs: Exists (field_selector output m) trX)
+  (Hjbs : Exists (field_selector output m) trX)
   : Exists (field_selector output m) tr.
 Proof.
   revert trX i HtrX Hjbs.
@@ -180,17 +180,17 @@ Qed.
   one of its projections must do so too.
 *)
 Lemma equivocator_vlsm_trace_project_output_reflecting_inv
-  (is: vstate equivocator_vlsm)
-  (tr: list (vtransition_item equivocator_vlsm))
-  (Htr: finite_valid_trace_from (pre_loaded_with_all_messages_vlsm equivocator_vlsm) is tr)
+  (is : vstate equivocator_vlsm)
+  (tr : list (vtransition_item equivocator_vlsm))
+  (Htr : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm equivocator_vlsm) is tr)
   (m : message)
   (Hbbs : Exists (field_selector output m) tr)
   : exists
     (j i : MachineDescriptor)
     (Hi : proper_descriptor X i is)
     (Hj : existing_descriptor X j (finite_trace_last is tr))
-    (trX: list (vtransition_item X))
-    (HtrX: equivocator_vlsm_trace_project _ tr j = Some (trX, i))
+    (trX : list (vtransition_item X))
+    (HtrX : equivocator_vlsm_trace_project _ tr j = Some (trX, i))
     ,
     Exists (field_selector output m) trX.
 Proof.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -442,7 +442,7 @@ Definition full_node_is_sent_locally_equivocating
   (s : vstate X) (v : validator) : Prop :=
   exists m1 m2, FullNodeSentLocalEquivocationEvidence s v m1 m2.
 
-Lemma full_node_is_sent_locally_equivocating_weaker s v:
+Lemma full_node_is_sent_locally_equivocating_weaker s v :
   full_node_is_locally_equivocating s v ->
   full_node_is_sent_locally_equivocating s v.
 Proof.
@@ -451,7 +451,7 @@ Proof.
   by contradict Hncomp; apply tc_comparable.
 Qed.
 
-Lemma full_node_is_locally_equivocating_stronger s v:
+Lemma full_node_is_locally_equivocating_stronger s v :
   full_node_is_locally_equivocating s v ->
   msg_dep_is_locally_equivocating s v.
 Proof.
@@ -826,7 +826,7 @@ Definition full_node_is_globally_equivocating
   (s : composite_state IM) (v : validator) : Prop :=
   exists m : message, FullNodeGlobalEquivocationEvidence s v m.
 
-Lemma full_node_is_globally_equivocating_stronger s v:
+Lemma full_node_is_globally_equivocating_stronger s v :
   full_node_is_globally_equivocating s v ->
   msg_dep_is_globally_equivocating s v.
 Proof.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -1005,7 +1005,7 @@ Qed.
 Lemma msg_dep_happens_before_wf : well_founded (msg_dep_happens_before message_dependencies).
 Proof.
   apply tc_wf_projected with (<) (fun m => length (elements (full_message_dependencies m)));
-    [by typeclasses eauto | | by apply Wf_nat.lt_wf ].
+    [by typeclasses eauto | | by apply Wf_nat.lt_wf].
   intros; unfold lt.
   change (S _) with (length (x :: elements (full_message_dependencies x))).
   apply NoDup_subseteq_length.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -656,7 +656,7 @@ Proof.
 Qed.
 
 Lemma CompositeHasBeenObserved_step_update :
-  forall l s im s' om, input_valid_transition RFree l (s,im) (s',om) ->
+  forall l s im s' om, input_valid_transition RFree l (s, im) (s', om) ->
   forall msg,
     CompositeHasBeenObserved s' msg
       <->
@@ -869,7 +869,7 @@ Proof.
   destruct Htr as (? & ? & ?).
   destruct (decide (has_been_sent (IM (A v)) (s (A v)) m1));
     [destruct (decide (has_been_sent (IM (A v)) (s (A v)) m2)) |]; cycle 1.
-  1,2: eexists; split;
+  1, 2: eexists; split;
       [..| by contradict n; eapply has_been_sent_iff_by_sender];
       [done | by eapply composite_HasBeenObserved_lift].
   contradict Hncomp; eapply tc_comparable, Hsent_comparable; [| done..].
@@ -891,7 +891,7 @@ Proof.
   destruct Htr as (? & ? & ?).
   destruct (decide (has_been_sent (IM (A v)) (s (A v)) m1));
     [destruct (decide (has_been_sent (IM (A v)) (s (A v)) m2)) |]; cycle 1.
-  1,2: eexists; split; cycle 2;
+  1, 2: eexists; split; cycle 2;
       [by contradict n; eapply has_been_sent_iff_by_sender | done |];
       by constructor 1; eexists.
   contradict Hncomp; eapply Hsent_comparable; [| done..].

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -202,7 +202,7 @@ Proof.
     by apply has_been_received_no_inits.
   - rewrite has_been_received_step_update by done; intros [-> | Hrcv] dm Hdm
     ; rewrite has_been_directly_observed_step_update by done; right.
-    + by eapply Hfull; [apply Ht|].
+    + by eapply Hfull; [apply Ht |].
     + by eapply IHHs.
 Qed.
 
@@ -217,7 +217,7 @@ Lemma msg_dep_full_node_reflects_has_been_directly_observed
   : forall dm m, msg_dep_rel dm m ->
     has_been_directly_observed X s m -> has_been_directly_observed X s dm.
 Proof.
-  intros dm m Hdm [Hsent|Hreceived].
+  intros dm m Hdm [Hsent | Hreceived].
   - by eapply msg_dep_has_been_sent.
   - by eapply full_node_has_been_received.
 Qed.
@@ -234,7 +234,7 @@ Lemma msg_dep_full_node_happens_before_reflects_has_been_directly_observed
     has_been_directly_observed X s m -> has_been_directly_observed X s dm.
 Proof.
   intros dm m Hdm Hobs.
-  eapply msg_dep_happens_before_reflect; [|done ..].
+  eapply msg_dep_happens_before_reflect; [| done ..].
   by apply msg_dep_full_node_reflects_has_been_directly_observed.
 Qed.
 
@@ -368,7 +368,7 @@ Proof.
   exists s, {| l := l; input := im; destination := s'; output := Some m |}.
   constructor; [done.. |].
   eapply @message_dependencies_are_necessary in Hdm as Hobs; [| done | by eexists _, _].
-  eapply has_been_directly_observed_step_update in Hobs as [[| Hout] |]; [..| done]; cycle 2.
+  eapply has_been_directly_observed_step_update in Hobs as [[| Hout] |]; [.. | done]; cycle 2.
   - by do 2 constructor.
   - by subst; cbn; constructor.
   - by contradict Hdm; inversion Hout; apply tc_reflect_irreflexive.
@@ -727,7 +727,7 @@ Lemma composite_ObservedBeforeSendTransition_project :
     (s i) (composite_transition_item_projection IM item) m1 m2.
 Proof.
   by intros * []; constructor;
-    [eapply input_valid_transition_preloaded_project_active |..].
+    [eapply input_valid_transition_preloaded_project_active | ..].
 Qed.
 
 Lemma composite_observed_before_send_iff m1 m2 :
@@ -786,7 +786,7 @@ Proof.
   by eapply emitted_messages_are_valid,
     msg_dep_reflects_happens_before_free_validity,
     emitted_messages_are_valid_iff
-    in Hm as [(i & [] & <-)|]; [exfalso; eapply no_initial_messages_in_IM | ..].
+    in Hm as [(i & [] & <-) |]; [exfalso; eapply no_initial_messages_in_IM | ..].
 Qed.
 
 (**
@@ -870,7 +870,7 @@ Proof.
   destruct (decide (has_been_sent (IM (A v)) (s (A v)) m1));
     [destruct (decide (has_been_sent (IM (A v)) (s (A v)) m2)) |]; cycle 1.
   1, 2: eexists; split;
-      [..| by contradict n; eapply has_been_sent_iff_by_sender];
+      [.. | by contradict n; eapply has_been_sent_iff_by_sender];
       [done | by eapply composite_HasBeenObserved_lift].
   contradict Hncomp; eapply tc_comparable, Hsent_comparable; [| done..].
   by eapply valid_state_project_preloaded_to_preloaded.
@@ -1247,7 +1247,7 @@ Lemma input_valid_transition_preserves_msg_dep_is_globally_equivocating :
       msg_dep_is_globally_equivocating IM message_dependencies sender (destination item) v.
 Proof.
   intros s item Ht j Hsj v Hv [m []].
-  exists m; constructor; [done |..].
+  exists m; constructor; [done | ..].
   - by eapply transition_preserves_CompositeHasBeenObserved.
   - contradict mdgee_not_sent0.
     apply exists_right_finite_trace_from in Ht as (is & tr & Htr & _).

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -96,11 +96,11 @@ Proof.
   rewrite rev_unit. unfold _apply_plan in IHa.
   simpl in *.
   destruct (fold_right _apply_plan_folder (start, []) (rev a)) as (final, items)
-    eqn:Happly.
+    eqn: Happly.
   simpl in IHa.
   simpl.
   destruct x.
-  destruct (transition label_a0 (final, input_a0)) as (dest, out) eqn:Ht.
+  destruct (transition label_a0 (final, input_a0)) as (dest, out) eqn: Ht.
   by simpl; rewrite finite_trace_last_is_last.
 Qed.
 
@@ -117,10 +117,10 @@ Proof.
   rewrite fold_right_app. simpl.
   destruct
     (fold_right _apply_plan_folder (@pair state _ start []) (rev  a))
-    as (afinal, aitems) eqn:Ha.
+    as (afinal, aitems) eqn: Ha.
   destruct
     (fold_right _apply_plan_folder (@pair state _ afinal []) (rev a'))
-    as (final, items) eqn:Ha'.
+    as (final, items) eqn: Ha'.
   clear - Ha'.
   specialize (_apply_plan_folder_additive afinal (rev a') aitems) as Hadd.
   rewrite Ha' in Hadd.
@@ -210,7 +210,7 @@ Proof.
   unfold finite_valid_plan_from.
   specialize (apply_plan_app s a b) as Happ.
   specialize (apply_plan_last s a) as Hlst.
-  destruct (apply_plan s a) as (aitems, afinal) eqn:Ha.
+  destruct (apply_plan s a) as (aitems, afinal) eqn: Ha.
   subst s_a.
   simpl in *.
   destruct (apply_plan afinal b) as (bitems, bfinal).
@@ -348,7 +348,7 @@ Proof.
       remember (snd (apply_plan s a)) as sa.
       unfold apply_plan, _apply_plan. simpl.
       destruct x.
-      destruct (vtransition X label_a0 (sa, input_a0)) as (dest, out) eqn:Ht.
+      destruct (vtransition X label_a0 (sa, input_a0)) as (dest, out) eqn: Ht.
       simpl.
       apply Forall_inv in Hinput_ai. simpl in Hinput_ai.
       unfold finite_valid_plan_from in Ha.

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -100,7 +100,7 @@ Proof.
   simpl in IHa.
   simpl.
   destruct x.
-  destruct (transition label_a0 (final, input_a0)) as (dest,out) eqn:Ht.
+  destruct (transition label_a0 (final, input_a0)) as (dest, out) eqn:Ht.
   by simpl; rewrite finite_trace_last_is_last.
 Qed.
 
@@ -322,7 +322,7 @@ Proof.
       unfold lst. clear lst.
       remember (snd (apply_plan s prefa)) as lst.
       unfold finite_valid_plan_from in Hx.
-      unfold apply_plan,_apply_plan in Hx. simpl in Hx.
+      unfold apply_plan, _apply_plan in Hx. simpl in Hx.
       destruct ai.
       destruct ( vtransition X label_a0 (lst, input_a0)) as (dest, out).
       simpl. simpl in Hx. inversion Hx. subst.
@@ -375,7 +375,7 @@ Proof.
   split;
   intros;
   destruct a;
-  unfold apply_plan,_apply_plan in *; simpl in *;
+  unfold apply_plan, _apply_plan in *; simpl in *;
   unfold finite_valid_plan_from in *;
   unfold apply_plan, _apply_plan in *; simpl in *.
   - match type of H with

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -356,7 +356,7 @@ Proof.
       specialize (apply_plan_last s a) as Hlst.
       simpl in Hlst, Ha.
       setoid_rewrite Hlst in Ha. setoid_rewrite <- Heqsa in Ha.
-      repeat constructor; [|done ..].
+      repeat constructor; [| done ..].
       exists out.
       replace (@pair (@state message (@type message X)) (option message) dest out)
         with (vtransition X label_a0 (sa, input_a0)).

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -380,13 +380,13 @@ Proof.
   unfold apply_plan, _apply_plan in *; simpl in *.
   - match type of H with
     | context[let (_, _) := let (_, _) := ?t in _ in _] =>
-      destruct t as [dest output] eqn : eq_trans
+      destruct t as [dest output] eqn: eq_trans
     end.
     inversion H; subst.
     by setoid_rewrite eq_trans.
   - match type of H with
     | input_valid_transition _ _ _ ?t =>
-      destruct t as [dest output] eqn : eq_trans
+      destruct t as [dest output] eqn: eq_trans
     end.
     setoid_rewrite eq_trans.
     apply finite_valid_trace_from_extend; [| done].

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -298,7 +298,7 @@ Lemma finite_valid_plan_iff
 Proof.
   induction a using rev_ind; repeat split; intros
   ; try
-    ( apply finite_valid_plan_from_app_iff in H
+    (apply finite_valid_plan_from_app_iff in H
     ; destruct H as [Ha Hx]; apply IHa in Ha as Ha').
   - by inversion H.
   - by constructor.
@@ -311,7 +311,7 @@ Proof.
     remember (snd (apply_plan s a)) as lst.
     unfold apply_plan, _apply_plan in Hx. simpl in Hx.
     destruct x.
-    destruct ( vtransition X label_a0 (lst, input_a0)) as (dest, out).
+    destruct (vtransition X label_a0 (lst, input_a0)) as (dest, out).
     simpl. simpl in Hx. inversion Hx. subst.
     by apply Ht.
   - assert (Hsuffa : suffa = [] \/ suffa <> []) by
@@ -324,7 +324,7 @@ Proof.
       unfold finite_valid_plan_from in Hx.
       unfold apply_plan, _apply_plan in Hx. simpl in Hx.
       destruct ai.
-      destruct ( vtransition X label_a0 (lst, input_a0)) as (dest, out).
+      destruct (vtransition X label_a0 (lst, input_a0)) as (dest, out).
       simpl. simpl in Hx. inversion Hx. subst.
       by apply Ht.
     + apply exists_last in H. destruct H as [suffa' [x' Heq]]. subst.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -228,7 +228,7 @@ Proof.
   destruct Ht as [[Hs1 [Hom1 [Hv _]]] Ht].
   simpl in Hv. simpl in Ht. cbn in Ht.
   destruct l as [il l].
-  destruct (vtransition _ _ _) as (si', om') eqn:Htj.
+  destruct (vtransition _ _ _) as (si', om') eqn: Htj.
   inversion Ht; subst; clear Ht.
   by state_update_simpl.
 Qed.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -139,7 +139,7 @@ Qed.
 
 Lemma composite_transition_item_projection_neq
   (item : composite_transition_item IM)
-  (Hneq: j <> projT1 (l item))
+  (Hneq : j <> projT1 (l item))
   : @pre_VLSM_projection_transition_item_project _ (composite_type IM) _
       (composite_project_label IM j) (fun s => s j)
       item

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -478,7 +478,7 @@ Lemma component_projection_validator_prop_is_induced
 Proof.
   split; intros Hvalidator li si omi Hvi.
   - apply Hvalidator in Hvi as (sX & <- & Hv).
-    by eexists (existT j li), sX; split; [apply composite_project_label_eq |..].
+    by eexists (existT j li), sX; split; [apply composite_project_label_eq | ..].
   - apply Hvalidator in Hvi as ([i _li] & sX & []).
     unfold composite_project_label in tiv_label_project; case_decide; [subst; cbn in * | done].
     apply Some_inj in tiv_label_project; subst _li.

--- a/theories/VLSM/Core/ReachableThreshold.v
+++ b/theories/VLSM/Core/ReachableThreshold.v
@@ -72,7 +72,7 @@ Lemma pivotal_validator_extension
   (sum_weights (vs ∪ vsfix) > threshold)%R /\
   exists v,
     v ∈ vs /\
-    (sum_weights (vs ∖ {[v]} ∪ vsfix) <= threshold)%R.
+    (sum_weights (vs ∖ {[ v ]} ∪ vsfix) <= threshold)%R.
 Proof.
   intros vsfix vss Hvsfix Hdisj Hall.
   destruct (pivotal_validator_extension_list (elements vsfix) (elements vss))
@@ -122,7 +122,7 @@ Lemma validators_pivotal_ind
   (sum_weights vs > threshold)%R /\
   exists v,
     v ∈ vs /\
-    (sum_weights (vs ∖ {[v]}) <= threshold)%R.
+    (sum_weights (vs ∖ {[ v ]}) <= threshold)%R.
 Proof.
   intros vss Hvss.
   destruct (pivotal_validator_extension ∅ vss)
@@ -145,7 +145,7 @@ Lemma sufficient_validators_pivotal
     (sum_weights vs > threshold)%R /\
     exists v,
       v ∈ vs /\
-      (sum_weights (vs ∖ {[v]}) <= threshold)%R.
+      (sum_weights (vs ∖ {[ v ]}) <= threshold)%R.
 Proof.
   destruct (rt_reachable (1 := Hrt)) as [vs Hweight].
   apply (validators_pivotal_ind vs) in Hweight as (vs' & Hincl & Hvs').
@@ -171,7 +171,7 @@ Lemma exists_pivotal_validator :
   exists v, potentially_pivotal v.
 Proof.
   destruct sufficient_validators_pivotal as (vs & Hgt & v & Hin & Hlte).
-  exists v, (vs ∖ {[v]}); split_and!.
+  exists v, (vs ∖ {[ v ]}); split_and!.
   - by rewrite elem_of_difference, elem_of_singleton; intros [].
   - done.
   - rewrite (sum_weights_in v) in Hgt by done.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -630,7 +630,7 @@ Proof.
       by apply valid_trace_add_last; auto.
     + apply Exists_exists.
       assert
-        (Hsome: is_Some
+        (Hsome : is_Some
           (pre_VLSM_projection_transition_item_project
             (composite_type IM) (composite_type sub_IM)
             composite_label_sub_projection_option composite_state_sub_projection
@@ -731,7 +731,7 @@ Proof.
 Qed.
 
 Lemma lift_sub_valid l s om
-  (Hv: composite_valid sub_IM l (s, om))
+  (Hv : composite_valid sub_IM l (s, om))
   : composite_valid IM (lift_sub_label l) (lift_sub_state s, om).
 Proof.
   revert Hv.
@@ -747,7 +747,7 @@ Proof.
 Qed.
 
 Lemma lift_sub_transition l s om s' om'
-  (Ht: composite_transition sub_IM l (s, om) = (s', om'))
+  (Ht : composite_transition sub_IM l (s, om) = (s', om'))
   : composite_transition IM
     (lift_sub_label l) (lift_sub_state s, om) = (lift_sub_state s', om').
 Proof.
@@ -935,7 +935,7 @@ Proof.
 Qed.
 
 Lemma lift_sub_to_transition l s om s' om'
-  (Ht: composite_transition (sub_IM IM equivocators) l (s, om) = (s', om'))
+  (Ht : composite_transition (sub_IM IM equivocators) l (s, om) = (s', om'))
   : composite_transition IM
     (lift_sub_label IM equivocators l) (lift_sub_state_to IM equivocators base_s s, om) =
     (lift_sub_state_to IM equivocators base_s s', om').
@@ -1106,7 +1106,7 @@ Definition lift_sub_incl_label
   existT (dexist i H2i) (projT2 l).
 
 Lemma lift_sub_incl_valid l s om
-  (Hv: composite_valid (sub_IM IM indices1) l (s, om))
+  (Hv : composite_valid (sub_IM IM indices1) l (s, om))
   : composite_valid (sub_IM IM indices2) (lift_sub_incl_label l) (lift_sub_incl_state s, om).
 Proof.
   revert Hv.
@@ -1119,7 +1119,7 @@ Proof.
 Qed.
 
 Lemma lift_sub_incl_transition l s om s' om'
-  (Ht: composite_transition (sub_IM IM indices1) l (s, om) = (s', om'))
+  (Ht : composite_transition (sub_IM IM indices1) l (s, om) = (s', om'))
   : composite_transition (sub_IM IM indices2)
     (lift_sub_incl_label l) (lift_sub_incl_state s, om) = (lift_sub_incl_state s', om').
 Proof.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -606,7 +606,7 @@ Proof.
       destruct (composite_label_sub_projection_option _); [| by congruence].
       by inversion HitemX.
   - clear -Hmsg Sub_Free Hlst His IHtr.
-    destruct iom as [m|]; [| done].
+    destruct iom as [m |]; [| done].
     simpl in *.
     remember {| input := Some m |} as x.
     assert (Hx : from_sub_projection x).
@@ -640,7 +640,7 @@ Proof.
         by (apply pre_VLSM_projection_transition_item_project_is_Some; done).
       exists (is_Some_proj Hsome).
       destruct (pre_VLSM_projection_transition_item_project _ _ _ _ _) eqn:Hproj;
-      [|contradict Hsome; apply is_Some_None].
+      [| contradict Hsome; apply is_Some_None].
       cbn.
       split.
       * by apply elem_of_map_option; exists item.
@@ -1115,7 +1115,7 @@ Proof.
   destruct l as (sub1_i, li); destruct_dec_sig sub1_i i Hi Heqsub1_i; subst; cbn.
   unfold vvalid, lift_sub_incl_state; cbn.
   unfold sub_IM in li; simpl in li.
-  destruct (decide (sub_index_prop indices1 i)) as [H_i|]
+  destruct (decide (sub_index_prop indices1 i)) as [H_i |]
   ; [| done].
   by rewrite (sub_IM_state_pi s H_i Hi).
 Qed.
@@ -1129,7 +1129,7 @@ Proof.
   destruct l as (sub1_i, li); destruct_dec_sig sub1_i i Hi Heqsub1_i; subst
   ; cbn; unfold vtransition, lift_sub_incl_state at 1
   ; cbn; unfold sub_IM in li; simpl in li.
-  destruct (decide (sub_index_prop indices1 i)) as [H_i|]
+  destruct (decide (sub_index_prop indices1 i)) as [H_i |]
   ; [| done].
   rewrite (sub_IM_state_pi s H_i Hi).
   destruct (transition _ _) as (si', _om'); inversion_clear 1; f_equal.
@@ -1158,7 +1158,7 @@ Lemma lift_sub_incl_preloaded_embedding
       (pre_loaded_vlsm (free_composite_vlsm sub_IM2) Q)
       lift_sub_incl_label lift_sub_incl_state.
 Proof.
-  apply basic_VLSM_embedding_preloaded_with; [done |..]; intro; intros.
+  apply basic_VLSM_embedding_preloaded_with; [done | ..]; intro; intros.
   - by split; [apply lift_sub_incl_valid, H |].
   - by apply lift_sub_incl_transition.
   - by apply lift_sub_incl_state_initial.
@@ -1566,7 +1566,7 @@ Lemma preloaded_sub_element_embedding
   (PreQSubFree := pre_loaded_vlsm (free_composite_vlsm (sub_IM IM (elements indices))) Q)
   : VLSM_embedding PrePXj PreQSubFree sub_element_label sub_element_state.
 Proof.
-  apply basic_VLSM_embedding_preloaded_with; [done |..].
+  apply basic_VLSM_embedding_preloaded_with; [done | ..].
   - intros l s om Hv.
     split; [cbn | done].
     by rewrite sub_element_state_eq with (H_j := Hj).
@@ -1796,7 +1796,7 @@ Lemma can_emit_sub_projection
   : can_emit PreSubFree m -> can_emit (pre_loaded_with_all_messages_vlsm (IM j)) m.
 Proof.
   intro Hemit.
-  apply can_emit_projection with validator A sender; [done | done|].
+  apply can_emit_projection with validator A sender; [done | done |].
   by apply (VLSM_embedding_can_emit lift_sub_preloaded_free_embedding).
 Qed.
 
@@ -1889,7 +1889,7 @@ Context
 Proof.
   intros sub_i.
   unfold sub_IM, updated_IM, update_IM.
-  case_decide as Hi; [|typeclasses eauto].
+  case_decide as Hi; [| typeclasses eauto].
   contradict Hi.
   destruct_dec_sig sub_i i Hi Heqsub_i; subst sub_i; simpl.
   apply elem_of_elements, set_diff_elim2 in Hi.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -134,7 +134,7 @@ Lemma lift_sub_state_to_neq
   (s0 : composite_state IM)
   (s : composite_state sub_IM)
   i
-  (Hni : ~sub_index_prop i)
+  (Hni : ~ sub_index_prop i)
   : lift_sub_state_to s0 s i = s0 i.
 Proof.
   by unfold lift_sub_state_to; case_decide.
@@ -157,7 +157,7 @@ Lemma lift_sub_state_to_neq_state_update
   (s0 : composite_state IM)
   (s : composite_state sub_IM)
   i
-  (Hni : ~sub_index_prop i)
+  (Hni : ~ sub_index_prop i)
   si'
   : state_update IM (lift_sub_state_to s0 s) i si' =
     lift_sub_state_to (state_update IM s0 i si') s.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -431,8 +431,7 @@ Lemma transition_sub_projection
   : composite_transition sub_IM
     (existT
       (dexist (projT1 l) Hsub)
-      (projT2 l)
-    )
+      (projT2 l))
     (composite_state_sub_projection s, om)
     = (composite_state_sub_projection s', om').
 Proof.
@@ -460,8 +459,7 @@ Lemma valid_sub_projection
   : composite_valid sub_IM
     (existT
       (dexist (projT1 l) Hsub)
-      (projT2 l)
-    )
+      (projT2 l))
     (composite_state_sub_projection s, om).
 Proof. by destruct l. Qed.
 
@@ -481,8 +479,8 @@ Proof.
       (no_equivocations_additional_constraint_with_pre_loaded sub_IM
         (free_constraint sub_IM)
         seed)
-      (free_constraint sub_IM)
-    ) as Hincl.
+      (free_constraint sub_IM))
+    as Hincl.
   spec Hincl; [done |].
   match goal with
   |- context [pre_loaded_vlsm ?v _] =>

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -466,7 +466,7 @@ Proof. by destruct l. Qed.
 Context
   (seed : message -> Prop)
   (sub_constraint : composite_label sub_IM -> composite_state sub_IM * option message -> Prop)
-  (Xj := composite_no_equivocation_vlsm_with_pre_loaded sub_IM (free_constraint sub_IM) seed )
+  (Xj := composite_no_equivocation_vlsm_with_pre_loaded sub_IM (free_constraint sub_IM) seed)
   .
 
 Lemma Xj_incl_Pre_Sub_Free
@@ -812,7 +812,7 @@ Context
   (equivocators : list index)
   (Free := free_composite_vlsm IM)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
-  (equivocating_IM := sub_IM IM equivocators )
+  (equivocating_IM := sub_IM IM equivocators)
   (SubFree : VLSM message :=  free_composite_vlsm equivocating_IM)
   (PreSubFree := pre_loaded_with_all_messages_vlsm SubFree)
   (base_s : composite_state IM)

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1630,7 +1630,7 @@ Lemma sub_transition_element_project_None
     forall s om s' om', composite_transition (sub_IM IM (elements indices)) lX (s, om) = (s', om') ->
     sub_state_element_project s' = sub_state_element_project s.
 Proof.
-  intros (sub_i,li) HlX s om s' om' HtX.
+  intros (sub_i, li) HlX s om s' om' HtX.
   destruct_dec_sig sub_i i Hi Heqsub_i; subst.
   unfold sub_label_element_project in HlX; cbn in HlX, HtX.
   case_decide as Hij; [by congruence |].

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -439,7 +439,7 @@ Proof.
   destruct l as (i, li).
   unfold vtransition. simpl.
   unfold composite_state_sub_projection at 1. simpl.
-  destruct (vtransition (IM i) li (s i, om)) as (si', omi') eqn:Hti.
+  destruct (vtransition (IM i) li (s i, om)) as (si', omi') eqn: Hti.
   inversion Ht. subst omi' s'. clear Ht.
   match goal with
   |- (let (_, _) := ?t in _) = _ =>
@@ -637,7 +637,7 @@ Proof.
             item))
         by (apply pre_VLSM_projection_transition_item_project_is_Some; done).
       exists (is_Some_proj Hsome).
-      destruct (pre_VLSM_projection_transition_item_project _ _ _ _ _) eqn:Hproj;
+      destruct (pre_VLSM_projection_transition_item_project _ _ _ _ _) eqn: Hproj;
       [| contradict Hsome; apply is_Some_None].
       cbn.
       split.

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -747,7 +747,7 @@ Proof.
   apply_funelim (indexed_composite_state_to_trace choose s' Hs' indices);
     clear choose s' Hs' indices;
     [by intros; inversion Heqis_tr; subst; destruct pre |..];
-    intros choose s' Hs' idx indices (j,nj); cbn.
+    intros choose s' Hs' idx indices (j, nj); cbn.
   - intros item s Hdestruct Hchoice is tr Heq ? _ _ ? ? ? ? ? ? [= <- <-] **;
       rewrite Heq in Hind.
     eapply composite_tv_state_destructor_preserves_not_in_indices_initial in Hinitial as Hinitials;

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -551,7 +551,7 @@ Proof.
     + replace i with j in * by (destruct (decide (i = j));
         [| contradict n; subst; apply StdppListSet.set_remove_3]; done).
       by erewrite indexed_composite_state_to_trace_reflects_initiality_1;
-        [..| done]; apply composite_tv_state_destructor_initial.
+        [.. | done]; apply composite_tv_state_destructor_initial.
   - by intros; subst; clear Heq1; contradict Hdestruct;
       eapply choosing_well_position_exists; [apply Hchoose |].
 Qed.
@@ -593,7 +593,7 @@ Proof.
   intros ? ? ? ?.
   apply_funelim (indexed_composite_state_to_trace choose s Hs indices);
     clear choose s Hs indices;
-    [by inversion 4; inversion 1 |..];
+    [by inversion 4; inversion 1 | ..];
     intros ? ? ? idx indices [j nj].
   - intros * -> Hind _ _ i Hi is' tr' [=] _item H_item; subst is' tr'.
     apply elem_of_app in H_item as [H_item | H_item].
@@ -626,7 +626,7 @@ Proof.
   intros choose Hwell s' Hs' indices; revert Hwell.
   apply_funelim (indexed_composite_state_to_trace choose s' Hs' indices);
     clear choose s' Hs' indices;
-    [by inversion 5 |..];
+    [by inversion 5 | ..];
     intros ? ? ? idx indices [j jn].
   - intros * -> Hind _ _ _ _ _ ? ? [= -> <-].
     rewrite finite_trace_last_is_last.
@@ -653,7 +653,7 @@ Proof.
   intros choose Hchoose s Hs indices; revert Hchoose.
   apply_funelim (indexed_composite_state_to_trace choose s Hs indices);
     clear choose s Hs indices; intros choose s' Hs';
-    [by inversion 4; subst; constructor |..];
+    [by inversion 4; subst; constructor | ..];
     intros idx indices.
   - intros ? ? ? ? _ ? ? -> Hind _ _ Hchoose Hnodup Hinitial is' tr' [= -> <-].
     eapply composite_tv_state_destructor_preserves_not_in_indices_initial  in Hinitial; [| done..].
@@ -746,7 +746,7 @@ Proof.
   revert Hinitial; generalize (enum index); intro indices; revert Hwell HchooseP.
   apply_funelim (indexed_composite_state_to_trace choose s' Hs' indices);
     clear choose s' Hs' indices;
-    [by intros; inversion Heqis_tr; subst; destruct pre |..];
+    [by intros; inversion Heqis_tr; subst; destruct pre | ..];
     intros choose s' Hs' idx indices (j, nj); cbn.
   - intros item s Hdestruct Hchoice is tr Heq ? _ _ ? ? ? ? ? ? [= <- <-] **;
       rewrite Heq in Hind.

--- a/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
+++ b/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
@@ -605,7 +605,7 @@ Proof.
   cut (output item <> Some m).
   {
     intro.
-    destruct (composite_has_been_sent_stepwise_props IM (free_constraint IM)) as [_ ].
+    destruct (composite_has_been_sent_stepwise_props IM (free_constraint IM)) as [_].
     rewrite oracle_step_update by done; cbn.
     by intros [].
   }

--- a/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
+++ b/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
@@ -203,7 +203,7 @@ Proof.
 Qed.
 
 Lemma composite_latest_sent_observed_in_before_send
-  (s' : composite_state IM) (i :index) (j : index)
+  (s' : composite_state IM) (i : index) (j : index)
   (s : composite_state IM) (item : composite_transition_item IM) (m : message)
   (Hij : CompositeLatestSentObservedIn s' i j s item m)
   (s_j : composite_state IM) (item_j : composite_transition_item IM) (m_j : message)

--- a/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
+++ b/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
@@ -237,10 +237,10 @@ Proof.
       by inversion Hti; rewrite state_update_neq.
     }
     eapply HasBeenObserved_step_update in Hobs as [Hobs | Hnow];
-      [by eexists s_j, _; constructor; [..| constructor 1] | | done].
+      [by eexists s_j, _; constructor; [.. | constructor 1] | | done].
     destruct Hnow as (_mj & [H_input | H_output] & [Hnow | Hbefore]); subst.
-    + by eexists s_j, _; constructor; [done..| constructor 2].
-    + by eexists s_j, _; constructor; [done..| constructor 3].
+    + by eexists s_j, _; constructor; [done.. | constructor 2].
+    + by eexists s_j, _; constructor; [done.. | constructor 3].
     + apply Some_inj in H_output as <-.
       contradict n.
       apply input_valid_transition_preloaded_project_active in Hti as Hti'; cbn in Hti'.
@@ -434,7 +434,7 @@ Proof.
     destruct is' as [| i is']; [by cbn in Hlen |].
     destruct (Hall_sent_observed i) as (i' & Hi' & Hcomposite); [by apply Hsub; left |].
     exists (i' :: i :: is').
-    split_and!; [by rewrite <- Hlen |..].
+    split_and!; [by rewrite <- Hlen | ..].
     + by inversion 1; subst; [| apply Hsub].
     + by constructor.
 Qed.
@@ -561,7 +561,7 @@ Proof.
         with (n := 0) in Hinitial_outside;
         [| typeclasses eauto | done | by rewrite Hdestruct].
       by apply Hinitial_outside.
-    - by exists s, item, m; constructor; [rewrite Hdestruct| ..].
+    - by exists s, item, m; constructor; [rewrite Hdestruct | ..].
   }
   destruct (composite_latest_sent_observed_in_chain _ His _ Hs' Hall_sent_observed)
     as (is' & Hsub & Hlen & Hall).

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -1102,7 +1102,7 @@ Lemma valid_trace_input_is_valid
 Proof.
   revert is Htr.
   induction Hinput as [item tr' Hm | item tr']; intros
-  ; inversion Htr as [| s _tr'  Htr' _is iom oom l Ht ]; subst.
+  ; inversion Htr as [| s _tr'  Htr' _is iom oom l Ht]; subst.
   - simpl in Hm.
     subst.
     by apply input_valid_transition_in in Ht.
@@ -2202,7 +2202,7 @@ Proof.
     ; apply finite_valid_trace_singleton.
   - intros last_p p Hind last tr Htr Hprefix.
     specialize (Hind last_p tr Htr).
-    destruct tr as [ | ]; unfold trace_prefix in Hprefix;   simpl in Hprefix
+    destruct tr as [|]; unfold trace_prefix in Hprefix;   simpl in Hprefix
     ; destruct Hprefix as [suffix Heq]; subst; destruct Htr as [Htr Hinit]; simpl; simpl in Hind
     ; split; try done.
     + assert

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -571,7 +571,7 @@ Definition input_valid
   let (s, om) := som in
      valid_state_prop s
   /\ option_valid_message_prop om
-  /\ valid l (s,om).
+  /\ valid l (s, om).
 
 (** Input valid transitions are transitions with [input_valid] inputs. *)
 Definition input_valid_transition
@@ -640,7 +640,7 @@ Lemma input_valid_transition_origin
       {l : label}
       {s s' : state}
       {om om' : option message}
-      (Ht : input_valid_transition l (s, om) (s',om'))
+      (Ht : input_valid_transition l (s, om) (s', om'))
   : valid_state_prop s.
 Proof.
   by destruct Ht as [[[_om Hp] _] _]; exists _om.
@@ -762,7 +762,7 @@ Definition can_produce
   (m : message)
   := option_can_produce s (Some m).
 
-(** Of course, if a VLSM [can_emit] <<(s,m)>>, then <<(s,m)>> is valid. *)
+(** Of course, if a VLSM [can_emit] <<(s, m)>>, then <<(s, m)>> is valid. *)
 
 Lemma option_can_produce_valid
   (s : state)
@@ -937,7 +937,7 @@ Qed.
   - <<(s, [])>> is a [finite_valid_trace_from] <<s>> if <<s>> is valid
   - if there is an [input_valid_transition] <<l (s', iom) (s, oom)>>
 
-    and if <<(s,steps)>> is a [valid_trace_from] <<s>>
+    and if <<(s, steps)>> is a [valid_trace_from] <<s>>
 
     then <<(s', ({| l := l; input := iom; destination := s; output := oom |} :: steps)>>
     is a [finite_valid_trace_from] <<s'>>.
@@ -1193,7 +1193,7 @@ Lemma finite_valid_trace_from_rev_ind
     finite_valid_trace_from s tr ->
     P s tr ->
     forall sf iom oom l
-    (Hx: input_valid_transition l (finite_trace_last s tr,iom) (sf,oom)),
+    (Hx: input_valid_transition l (finite_trace_last s tr, iom) (sf, oom)),
     let x:= {|l:=l; input:=iom; destination:=sf; output:=oom|} in
     P s (tr++[x])):
   forall s tr,
@@ -1216,7 +1216,7 @@ Lemma finite_valid_trace_rev_ind
     finite_valid_trace si tr ->
     P si tr ->
     forall sf iom oom l
-    (Hx: input_valid_transition l (finite_trace_last si tr,iom) (sf,oom)),
+    (Hx: input_valid_transition l (finite_trace_last si tr, iom) (sf, oom)),
     let x:= {|l:=l; input:=iom; destination:=sf; output:=oom|} in
     P si (tr++[x])):
   forall si tr,
@@ -1294,7 +1294,7 @@ Lemma can_produce_from_valid_trace si tr
 Proof.
   intros item Hitem.
   apply elem_of_list_split in Hitem as (l1 & l2 & Heq).
-  eexists _,_.
+  eexists _, _.
   by eapply input_valid_transition_to; cbn.
 Qed.
 
@@ -1480,7 +1480,7 @@ Lemma finite_valid_trace_from_to_rev_ind
     (IHtr : P si s tr)
     (Htr : finite_valid_trace_from_to si s tr)
     sf iom oom l
-    (Ht : input_valid_transition l (s,iom) (sf,oom)),
+    (Ht : input_valid_transition l (s, iom) (sf, oom)),
     P si sf (tr++[{|l:=l; input:=iom; destination:=sf; output:=oom|}])):
   forall si sf tr,
     finite_valid_trace_from_to si sf tr ->
@@ -1509,7 +1509,7 @@ Lemma finite_valid_trace_init_to_rev_ind
     (IHtr : P si s tr)
     (Htr : finite_valid_trace_init_to si s tr)
     sf iom oom l
-    (Ht : input_valid_transition l (s,iom) (sf,oom)),
+    (Ht : input_valid_transition l (s, iom) (sf, oom)),
     P si sf (tr++[{|l:=l; input:=iom; destination:=sf; output:=oom|}])):
   forall si sf tr,
     finite_valid_trace_init_to si sf tr ->
@@ -1529,7 +1529,7 @@ Qed.
   [finite_valid_trace_init_to_emit_valid_state_message_rev] lemmas below, this definition
   is the trace-equivalent of the [valid_state_message_prop]erty.
 
-  This inductive property is reflecting that fact that a that <<valid_state_message_prop (s,om)>>
+  This inductive property is reflecting that fact that a that <<valid_state_message_prop (s, om)>>
   holds only if <<s>> and <<om>> are the final state and output of an initial valid
   trace, or a pair of an initial state and option-initial message.
   It follows the inductive structure of <<valid_state_message_prop>>, but augments every node of
@@ -1670,7 +1670,7 @@ Lemma finite_valid_trace_init_to_rev_strong_ind
     (IHiom : P iom_si iom_s iom_tr)
     (Hiom : finite_valid_trace_init_to iom_si iom_s iom_tr)
     sf oom l
-    (Ht : input_valid_transition l (s,iom) (sf,oom)),
+    (Ht : input_valid_transition l (s, iom) (sf, oom)),
     P is sf (tr++[{|l:=l; input:=iom; destination:=sf; output:=oom|}]))
   : forall si sf tr,
     finite_valid_trace_init_to si sf tr ->
@@ -1888,7 +1888,7 @@ Proof.
     inversion Htr; [done |].
     by destruct tl; simpl in *; congruence.
   - apply finite_valid_trace_init_to_emit_forget_emit in Htr.
-    by right; eexists _,_; rewrite finite_trace_last_output_is_last.
+    by right; eexists _, _; rewrite finite_trace_last_output_is_last.
 Qed.
 
 (**
@@ -2640,8 +2640,8 @@ Qed.
 
 Lemma preloaded_weaken_input_valid_transition
       l s om s' om':
-  input_valid_transition X l (s,om) (s',om') ->
-  input_valid_transition pre_loaded_with_all_messages_vlsm l (s,om) (s',om').
+  input_valid_transition X l (s, om) (s', om') ->
+  input_valid_transition pre_loaded_with_all_messages_vlsm l (s, om) (s', om').
 Proof.
   unfold input_valid_transition.
   intros [[[_om valid_s] [_ Hvalid]] Htrans].

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -258,7 +258,7 @@ Qed.
 
 Lemma finite_trace_last_cons
   s x tl:
-  finite_trace_last s (x::tl) = finite_trace_last (destination x) tl.
+  finite_trace_last s (x:: tl) = finite_trace_last (destination x) tl.
 Proof.
   by unfold finite_trace_last; rewrite map_cons, unroll_last.
 Qed.
@@ -479,7 +479,7 @@ Inductive valid_state_message_prop : state -> option message -> Prop :=
   : valid_state_message_prop s' om'.
 
 Definition valid_initial_state
-  [s:state] (Hs: initial_state_prop s)
+  [s: state] (Hs: initial_state_prop s)
   : valid_state_message_prop s None
   := valid_initial_state_message s Hs None I.
 
@@ -2272,7 +2272,7 @@ Proof.
       ; (split; [| done])
       ; constructor
       ; apply initial_state_is_valid.
-    + assert (Hnnil : item ::l <> [])
+    + assert (Hnnil : item :: l <> [])
         by (intro Hnil; inversion Hnil).
       specialize (exists_last Hnnil); intros [prefix [last Heq]].
       rewrite Heq in *; clear Hnnil Heq l item.
@@ -2460,7 +2460,7 @@ Class TraceWithLast
 
 Definition valid_trace_add_default_last
   `{TraceWithLast base_prop trace_prop}
-  [msg] [X:VLSM msg] [s tr] (Htr: base_prop msg X s tr):
+  [msg] [X: VLSM msg] [s tr] (Htr: base_prop msg X s tr):
     trace_prop msg X s (finite_trace_last s tr) tr.
 Proof.
   by apply valid_trace_add_last.
@@ -2597,7 +2597,7 @@ Qed.
 
 Inductive preloaded_valid_state_prop : state -> Prop :=
 | preloaded_valid_initial_state
-    (s:state)
+    (s: state)
     (Hs: initial_state_prop (VLSMMachine := pre_loaded_with_all_messages_vlsm_machine) s):
        preloaded_valid_state_prop s
 | preloaded_protocol_generated

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -325,12 +325,12 @@ Lemma finite_trace_nth_app2
 Proof.
   intro H.
   apply Compare_dec.le_lt_eq_dec in H.
-  destruct H as [H |<-].
+  destruct H as [H | <-].
   - unfold finite_trace_nth.
     rewrite map_app, app_comm_cons.
     rewrite nth_error_app2; simpl length; rewrite map_length; [| by auto with arith].
     destruct n; [by exfalso; lia |].
-    by rewrite (Nat.sub_succ_l (length t1) n); [|lia].
+    by rewrite (Nat.sub_succ_l (length t1) n); [| lia].
   - by rewrite finite_trace_nth_app1, finite_trace_nth_last,
       Nat.sub_diag, finite_trace_nth_first.
 Qed.
@@ -1085,7 +1085,7 @@ Lemma valid_trace_output_is_valid
   : valid_message_prop m.
 Proof.
   revert is Htr.
-  induction Houtput as [item tr' Hm| item tr']; intros; inversion Htr; subst.
+  induction Houtput as [item tr' Hm | item tr']; intros; inversion Htr; subst.
   - simpl in Hm.
     subst.
     by apply input_valid_transition_out in Ht.
@@ -1101,8 +1101,8 @@ Lemma valid_trace_input_is_valid
   : valid_message_prop m.
 Proof.
   revert is Htr.
-  induction Hinput as [item tr' Hm| item tr']; intros
-  ; inversion Htr as [|s _tr'  Htr' _is iom oom l Ht ]; subst.
+  induction Hinput as [item tr' Hm | item tr']; intros
+  ; inversion Htr as [| s _tr'  Htr' _is iom oom l Ht ]; subst.
   - simpl in Hm.
     subst.
     by apply input_valid_transition_in in Ht.
@@ -1117,7 +1117,7 @@ Lemma valid_trace_observed_is_valid
   (Hobserved : trace_has_message item_sends_or_receives m tr)
   : valid_message_prop m.
 Proof.
-  by apply trace_has_message_observed_iff in Hobserved as [Hm |Hm]
+  by apply trace_has_message_observed_iff in Hobserved as [Hm | Hm]
   ; revert Htr m Hm; [apply valid_trace_input_is_valid | apply valid_trace_output_is_valid].
 Qed.
 
@@ -1179,10 +1179,10 @@ Proof.
     split.
     + intros [Hal Hl'].
       inversion Hal; subst; simpl in *.
-      by constructor; [apply IHls|].
+      by constructor; [apply IHls |].
     + inversion 1; subst; simpl in *.
       apply IHls in Htl as [Hl Hl'].
-      by split; [constructor|].
+      by split; [constructor |].
 Qed.
 
 Lemma finite_valid_trace_from_rev_ind
@@ -1194,7 +1194,7 @@ Lemma finite_valid_trace_from_rev_ind
     P s tr ->
     forall sf iom oom l
     (Hx: input_valid_transition l (finite_trace_last s tr, iom) (sf, oom)),
-    let x := {|l := l; input := iom; destination := sf; output := oom|} in
+    let x := {| l := l; input := iom; destination := sf; output := oom |} in
     P s (tr++[x])):
   forall s tr,
     finite_valid_trace_from s tr ->
@@ -1217,7 +1217,7 @@ Lemma finite_valid_trace_rev_ind
     P si tr ->
     forall sf iom oom l
     (Hx: input_valid_transition l (finite_trace_last si tr, iom) (sf, oom)),
-    let x := {|l := l; input := iom; destination := sf; output := oom|} in
+    let x := {| l := l; input := iom; destination := sf; output := oom |} in
     P si (tr++[x])):
   forall si tr,
     finite_valid_trace si tr ->
@@ -1403,7 +1403,7 @@ Lemma finite_valid_trace_from_to_app
     -> finite_valid_trace_from_to m f ls'
     -> finite_valid_trace_from_to s f (ls ++ ls').
 Proof.
-  by intros Hl Hl'; induction Hl; [|constructor; auto].
+  by intros Hl Hl'; induction Hl; [| constructor; auto].
 Qed.
 
 Lemma finite_valid_trace_from_to_app_split
@@ -1481,7 +1481,7 @@ Lemma finite_valid_trace_from_to_rev_ind
     (Htr : finite_valid_trace_from_to si s tr)
     sf iom oom l
     (Ht : input_valid_transition l (s, iom) (sf, oom)),
-    P si sf (tr++[{|l := l; input := iom; destination := sf; output := oom|}])):
+    P si sf (tr++[{| l := l; input := iom; destination := sf; output := oom |}])):
   forall si sf tr,
     finite_valid_trace_from_to si sf tr ->
     P si sf tr.
@@ -1510,7 +1510,7 @@ Lemma finite_valid_trace_init_to_rev_ind
     (Htr : finite_valid_trace_init_to si s tr)
     sf iom oom l
     (Ht : input_valid_transition l (s, iom) (sf, oom)),
-    P si sf (tr++[{|l := l; input := iom; destination := sf; output := oom|}])):
+    P si sf (tr++[{| l := l; input := iom; destination := sf; output := oom |}])):
   forall si sf tr,
     finite_valid_trace_init_to si sf tr ->
     P si sf tr.
@@ -1671,7 +1671,7 @@ Lemma finite_valid_trace_init_to_rev_strong_ind
     (Hiom : finite_valid_trace_init_to iom_si iom_s iom_tr)
     sf oom l
     (Ht : input_valid_transition l (s, iom) (sf, oom)),
-    P is sf (tr++[{|l := l; input := iom; destination := sf; output := oom|}]))
+    P is sf (tr++[{| l := l; input := iom; destination := sf; output := oom |}]))
   : forall si sf tr,
     finite_valid_trace_init_to si sf tr ->
     P si sf tr.
@@ -1905,7 +1905,7 @@ Lemma valid_state_has_trace
 Proof using.
   destruct Hp as [_om Hp].
   apply valid_state_message_has_trace in Hp.
-  destruct Hp as [[Hinit _]|Htrace].
+  destruct Hp as [[Hinit _] | Htrace].
   - exists s, [].
     split; [| done].
     constructor.
@@ -2115,13 +2115,13 @@ Proof.
   exists (exist _ _ Htr).
   simpl.
   exists (length prefix_tr), (length prefix_tr + length suffix_tr).
-  split; [lia|].
+  split; [lia |].
   apply finite_valid_trace_from_to_last in Hprefix_tr.
   apply finite_valid_trace_from_to_last in Hsuffix_tr.
   split.
-  - rewrite finite_trace_nth_app1; [|lia].
+  - rewrite finite_trace_nth_app1; [| lia].
     by rewrite finite_trace_nth_last; congruence.
-  - rewrite finite_trace_nth_app2; [|lia].
+  - rewrite finite_trace_nth_app2; [| lia].
     by rewrite Nat.add_comm, Nat.add_sub, finite_trace_nth_last; congruence.
 Qed.
 

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -174,7 +174,7 @@ Definition trace_received_not_sent_before_or_after
   (m : message)
   : Prop
   := trace_has_message (field_selector input) m tr /\
-     ~trace_has_message (field_selector output) m tr.
+     ~ trace_has_message (field_selector output) m tr.
 
 (** States that a property holds for all messages received but not sent by a trace. *)
 Definition trace_received_not_sent_before_or_after_invariant
@@ -2416,7 +2416,7 @@ Definition composition_constraint : Type :=
 
 Class VLSM_vdecidable : Type :=
 {
-  valid_decidable : forall l som, {valid l som} + {~valid l som}
+  valid_decidable : forall l som, {valid l som} + {~ valid l som}
 }.
 
 (* end hide *)

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -1194,7 +1194,7 @@ Lemma finite_valid_trace_from_rev_ind
     P s tr ->
     forall sf iom oom l
     (Hx: input_valid_transition l (finite_trace_last s tr, iom) (sf, oom)),
-    let x:= {|l:=l; input:=iom; destination:=sf; output:=oom|} in
+    let x := {|l := l; input := iom; destination := sf; output := oom|} in
     P s (tr++[x])):
   forall s tr,
     finite_valid_trace_from s tr ->
@@ -1217,7 +1217,7 @@ Lemma finite_valid_trace_rev_ind
     P si tr ->
     forall sf iom oom l
     (Hx: input_valid_transition l (finite_trace_last si tr, iom) (sf, oom)),
-    let x:= {|l:=l; input:=iom; destination:=sf; output:=oom|} in
+    let x := {|l := l; input := iom; destination := sf; output := oom|} in
     P si (tr++[x])):
   forall si tr,
     finite_valid_trace si tr ->
@@ -1481,7 +1481,7 @@ Lemma finite_valid_trace_from_to_rev_ind
     (Htr : finite_valid_trace_from_to si s tr)
     sf iom oom l
     (Ht : input_valid_transition l (s, iom) (sf, oom)),
-    P si sf (tr++[{|l:=l; input:=iom; destination:=sf; output:=oom|}])):
+    P si sf (tr++[{|l := l; input := iom; destination := sf; output := oom|}])):
   forall si sf tr,
     finite_valid_trace_from_to si sf tr ->
     P si sf tr.
@@ -1510,7 +1510,7 @@ Lemma finite_valid_trace_init_to_rev_ind
     (Htr : finite_valid_trace_init_to si s tr)
     sf iom oom l
     (Ht : input_valid_transition l (s, iom) (sf, oom)),
-    P si sf (tr++[{|l:=l; input:=iom; destination:=sf; output:=oom|}])):
+    P si sf (tr++[{|l := l; input := iom; destination := sf; output := oom|}])):
   forall si sf tr,
     finite_valid_trace_init_to si sf tr ->
     P si sf tr.
@@ -1671,7 +1671,7 @@ Lemma finite_valid_trace_init_to_rev_strong_ind
     (Hiom : finite_valid_trace_init_to iom_si iom_s iom_tr)
     sf oom l
     (Ht : input_valid_transition l (s, iom) (sf, oom)),
-    P is sf (tr++[{|l:=l; input:=iom; destination:=sf; output:=oom|}]))
+    P is sf (tr++[{|l := l; input := iom; destination := sf; output := oom|}]))
   : forall si sf tr,
     finite_valid_trace_init_to si sf tr ->
     P si sf tr.
@@ -2600,16 +2600,16 @@ Qed.
 Inductive preloaded_valid_state_prop : state -> Prop :=
 | preloaded_valid_initial_state
     (s:state)
-    (Hs: initial_state_prop (VLSMMachine:=pre_loaded_with_all_messages_vlsm_machine) s):
+    (Hs: initial_state_prop (VLSMMachine := pre_loaded_with_all_messages_vlsm_machine) s):
        preloaded_valid_state_prop s
 | preloaded_protocol_generated
     (l : label)
     (s : state)
     (Hps : preloaded_valid_state_prop s)
     (om : option message)
-    (Hv : valid (VLSMMachine:=pre_loaded_with_all_messages_vlsm_machine) l (s, om))
+    (Hv : valid (VLSMMachine := pre_loaded_with_all_messages_vlsm_machine) l (s, om))
     s' om'
-    (Ht : transition (VLSMMachine:=pre_loaded_with_all_messages_vlsm_machine) l (s, om) = (s', om'))
+    (Ht : transition (VLSMMachine := pre_loaded_with_all_messages_vlsm_machine) l (s, om) = (s', om'))
   : preloaded_valid_state_prop s'.
 
 Lemma preloaded_valid_state_prop_iff s:

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -1085,7 +1085,7 @@ Lemma valid_trace_output_is_valid
   : valid_message_prop m.
 Proof.
   revert is Htr.
-  induction Houtput as [item tr' Hm| item tr'];intros;inversion Htr; subst.
+  induction Houtput as [item tr' Hm| item tr']; intros; inversion Htr; subst.
   - simpl in Hm.
     subst.
     by apply input_valid_transition_out in Ht.
@@ -1101,8 +1101,8 @@ Lemma valid_trace_input_is_valid
   : valid_message_prop m.
 Proof.
   revert is Htr.
-  induction Hinput as [item tr' Hm| item tr'];intros
-  ;inversion Htr as [|s _tr'  Htr' _is iom oom l Ht ];subst.
+  induction Hinput as [item tr' Hm| item tr']; intros
+  ; inversion Htr as [|s _tr'  Htr' _is iom oom l Ht ]; subst.
   - simpl in Hm.
     subst.
     by apply input_valid_transition_in in Ht.
@@ -1171,7 +1171,7 @@ Lemma finite_valid_trace_from_app_iff
 Proof.
   subst s'.
   revert s.
-  induction ls;intro s.
+  induction ls; intro s.
   - rewrite finite_trace_last_nil. simpl.
     by itauto (eauto using finite_valid_trace_first_pstate, finite_valid_trace_from_empty).
   - rewrite finite_trace_last_cons. simpl.
@@ -1180,7 +1180,7 @@ Proof.
     + intros [Hal Hl'].
       inversion Hal; subst; simpl in *.
       by constructor; [apply IHls|].
-    + inversion 1;subst; simpl in *.
+    + inversion 1; subst; simpl in *.
       apply IHls in Htl as [Hl Hl'].
       by split; [constructor|].
 Qed.
@@ -1413,7 +1413,7 @@ Lemma finite_valid_trace_from_to_app_split
     finite_valid_trace_from_to s m ls
     /\ finite_valid_trace_from_to m f ls'.
 Proof.
-  revert s;induction ls;intros s;simpl.
+  revert s; induction ls; intros s; simpl.
   - rewrite finite_trace_last_nil.
     intro Htr. split; [| done].
     apply finite_valid_trace_from_to_first_pstate in Htr.
@@ -1434,7 +1434,7 @@ Lemma finite_valid_trace_init_add_last si sf tr:
   finite_valid_trace_init_to si sf tr.
 Proof.
   intros [Htr Hinit] Hf.
-  split;eauto using finite_valid_trace_from_add_last.
+  split; eauto using finite_valid_trace_from_add_last.
 Qed.
 
 Lemma finite_valid_trace_init_to_forget_last si sf tr:
@@ -1442,7 +1442,7 @@ Lemma finite_valid_trace_init_to_forget_last si sf tr:
   finite_valid_trace si tr.
 Proof.
   intros [Hinit Htr].
-  split;eauto using finite_valid_trace_from_to_forget_last.
+  split; eauto using finite_valid_trace_from_to_forget_last.
 Qed.
 
 Lemma finite_valid_trace_init_to_last si sf tr:
@@ -1493,8 +1493,8 @@ Proof.
   - by inversion Htr; subst; apply Hempty.
   - apply finite_valid_trace_from_to_app_split in Htr.
     destruct Htr as [Htr Hstep].
-    inversion Hstep;subst.
-    inversion Htl;subst.
+    inversion Hstep; subst.
+    inversion Htl; subst.
     revert Ht.
     apply Hextend; [| done].
     by apply IHtr.
@@ -1907,7 +1907,7 @@ Proof using.
   apply valid_state_message_has_trace in Hp.
   destruct Hp as [[Hinit _]|Htrace].
   - exists s, [].
-    split;[| done].
+    split; [| done].
     constructor.
     by apply initial_state_is_valid.
   - by destruct Htrace as [is [tr [Htr _]]]; eauto.
@@ -2115,13 +2115,13 @@ Proof.
   exists (exist _ _ Htr).
   simpl.
   exists (length prefix_tr), (length prefix_tr + length suffix_tr).
-  split;[lia|].
+  split; [lia|].
   apply finite_valid_trace_from_to_last in Hprefix_tr.
   apply finite_valid_trace_from_to_last in Hsuffix_tr.
   split.
-  - rewrite finite_trace_nth_app1;[|lia].
+  - rewrite finite_trace_nth_app1; [|lia].
     by rewrite finite_trace_nth_last; congruence.
-  - rewrite finite_trace_nth_app2;[|lia].
+  - rewrite finite_trace_nth_app2; [|lia].
     by rewrite Nat.add_comm, Nat.add_sub, finite_trace_nth_last; congruence.
 Qed.
 

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -136,11 +136,11 @@ Record transition_item : Type :=
 }.
 
 Definition field_selector
-           (field: transition_item -> option message) :
+           (field : transition_item -> option message) :
   (message -> transition_item -> Prop) :=
   fun m item => field item = Some m.
 
-Definition item_sends_or_receives:
+Definition item_sends_or_receives :
   message -> transition_item -> Prop :=
   fun m item => input item = Some m \/ output item = Some m.
 
@@ -257,45 +257,45 @@ Proof.
 Qed.
 
 Lemma finite_trace_last_cons
-  s x tl:
-  finite_trace_last s (x:: tl) = finite_trace_last (destination x) tl.
+  s x tl :
+  finite_trace_last s (x :: tl) = finite_trace_last (destination x) tl.
 Proof.
   by unfold finite_trace_last; rewrite map_cons, unroll_last.
 Qed.
 
 Lemma finite_trace_last_nil
-  s:
+  s :
   finite_trace_last s [] = s.
 Proof. done. Qed.
 
 Lemma finite_trace_last_app
-  s t1 t2:
+  s t1 t2 :
   finite_trace_last s (t1 ++ t2) = finite_trace_last (finite_trace_last s t1) t2.
 Proof.
   by unfold finite_trace_last; rewrite map_app, last_app.
 Qed.
 
 Lemma finite_trace_last_is_last
-  s x tl:
+  s x tl :
   finite_trace_last s (tl++[x]) = destination x.
 Proof.
   by unfold finite_trace_last; rewrite map_app; cbn; rewrite last_is_last.
 Qed.
 
 Lemma finite_trace_last_output_is_last
-  x tl:
+  x tl :
   finite_trace_last_output (tl++[x]) = output x.
 Proof.
   by unfold finite_trace_last_output; rewrite map_app; cbn; rewrite last_is_last.
 Qed.
 
 Lemma finite_trace_nth_first
-  (si : state) (tr : list transition_item):
+  (si : state) (tr : list transition_item) :
   finite_trace_nth si tr 0 = Some si.
 Proof. done. Qed.
 
 Lemma finite_trace_nth_last
-  (si : state) (tr : list transition_item):
+  (si : state) (tr : list transition_item) :
   finite_trace_nth si tr (length tr) = Some (finite_trace_last si tr).
 Proof.
   unfold finite_trace_nth, finite_trace_last.
@@ -306,7 +306,7 @@ Proof.
 Qed.
 
 Lemma finite_trace_nth_app1
-  (si : state) (t1 t2 : list transition_item) n:
+  (si : state) (t1 t2 : list transition_item) n :
   n <= length t1 ->
   finite_trace_nth si (t1++t2) n = finite_trace_nth si t1 n.
 Proof.
@@ -319,7 +319,7 @@ Proof.
 Qed.
 
 Lemma finite_trace_nth_app2
-  (si : state) (t1 t2 : list transition_item) n:
+  (si : state) (t1 t2 : list transition_item) n :
   length t1 <= n ->
   finite_trace_nth si (t1++t2) n = finite_trace_nth (finite_trace_last si t1) t2 (n - length t1).
 Proof.
@@ -336,7 +336,7 @@ Proof.
 Qed.
 
 Lemma finite_trace_nth_length
-  (si : state) (tr : list transition_item) n s:
+  (si : state) (tr : list transition_item) n s :
   finite_trace_nth si tr n = Some s ->
   n <= length tr.
 Proof.
@@ -347,7 +347,7 @@ Proof.
 Qed.
 
 Lemma finite_trace_last_prefix
-  (s: state) (tr: list transition_item) n nth:
+  (s : state) (tr : list transition_item) n nth :
   finite_trace_nth s tr n = Some nth ->
   finite_trace_last s (list_prefix tr n) = nth.
 Proof.
@@ -360,7 +360,7 @@ Proof.
 Qed.
 
 Lemma finite_trace_last_suffix
-  (s: state) (tr: list transition_item) n:
+  (s : state) (tr : list transition_item) n :
   n < length tr ->
   finite_trace_last s (list_suffix tr n) = finite_trace_last s tr.
 Proof.
@@ -371,7 +371,7 @@ Proof.
   by rewrite map_length.
 Qed.
 
-Lemma unlock_finite_trace_last s tr:
+Lemma unlock_finite_trace_last s tr :
   finite_trace_last s tr = List.last (List.map destination tr) s.
 Proof. done. Qed.
 Opaque finite_trace_last.
@@ -479,7 +479,7 @@ Inductive valid_state_message_prop : state -> option message -> Prop :=
   : valid_state_message_prop s' om'.
 
 Definition valid_initial_state
-  [s: state] (Hs: initial_state_prop s)
+  [s : state] (Hs : initial_state_prop s)
   : valid_state_message_prop s None
   := valid_initial_state_message s Hs None I.
 
@@ -596,7 +596,7 @@ Definition input_valid_transition_preserving
     (s1 s2 : state)
     (l : label)
     (om1 om2 : option message)
-    (Hvalid_transition: input_valid_transition l (s1, om1) (s2, om2)),
+    (Hvalid_transition : input_valid_transition l (s1, om1) (s2, om2)),
     R s1 s2.
 
 (** Next three lemmas show the two definitions above are strongly related. *)
@@ -889,7 +889,7 @@ Lemma valid_state_prop_ind
   (P : state -> Prop)
   (IHinit : forall (s : state) (Hs : initial_state_prop s), P s)
   (IHgen :
-    forall (s' : state) (l: label) (om om' : option message) (s : state)
+    forall (s' : state) (l : label) (om om' : option message) (s : state)
       (Ht : input_valid_transition l (s, om) (s', om')) (Hs : P s),
       P s')
   : forall (s : state) (Hs : valid_state_prop s), P s.
@@ -958,7 +958,7 @@ Inductive finite_valid_trace_from : state -> list transition_item -> Prop :=
     finite_valid_trace_from  s' ({| l := l; input := iom; destination := s; output := oom |} :: tl).
 
 Definition finite_valid_trace_singleton :
-  forall {l : label} {s s': state} {iom oom : option message},
+  forall {l : label} {s s' : state} {iom oom : option message},
     input_valid_transition l (s, iom) (s', oom) ->
     finite_valid_trace_from  s ({| l := l; input := iom; destination := s'; output := oom |} :: [])
   := fun l s s' iom oom Hptrans =>
@@ -989,7 +989,7 @@ Opaque finite_valid_trace.
   require an <<assert>> and writing out the full VLSM and state expressions
   as part of the proof script.
 *)
-Lemma finite_valid_trace_empty (s : state):
+Lemma finite_valid_trace_empty (s : state) :
   vinitial_state_prop X s ->
   finite_valid_trace s [].
 Proof.
@@ -1186,15 +1186,15 @@ Qed.
 
 Lemma finite_valid_trace_from_rev_ind
   (P : state -> list transition_item -> Prop)
-  (Hempty: forall s,
+  (Hempty : forall s,
     valid_state_prop s -> P s nil)
   (Hextend : forall s tr,
     finite_valid_trace_from s tr ->
     P s tr ->
     forall sf iom oom l
-    (Hx: input_valid_transition l (finite_trace_last s tr, iom) (sf, oom)),
+    (Hx : input_valid_transition l (finite_trace_last s tr, iom) (sf, oom)),
     let x := {| l := l; input := iom; destination := sf; output := oom |} in
-    P s (tr++[x])):
+    P s (tr++[x])) :
   forall s tr,
     finite_valid_trace_from s tr ->
     P s tr.
@@ -1209,15 +1209,15 @@ Qed.
 
 Lemma finite_valid_trace_rev_ind
   (P : state -> list transition_item -> Prop)
-  (Hempty: forall si,
+  (Hempty : forall si,
     initial_state_prop si -> P si nil)
   (Hextend : forall si tr,
     finite_valid_trace si tr ->
     P si tr ->
     forall sf iom oom l
-    (Hx: input_valid_transition l (finite_trace_last si tr, iom) (sf, oom)),
+    (Hx : input_valid_transition l (finite_trace_last si tr, iom) (sf, oom)),
     let x := {| l := l; input := iom; destination := sf; output := oom |} in
-    P si (tr++[x])):
+    P si (tr++[x])) :
   forall si tr,
     finite_valid_trace si tr ->
     P si tr.
@@ -1287,7 +1287,7 @@ Qed.
 (* begin hide *)
 
 Lemma can_produce_from_valid_trace si tr
-  (Htr: finite_valid_trace_from si tr)
+  (Htr : finite_valid_trace_from si tr)
   : forall item, item ∈ tr ->
     option_can_produce (destination item) (output item).
 Proof.
@@ -1301,7 +1301,7 @@ Lemma can_emit_from_valid_trace
   (si : state)
   (m : message)
   (tr : list transition_item)
-  (Htr: finite_valid_trace si tr)
+  (Htr : finite_valid_trace si tr)
   (Hm : trace_has_message (field_selector output) m tr) :
   can_emit m.
 Proof.
@@ -1397,7 +1397,7 @@ Proof.
 Qed.
 
 Lemma finite_valid_trace_from_to_app
-  (m s f: state) (ls ls' : list transition_item)
+  (m s f : state) (ls ls' : list transition_item)
   : finite_valid_trace_from_to s m ls
     -> finite_valid_trace_from_to m f ls'
     -> finite_valid_trace_from_to s f (ls ++ ls').
@@ -1406,7 +1406,7 @@ Proof.
 Qed.
 
 Lemma finite_valid_trace_from_to_app_split
-  (s f: state) (ls ls' : list transition_item)
+  (s f : state) (ls ls' : list transition_item)
   : finite_valid_trace_from_to s f (ls ++ ls') ->
     let m := finite_trace_last s ls in
     finite_valid_trace_from_to s m ls
@@ -1427,7 +1427,7 @@ Definition finite_valid_trace_init_to si sf tr : Prop
   := finite_valid_trace_from_to si sf tr
       /\ initial_state_prop si.
 
-Lemma finite_valid_trace_init_add_last si sf tr:
+Lemma finite_valid_trace_init_add_last si sf tr :
   finite_valid_trace si tr ->
   finite_trace_last si tr = sf ->
   finite_valid_trace_init_to si sf tr.
@@ -1436,7 +1436,7 @@ Proof.
   split; eauto using finite_valid_trace_from_add_last.
 Qed.
 
-Lemma finite_valid_trace_init_to_forget_last si sf tr:
+Lemma finite_valid_trace_init_to_forget_last si sf tr :
   finite_valid_trace_init_to si sf tr ->
   finite_valid_trace si tr.
 Proof.
@@ -1444,7 +1444,7 @@ Proof.
   split; eauto using finite_valid_trace_from_to_forget_last.
 Qed.
 
-Lemma finite_valid_trace_init_to_last si sf tr:
+Lemma finite_valid_trace_init_to_last si sf tr :
   finite_valid_trace_init_to si sf tr ->
   finite_trace_last si tr = sf.
 Proof.
@@ -1472,7 +1472,7 @@ Qed.
 
 Lemma finite_valid_trace_from_to_rev_ind
   (P : state -> state -> list transition_item -> Prop)
-  (Hempty: forall si
+  (Hempty : forall si
     (Hsi : valid_state_prop si),
     P si si nil)
   (Hextend : forall si s tr
@@ -1480,7 +1480,7 @@ Lemma finite_valid_trace_from_to_rev_ind
     (Htr : finite_valid_trace_from_to si s tr)
     sf iom oom l
     (Ht : input_valid_transition l (s, iom) (sf, oom)),
-    P si sf (tr++[{| l := l; input := iom; destination := sf; output := oom |}])):
+    P si sf (tr++[{| l := l; input := iom; destination := sf; output := oom |}])) :
   forall si sf tr,
     finite_valid_trace_from_to si sf tr ->
     P si sf tr.
@@ -1501,7 +1501,7 @@ Qed.
 
 Lemma finite_valid_trace_init_to_rev_ind
   (P : state -> state -> list transition_item -> Prop)
-  (Hempty: forall si
+  (Hempty : forall si
     (Hsi : initial_state_prop si),
     P si si nil)
   (Hextend : forall si s tr
@@ -1509,7 +1509,7 @@ Lemma finite_valid_trace_init_to_rev_ind
     (Htr : finite_valid_trace_init_to si s tr)
     sf iom oom l
     (Ht : input_valid_transition l (s, iom) (sf, oom)),
-    P si sf (tr++[{| l := l; input := iom; destination := sf; output := oom |}])):
+    P si sf (tr++[{| l := l; input := iom; destination := sf; output := oom |}])) :
   forall si sf tr,
     finite_valid_trace_init_to si sf tr ->
     P si sf tr.
@@ -1658,7 +1658,7 @@ Qed.
 *)
 Lemma finite_valid_trace_init_to_rev_strong_ind
   (P : state -> state -> list transition_item -> Prop)
-  (Hempty: forall is
+  (Hempty : forall is
     (His : initial_state_prop is),
     P is is nil)
   (Hextend : forall is s tr
@@ -1775,7 +1775,7 @@ Qed.
 Lemma infinite_valid_trace_from_prefix_rev
   (s : state)
   (ls : Stream transition_item)
-  (Hpref: forall n : nat, finite_valid_trace_from s (stream_prefix ls n))
+  (Hpref : forall n : nat, finite_valid_trace_from s (stream_prefix ls n))
   : infinite_valid_trace_from s ls.
 Proof.
   revert s ls Hpref.
@@ -1898,7 +1898,7 @@ Qed.
 *)
 Lemma valid_state_has_trace
       (s : state)
-      (Hp : valid_state_prop s):
+      (Hp : valid_state_prop s) :
   exists (is : state) (tr : list transition_item),
     finite_valid_trace_init_to is s tr.
 Proof using.
@@ -2040,7 +2040,7 @@ Qed.
 
 Lemma in_futures_valid_fst
   (first second : state)
-  (Hfuture: in_futures first second)
+  (Hfuture : in_futures first second)
   : valid_state_prop first.
 Proof.
   destruct Hfuture as [tr Htr].
@@ -2051,7 +2051,7 @@ Qed.
 (* begin hide *)
 
 Lemma in_futures_refl
-  (first: state)
+  (first : state)
   (Hps : valid_state_prop first)
   : in_futures first first.
 Proof.
@@ -2317,7 +2317,7 @@ Qed.
 
 Lemma in_futures_valid_snd
   (first second : state)
-  (Hfutures: in_futures first second)
+  (Hfutures : in_futures first second)
   : valid_state_prop second.
 Proof.
   specialize (in_futures_witness first second Hfutures)
@@ -2445,13 +2445,13 @@ Class TraceWithLast
     state -> state -> list transition_item -> Prop)
   : Prop :=
 {
-  valid_trace_add_last : forall [msg] [X: VLSM msg] [s f tr],
+  valid_trace_add_last : forall [msg] [X : VLSM msg] [s f tr],
     base_prop X s tr -> finite_trace_last s tr = f -> trace_prop X s f tr;
-  valid_trace_get_last : forall [msg] [X: VLSM msg] [s f tr],
+  valid_trace_get_last : forall [msg] [X : VLSM msg] [s f tr],
     trace_prop X s f tr -> finite_trace_last s tr = f;
-  valid_trace_last_pstate : forall [msg] [X: VLSM msg] [s f tr],
+  valid_trace_last_pstate : forall [msg] [X : VLSM msg] [s f tr],
     trace_prop X s f tr -> valid_state_prop X f;
-  valid_trace_forget_last : forall [msg] [X: VLSM msg] [s f tr],
+  valid_trace_forget_last : forall [msg] [X : VLSM msg] [s f tr],
     trace_prop X s f tr -> base_prop X s tr;
 }.
 
@@ -2460,13 +2460,13 @@ Class TraceWithLast
 
 Definition valid_trace_add_default_last
   `{TraceWithLast base_prop trace_prop}
-  [msg] [X: VLSM msg] [s tr] (Htr: base_prop msg X s tr):
+  [msg] [X : VLSM msg] [s tr] (Htr : base_prop msg X s tr) :
     trace_prop msg X s (finite_trace_last s tr) tr.
 Proof.
   by apply valid_trace_add_last.
 Defined.
 
-#[export] Instance trace_with_last_valid_trace_from:
+#[export] Instance trace_with_last_valid_trace_from :
   TraceWithLast (@finite_valid_trace_from) (@finite_valid_trace_from_to)
   := {valid_trace_add_last := @finite_valid_trace_from_add_last;
       valid_trace_get_last := @finite_valid_trace_from_to_last;
@@ -2474,7 +2474,7 @@ Defined.
       valid_trace_forget_last := @finite_valid_trace_from_to_forget_last;
      }.
 
-#[export] Instance trace_with_last_valid_trace_init:
+#[export] Instance trace_with_last_valid_trace_init :
   TraceWithLast (@finite_valid_trace) (@finite_valid_trace_init_to)
   := {valid_trace_add_last := @finite_valid_trace_init_add_last;
       valid_trace_get_last := @finite_valid_trace_init_to_last;
@@ -2494,16 +2494,16 @@ Class TraceWithStart
 
 #[global] Hint Mode TraceWithStart - - - ! : typeclass_instances.
 
-#[export] Instance trace_with_start_valid_trace_from message (X: VLSM message) s:
+#[export] Instance trace_with_start_valid_trace_from message (X : VLSM message) s :
   TraceWithStart s (finite_valid_trace_from X s)
   := {valid_trace_first_pstate := finite_valid_trace_first_pstate X s}.
-#[export] Instance trace_with_start_valid_trace message (X: VLSM message) s:
+#[export] Instance trace_with_start_valid_trace message (X : VLSM message) s :
   TraceWithStart s (finite_valid_trace X s)
   := {valid_trace_first_pstate tr H := valid_trace_first_pstate (proj1 H)}.
-#[export] Instance trace_with_start_valid_trace_from_to message (X: VLSM message) s f:
+#[export] Instance trace_with_start_valid_trace_from_to message (X : VLSM message) s f :
   TraceWithStart s (finite_valid_trace_from_to X s f)
   := {valid_trace_first_pstate tr H := valid_trace_first_pstate (valid_trace_forget_last H)}.
-#[export] Instance trace_with_start_valid_trace_init_to message (X: VLSM message) s f:
+#[export] Instance trace_with_start_valid_trace_init_to message (X : VLSM message) s f :
   TraceWithStart s (finite_valid_trace_init_to X s f)
   := {valid_trace_first_pstate tr H := valid_trace_first_pstate (valid_trace_forget_last H)}.
 
@@ -2588,7 +2588,7 @@ Proof.
 Qed.
 (* end hide *)
 
-Lemma any_message_is_valid_in_preloaded (om: option message):
+Lemma any_message_is_valid_in_preloaded (om : option message) :
   option_valid_message_prop pre_loaded_with_all_messages_vlsm om.
 Proof.
   eexists.
@@ -2597,8 +2597,8 @@ Qed.
 
 Inductive preloaded_valid_state_prop : state -> Prop :=
 | preloaded_valid_initial_state
-    (s: state)
-    (Hs: initial_state_prop (VLSMMachine := pre_loaded_with_all_messages_vlsm_machine) s):
+    (s : state)
+    (Hs : initial_state_prop (VLSMMachine := pre_loaded_with_all_messages_vlsm_machine) s) :
        preloaded_valid_state_prop s
 | preloaded_protocol_generated
     (l : label)
@@ -2610,7 +2610,7 @@ Inductive preloaded_valid_state_prop : state -> Prop :=
     (Ht : transition (VLSMMachine := pre_loaded_with_all_messages_vlsm_machine) l (s, om) = (s', om'))
   : preloaded_valid_state_prop s'.
 
-Lemma preloaded_valid_state_prop_iff s:
+Lemma preloaded_valid_state_prop_iff s :
   valid_state_prop pre_loaded_with_all_messages_vlsm s
   <-> preloaded_valid_state_prop s.
 Proof.
@@ -2626,7 +2626,7 @@ Proof.
       by apply (valid_generated_state_message pre_loaded_with_all_messages_vlsm) with s _om _s om l0.
 Qed.
 
-Lemma preloaded_weaken_valid_state_message_prop s om:
+Lemma preloaded_weaken_valid_state_message_prop s om :
   valid_state_message_prop X s om ->
   valid_state_message_prop pre_loaded_with_all_messages_vlsm s om.
 Proof.
@@ -2637,7 +2637,7 @@ Proof.
 Qed.
 
 Lemma preloaded_weaken_input_valid_transition
-      l s om s' om':
+      l s om s' om' :
   input_valid_transition X l (s, om) (s', om') ->
   input_valid_transition pre_loaded_with_all_messages_vlsm l (s, om) (s', om').
 Proof.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -891,8 +891,7 @@ Lemma valid_state_prop_ind
   (IHgen :
     forall (s' : state) (l: label) (om om' : option message) (s : state)
       (Ht : input_valid_transition l (s, om) (s', om')) (Hs : P s),
-      P s'
-  )
+      P s')
   : forall (s : state) (Hs : valid_state_prop s), P s.
 Proof.
   intros.
@@ -2207,8 +2206,8 @@ Proof.
     ; split; try done.
     + assert
         (Hex : exists suffix0 : list transition_item,
-            (p ++ [last_p]) ++ last :: suffix = p ++ last_p :: suffix0
-        ) by (exists (last :: suffix); rewrite <- app_assoc; done)
+            (p ++ [last_p]) ++ last :: suffix = p ++ last_p :: suffix0)
+          by (exists (last :: suffix); rewrite <- app_assoc; done)
       ; specialize (Hind Hex); clear Hex
       ; destruct Hind as [Hptr _]
       ; destruct last
@@ -2222,8 +2221,8 @@ Proof.
       by rewrite finite_trace_last_is_last.
     + assert
         (Hex : exists suffix0 : Stream transition_item,
-            stream_app (p ++ [last_p])  (Cons last suffix) = stream_app p (Cons last_p suffix0)
-        ) by (exists (Cons last suffix); rewrite <- stream_app_assoc; done)
+            stream_app (p ++ [last_p])  (Cons last suffix) = stream_app p (Cons last_p suffix0))
+          by (exists (Cons last suffix); rewrite <- stream_app_assoc; done)
       ; specialize (Hind Hex); clear Hex
       ; destruct Hind as [Hptr _]
       ; destruct last
@@ -2242,8 +2241,7 @@ Proof.
            last_p
            {| l := l0; input := input0; destination := destination0; output := output0 |}
            Htr
-           eq_refl
-        ).
+           eq_refl).
       simpl.
       by rewrite finite_trace_last_is_last.
 Qed.
@@ -2668,8 +2666,7 @@ Lemma pre_traces_with_valid_inputs_are_valid is s tr
   (Htr : finite_valid_trace_init_to pre_loaded_with_all_messages_vlsm is s tr)
   (Hobs : forall m,
     trace_has_message (field_selector input) m tr ->
-    valid_message_prop X m
-  )
+    valid_message_prop X m)
   : finite_valid_trace_init_to X is s tr.
 Proof.
   revert s Htr Hobs.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -344,8 +344,8 @@ Definition VLSM_weak_embedding_in_futures
 
 Lemma VLSM_weak_embedding_input_valid_transition
   : forall l s im s' om,
-  input_valid_transition X l (s,im) (s',om) ->
-  input_valid_transition Y (label_project l) (state_project s,im) (state_project s',om).
+  input_valid_transition X l (s, im) (s', om) ->
+  input_valid_transition Y (label_project l) (state_project s, im) (state_project s', om).
 Proof.
   intros.
   by apply (VLSM_weak_projection_input_valid_transition VLSM_weak_embedding_is_projection)
@@ -353,7 +353,7 @@ Proof.
 Qed.
 
 Lemma VLSM_weak_embedding_input_valid l s im
-  : input_valid X l (s,im) -> input_valid Y (label_project l) (state_project s,im).
+  : input_valid X l (s, im) -> input_valid Y (label_project l) (state_project s, im).
 Proof.
   by intros; eapply (VLSM_weak_projection_input_valid VLSM_weak_embedding_is_projection).
 Qed.
@@ -490,14 +490,14 @@ Definition VLSM_embedding_in_futures
 
 Definition VLSM_embedding_input_valid_transition
   : forall l s im s' om,
-  input_valid_transition X l (s,im) (s',om) ->
-  input_valid_transition Y (label_project l) (state_project s,im) (state_project s',om)
+  input_valid_transition X l (s, im) (s', om) ->
+  input_valid_transition Y (label_project l) (state_project s, im) (state_project s', om)
   := VLSM_weak_embedding_input_valid_transition VLSM_embedding_weaken.
 
 Definition VLSM_embedding_input_valid
   : forall l s im,
-  input_valid X l (s,im) ->
-  input_valid Y (label_project l) (state_project s,im)
+  input_valid X l (s, im) ->
+  input_valid Y (label_project l) (state_project s, im)
   := VLSM_weak_embedding_input_valid VLSM_embedding_weaken.
 
 Definition VLSM_embedding_can_produce

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -672,8 +672,8 @@ Qed.
 Lemma basic_VLSM_weak_embedding : VLSM_weak_embedding X Y label_project state_project.
 Proof.
   specialize (basic_VLSM_weak_projection X Y (Some ∘ label_project) state_project) as Hproj.
-  spec Hproj; [by apply weak_projection_valid_preservation_from_full|].
-  spec Hproj; [by apply weak_projection_transition_preservation_Some_from_full|].
+  spec Hproj; [by apply weak_projection_valid_preservation_from_full |].
+  spec Hproj; [by apply weak_projection_transition_preservation_Some_from_full |].
   spec Hproj; [by apply weak_projection_transition_consistency_None_from_full |].
   spec Hproj; [done |].
   spec Hproj; [by apply weak_projection_valid_message_preservation_from_full |].
@@ -785,7 +785,7 @@ Proof.
     + destruct iom as [m |]; [| by apply option_valid_message_None].
       unfold empty_initial_message_or_final_output in Heqiom.
       destruct_list_last iom_tr iom_tr' iom_lst Heqiom_tr
-      ; [apply option_initial_message_is_valid; destruct Heqiom as [Him | Hp]|].
+      ; [apply option_initial_message_is_valid; destruct Heqiom as [Him | Hp] |].
       * by left; revert Him; apply Hmessage.
       * by right; auto.
       * apply

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -176,8 +176,8 @@ Qed.
 
 Lemma VLSM_eq_input_valid_transition
   : forall l s im s' om,
-  input_valid_transition X l (s,im) (s',om) <->
-  input_valid_transition Y l (s,im) (s',om).
+  input_valid_transition X l (s, im) (s', om) <->
+  input_valid_transition Y l (s, im) (s', om).
 Proof.
   split.
   - by apply (VLSM_incl_input_valid_transition VLSM_eq_proj1).
@@ -186,7 +186,7 @@ Qed.
 
 Lemma VLSM_eq_input_valid
   : forall l s im,
-  input_valid X l (s,im) <-> input_valid Y l (s,im).
+  input_valid X l (s, im) <-> input_valid Y l (s, im).
 Proof.
   split.
   - by apply (VLSM_incl_input_valid VLSM_eq_proj1).

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -54,7 +54,7 @@ Proof.
     destruct tr as [is tr | is tr]; simpl in *.
     + by apply Hincl.
     + destruct Htr as [HtrX HisX].
-      assert (His_tr: finite_valid_trace X is []).
+      assert (His_tr : finite_valid_trace X is []).
       {
         split; [| done].
         by constructor; apply initial_state_is_valid.

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -233,16 +233,16 @@ Qed.
 
 Lemma VLSM_incl_input_valid_transition
   : forall l s im s' om,
-  input_valid_transition X l (s,im) (s',om) ->
-  input_valid_transition Y l (s,im) (s',om).
+  input_valid_transition X l (s, im) (s', om) ->
+  input_valid_transition Y l (s, im) (s', om).
 Proof.
   by apply (VLSM_embedding_input_valid_transition (VLSM_incl_is_embedding Hincl)).
 Qed.
 
 Lemma VLSM_incl_input_valid
   : forall l s im,
-  input_valid X l (s,im) ->
-  input_valid Y l (s,im).
+  input_valid X l (s, im) ->
+  input_valid Y l (s, im).
 Proof.
   by apply (VLSM_embedding_input_valid (VLSM_incl_is_embedding Hincl)).
 Qed.

--- a/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
@@ -96,7 +96,7 @@ Definition strong_transition_item_project_consistency
     vtransition X lX (sX, inputX) = (destinationX, outputX) ->
     finite_trace_last (state_project sX)
       (transition_item_project
-        {| l := lX; input := inputX; destination := destinationX; output := outputX|})
+        {| l := lX; input := inputX; destination := destinationX; output := outputX |})
       =
     state_project destinationX.
 
@@ -486,7 +486,7 @@ Lemma VLSM_stuttering_embedding_finite_valid_trace_from :
       (VLSM_stuttering_embedding_finite_trace_project Hsimul trX).
 Proof.
   by intros; eapply VLSM_partial_projection_finite_valid_trace_from;
-    [apply VLSM_partial_projection_from_stuttering_embedding |..].
+    [apply VLSM_partial_projection_from_stuttering_embedding | ..].
 Qed.
 
 Definition VLSM_stuttering_embedding_weaken :
@@ -539,7 +539,7 @@ Lemma VLSM_stuttering_embedding_initial_state :
   forall sX, vinitial_state_prop X sX -> vinitial_state_prop Y (state_project sX).
 Proof.
   by intros; eapply VLSM_partial_projection_initial_state;
-    [apply VLSM_partial_projection_from_stuttering_embedding |..].
+    [apply VLSM_partial_projection_from_stuttering_embedding | ..].
 Qed.
 
 Lemma VLSM_stuttering_embedding_finite_valid_trace_init_to :
@@ -705,7 +705,7 @@ Proof.
   rewrite pre_VLSM_stuttering_embedding_finite_trace_project_app.
   apply finite_valid_trace_from_to_app with (state_project s); [done |].
   cbn; rewrite app_nil_r.
-  remember {| l := _|} as itemX; replace sf with (destination itemX) by (subst; done).
+  remember {| l := _ |} as itemX; replace sf with (destination itemX) by (subst; done).
   by apply Htransition; subst.
 Qed.
 

--- a/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
@@ -87,7 +87,7 @@ Qed.
 Lemma pre_VLSM_projection_transition_item_project_finitely_many
   (s : Streams.Stream (@transition_item _ TX))
   : FinitelyManyBound pre_VLSM_projection_in_projection s ->
-    FinitelyManyBound (is_Some ∘ pre_VLSM_projection_transition_item_project ) s.
+    FinitelyManyBound (is_Some ∘ pre_VLSM_projection_transition_item_project) s.
 Proof.
   apply FinitelyManyBound_impl_rev.
   intro item.
@@ -475,7 +475,7 @@ Qed.
 Lemma VLSM_weak_projection_input_valid_transition
   : forall lX lY, label_project lX = Some lY ->
     forall s im s' om,
-    input_valid_transition X lX (s, im) (s', om ) ->
+    input_valid_transition X lX (s, im) (s', om) ->
     input_valid_transition Y lY (state_project s, im) (state_project s', om).
 Proof.
   specialize VLSM_weak_partial_projection_from_projection as Hpart_simul.
@@ -643,7 +643,7 @@ Definition VLSM_projection_valid_state
 Definition VLSM_projection_input_valid_transition
   : forall lX lY, label_project lX = Some lY ->
     forall s im s' om,
-    input_valid_transition X lX (s, im) (s', om ) ->
+    input_valid_transition X lX (s, im) (s', om) ->
     input_valid_transition Y lY (state_project s, im) (state_project s', om)
   := VLSM_weak_projection_input_valid_transition VLSM_projection_weaken.
 

--- a/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
@@ -482,8 +482,8 @@ Proof.
   specialize (VLSM_weak_partial_projection_input_valid_transition Hpart_simul) as Hivt.
   intros.
   apply
-    (Hivt s {| l := lX; input := im; destination := s'; output := om|}
-      (state_project s) {| l := lY; input := im; destination := state_project s'; output := om|})
+    (Hivt s {| l := lX; input := im; destination := s'; output := om |}
+      (state_project s) {| l := lY; input := im; destination := state_project s'; output := om |})
   ; [| done].
   by cbn; unfold pre_VLSM_projection_transition_item_project; cbn; rewrite H.
 Qed.
@@ -924,7 +924,7 @@ Lemma basic_VLSM_weak_projection_strengthen
   (Hstate : strong_projection_initial_state_preservation X Y state_project)
   : VLSM_projection X Y label_project state_project.
 Proof.
-  constructor; [by apply Hweak|].
+  constructor; [by apply Hweak |].
   intros sX trX [HtrX HsX]; split.
   - by apply (VLSM_weak_projection_finite_valid_trace_from Hweak).
   - by apply Hstate.
@@ -981,7 +981,7 @@ Proof.
   clear IHHtr.
   simpl.
   unfold pre_VLSM_projection_transition_item_project.
-  destruct (label_project _) as [lY|] eqn:Hl; [done |].
+  destruct (label_project _) as [lY |] eqn:Hl; [done |].
   apply proj2, (Htransition_None _ Hl) in Hx.
   by rewrite Hx.
 Qed.
@@ -1015,11 +1015,11 @@ Proof.
     apply finite_valid_trace_last_pstate in IHHtrX.
     destruct Hx as [[_ [_ Hv]] Ht].
     rewrite <- (final_state_project _ _ _ _ Htype) in IHHtrX |- * by apply HtrX.
-    destruct (label_project l) as [lY|] eqn:Hl.
+    destruct (label_project l) as [lY |] eqn:Hl.
     + apply (finite_valid_trace_singleton (pre_loaded_with_all_messages_vlsm Y)).
       assert (Hiom : option_valid_message_prop (pre_loaded_with_all_messages_vlsm Y) iom).
       {
-        destruct iom as [im|]; [| by apply option_valid_message_None].
+        destruct iom as [im |]; [| by apply option_valid_message_None].
         by apply (any_message_is_valid_in_preloaded Y).
       }
       apply (Hvalid _ _ Hl) in Hv.
@@ -1047,7 +1047,7 @@ Proof.
   clear IHHtr.
   simpl.
   unfold pre_VLSM_projection_transition_item_project.
-  destruct (label_project _) as [lY|] eqn:Hl; [done |].
+  destruct (label_project _) as [lY |] eqn:Hl; [done |].
   apply proj2, (Htransition_None _ Hl) in Hx.
   by rewrite Hx.
 Qed.
@@ -1083,10 +1083,10 @@ Proof.
     apply proj1 in Hx as Hpv.
     destruct Hx as [[_ [_ Hv]] Ht].
     rewrite <- (final_state_project _ _ _ _ Htype) in IHHtrX |- * by apply HtrX.
-    destruct (label_project l) as [lY|] eqn:Hl.
+    destruct (label_project l) as [lY |] eqn:Hl.
     + apply (finite_valid_trace_singleton (pre_loaded_vlsm Y Q)).
       assert (Hiom : option_valid_message_prop (pre_loaded_vlsm Y Q) iom).
-      { destruct iom as [im|]; [| by apply option_valid_message_None].
+      { destruct iom as [im |]; [| by apply option_valid_message_None].
         by apply (Hmessage _ _ Hl) in Hpv.
       }
       apply (Hvalid _ _ Hl) in Hv.

--- a/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
@@ -493,7 +493,7 @@ Lemma VLSM_weak_projection_input_valid
     forall s im, input_valid X lX (s, im) -> input_valid Y lY (state_project s, im).
 Proof.
   intros lX lY Hpr sX im HvX.
-  destruct (vtransition X lX (sX, im)) eqn:HtX.
+  destruct (vtransition X lX (sX, im)) eqn: HtX.
   by eapply VLSM_weak_projection_input_valid_transition, input_valid_can_transition.
 Qed.
 
@@ -981,7 +981,7 @@ Proof.
   clear IHHtr.
   simpl.
   unfold pre_VLSM_projection_transition_item_project.
-  destruct (label_project _) as [lY |] eqn:Hl; [done |].
+  destruct (label_project _) as [lY |] eqn: Hl; [done |].
   apply proj2, (Htransition_None _ Hl) in Hx.
   by rewrite Hx.
 Qed.
@@ -1015,7 +1015,7 @@ Proof.
     apply finite_valid_trace_last_pstate in IHHtrX.
     destruct Hx as [[_ [_ Hv]] Ht].
     rewrite <- (final_state_project _ _ _ _ Htype) in IHHtrX |- * by apply HtrX.
-    destruct (label_project l) as [lY |] eqn:Hl.
+    destruct (label_project l) as [lY |] eqn: Hl.
     + apply (finite_valid_trace_singleton (pre_loaded_with_all_messages_vlsm Y)).
       assert (Hiom : option_valid_message_prop (pre_loaded_with_all_messages_vlsm Y) iom).
       {
@@ -1047,7 +1047,7 @@ Proof.
   clear IHHtr.
   simpl.
   unfold pre_VLSM_projection_transition_item_project.
-  destruct (label_project _) as [lY |] eqn:Hl; [done |].
+  destruct (label_project _) as [lY |] eqn: Hl; [done |].
   apply proj2, (Htransition_None _ Hl) in Hx.
   by rewrite Hx.
 Qed.
@@ -1083,7 +1083,7 @@ Proof.
     apply proj1 in Hx as Hpv.
     destruct Hx as [[_ [_ Hv]] Ht].
     rewrite <- (final_state_project _ _ _ _ Htype) in IHHtrX |- * by apply HtrX.
-    destruct (label_project l) as [lY |] eqn:Hl.
+    destruct (label_project l) as [lY |] eqn: Hl.
     + apply (finite_valid_trace_singleton (pre_loaded_vlsm Y Q)).
       assert (Hiom : option_valid_message_prop (pre_loaded_vlsm Y Q) iom).
       { destruct iom as [im |]; [| by apply option_valid_message_None].

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -898,7 +898,7 @@ Proof.
 Qed.
 
 Lemma composite_vlsm_induced_projection_validator_iff
-  (Hno_inits : forall m, ~vinitial_message_prop (IM i) m)
+  (Hno_inits : forall m, ~ vinitial_message_prop (IM i) m)
   : VLSM_eq
       composite_vlsm_induced_projection_validator
       (composite_vlsm_induced_validator IM constraint i).

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -109,7 +109,7 @@ Lemma projection_validator_messages_transitions
 Proof.
   intros Hvalidator li si omi Hpvi.
   apply Hvalidator in Hpvi as (l & s & Hiv).
-  destruct (vtransition X l (s, omi)) as (s', omo) eqn:Ht.
+  destruct (vtransition X l (s, omi)) as (s', omo) eqn: Ht.
   eexists l, s, s', omo; split with (tv_tiv := Hiv) (tv_transition := Ht).
 Qed.
 

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -481,8 +481,8 @@ Lemma projection_induced_validator_eq
   : VLSM_eq X1 X2 -> VLSM_eq XY1 XY2.
 Proof.
   intro Heq; apply VLSM_eq_incl_iff; split.
-  - by apply (projection_induced_validator_incl MX1 MX2); [..| apply VLSM_eq_proj1].
-  - by apply (projection_induced_validator_incl MX2 MX1); [..| apply VLSM_eq_proj2].
+  - by apply (projection_induced_validator_incl MX1 MX2); [.. | apply VLSM_eq_proj1].
+  - by apply (projection_induced_validator_incl MX2 MX1); [.. | apply VLSM_eq_proj2].
 Qed.
 
 End sec_projection_induced_validator_incl.
@@ -854,7 +854,7 @@ Proof.
   - by intros m [Him | Hpm]; right; [by apply Hinits |].
   - intros l s iom [sX [<- Hv]].
     exists (existT i l), sX.
-    by split; [apply composite_project_label_eq |..].
+    by split; [apply composite_project_label_eq | ..].
   - intros l s iom s' oom.
     cbn; unfold lift_to_composite_state' at 1.
     state_update_simpl.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -74,7 +74,7 @@ Context
 *)
 Definition projection_validator_prop :=
   forall li si omi,
-    input_valid PreY li (si,omi) ->
+    input_valid PreY li (si, omi) ->
     exists lX sX, InputValidation label_project state_project li si omi lX sX.
 
 (**
@@ -239,7 +239,7 @@ Lemma induced_validator_valid_is_input_valid
   (Hproj : VLSM_projection X pre_projection_induced_validator label_project state_project)
   l s om
   : vvalid projection_induced_validator l (s, om) ->
-      input_valid pre_projection_induced_validator l (s,om).
+      input_valid pre_projection_induced_validator l (s, om).
 Proof.
   intro Hv.
   destruct (id Hv) as (lX & sX & [HlX  HsX (Hps & Hopm & _)]); cbn in HsX; subst.

--- a/theories/VLSM/Lib/FinFunExtras.v
+++ b/theories/VLSM/Lib/FinFunExtras.v
@@ -21,7 +21,7 @@ Proof.
   split.
   - clear Hfull.
     induction A_listing as [| a l IHl]; [by constructor |].
-    inversion_clear Hnodup as [|? ? H1 H2].
+    inversion_clear Hnodup as [| ? ? H1 H2].
     specialize (IHl H2); clear H2.
     simpl.
     destruct (f a) eqn: Hfa; [| done].

--- a/theories/VLSM/Lib/FinFunExtras.v
+++ b/theories/VLSM/Lib/FinFunExtras.v
@@ -12,10 +12,10 @@ Proof.
 Qed.
 
 Lemma map_option_listing
-      {A B : Type} (f: A -> option B) (g: B -> A)
-      (f_proj_inj: forall a b, f a = Some b -> a = g b)
-      (f_surj: forall b, f (g b) = Some b)
-      (A_listing: list A) (A_finite : Listing A_listing) : Listing (map_option f A_listing).
+      {A B : Type} (f : A -> option B) (g : B -> A)
+      (f_proj_inj : forall a b, f a = Some b -> a = g b)
+      (f_surj : forall b, f (g b) = Some b)
+      (A_listing : list A) (A_finite : Listing A_listing) : Listing (map_option f A_listing).
 Proof.
   destruct A_finite as [Hnodup Hfull].
   split.

--- a/theories/VLSM/Lib/FinFunExtras.v
+++ b/theories/VLSM/Lib/FinFunExtras.v
@@ -64,7 +64,7 @@ Lemma left_finite
 Proof.
   revert sum_finite.
   apply map_option_listing with (g:=inl); [| done].
-  by destruct a;simpl;congruence.
+  by destruct a; simpl; congruence.
 Qed.
 
 Lemma right_finite
@@ -73,7 +73,7 @@ Lemma right_finite
 Proof.
   revert sum_finite.
   apply map_option_listing with (g:=inr); [| done].
-  by destruct a;simpl;congruence.
+  by destruct a; simpl; congruence.
 Qed.
 
 End sec_sum_listing.

--- a/theories/VLSM/Lib/FinFunExtras.v
+++ b/theories/VLSM/Lib/FinFunExtras.v
@@ -63,7 +63,7 @@ Lemma left_finite
   : Listing (left_listing sum_finite).
 Proof.
   revert sum_finite.
-  apply map_option_listing with (g:=inl); [| done].
+  apply map_option_listing with (g := inl); [| done].
   by destruct a; simpl; congruence.
 Qed.
 
@@ -72,7 +72,7 @@ Lemma right_finite
   : Listing (right_listing sum_finite).
 Proof.
   revert sum_finite.
-  apply map_option_listing with (g:=inr); [| done].
+  apply map_option_listing with (g := inr); [| done].
   by destruct a; simpl; congruence.
 Qed.
 

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -202,7 +202,7 @@ Proof.
   unfold set_map.
   remember (f <$> elements X) as fX.
   set (x := size (list_to_set _)).
-  cut (x <= length fX); [|by apply list_to_set_size].
+  cut (x <= length fX); [| by apply list_to_set_size].
   enough (length fX = size X) by lia.
   unfold size, set_size.
   simpl; subst fX.

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -138,7 +138,7 @@ Lemma list_to_set_size
 Proof.
   induction l; cbn.
   - by rewrite size_empty; lia.
-  - specialize (union_size_le_sum ({[a]}) (list_to_set l)) as Hun_size.
+  - specialize (union_size_le_sum ({[ a ]}) (list_to_set l)) as Hun_size.
     by rewrite size_singleton in Hun_size; lia.
 Qed.
 

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -6,7 +6,7 @@ From VLSM.Lib Require Import Preamble.
 (** * Utility lemmas about lists *)
 
 (** A list is empty if it has no members. *)
-Lemma empty_nil [X:Type] (l:list X) :
+Lemma empty_nil [X: Type] (l: list X) :
   (forall v, ~ In v l) -> l = [].
 Proof.
   clear.
@@ -25,7 +25,7 @@ Qed.
   and a last element.
 *)
 Lemma has_last_or_null {S} (l : list S)
-  : {l' : list S & {a : S | l = l' ++ (a::nil)}} + {l = nil} .
+  : {l' : list S & {a : S | l = l' ++ (a:: nil)}} + {l = nil} .
 Proof.
   destruct (null_dec l).
   - by right.
@@ -157,13 +157,13 @@ Proof.
     by itauto.
 Qed.
 
-Lemma in_not_in : forall A (x y : A) (l:list A),
+Lemma in_not_in : forall A (x y : A) (l: list A),
   x ∈ l ->
   y ∉ l ->
   x <> y.
 Proof. by itauto congruence. Qed.
 
-Definition inb {A} (Aeq_dec : forall x y:A, {x = y} + {x <> y}) (x : A) (xs : list A) :=
+Definition inb {A} (Aeq_dec : forall x y: A, {x = y} + {x <> y}) (x : A) (xs : list A) :=
   if in_dec Aeq_dec x xs then true else false.
 
 Lemma in_correct `{EqDecision X} :
@@ -585,7 +585,7 @@ Proof.
 Qed.
 
 Fixpoint nth_error_filter_index
-  {A} P `{forall (x:A), Decision (P x)}
+  {A} P `{forall (x: A), Decision (P x)}
   (l : list A)
   (n : nat)
   :=
@@ -602,7 +602,7 @@ Fixpoint nth_error_filter_index
   end.
 
 Lemma nth_error_filter_index_le
-  {A} P `{forall (x:A), Decision (P x)}
+  {A} P `{forall (x: A), Decision (P x)}
   (l : list A)
   (n1 n2 : nat)
   (Hle : n1 <= n2)
@@ -627,15 +627,15 @@ Proof.
       * by destruct (nth_error_filter_index P l n2); inversion Hin2.
       * assert (Hle' : n1 <= n2) by lia.
         specialize (IHl n1 n2 Hle').
-        destruct (nth_error_filter_index P l n1) eqn:Hin1'; inversion Hin1;
+        destruct (nth_error_filter_index P l n1) eqn: Hin1'; inversion Hin1;
         subst; clear Hin1.
-        destruct (nth_error_filter_index P l n2) eqn:Hin2'; inversion Hin2
+        destruct (nth_error_filter_index P l n2) eqn: Hin2'; inversion Hin2
         ; subst; clear Hin2.
         by specialize (IHl in1 eq_refl in2 eq_refl); lia.
   - specialize (IHl n1 n2 Hle).
-    destruct (nth_error_filter_index P l n1) eqn:Hin1'; inversion Hin1
+    destruct (nth_error_filter_index P l n1) eqn: Hin1'; inversion Hin1
     ; subst; clear Hin1.
-    destruct (nth_error_filter_index P l n2) eqn:Hin2'; inversion Hin2
+    destruct (nth_error_filter_index P l n2) eqn: Hin2'; inversion Hin2
     ; subst; clear Hin2.
     by specialize (IHl n0 eq_refl n3 eq_refl); lia.
 Qed.
@@ -934,7 +934,7 @@ Proof.
     apply app_eq_nil in Happ_rev as [Hl1' Hl2']; subst.
     by exists [], [].
   - simpl in Happ_rev.
-    destruct (f a) eqn:Hfa; swap 1 2.
+    destruct (f a) eqn: Hfa; swap 1 2.
     + destruct (IHl _ _ Happ_rev) as [_l1 [l2 [-> [<- <-]]]].
       by exists (a :: _l1), l2; cbn; rewrite Hfa.
     + destruct l1' as [| _b l1']; swap 1 2.
@@ -1430,7 +1430,7 @@ Proof.
   - by refine (if X a then if IHl then left _ else right _ else right _); constructor.
 Qed.
 
-Lemma list_sum_decrease [A:Type] (f g: A -> nat) (l: list A):
+Lemma list_sum_decrease [A: Type] (f g: A -> nat) (l: list A):
   (forall a, In a l -> f a <= g a) -> Exists (fun a => f a < g a) l ->
   list_sum (map f l) < list_sum (map g l).
 Proof.
@@ -1451,7 +1451,7 @@ Qed.
   natural examples.
 *)
 Lemma fold_left_ind
-      [A B:Type] (f: B -> A -> B) (P : list A -> B -> B -> Prop)
+      [A B: Type] (f: B -> A -> B) (P : list A -> B -> B -> Prop)
       (Hstart : forall x, P nil x x)
       (Hstep : forall x a l r,
           P l (f x a) r ->
@@ -1469,10 +1469,10 @@ Qed.
   decomposes the list from the right.
 *)
 Lemma fold_left_ind_rev
-      [A B:Type] (f: B -> A -> B) (x0: B)
+      [A B: Type] (f: B -> A -> B) (x0: B)
       (P : list A -> B -> Prop)
       (Hstart : P nil x0)
-      (Hstep: forall l a x, P l x -> P (l++a::nil) (f x a)):
+      (Hstep: forall l a x, P l x -> P (l++a:: nil) (f x a)):
   forall l, P l (fold_left f l x0).
 Proof.
   induction l using rev_ind.
@@ -1564,7 +1564,7 @@ Definition ForAllSuffix2 [A : Type] (R : A -> A -> Prop) : list A -> Prop :=
   ForAllSuffix (fun l => match l with | a :: b :: _ => R a b | _ => True end).
 
 Lemma fsFurther2_transitive [A : Type] (R : A -> A -> Prop) {HT : Transitive R}
-  : forall a b l, ForAllSuffix2 R (a::b::l) -> ForAllSuffix2 R (a::l).
+  : forall a b l, ForAllSuffix2 R (a:: b:: l) -> ForAllSuffix2 R (a:: l).
 Proof.
   inversion 1. subst. destruct l.
   - by repeat constructor.
@@ -1608,7 +1608,7 @@ Proof.
       by intros b Hb; apply Hsub; right.
 Qed.
 
-Lemma elem_of_empty_nil [X:Type] (l:list X) :
+Lemma elem_of_empty_nil [X: Type] (l: list X) :
   (forall v, v ∉ l) -> l = [].
 Proof.
   destruct l as [| a]; [done |].
@@ -1645,7 +1645,7 @@ Proof.
   by apply submseteq_length, NoDup_submseteq.
 Qed.
 
-Lemma submseteq_tail_l [A] (x:A) l1 l2 :
+Lemma submseteq_tail_l [A] (x: A) l1 l2 :
   x :: l1 ⊆+ l2 -> l1 ⊆+ l2.
 Proof.
   by apply submseteq_trans, submseteq_cons.

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -150,7 +150,7 @@ Proof.
     by itauto.
   - apply Exists_cons in Hsomething.
     destruct Hsomething; [by itauto |].
-    specialize (IHl H);clear H.
+    specialize (IHl H); clear H.
     destruct IHl as [prefix [suffix [first [Hf [-> Hnone_before]]]]].
     exists (a :: prefix), suffix, first.
     rewrite Exists_cons.
@@ -1282,9 +1282,9 @@ Fixpoint complete_prefix
                                end
   end.
 
-Example complete_prefix_some : complete_prefix [1;2;3;4] [1;2] = Some [3;4].
+Example complete_prefix_some : complete_prefix [1; 2; 3; 4] [1; 2] = Some [3; 4].
 Proof. by itauto. Qed.
-Example complete_prefix_none : complete_prefix [1;2;3;4] [1;3] = None.
+Example complete_prefix_none : complete_prefix [1; 2; 3; 4] [1; 3] = None.
 Proof. by itauto. Qed.
 
 Lemma complete_prefix_empty
@@ -1347,7 +1347,7 @@ Definition complete_suffix
   | Some ls => Some (rev ls)
   end.
 
-Example complete_suffix_some : complete_suffix [1;2;3;4] [3;4] = Some [1;2].
+Example complete_suffix_some : complete_suffix [1; 2; 3; 4] [3; 4] = Some [1; 2].
 Proof. by itauto. Qed.
 
 Lemma complete_suffix_correct

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -6,7 +6,7 @@ From VLSM.Lib Require Import Preamble.
 (** * Utility lemmas about lists *)
 
 (** A list is empty if it has no members. *)
-Lemma empty_nil [X: Type] (l: list X) :
+Lemma empty_nil [X : Type] (l : list X) :
   (forall v, ~ In v l) -> l = [].
 Proof.
   clear.
@@ -25,7 +25,7 @@ Qed.
   and a last element.
 *)
 Lemma has_last_or_null {S} (l : list S)
-  : {l' : list S & {a : S | l = l' ++ (a:: nil)}} + {l = nil} .
+  : {l' : list S & {a : S | l = l' ++ (a :: nil)}} + {l = nil} .
 Proof.
   destruct (null_dec l).
   - by right.
@@ -157,13 +157,13 @@ Proof.
     by itauto.
 Qed.
 
-Lemma in_not_in : forall A (x y : A) (l: list A),
+Lemma in_not_in : forall A (x y : A) (l : list A),
   x ∈ l ->
   y ∉ l ->
   x <> y.
 Proof. by itauto congruence. Qed.
 
-Definition inb {A} (Aeq_dec : forall x y: A, {x = y} + {x <> y}) (x : A) (xs : list A) :=
+Definition inb {A} (Aeq_dec : forall x y : A, {x = y} + {x <> y}) (x : A) (xs : list A) :=
   if in_dec Aeq_dec x xs then true else false.
 
 Lemma in_correct `{EqDecision X} :
@@ -221,7 +221,7 @@ Definition app_cons {A}
   : [a] ++ l = a :: l
   := eq_refl.
 
-Lemma append_nodup_left {A}:
+Lemma append_nodup_left {A} :
   forall (l1 l2 : list A), List.NoDup (l1 ++ l2) -> List.NoDup l1.
 Proof.
   induction l1; intros.
@@ -230,13 +230,13 @@ Proof.
     by rewrite in_app_iff in H2; itauto.
 Qed.
 
-Lemma append_nodup_right {A}:
+Lemma append_nodup_right {A} :
   forall (l1 l2 : list A), List.NoDup (l1 ++ l2) -> List.NoDup l2.
 Proof.
   by induction l1; cbn; intros; [| inversion H; auto].
 Qed.
 
-Lemma last_is_last {A} : forall (l : list A) (x dummy: A),
+Lemma last_is_last {A} : forall (l : list A) (x dummy : A),
   List.last (l ++ [x]) dummy = x.
 Proof.
   induction l; intros; [done |].
@@ -297,7 +297,7 @@ Lemma nth_error_last
   {A : Type}
   (l : list A)
   (n : nat)
-  (Hlast: S n = length l)
+  (Hlast : S n = length l)
   (_last : A)
   : nth_error l n = Some (List.last l _last).
 Proof.
@@ -348,7 +348,7 @@ Fixpoint list_prefix
 
 Lemma list_prefix_split
   {A : Type}
-  (l left right: list A)
+  (l left right : list A)
   (left_len : nat)
   (Hlen : left_len = length left)
   (Hsplit : l = left ++ right) :
@@ -413,7 +413,7 @@ Lemma list_prefix_prefix
   {A : Type}
   (l : list A)
   (n1 n2 : nat)
-  (Hn: n1 <= n2)
+  (Hn : n1 <= n2)
   : list_prefix (list_prefix l n2) n1 = list_prefix l n1.
 Proof.
   generalize dependent n1. generalize dependent n2.
@@ -585,7 +585,7 @@ Proof.
 Qed.
 
 Fixpoint nth_error_filter_index
-  {A} P `{forall (x: A), Decision (P x)}
+  {A} P `{forall (x : A), Decision (P x)}
   (l : list A)
   (n : nat)
   :=
@@ -602,7 +602,7 @@ Fixpoint nth_error_filter_index
   end.
 
 Lemma nth_error_filter_index_le
-  {A} P `{forall (x: A), Decision (P x)}
+  {A} P `{forall (x : A), Decision (P x)}
   (l : list A)
   (n1 n2 : nat)
   (Hle : n1 <= n2)
@@ -791,7 +791,7 @@ Lemma list_suffix_last
 Proof.
   revert l Hlt; induction i; intros [| a l] Hlt; [done.. |].
   simpl in Hlt.
-  assert (Hlt': i < length l) by lia.
+  assert (Hlt' : i < length l) by lia.
   specialize (IHi l Hlt').
   rewrite unroll_last. simpl.
   rewrite IHi.
@@ -868,7 +868,7 @@ Proof.
   specialize (list_suffix_length (list_prefix l (S n)) n).
   rewrite list_prefix_length; [| done].
   intro Hlength.
-  assert (Hs: S n - n = 1) by lia.
+  assert (Hs : S n - n = 1) by lia.
   rewrite Hs in Hlength.
   remember (list_suffix (list_prefix l (S n)) n) as x.
   clear -Hlength Hlast1.
@@ -1049,7 +1049,7 @@ Qed.
 Lemma nth_error_eq
   {A : Type}
   (l1 l2 : list A)
-  (Hnth: forall n : nat, nth_error l1 n = nth_error l2 n)
+  (Hnth : forall n : nat, nth_error l1 n = nth_error l2 n)
   : l1 = l2.
 Proof.
   generalize dependent l2.
@@ -1222,7 +1222,7 @@ Proof.
   induction l.
   - by simpl in nz; lia.
   - simpl in *.
-    destruct (a <=? (list_max l)) eqn : eq_leb.
+    destruct (a <=? (list_max l)) eqn: eq_leb.
     + assert (Nat.max a (list_max l) = list_max l) by lia.
       by itauto congruence.
     + assert (Nat.max a (list_max l) = a) by lia.
@@ -1234,7 +1234,7 @@ Lemma list_max_exists2
    (Hne : l <> []) :
    In (list_max l) l.
 Proof.
-  destruct (list_max l) eqn : eq_max.
+  destruct (list_max l) eqn: eq_max.
   - destruct l; [by itauto congruence |].
     specialize (list_max_le (n :: l) 0) as Hle.
     destruct Hle as [Hle _].
@@ -1317,14 +1317,14 @@ Proof.
     induction l; intros.
     + by destruct pref; destruct suff;
         simpl in H; itauto (auto || congruence).
-    + destruct pref eqn : eq_pref.
+    + destruct pref eqn: eq_pref.
       rewrite complete_prefix_empty in H.
       inversion H.
       itauto.
       simpl.
       simpl in H.
       destruct (decide (a = a0)); [| done].
-      destruct (complete_prefix l l0) eqn : eq_cp; [| done].
+      destruct (complete_prefix l l0) eqn: eq_cp; [| done].
       inversion H; subst.
       f_equal.
       specialize (IHl l0 suff).
@@ -1357,7 +1357,7 @@ Proof.
   unfold complete_suffix.
   split.
   - intros.
-    destruct (complete_prefix (rev l) (rev suff)) eqn : eq_c.
+    destruct (complete_prefix (rev l) (rev suff)) eqn: eq_c.
     apply complete_prefix_correct in eq_c.
     rewrite H in eq_c.
     rewrite rev_app_distr in eq_c.
@@ -1402,7 +1402,7 @@ Definition list_sum_project_right
   :=
   map_option sum_project_right x.
 
-Lemma fold_right_andb_false l:
+Lemma fold_right_andb_false l :
   fold_right andb false l = false.
 Proof.
   induction l; cbn; [done |].
@@ -1422,7 +1422,7 @@ Proof.
   by eapply Listing_finite_transparent.
 Qed.
 
-Lemma sumbool_forall [A : Type] [P Q : A -> Prop]:
+Lemma sumbool_forall [A : Type] [P Q : A -> Prop] :
   (forall x : A, {P x} + {Q x}) -> forall l : list A, {Forall P l} + {Exists Q l}.
 Proof.
   induction l.
@@ -1430,7 +1430,7 @@ Proof.
   - by refine (if X a then if IHl then left _ else right _ else right _); constructor.
 Qed.
 
-Lemma list_sum_decrease [A: Type] (f g: A -> nat) (l: list A):
+Lemma list_sum_decrease [A : Type] (f g : A -> nat) (l : list A) :
   (forall a, In a l -> f a <= g a) -> Exists (fun a => f a < g a) l ->
   list_sum (map f l) < list_sum (map g l).
 Proof.
@@ -1451,11 +1451,11 @@ Qed.
   natural examples.
 *)
 Lemma fold_left_ind
-      [A B: Type] (f: B -> A -> B) (P : list A -> B -> B -> Prop)
+      [A B : Type] (f : B -> A -> B) (P : list A -> B -> B -> Prop)
       (Hstart : forall x, P nil x x)
       (Hstep : forall x a l r,
           P l (f x a) r ->
-          P (a :: l) x r):
+          P (a :: l) x r) :
   forall l x, P l x (fold_left f l x).
 Proof.
   induction l.
@@ -1469,10 +1469,10 @@ Qed.
   decomposes the list from the right.
 *)
 Lemma fold_left_ind_rev
-      [A B: Type] (f: B -> A -> B) (x0: B)
+      [A B : Type] (f : B -> A -> B) (x0 : B)
       (P : list A -> B -> Prop)
       (Hstart : P nil x0)
-      (Hstep: forall l a x, P l x -> P (l++a:: nil) (f x a)):
+      (Hstep : forall l a x, P l x -> P (l++a :: nil) (f x a)) :
   forall l, P l (fold_left f l x0).
 Proof.
   induction l using rev_ind.
@@ -1564,7 +1564,7 @@ Definition ForAllSuffix2 [A : Type] (R : A -> A -> Prop) : list A -> Prop :=
   ForAllSuffix (fun l => match l with | a :: b :: _ => R a b | _ => True end).
 
 Lemma fsFurther2_transitive [A : Type] (R : A -> A -> Prop) {HT : Transitive R}
-  : forall a b l, ForAllSuffix2 R (a:: b:: l) -> ForAllSuffix2 R (a:: l).
+  : forall a b l, ForAllSuffix2 R (a :: b :: l) -> ForAllSuffix2 R (a :: l).
 Proof.
   inversion 1. subst. destruct l.
   - by repeat constructor.
@@ -1608,14 +1608,14 @@ Proof.
       by intros b Hb; apply Hsub; right.
 Qed.
 
-Lemma elem_of_empty_nil [X: Type] (l: list X) :
+Lemma elem_of_empty_nil [X : Type] (l : list X) :
   (forall v, v ∉ l) -> l = [].
 Proof.
   destruct l as [| a]; [done |].
   by intro H; elim (H a); left.
 Qed.
 
-Lemma nodup_append_left {A}:
+Lemma nodup_append_left {A} :
   forall (l1 l2 : list A), NoDup (l1 ++ l2) -> NoDup l1.
 Proof.
   by intros l1 l2 [? _]%NoDup_app.
@@ -1645,13 +1645,13 @@ Proof.
   by apply submseteq_length, NoDup_submseteq.
 Qed.
 
-Lemma submseteq_tail_l [A] (x: A) l1 l2 :
+Lemma submseteq_tail_l [A] (x : A) l1 l2 :
   x :: l1 ⊆+ l2 -> l1 ⊆+ l2.
 Proof.
   by apply submseteq_trans, submseteq_cons.
 Qed.
 
-Lemma submseteq_list_subseteq [A] (l1 l2 : list A):
+Lemma submseteq_list_subseteq [A] (l1 l2 : list A) :
   l1 ⊆+ l2 -> l1 ⊆ l2.
 Proof.
   by intros H ? Hx; eapply elem_of_submseteq.

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -108,7 +108,7 @@ Lemma last_error_some {S}
   (Herr : last_error l = Some s) :
   List.last l random = s.
 Proof.
-  by destruct l; [|inversion Herr; apply unroll_last].
+  by destruct l; [| inversion Herr; apply unroll_last].
 Qed.
 
 Lemma incl_empty : forall A (l : list A),
@@ -396,7 +396,7 @@ Lemma list_prefix_length
   (Hlen : n <= length l)
   : length (list_prefix l n) = n.
 Proof.
-  by revert l Hlen; induction n; intros [|a l] Hlen; cbn in *;
+  by revert l Hlen; induction n; intros [| a l] Hlen; cbn in *;
     [| | inversion Hlen | rewrite IHn; lia].
 Qed.
 
@@ -406,7 +406,7 @@ Lemma list_suffix_length
   (n : nat)
   : length (list_suffix l n) = length l - n.
 Proof.
-  by revert l; induction n; intros [|a l]; [.. | apply IHn].
+  by revert l; induction n; intros [| a l]; [.. | apply IHn].
 Qed.
 
 Lemma list_prefix_prefix
@@ -531,7 +531,7 @@ Lemma list_annotate_eq
   (Hl2 : Forall P l2)
   : list_annotate P l1 Hl1 = list_annotate P l2 Hl2 <-> l1 = l2.
 Proof.
-  split; [|intro; subst; apply list_annotate_pi].
+  split; [| intro; subst; apply list_annotate_pi].
   revert Hl1 l2 Hl2.
   induction l1; destruct l2; simpl; intros; [done.. |].
   inversion H.
@@ -808,7 +808,7 @@ Lemma list_suffix_last_default
   (_default : A)
   : List.last (list_suffix l i) _default  = _default.
 Proof.
-  revert l Hlast; induction i; intros [|a l] Hlast; [done.. |].
+  revert l Hlast; induction i; intros [| a l] Hlast; [done.. |].
   by apply IHi; inversion Hlast.
 Qed.
 
@@ -938,7 +938,7 @@ Proof.
     destruct (f a) eqn:Hfa; swap 1 2.
     + destruct (IHl _ _ Happ_rev) as [_l1 [l2 [-> [<- <-]]]].
       by exists (a :: _l1), l2; cbn; rewrite Hfa.
-    + destruct l1' as [|_b l1']; swap 1 2.
+    + destruct l1' as [| _b l1']; swap 1 2.
       * change (_b :: l1') with ([_b] ++ l1') in Happ_rev.
         rewrite <- app_assoc in Happ_rev. inversion Happ_rev.
         subst _b.
@@ -1054,7 +1054,7 @@ Lemma nth_error_eq
   : l1 = l2.
 Proof.
   generalize dependent l2.
-  induction l1; intros [| a2 l2] Hnth; [done |..].
+  induction l1; intros [| a2 l2] Hnth; [done | ..].
   - by specialize (Hnth 0); simpl in Hnth; inversion Hnth.
   - by specialize (Hnth 0); simpl in Hnth; inversion Hnth.
   - assert (H0 := Hnth 0); cbn in H0; inversion H0; subst.
@@ -1209,7 +1209,7 @@ Proof.
   induction l; intros.
   - left. symmetry in Heql, Heq.
     by apply app_nil in Heql as [-> ->], Heq as [-> ->].
-  - destruct pre1 as [| a1 pre1]; destruct pre2 as [|a2 pre2]. 1-3: eauto.
+  - destruct pre1 as [| a1 pre1]; destruct pre2 as [| a2 pre2]. 1-3: eauto.
     inversion Heql; subst a1; clear Heql.
     inversion Heq; subst a2; clear Heq.
     by destruct (IHl pre1 suf1 pre2 suf2 H1 H2)

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -7,7 +7,7 @@ From VLSM.Lib Require Import Preamble.
 
 (** A list is empty if it has no members. *)
 Lemma empty_nil [X:Type] (l:list X) :
-  (forall v, ~In v l) -> l = [].
+  (forall v, ~ In v l) -> l = [].
 Proof.
   clear.
   destruct l as [| a]; cbn; [done |].
@@ -140,7 +140,7 @@ Lemma Exists_first
          (first : A),
          P first /\
          l = prefix ++ [first] ++ suffix /\
-         ~Exists P prefix.
+         ~ Exists P prefix.
 
 Proof.
   induction l; [by inversion Hsomething |].
@@ -1069,14 +1069,14 @@ Lemma exists_first
   {A : Type}
   (l : list A)
   (P : A -> Prop)
-  (Pdec : forall a : A, {P a } + {~P a})
+  (Pdec : forall a : A, {P a } + {~ P a})
   (Hsomething : Exists P l) :
   exists (prefix : list A)
          (suffix : list A)
          (first : A),
          (P first) /\
          l = prefix ++ [first] ++ suffix /\
-         ~Exists P prefix.
+         ~ Exists P prefix.
 Proof.
   induction l.
   - by inversion Hsomething.

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -907,8 +907,7 @@ Definition map_option
       match f x with
       | None => lb
       | Some b => b :: lb
-      end
-    )
+      end)
     [].
 
 Lemma map_option_app
@@ -1166,8 +1165,7 @@ Definition two_element_decompositions
         map
           (fun t => match t with (l2', e2, l3) => (l1, e1, l2', e2, l3) end)
           (one_element_decompositions l2)
-      end
-    )
+      end)
     (one_element_decompositions l).
 
 Lemma in_two_element_decompositions_iff

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -319,9 +319,9 @@ Fixpoint list_suffix
   (n : nat)
   {struct n}
   : list A
-  := match n,l with
-    | 0,_ => l
-    | _,[] => []
+  := match n, l with
+    | 0, _ => l
+    | _, [] => []
     | S n, a :: l => list_suffix l n
     end.
 
@@ -340,9 +340,9 @@ Fixpoint list_prefix
   (l : list A)
   (n : nat)
   : list A
-  := match n,l with
-    | 0,_ => []
-    | _,[] => []
+  := match n, l with
+    | 0, _ => []
+    | _, [] => []
     | S n, a :: l => a :: list_prefix l n
     end.
 
@@ -1129,7 +1129,7 @@ Proof.
   - by destruct pre; inversion H.
   - inversion H; subst; [done |].
     apply elem_of_list_fmap in H2 as [x0 [Heq Hin]].
-    destruct x0 as ((prex0,x0),sufx0).
+    destruct x0 as ((prex0, x0), sufx0).
     specialize (IHl prex0 x0 sufx0).
     apply IHl in Hin.
     by inversion Heq; subst.
@@ -1164,7 +1164,7 @@ Definition two_element_decompositions
       match t with
         (l1, e1, l2) =>
         map
-          (fun t => match t with (l2',e2, l3) => (l1, e1, l2', e2, l3) end)
+          (fun t => match t with (l2', e2, l3) => (l1, e1, l2', e2, l3) end)
           (one_element_decompositions l2)
       end
     )

--- a/theories/VLSM/Lib/ListFinSetExtras.v
+++ b/theories/VLSM/Lib/ListFinSetExtras.v
@@ -10,9 +10,9 @@ Definition set := C.
 
 Definition empty_set : set := ∅.
 
-Definition set_add (a : A) (x : set) : set := {[a]} ∪ x.
+Definition set_add (a : A) (x : set) : set := {[ a ]} ∪ x.
 
-Definition set_remove (a : A) (x : set) : set := x ∖ {[a]}.
+Definition set_remove (a : A) (x : set) : set := x ∖ {[ a ]}.
 
 Definition set_union (x y : set) : set := x ∪ y.
 

--- a/theories/VLSM/Lib/ListFinSetExtras.v
+++ b/theories/VLSM/Lib/ListFinSetExtras.v
@@ -12,7 +12,7 @@ Definition empty_set : set := ∅.
 
 Definition set_add (a : A) (x : set) : set := {[a]} ∪ x.
 
-Definition set_remove (a : A) (x : set) : set := x ∖ {[ a ]}.
+Definition set_remove (a : A) (x : set) : set := x ∖ {[a]}.
 
 Definition set_union (x y : set) : set := x ∪ y.
 

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -64,7 +64,7 @@ Lemma set_eq_empty_iff
   : forall (l : list A),
     set_eq l [] <-> l = [].
 Proof.
-  split; intros; [|subst; apply set_eq_refl].
+  split; intros; [| subst; apply set_eq_refl].
   destruct l as [| hd tl]; [done |].
   destruct H.
   specialize (H hd (elem_of_list_here hd tl)).
@@ -278,7 +278,7 @@ Lemma filter_set_add `{StrictlyComparable X} P
   forall (l:list X) x, ~ P x ->
   filter P l = filter P (set_add x l).
 Proof.
-  induction l as [|hd tl IHl]; intros x H_false; cbn.
+  induction l as [| hd tl IHl]; intros x H_false; cbn.
   - by rewrite decide_False.
   - destruct (decide (x = hd)); cbn; [done |].
     by destruct (decide (P hd)); rewrite <- IHl.
@@ -289,7 +289,7 @@ Lemma set_add_ignore `{StrictlyComparable X} :
     x ∈ l ->
     set_add x l = l.
 Proof.
-  induction l as [|hd tl IHl]; inversion 1; subst; cbn.
+  induction l as [| hd tl IHl]; inversion 1; subst; cbn.
   - by rewrite decide_True.
   - by case_decide; [| rewrite IHl].
 Qed.
@@ -448,7 +448,7 @@ Qed.
 Lemma set_diff_nodup' `{EqDecision A} (l l' : list A)
   : NoDup l -> NoDup (set_diff l l').
 Proof.
- induction 1 as [|x l H H' IH]; simpl.
+ induction 1 as [| x l H H' IH]; simpl.
  - by constructor.
  - case_decide.
    + by apply IH.

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -496,10 +496,10 @@ Qed.
 Definition set_remove_list `{EqDecision A} (l1 l2 : list A) : list A :=
   fold_right set_remove l2 l1.
 
-Example set_remove_list1 : set_remove_list [3;1;3] [1;1;2;3;3;3;3] = [1;2;3;3].
+Example set_remove_list1 : set_remove_list [3; 1; 3] [1; 1; 2; 3; 3; 3; 3] = [1; 2; 3; 3].
 Proof. done. Qed.
 
-Example set_remove_list2 : set_remove_list [4] [1;2;3] = [1;2;3].
+Example set_remove_list2 : set_remove_list [4] [1; 2; 3] = [1; 2; 3].
 Proof. done. Qed.
 
 Lemma set_remove_list_1
@@ -548,7 +548,7 @@ Definition set_diff_filter `{EqDecision A} (l r : list A) :=
 Lemma set_diff_filter_iff `{EqDecision A} (a:A) l r:
   a ∈ set_diff_filter l r <-> a ∈ l /\ a ∉ r.
 Proof.
-  induction l;simpl.
+  induction l; simpl.
   - by cbn; split; intros; [inversion H | itauto].
   - unfold set_diff_filter in *.
     rewrite filter_cons.
@@ -604,7 +604,7 @@ Proof.
     destruct (decide (new ∉ b)); [| by contradict n0; itauto].
     simpl.
     by apply le_n_S, len_set_diff_incl_le.
-  - specialize (IHl H);clear H.
+  - specialize (IHl H); clear H.
     unfold set_diff_filter.
     rewrite 2 filter_cons.
     destruct (decide (a0 ∉ a)); destruct (decide (a0 ∉ b)).

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -170,7 +170,7 @@ Qed.
 
 Lemma set_union_iterated_subseteq
   `{EqDecision A}
-  (ss ss': list (set A))
+  (ss ss' : list (set A))
   (Hincl : ss ⊆ ss') :
   fold_right set_union [] ss ⊆
   fold_right set_union [] ss'.
@@ -274,8 +274,8 @@ Proof.
 Qed.
 
 Lemma filter_set_add `{StrictlyComparable X} P
-  `{forall (x: X), Decision (P x)} :
-  forall (l: list X) x, ~ P x ->
+  `{forall (x : X), Decision (P x)} :
+  forall (l : list X) x, ~ P x ->
   filter P l = filter P (set_add x l).
 Proof.
   induction l as [| hd tl IHl]; intros x H_false; cbn.
@@ -294,8 +294,8 @@ Proof.
   - by case_decide; [| rewrite IHl].
 Qed.
 
-Lemma set_add_new `{EqDecision A}:
-  forall (x: A) l, x ∉ l -> set_add x l = l++[x].
+Lemma set_add_new `{EqDecision A} :
+  forall (x : A) l, x ∉ l -> set_add x l = l++[x].
 Proof.
   induction l; cbn; [done |]; intros H_not_in.
   rewrite decide_False; cycle 1.
@@ -321,7 +321,7 @@ Proof.
 Qed.
 
 Lemma set_remove_first `{EqDecision A} : forall x y (s : list A),
-  x = y -> set_remove x (y:: s) = s.
+  x = y -> set_remove x (y :: s) = s.
 Proof.
   by intros x y s ->; cbn; rewrite decide_True.
 Qed.
@@ -466,7 +466,7 @@ Proof.
   - by intros a; apply (set_diff_elim2 a s1).
 Qed.
 
-Lemma add_remove_inverse `{EqDecision X}:
+Lemma add_remove_inverse `{EqDecision X} :
   forall (lv : list X) (v : X),
     v ∉ lv ->
     set_remove v (set_add v lv) = lv.
@@ -515,7 +515,7 @@ Proof.
   - by simpl in Hin; apply set_remove_1, IHl1 in Hin.
 Qed.
 
-Lemma set_prod_nodup `(s1: set A) `(s2: set B):
+Lemma set_prod_nodup `(s1 : set A) `(s2 : set B) :
   NoDup s1 ->
   NoDup s2 ->
   NoDup (set_prod s1 s2).
@@ -545,7 +545,7 @@ Definition set_diff_filter `{EqDecision A} (l r : list A) :=
   The characteristic membership property, parallel to
   [set_diff_iff].
 *)
-Lemma set_diff_filter_iff `{EqDecision A} (a: A) l r:
+Lemma set_diff_filter_iff `{EqDecision A} (a : A) l r :
   a ∈ set_diff_filter l r <-> a ∈ l /\ a ∉ r.
 Proof.
   induction l; simpl.
@@ -559,7 +559,7 @@ Proof.
       by split; itauto congruence.
 Qed.
 
-Lemma set_diff_filter_nodup `{EqDecision A} (l r: list A):
+Lemma set_diff_filter_nodup `{EqDecision A} (l r : list A) :
   NoDup l -> NoDup (set_diff_filter l r).
 Proof.
   by intros H; apply NoDup_filter.
@@ -570,8 +570,8 @@ Qed.
   a smaller result.
   This lemma is used to prove [len_set_diff_decrease].
 *)
-Lemma len_set_diff_incl_le `{EqDecision A} (l a b: list A)
-      (H_subseteq: forall x, x ∈ b -> x ∈ a):
+Lemma len_set_diff_incl_le `{EqDecision A} (l a b : list A)
+      (H_subseteq : forall x, x ∈ b -> x ∈ a) :
   length (set_diff_filter l a) <= length (set_diff_filter l b).
 Proof.
   induction l; [done |].
@@ -589,10 +589,10 @@ Qed.
   by adding an element actually found in <<l>> will decrease
   the size of the result.
 *)
-Lemma len_set_diff_decrease `{EqDecision A} (new: A) (l a b: list A)
-      (H_subseteq: forall x, x ∈ b -> x ∈ a)
-      (H_new_is_new: new ∈ a /\ new ∉ b)
-      (H_new_is_relevant: new ∈ l):
+Lemma len_set_diff_decrease `{EqDecision A} (new : A) (l a b : list A)
+      (H_subseteq : forall x, x ∈ b -> x ∈ a)
+      (H_new_is_new : new ∈ a /\ new ∉ b)
+      (H_new_is_relevant : new ∈ l) :
   length (set_diff_filter l a) < length (set_diff_filter l b).
 Proof.
   induction l; [by inversion H_new_is_relevant |];
@@ -620,10 +620,10 @@ Proof.
     + by apply IHl.
 Qed.
 
-Lemma len_set_diff_map_set_add `{EqDecision B} (new: B) `{EqDecision A} (f: B -> A)
-      (a: list B) (l: list A)
-      (H_new_is_new: f new ∉ map f a)
-      (H_new_is_relevant: f new ∈ l):
+Lemma len_set_diff_map_set_add `{EqDecision B} (new : B) `{EqDecision A} (f : B -> A)
+      (a : list B) (l : list A)
+      (H_new_is_new : f new ∉ map f a)
+      (H_new_is_relevant : f new ∈ l) :
   length (set_diff_filter l (map f (set_add new a))) <
     length (set_diff_filter l (map f a)).
 Proof.
@@ -665,7 +665,7 @@ Proof.
 Qed.
 
 Lemma filter_set_eq {X} P Q
- `{forall (x: X), Decision (P x)} `{forall (x: X), Decision (Q x)}
+ `{forall (x : X), Decision (P x)} `{forall (x : X), Decision (Q x)}
    (l : list X)
    (resf := filter P l)
    (resg := filter Q l) :
@@ -722,7 +722,7 @@ Proof.
          by exists needle.
 Qed.
 
-Lemma subseteq_Forall (A: Type) (P : A -> Prop) (l1 l2 : list A) :
+Lemma subseteq_Forall (A : Type) (P : A -> Prop) (l1 l2 : list A) :
  l2 ⊆ l1 -> Forall P l1 -> Forall P l2.
 Proof.
   intros Hsub Hfor.

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -274,8 +274,8 @@ Proof.
 Qed.
 
 Lemma filter_set_add `{StrictlyComparable X} P
-  `{forall (x:X), Decision (P x)} :
-  forall (l:list X) x, ~ P x ->
+  `{forall (x: X), Decision (P x)} :
+  forall (l: list X) x, ~ P x ->
   filter P l = filter P (set_add x l).
 Proof.
   induction l as [| hd tl IHl]; intros x H_false; cbn.
@@ -295,7 +295,7 @@ Proof.
 Qed.
 
 Lemma set_add_new `{EqDecision A}:
-  forall (x:A) l, x ∉ l -> set_add x l = l++[x].
+  forall (x: A) l, x ∉ l -> set_add x l = l++[x].
 Proof.
   induction l; cbn; [done |]; intros H_not_in.
   rewrite decide_False; cycle 1.
@@ -321,7 +321,7 @@ Proof.
 Qed.
 
 Lemma set_remove_first `{EqDecision A} : forall x y (s : list A),
-  x = y -> set_remove x (y::s) = s.
+  x = y -> set_remove x (y:: s) = s.
 Proof.
   by intros x y s ->; cbn; rewrite decide_True.
 Qed.
@@ -545,7 +545,7 @@ Definition set_diff_filter `{EqDecision A} (l r : list A) :=
   The characteristic membership property, parallel to
   [set_diff_iff].
 *)
-Lemma set_diff_filter_iff `{EqDecision A} (a:A) l r:
+Lemma set_diff_filter_iff `{EqDecision A} (a: A) l r:
   a ∈ set_diff_filter l r <-> a ∈ l /\ a ∉ r.
 Proof.
   induction l; simpl.
@@ -559,7 +559,7 @@ Proof.
       by split; itauto congruence.
 Qed.
 
-Lemma set_diff_filter_nodup `{EqDecision A} (l r:list A):
+Lemma set_diff_filter_nodup `{EqDecision A} (l r: list A):
   NoDup l -> NoDup (set_diff_filter l r).
 Proof.
   by intros H; apply NoDup_filter.
@@ -589,7 +589,7 @@ Qed.
   by adding an element actually found in <<l>> will decrease
   the size of the result.
 *)
-Lemma len_set_diff_decrease `{EqDecision A} (new:A) (l a b: list A)
+Lemma len_set_diff_decrease `{EqDecision A} (new: A) (l a b: list A)
       (H_subseteq: forall x, x ∈ b -> x ∈ a)
       (H_new_is_new: new ∈ a /\ new ∉ b)
       (H_new_is_relevant: new ∈ l):
@@ -620,7 +620,7 @@ Proof.
     + by apply IHl.
 Qed.
 
-Lemma len_set_diff_map_set_add `{EqDecision B} (new:B) `{EqDecision A} (f: B -> A)
+Lemma len_set_diff_map_set_add `{EqDecision B} (new: B) `{EqDecision A} (f: B -> A)
       (a: list B) (l: list A)
       (H_new_is_new: f new ∉ map f a)
       (H_new_is_relevant: f new ∈ l):
@@ -665,7 +665,7 @@ Proof.
 Qed.
 
 Lemma filter_set_eq {X} P Q
- `{forall (x:X), Decision (P x)} `{forall (x:X), Decision (Q x)}
+ `{forall (x: X), Decision (P x)} `{forall (x: X), Decision (Q x)}
    (l : list X)
    (resf := filter P l)
    (resg := filter Q l) :
@@ -722,7 +722,7 @@ Proof.
          by exists needle.
 Qed.
 
-Lemma subseteq_Forall (A:Type) (P : A -> Prop) (l1 l2 : list A) :
+Lemma subseteq_Forall (A: Type) (P : A -> Prop) (l1 l2 : list A) :
  l2 ⊆ l1 -> Forall P l1 -> Forall P l2.
 Proof.
   intros Hsub Hfor.

--- a/theories/VLSM/Lib/Measurable.v
+++ b/theories/VLSM/Lib/Measurable.v
@@ -67,7 +67,7 @@ Proof.
   - inversion Hnodup; subst; clear Hnodup.
     apply Rplus_eq_compat_l.
     by rewrite decide_True.
-  - inversion Hnodup as [|? ? Ha Hnodup']; subst; clear Hnodup.
+  - inversion Hnodup as [| ? ? Ha Hnodup']; subst; clear Hnodup.
     pose proof (in_not_in _ _ _ _ Hv' Ha).
     rewrite decide_False; cbn; [| done].
     rewrite <- Rplus_assoc, (Rplus_comm (proj1_sig (weight v))), Rplus_assoc.

--- a/theories/VLSM/Lib/NeList.v
+++ b/theories/VLSM/Lib/NeList.v
@@ -9,7 +9,7 @@ Inductive ne_list (A : Type) : Type :=
 Arguments nel_singl  {_} _ : assert.
 Arguments nel_cons {_} _ _ : assert.
 
-Infix ":::" := nel_cons (at level 60, right associativity).
+Infix "::: " := nel_cons (at level 60, right associativity).
 
 Definition ne_list_hd {A} (l : ne_list A) : A :=
   match l with

--- a/theories/VLSM/Lib/NeList.v
+++ b/theories/VLSM/Lib/NeList.v
@@ -103,7 +103,7 @@ Definition NeList_to_ne_list {A} (l : NeList A) : ne_list A :=
 Lemma NeList_to_ne_list_unroll {A} (a b : A) (l : list A) :
   NeList_to_ne_list {| nl_hd := a; nl_tl := b :: l |}
     =
-  nel_cons a (NeList_to_ne_list {| nl_hd := b; nl_tl := l|}).
+  nel_cons a (NeList_to_ne_list {| nl_hd := b; nl_tl := l |}).
 Proof. done. Qed.
 
 Lemma NeList_to_ne_list_to_list {A} :

--- a/theories/VLSM/Lib/NeList.v
+++ b/theories/VLSM/Lib/NeList.v
@@ -9,7 +9,7 @@ Inductive ne_list (A : Type) : Type :=
 Arguments nel_singl  {_} _ : assert.
 Arguments nel_cons {_} _ _ : assert.
 
-Infix "::: " := nel_cons (at level 60, right associativity).
+Infix ":::" := nel_cons (at level 60, right associativity).
 
 Definition ne_list_hd {A} (l : ne_list A) : A :=
   match l with

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -8,7 +8,7 @@ From Coq Require Import Eqdep_dec.
 Tactic Notation "spec" hyp(H) :=
   match type of H with ?a -> _ =>
   let H1 := fresh in (assert (H1: a);
-  [|generalize (H H1); clear H H1; intro H]) end.
+  [| generalize (H H1); clear H H1; intro H]) end.
 
 (** ** Basic logic *)
 

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -626,7 +626,7 @@ Definition liveness (P : nat -> Prop)
   := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2}.
 
 Definition liveness_dec (P : nat -> Prop)
-  := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2} + {~ exists n2:nat, n1 <= n2 /\ P n2}.
+  := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2} + {~ exists n2: nat, n1 <= n2 /\ P n2}.
 
 Definition min_liveness (P : nat -> Prop)
   := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2
@@ -635,7 +635,7 @@ Definition min_liveness (P : nat -> Prop)
 Lemma not_bounding_impl_liveness
   (P : nat -> Prop)
   (Hdec : liveness_dec P)
-  (Hnbound : ~ exists n1:nat, forall (n2:nat), n1 <= n2 -> ~ P n2)
+  (Hnbound : ~ exists n1: nat, forall (n2: nat), n1 <= n2 -> ~ P n2)
   : liveness P.
 Proof.
   intros n1.

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -7,12 +7,12 @@ From Coq Require Import Eqdep_dec.
 
 Tactic Notation "spec" hyp(H) :=
   match type of H with ?a -> _ =>
-  let H1 := fresh in (assert (H1: a);
+  let H1 := fresh in (assert (H1 : a);
   [| generalize (H H1); clear H H1; intro H]) end.
 
 (** ** Basic logic *)
 
-Lemma Is_true_iff_eq_true: forall x: bool, x = true <-> x.
+Lemma Is_true_iff_eq_true : forall x : bool, x = true <-> x.
 Proof.
   split.
   - by apply Is_true_eq_left.
@@ -626,7 +626,7 @@ Definition liveness (P : nat -> Prop)
   := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2}.
 
 Definition liveness_dec (P : nat -> Prop)
-  := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2} + {~ exists n2: nat, n1 <= n2 /\ P n2}.
+  := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2} + {~ exists n2 : nat, n1 <= n2 /\ P n2}.
 
 Definition min_liveness (P : nat -> Prop)
   := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2
@@ -635,7 +635,7 @@ Definition min_liveness (P : nat -> Prop)
 Lemma not_bounding_impl_liveness
   (P : nat -> Prop)
   (Hdec : liveness_dec P)
-  (Hnbound : ~ exists n1: nat, forall (n2: nat), n1 <= n2 -> ~ P n2)
+  (Hnbound : ~ exists n1 : nat, forall (n2 : nat), n1 <= n2 -> ~ P n2)
   : liveness P.
 Proof.
   intros n1.

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -33,7 +33,7 @@ Lemma Decision_and : forall {P Q}, Decision P -> Decision Q -> Decision (P /\ Q)
 Proof. by firstorder. Qed.
 Lemma Decision_or : forall {P Q}, Decision P -> Decision Q -> Decision (P \/ Q).
 Proof. by firstorder. Qed.
-Lemma Decision_not : forall {P}, Decision P -> Decision (~P).
+Lemma Decision_not : forall {P}, Decision P -> Decision (~ P).
 Proof. by firstorder. Qed.
 
 #[export] Instance bool_decision {b : bool} : Decision b :=
@@ -620,13 +620,13 @@ Qed.
 (** ** Liveness *)
 
 Definition bounding (P : nat -> Prop)
-  :=  {n1 : nat | forall (n2 : nat), n1 <= n2 -> ~P n2}.
+  :=  {n1 : nat | forall (n2 : nat), n1 <= n2 -> ~ P n2}.
 
 Definition liveness (P : nat -> Prop)
   := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2}.
 
 Definition liveness_dec (P : nat -> Prop)
-  := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2} + {~exists n2:nat, n1 <= n2 /\ P n2}.
+  := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2} + {~ exists n2:nat, n1 <= n2 /\ P n2}.
 
 Definition min_liveness (P : nat -> Prop)
   := forall (n1 : nat), { n2 : nat | n1 <= n2 /\ P n2
@@ -635,7 +635,7 @@ Definition min_liveness (P : nat -> Prop)
 Lemma not_bounding_impl_liveness
   (P : nat -> Prop)
   (Hdec : liveness_dec P)
-  (Hnbound : ~exists n1:nat, forall (n2:nat), n1 <= n2 -> ~P n2)
+  (Hnbound : ~ exists n1:nat, forall (n2:nat), n1 <= n2 -> ~ P n2)
   : liveness P.
 Proof.
   intros n1.
@@ -664,7 +664,7 @@ Definition sum_project_right {A B : Type} (x : A + B) : option B :=
   | inr b => Some b
   end.
 
-Program Definition not_lt_plus_dec {m n} (Hnlt : ~n < m) : {k | k + m = n} :=
+Program Definition not_lt_plus_dec {m n} (Hnlt : ~ n < m) : {k | k + m = n} :=
   exist _ (n - m) _.
 Next Obligation.
 Proof. by cbn; lia. Qed.

--- a/theories/VLSM/Lib/SortedLists.v
+++ b/theories/VLSM/Lib/SortedLists.v
@@ -7,7 +7,7 @@ From VLSM.Lib Require Import Preamble ListExtras ListSetExtras.
 
 Fixpoint list_compare {A} (compare : A -> A -> comparison)
     (l1 l2 : list A) : comparison :=
-  match l1,l2 with
+  match l1, l2 with
   | [], [] => Eq
   | [], _ => Lt
   | _, [] => Gt

--- a/theories/VLSM/Lib/SortedLists.v
+++ b/theories/VLSM/Lib/SortedLists.v
@@ -358,7 +358,7 @@ Proof.
   apply elem_of_app in Hin_y.
   rewrite elem_of_cons in Hin_y.
   assert (y =x \/ y ∈ pref1 ++ suf1). {
-    destruct Hin_y as [Hin_y|Hin_y]; [|destruct Hin_y].
+    destruct Hin_y as [Hin_y | Hin_y]; [| destruct Hin_y].
     - by right; apply elem_of_app; left.
     - by left.
     - by right; apply elem_of_app; right.

--- a/theories/VLSM/Lib/SortedLists.v
+++ b/theories/VLSM/Lib/SortedLists.v
@@ -33,8 +33,8 @@ Proof.
   - intros x y. generalize dependent x.
     by induction y; intros; destruct x; destruct z; try done
     ; destruct c; try done
-    ; inversion H; clear H; destruct (compare a0 a) eqn:Ha0; try done
-    ; inversion H0; clear H0; destruct (compare a a1) eqn:Ha1; try done
+    ; inversion H; clear H; destruct (compare a0 a) eqn: Ha0; try done
+    ; inversion H0; clear H0; destruct (compare a a1) eqn: Ha1; try done
     ; try apply (IHy _ _ _ H2) in H1; try apply (T _ _ _ _ Ha0) in Ha1
     ; try apply R in Ha0; subst
     ; try (by simpl; rewrite Ha1; try rewrite H1, H2)
@@ -78,7 +78,7 @@ Proof.
   intros. induction sigma; simpl in H0.
   - rewrite elem_of_cons in H0.
     by destruct H0 as [H0 | H0]; subst; try inversion H0; left.
-  - destruct (compare msg a) eqn:Hcmp.
+  - destruct (compare msg a) eqn: Hcmp.
     + by rewrite compare_eq in Hcmp; subst; right.
     + rewrite elem_of_cons in H0.
       by destruct H0 as [Heq | Hin]; subst; [left | right].
@@ -210,7 +210,7 @@ Proof.
   - by subst; simpl; rewrite compare_eq_refl.
   - apply LocallySorted_tl in H0 as LS.
     specialize (IHsigma LS Hin). simpl.
-    destruct (compare msg a) eqn:Hcmp; try rewrite IHsigma; [done | | done].
+    destruct (compare msg a) eqn: Hcmp; try rewrite IHsigma; [done | | done].
     apply (@LocallySorted_elem_of_lt _ _ compare_lt_strict_order msg a sigma H0) in Hin.
     unfold compare_lt in Hin.
     by rewrite compare_asymmetric, Hcmp in Hin; inversion Hin.

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -537,7 +537,7 @@ Proof.
   generalize dependent lb2. generalize dependent la2.
   generalize dependent b. generalize dependent lb1.
   generalize dependent a.
-  induction la1; intros; destruct lb1 as [|b0 lb1]; simpl in *
+  induction la1; intros; destruct lb1 as [| b0 lb1]; simpl in *
   ; inversion Heq; subst.
   - by contradict Ha; left.
   - by exists lb1.

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -73,7 +73,7 @@ Proof.
   by destruct l.
 Qed.
 
-Lemma existsb_Exists {A} (f : A -> bool):
+Lemma existsb_Exists {A} (f : A -> bool) :
   forall l, existsb f l = true <-> Exists (fun x => f x = true) l.
 Proof.
   intro l.
@@ -129,7 +129,7 @@ Proof.
   - by apply existsb_Exists.
 Qed.
 
-Lemma existsb_forall {A} (f : A -> bool):
+Lemma existsb_forall {A} (f : A -> bool) :
   forall l, existsb f l = false <-> forall x, In x l -> f x = false.
 Proof.
   intro l.
@@ -163,11 +163,11 @@ Qed.
 *)
 
 Definition maximal_elements_list
-  {A} (precedes: relation A) `{!RelDecision precedes} (l : list A)
+  {A} (precedes : relation A) `{!RelDecision precedes} (l : list A)
   : list A :=
   filter (fun a => Forall (fun b => ~ precedes a b) l) l.
 
-Example maximal_elements_list1: maximal_elements_list Nat.lt [1; 4; 2; 4] = [4; 4].
+Example maximal_elements_list1 : maximal_elements_list Nat.lt [1; 4; 2; 4] = [4; 4].
 Proof. by itauto. Qed.
 
 Example maximal_elements_list2 : maximal_elements_list Nat.le [1; 4; 2; 4] = [].
@@ -179,12 +179,12 @@ Proof. by itauto. Qed.
 *)
 Definition maximal_elements_set
   `{HfinSetMessage : FinSet A SetA}
-   (precedes: relation A) `{!RelDecision precedes} (s : SetA)
+   (precedes : relation A) `{!RelDecision precedes} (s : SetA)
    : SetA :=
     filter (fun a => set_Forall (fun b => ~ precedes a b) s) s.
 
 Lemma filter_ext_elem_of {A} P Q
- `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)} (l: list A) :
+ `{forall (x : A), Decision (P x)} `{forall (x : A), Decision (Q x)} (l : list A) :
  (forall a, a ∈ l -> (P a <-> Q a)) ->
  filter P l = filter Q l.
 Proof.
@@ -196,7 +196,7 @@ Proof.
 Qed.
 
 Lemma ext_elem_of_filter {A} P Q
- `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)}
+ `{forall (x : A), Decision (P x)} `{forall (x : A), Decision (Q x)}
  (l : list A) :
  filter P l = filter Q l -> forall a, a ∈ l -> (P a <-> Q a).
 Proof.
@@ -207,7 +207,7 @@ Proof.
 Qed.
 
 Lemma filter_complement {X} P Q
- `{forall (x: X), Decision (P x)} `{forall (x: X), Decision (Q x)}
+ `{forall (x : X), Decision (P x)} `{forall (x : X), Decision (Q x)}
  (l : list X) :
  filter P l = filter Q l <->
  filter (fun x => ~ P x) l = filter (fun x => ~ Q x) l.
@@ -351,7 +351,7 @@ Proof.
   by apply drop_S.
 Qed.
 
-Lemma filter_in {A} P `{forall (x: A), Decision (P x)} x s :
+Lemma filter_in {A} P `{forall (x : A), Decision (P x)} x s :
   In x s ->
   P x ->
   In x (filter P s).
@@ -363,7 +363,7 @@ Proof.
 Qed.
 
 Lemma filter_incl_fn {A} P Q
-  `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)} :
+  `{forall (x : A), Decision (P x)} `{forall (x : A), Decision (Q x)} :
   (forall a, P a -> Q a) ->
   forall s, incl (filter P s) (filter Q s).
 Proof.
@@ -374,7 +374,7 @@ Proof.
 Qed.
 
 Lemma filter_length_fn {A} P Q
-  `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)}
+  `{forall (x : A), Decision (P x)} `{forall (x : A), Decision (Q x)}
   s (Hfg : Forall (fun a => P a -> Q a) s) :
   length (filter P s) <= length (filter Q s).
 Proof.
@@ -385,7 +385,7 @@ Proof.
 Qed.
 
 Lemma filter_eq_fn {A} P Q
- `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)} s :
+ `{forall (x : A), Decision (P x)} `{forall (x : A), Decision (Q x)} s :
   (forall a, In a s -> P a <-> Q a) ->
   filter P s = filter Q s.
 Proof.
@@ -398,7 +398,7 @@ Proof.
 Qed.
 
 Lemma nth_error_filter
-  {A} P `{forall (x: A), Decision (P x)}
+  {A} P `{forall (x : A), Decision (P x)}
   (l : list A)
   (n : nat)
   (a : A)
@@ -424,7 +424,7 @@ Proof.
       by rewrite Hnth'.
 Qed.
 
-Lemma filter_subseteq {A} P `{forall (x: A), Decision (P x)} (s1 s2 : list A) :
+Lemma filter_subseteq {A} P `{forall (x : A), Decision (P x)} (s1 s2 : list A) :
   s1 ⊆ s2 ->
   filter P s1 ⊆ filter P s2.
 Proof.
@@ -443,7 +443,7 @@ Proof.
 Qed.
 
 Lemma filter_subseteq_fn {A} P Q
-  `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)} :
+  `{forall (x : A), Decision (P x)} `{forall (x : A), Decision (Q x)} :
   (forall a, P a -> Q a) ->
   forall (s : list A), filter P s ⊆ filter Q s.
 Proof.
@@ -455,7 +455,7 @@ Proof.
   - by itauto.
 Qed.
 
-Lemma filter_incl {A} P `{forall (x: A), Decision (P x)} s1 s2 :
+Lemma filter_incl {A} P `{forall (x : A), Decision (P x)} s1 s2 :
   incl s1 s2 ->
   incl (filter P s1) (filter P s2).
 Proof.
@@ -469,7 +469,7 @@ Proof.
     by intros y HIn; apply H0; right.
 Qed.
 
-Lemma Forall_filter_nil {A} P `{forall (x: A), Decision (P x)} l :
+Lemma Forall_filter_nil {A} P `{forall (x : A), Decision (P x)} l :
   Forall (fun a : A => ~ P a) l <-> filter P l = [].
 Proof.
   rewrite Forall_forall.
@@ -634,14 +634,14 @@ Lemma list_max_elem_of_exists2
    (Hne : l <> []) :
    list_max l ∈ l.
 Proof.
-  destruct (list_max l) eqn : eq_max.
+  destruct (list_max l) eqn: eq_max.
   - destruct l; [by itauto congruence |].
     specialize (list_max_le (n :: l) 0) as Hle.
     destruct Hle as [Hle _].
     rewrite eq_max in Hle. spec Hle. apply Nat.le_refl.
     rewrite Forall_forall in Hle.
     specialize (Hle n). spec Hle. left.
-    assert (Hn0: n = 0) by lia.
+    assert (Hn0 : n = 0) by lia.
     by rewrite Hn0; left.
   - specialize (list_max_elem_of_exists l) as Hmax.
     by rewrite <- eq_max; itauto lia.
@@ -657,7 +657,7 @@ Proof.
   remember (a :: l) as l'.
   remember (List.map (count_occ decide_eq l') l') as occurrences.
 
-  assert (Hmaxp: list_max occurrences > 0). {
+  assert (Hmaxp : list_max occurrences > 0). {
     rewrite Heqoccurrences, Heql'; cbn.
     by rewrite decide_True; [lia |].
   }

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -102,7 +102,7 @@ Proof.
     by itauto.
   - apply Exists_app in Hsomething.
     destruct Hsomething; [| by inversion H; [| inversion H1]].
-    specialize (IHl H);clear H.
+    specialize (IHl H); clear H.
     destruct IHl as [prefix [suffix [last [Hf [-> Hnone_after]]]]].
     exists prefix, (suffix ++ [x]), last.
     simpl. rewrite app_assoc_reverse. simpl.
@@ -167,7 +167,7 @@ Definition maximal_elements_list
   : list A :=
   filter (fun a => Forall (fun b => ~ precedes a b) l) l.
 
-Example maximal_elements_list1: maximal_elements_list Nat.lt [1; 4; 2; 4] = [4;4].
+Example maximal_elements_list1: maximal_elements_list Nat.lt [1; 4; 2; 4] = [4; 4].
 Proof. by itauto. Qed.
 
 Example maximal_elements_list2 : maximal_elements_list Nat.le [1; 4; 2; 4] = [].

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -92,7 +92,7 @@ Lemma Exists_last
          (last : A),
          P last /\
          l = prefix ++ [last] ++ suffix /\
-         ~Exists P suffix.
+         ~ Exists P suffix.
 
 Proof.
   induction l using rev_ind; [by inversion Hsomething |].

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -493,7 +493,7 @@ Lemma elem_of_list_annotate_forget
 Proof.
   induction l.
   - by inversion Hin.
-  - rewrite list_annotate_unroll,elem_of_cons in Hin.
+  - rewrite list_annotate_unroll, elem_of_cons in Hin.
     destruct Hin as [-> | Hin].
     + by left.
     + by right; apply (IHl (Forall_tl Hs)).

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -184,7 +184,7 @@ Definition maximal_elements_set
     filter (fun a => set_Forall (fun b => ~ precedes a b) s) s.
 
 Lemma filter_ext_elem_of {A} P Q
- `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)} (l:list A) :
+ `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)} (l: list A) :
  (forall a, a ∈ l -> (P a <-> Q a)) ->
  filter P l = filter Q l.
 Proof.
@@ -196,7 +196,7 @@ Proof.
 Qed.
 
 Lemma ext_elem_of_filter {A} P Q
- `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)}
+ `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)}
  (l : list A) :
  filter P l = filter Q l -> forall a, a ∈ l -> (P a <-> Q a).
 Proof.
@@ -207,7 +207,7 @@ Proof.
 Qed.
 
 Lemma filter_complement {X} P Q
- `{forall (x:X), Decision (P x)} `{forall (x:X), Decision (Q x)}
+ `{forall (x: X), Decision (P x)} `{forall (x: X), Decision (Q x)}
  (l : list X) :
  filter P l = filter Q l <->
  filter (fun x => ~ P x) l = filter (fun x => ~ Q x) l.
@@ -351,7 +351,7 @@ Proof.
   by apply drop_S.
 Qed.
 
-Lemma filter_in {A} P `{forall (x:A), Decision (P x)} x s :
+Lemma filter_in {A} P `{forall (x: A), Decision (P x)} x s :
   In x s ->
   P x ->
   In x (filter P s).
@@ -363,7 +363,7 @@ Proof.
 Qed.
 
 Lemma filter_incl_fn {A} P Q
-  `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)} :
+  `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)} :
   (forall a, P a -> Q a) ->
   forall s, incl (filter P s) (filter Q s).
 Proof.
@@ -374,7 +374,7 @@ Proof.
 Qed.
 
 Lemma filter_length_fn {A} P Q
-  `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)}
+  `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)}
   s (Hfg : Forall (fun a => P a -> Q a) s) :
   length (filter P s) <= length (filter Q s).
 Proof.
@@ -385,7 +385,7 @@ Proof.
 Qed.
 
 Lemma filter_eq_fn {A} P Q
- `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)} s :
+ `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)} s :
   (forall a, In a s -> P a <-> Q a) ->
   filter P s = filter Q s.
 Proof.
@@ -398,7 +398,7 @@ Proof.
 Qed.
 
 Lemma nth_error_filter
-  {A} P `{forall (x:A), Decision (P x)}
+  {A} P `{forall (x: A), Decision (P x)}
   (l : list A)
   (n : nat)
   (a : A)
@@ -424,7 +424,7 @@ Proof.
       by rewrite Hnth'.
 Qed.
 
-Lemma filter_subseteq {A} P `{forall (x:A), Decision (P x)} (s1 s2 : list A) :
+Lemma filter_subseteq {A} P `{forall (x: A), Decision (P x)} (s1 s2 : list A) :
   s1 ⊆ s2 ->
   filter P s1 ⊆ filter P s2.
 Proof.
@@ -443,7 +443,7 @@ Proof.
 Qed.
 
 Lemma filter_subseteq_fn {A} P Q
-  `{forall (x:A), Decision (P x)} `{forall (x:A), Decision (Q x)} :
+  `{forall (x: A), Decision (P x)} `{forall (x: A), Decision (Q x)} :
   (forall a, P a -> Q a) ->
   forall (s : list A), filter P s ⊆ filter Q s.
 Proof.
@@ -455,7 +455,7 @@ Proof.
   - by itauto.
 Qed.
 
-Lemma filter_incl {A} P `{forall (x:A), Decision (P x)} s1 s2 :
+Lemma filter_incl {A} P `{forall (x: A), Decision (P x)} s1 s2 :
   incl s1 s2 ->
   incl (filter P s1) (filter P s2).
 Proof.
@@ -469,7 +469,7 @@ Proof.
     by intros y HIn; apply H0; right.
 Qed.
 
-Lemma Forall_filter_nil {A} P `{forall (x:A), Decision (P x)} l :
+Lemma Forall_filter_nil {A} P `{forall (x: A), Decision (P x)} l :
   Forall (fun a : A => ~ P a) l <-> filter P l = [].
 Proof.
   rewrite Forall_forall.

--- a/theories/VLSM/Lib/StdppListFinSet.v
+++ b/theories/VLSM/Lib/StdppListFinSet.v
@@ -13,7 +13,7 @@ Definition empty_set : set := ∅.
 
 Definition set_add (a : A) (x : set) : set := {[a]} ∪ x.
 
-Definition set_remove (a : A) (x : set) : set := x ∖ {[ a ]}.
+Definition set_remove (a : A) (x : set) : set := x ∖ {[a]}.
 
 Definition set_union (x y : set) : set := x ∪ y.
 

--- a/theories/VLSM/Lib/StdppListFinSet.v
+++ b/theories/VLSM/Lib/StdppListFinSet.v
@@ -11,9 +11,9 @@ Definition set := C.
 
 Definition empty_set : set := ∅.
 
-Definition set_add (a : A) (x : set) : set := {[a]} ∪ x.
+Definition set_add (a : A) (x : set) : set := {[ a ]} ∪ x.
 
-Definition set_remove (a : A) (x : set) : set := x ∖ {[a]}.
+Definition set_remove (a : A) (x : set) : set := x ∖ {[ a ]}.
 
 Definition set_union (x y : set) : set := x ∪ y.
 

--- a/theories/VLSM/Lib/StdppListSet.v
+++ b/theories/VLSM/Lib/StdppListSet.v
@@ -54,7 +54,7 @@ Qed.
 Lemma set_add_intro :
   forall (a b : A) (x : set), a = b \/ a ∈ x -> a ∈ set_add b x.
 Proof.
-  by intros a b x [H1| H2]; auto.
+  by intros a b x [H1 | H2]; auto.
 Qed.
 
 Lemma set_add_elim :
@@ -83,7 +83,7 @@ Lemma set_add_nodup a l :
   NoDup l -> NoDup (set_add a l).
 Proof.
   induction 1 as [| x l H H' IH]; cbn.
-  - by constructor; [inversion 1| apply NoDup_nil].
+  - by constructor; [inversion 1 | apply NoDup_nil].
   - by destruct (decide (a = x)) as [<- | Hax]; constructor
     ; rewrite ?set_add_iff; itauto.
 Qed.

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -169,7 +169,7 @@ Lemma stream_prefix_nth
   : nth_error (stream_prefix s n) i = Some (Str_nth i s).
 Proof.
   revert s n Hi.
-  induction i; intros [a s] [| n] Hi; [by inversion Hi ..|].
+  induction i; intros [a s] [| n] Hi; [by inversion Hi .. |].
   by apply IHi; lia.
 Qed.
 
@@ -182,7 +182,7 @@ Lemma stream_prefix_lookup
   : stream_prefix s n !! i = Some (Str_nth i s).
 Proof.
   revert s n Hi.
-  induction i; intros [a s] [| n] Hi; [by inversion Hi ..|].
+  induction i; intros [a s] [| n] Hi; [by inversion Hi .. |].
   by apply IHi; lia.
 Qed.
 
@@ -404,7 +404,7 @@ Proof.
   destruct (decide (m = n)); [done |].
   elim (HI (Str_nth n l)).
   by destruct (decide (m < n))
-  ; [specialize (Hl m n)|specialize (Hl n m)]; (spec Hl; [lia|])
+  ; [specialize (Hl m n) | specialize (Hl n m)]; (spec Hl; [lia |])
   ; rewrite Hmn in Hl.
 Qed.
 
@@ -606,7 +606,7 @@ Proof.
     destruct IHn as [Hlt | [k Hk]]
     ; [by exists 0; left; cbv in *; lia |].
     destruct (decide (Str_nth (S k) s = S n))
-    ; [by exists (S k); left|].
+    ; [by exists (S k); left |].
     exists k; right.
     cut (Str_nth k s < Str_nth (S k) s); [by lia |].
     by apply (Hs k (S k)); lia.

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -155,8 +155,8 @@ Fixpoint stream_prefix
   (l : Stream A)
   (n : nat)
   : list A
-  := match n,l with
-  | 0,_ => []
+  := match n, l with
+  | 0, _ => []
   | S n, Cons a l => a :: stream_prefix l n
   end.
 

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -8,13 +8,13 @@ Lemma stream_eq_hd_tl {A} (s s' : Stream A) :
   hd s = hd s' -> tl s = tl s' -> s = s'.
 Proof. by destruct s, s'; cbn; intros -> ->. Qed.
 
-Lemma fHere [A: Type] (P: Stream A -> Prop) : forall s, ForAll P s -> P s.
+Lemma fHere [A : Type] (P : Stream A -> Prop) : forall s, ForAll P s -> P s.
 Proof. by intros s []. Qed.
 
-Lemma fFurther [A: Type] (P: Stream A -> Prop) : forall s, ForAll P s -> ForAll P (tl s).
+Lemma fFurther [A : Type] (P : Stream A -> Prop) : forall s, ForAll P s -> ForAll P (tl s).
 Proof. by intros s []. Qed.
 
-Lemma ForAll_subsumption [A: Type] (P Q: Stream A -> Prop)
+Lemma ForAll_subsumption [A : Type] (P Q : Stream A -> Prop)
   (HPQ : forall s, P s -> Q s)
   : forall s, ForAll P s -> ForAll Q s.
 Proof.
@@ -53,7 +53,7 @@ Qed.
 
 Definition ForAll1 [A : Type] (P : A -> Prop) := ForAll (fun s => P (hd s)).
 
-Lemma ForAll1_subsumption [A: Type] (P Q: A -> Prop)
+Lemma ForAll1_subsumption [A : Type] (P Q : A -> Prop)
   (HPQ : forall a, P a -> Q a)
   : forall s, ForAll1 P s -> ForAll1 Q s.
 Proof.
@@ -74,7 +74,7 @@ Qed.
 
 Definition ForAll2 [A : Type] (R : A -> A -> Prop) := ForAll (fun s => R (hd s) (hd (tl s))).
 
-Lemma ForAll2_subsumption [A: Type] (R1 R2 : A -> A -> Prop)
+Lemma ForAll2_subsumption [A : Type] (R1 R2 : A -> A -> Prop)
   (HR : forall a b, R1 a b -> R2 a b)
   : forall s, ForAll2 R1 s -> ForAll2 R2 s.
 Proof.
@@ -451,7 +451,7 @@ Lemma stream_prefix_prefix
   {A : Type}
   (l : Stream A)
   (n1 n2 : nat)
-  (Hn: n1 <= n2)
+  (Hn : n1 <= n2)
   : list_prefix (stream_prefix l n2) n1 = stream_prefix l n1.
 Proof.
   revert l n2 Hn.
@@ -463,7 +463,7 @@ Lemma stream_prefix_of
   {A : Type}
   (l : Stream A)
   (n1 n2 : nat)
-  (Hn: n1 <= n2)
+  (Hn : n1 <= n2)
   : stream_prefix l n1 `prefix_of` stream_prefix l n2.
 Proof.
   rewrite <- (stream_prefix_prefix l n1 n2 Hn).
@@ -519,7 +519,7 @@ Proof.
     specialize (list_suffix_nth (stream_prefix l n2) n1 (n1 + k) Hle)
     ; intro Heq.
     clear Hle.
-    assert (Hs: n1 + k - n1 = k) by lia.
+    assert (Hs : n1 + k - n1 = k) by lia.
     rewrite Hs in Heq.
     by rewrite Heq, stream_prefix_nth; [do 2 f_equal |]; lia.
 Qed.

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -8,13 +8,13 @@ Lemma stream_eq_hd_tl {A} (s s' : Stream A) :
   hd s = hd s' -> tl s = tl s' -> s = s'.
 Proof. by destruct s, s'; cbn; intros -> ->. Qed.
 
-Lemma fHere [A:Type] (P: Stream A -> Prop) : forall s, ForAll P s -> P s.
+Lemma fHere [A: Type] (P: Stream A -> Prop) : forall s, ForAll P s -> P s.
 Proof. by intros s []. Qed.
 
-Lemma fFurther [A:Type] (P: Stream A -> Prop) : forall s, ForAll P s -> ForAll P (tl s).
+Lemma fFurther [A: Type] (P: Stream A -> Prop) : forall s, ForAll P s -> ForAll P (tl s).
 Proof. by intros s []. Qed.
 
-Lemma ForAll_subsumption [A:Type] (P Q: Stream A -> Prop)
+Lemma ForAll_subsumption [A: Type] (P Q: Stream A -> Prop)
   (HPQ : forall s, P s -> Q s)
   : forall s, ForAll P s -> ForAll Q s.
 Proof.
@@ -53,7 +53,7 @@ Qed.
 
 Definition ForAll1 [A : Type] (P : A -> Prop) := ForAll (fun s => P (hd s)).
 
-Lemma ForAll1_subsumption [A:Type] (P Q: A -> Prop)
+Lemma ForAll1_subsumption [A: Type] (P Q: A -> Prop)
   (HPQ : forall a, P a -> Q a)
   : forall s, ForAll1 P s -> ForAll1 Q s.
 Proof.
@@ -74,7 +74,7 @@ Qed.
 
 Definition ForAll2 [A : Type] (R : A -> A -> Prop) := ForAll (fun s => R (hd s) (hd (tl s))).
 
-Lemma ForAll2_subsumption [A:Type] (R1 R2 : A -> A -> Prop)
+Lemma ForAll2_subsumption [A: Type] (R1 R2 : A -> A -> Prop)
   (HR : forall a b, R1 a b -> R2 a b)
   : forall s, ForAll2 R1 s -> ForAll2 R2 s.
 Proof.

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -542,10 +542,7 @@ Lemma stream_prefix_segment_suffix
   (n1 n2 : nat)
   (Hn : n1 <= n2)
   : stream_app
-      ((stream_prefix l n1)
-        ++
-       (stream_segment l n1 n2)
-      )
+      (stream_prefix l n1 ++ stream_segment l n1 n2)
       (stream_suffix l n2)
   = l.
 Proof.

--- a/theories/VLSM/Lib/StreamFilters.v
+++ b/theories/VLSM/Lib/StreamFilters.v
@@ -13,7 +13,7 @@ Definition filtering_subsequence
   (s : Stream A)
   (ns : Stream nat)
   : Prop
-  := (forall i, i < hd ns -> ~P (Str_nth i s)) /\
+  := (forall i, i < hd ns -> ~ P (Str_nth i s)) /\
      ForAll2 (fun m n => P (Str_nth m s) /\ m < n /\ forall i, m < i < n -> ~ P (Str_nth i s)) ns.
 
 (**

--- a/theories/VLSM/Lib/StreamFilters.v
+++ b/theories/VLSM/Lib/StreamFilters.v
@@ -165,8 +165,8 @@ Proof.
       subst.
       split; [by apply filtering_subsequence_witness |].
       eexists; split; [| done].
-      destruct (decide (i = k)); [subst; lia|].
-      cut (Str_nth i ss < Str_nth k ss); [lia|].
+      destruct (decide (i = k)); [subst; lia |].
+      cut (Str_nth i ss < Str_nth k ss); [lia |].
       apply ForAll2_transitive_lookup; [by typeclasses eauto | | lia].
       by apply filtering_subsequence_sorted in Hfs.
     + destruct H as [Hpa [_a [Hlt H_a]]].
@@ -405,7 +405,7 @@ Proof.
     + by exists 0; split_and!; f_equal; [lia | | lia].
     + specialize (H (tl s) Hev (S n)) as (k & Heq & Hp & Hnp).
       exists (S k). rewrite Heq.
-      split; [f_equal; lia|].
+      split; [f_equal; lia |].
       split; [done |].
       intros. destruct i; [done |].
       by apply Hnp; lia.
@@ -551,7 +551,7 @@ Proof.
     rewrite Hnth; simpl.
     split; [done |].
     rewrite Heq. simpl.
-    split; [lia|].
+    split; [lia |].
     intros i [Hle Hlt].
     apply stdpp_nat_le_sum in Hle as [k' ->].
     rewrite Nat.add_comm, <- Str_nth_tl_plus. simpl.
@@ -755,7 +755,7 @@ Proof.
     end.
     rewrite Heq1.
     simpl.
-    destruct _k; [lia|].
+    destruct _k; [lia |].
     by exfalso; apply (H_k 0); [lia | eexists].
   }
   induction n; intros; rewrite stream_filter_positions_unroll; unfold Streams.Str_nth; simpl.

--- a/theories/VLSM/Lib/Temporal.v
+++ b/theories/VLSM/Lib/Temporal.v
@@ -42,7 +42,7 @@ Qed.
 Lemma Forever_map [A B:Type] (f: A -> B) (P: Stream B -> Prop): forall s,
   Forever P (Streams.map f s) <-> Forever (fun s => P (Streams.map f s)) s.
 Proof.
-  split;revert s.
+  split; revert s.
   - cofix lem. destruct s.
     rewrite (unfold_Stream (map f (Cons a s))).
     simpl.
@@ -165,7 +165,7 @@ Proof.
     specialize (H a).
     destruct H as [x H _]. revert Hprogress.
     clear s.
-    induction H;intro Hprogress.
+    induction H; intro Hprogress.
     + by destruct s; cbn in *; congruence.
     + simpl. intro. subst a0.
       apply elater.

--- a/theories/VLSM/Lib/Temporal.v
+++ b/theories/VLSM/Lib/Temporal.v
@@ -6,24 +6,24 @@ From Coq Require Import Streams Classical.
 
 Set Implicit Arguments.
 
-Inductive Eventually [A: Type] (P: Stream A -> Prop) : Stream A -> Prop :=
+Inductive Eventually [A : Type] (P : Stream A -> Prop) : Stream A -> Prop :=
 | ehere : forall s, P s -> Eventually P s
 | elater : forall s, Eventually P s -> forall a, Eventually P (Cons a s).
 
-CoInductive Forever [A: Type] (P: Stream A -> Prop) : Stream A -> Prop :=
+CoInductive Forever [A : Type] (P : Stream A -> Prop) : Stream A -> Prop :=
 | fcons : forall s, P s -> Forever P (tl s) -> Forever P s.
 
-Lemma fhere [A: Type] (P: Stream A -> Prop) : forall s, Forever P s -> P s.
+Lemma fhere [A : Type] (P : Stream A -> Prop) : forall s, Forever P s -> P s.
 Proof.
   by destruct 1.
 Qed.
 
-Lemma flater [A: Type] (P: Stream A -> Prop) : forall a s, Forever P (Cons a s) -> Forever P s.
+Lemma flater [A : Type] (P : Stream A -> Prop) : forall a s, Forever P (Cons a s) -> Forever P s.
 Proof.
   by inversion 1.
 Qed.
 
-Lemma Eventually_map [A B: Type] (f: A -> B) (P: Stream B -> Prop): forall s,
+Lemma Eventually_map [A B : Type] (f : A -> B) (P : Stream B -> Prop) : forall s,
   Eventually P (Streams.map f s) <-> Eventually (fun s => P (Streams.map f s)) s.
 Proof.
   split.
@@ -39,7 +39,7 @@ Proof.
     + by rewrite unfold_Stream; constructor.
 Qed.
 
-Lemma Forever_map [A B: Type] (f: A -> B) (P: Stream B -> Prop): forall s,
+Lemma Forever_map [A B : Type] (f : A -> B) (P : Stream B -> Prop) : forall s,
   Forever P (Streams.map f s) <-> Forever (fun s => P (Streams.map f s)) s.
 Proof.
   split; revert s.
@@ -53,10 +53,10 @@ Proof.
     by inversion 1; subst; constructor; [| apply lem].
 Qed.
 
-Definition progress [A: Type] (R: A -> A -> Prop) : Stream A -> Prop :=
+Definition progress [A : Type] (R : A -> A -> Prop) : Stream A -> Prop :=
   Forever (fun s => let x := hd s in let a := hd (tl s) in a = x \/ R a x).
 
-Lemma not_eventually [A: Type] (P: Stream A -> Prop):
+Lemma not_eventually [A : Type] (P : Stream A -> Prop) :
   forall s, ~ Eventually P s -> Forever (fun s => ~ P s) s.
 Proof.
   cofix not_eventually.
@@ -66,7 +66,7 @@ Proof.
   - by apply not_eventually; contradict H; constructor.
 Qed.
 
-Lemma forever_impl [A: Type] (P Q : Stream A -> Prop):
+Lemma forever_impl [A : Type] (P Q : Stream A -> Prop) :
   forall s, Forever (fun s => P s -> Q s) s -> Forever P s -> Forever Q s.
 Proof.
   cofix forever_impl.
@@ -75,7 +75,7 @@ Proof.
   by constructor; auto.
 Qed.
 
-Lemma eventually_impl [A: Type] (P Q : Stream A -> Prop):
+Lemma eventually_impl [A : Type] (P Q : Stream A -> Prop) :
   forall s, Forever (fun s => P s -> Q s) s -> Eventually P s -> Eventually Q s.
 Proof.
   induction 2.
@@ -83,14 +83,14 @@ Proof.
   - by apply flater in H; apply elater, IHEventually.
 Qed.
 
-Lemma forever_tauto [A: Type] (P: Stream A -> Prop):
+Lemma forever_tauto [A : Type] (P : Stream A -> Prop) :
   (forall s, P s) -> forall s, Forever P s.
 Proof.
   cofix forever_tauto.
   by destruct s; constructor; auto.
 Qed.
 
-Lemma use_eventually [A: Type] (P Q : Stream A -> Prop):
+Lemma use_eventually [A : Type] (P Q : Stream A -> Prop) :
   forall s, Eventually P s -> Forever Q s ->
             exists s', P s' /\ Forever Q s'.
 Proof.
@@ -99,8 +99,8 @@ Proof.
   - by inversion 1; subst; itauto.
 Qed.
 
-Lemma refutation [A: Type] [R: A -> A-> Prop] (HR: well_founded R)
-      [s]: ~ Forever (fun s => Eventually (fun x => R (hd x) (hd s)) s) s.
+Lemma refutation [A : Type] [R : A -> A-> Prop] (HR : well_founded R)
+      [s] : ~ Forever (fun s => Eventually (fun x => R (hd x) (hd s)) s) s.
 Proof.
   remember (hd s) as x.
   revert s Heqx.
@@ -114,8 +114,8 @@ Proof.
   by eapply H0; eauto.
 Qed.
 
-Lemma forall_forever: forall [A B: Type] (P: A -> Stream B -> Prop) [s: Stream B],
-    (forall (a: A), Forever (P a) s) -> Forever (fun s => forall a, P a s) s.
+Lemma forall_forever : forall [A B : Type] (P : A -> Stream B -> Prop) [s : Stream B],
+    (forall (a : A), Forever (P a) s) -> Forever (fun s => forall a, P a s) s.
 Proof.
   intros A B P.
   cofix forall_forever.
@@ -127,7 +127,7 @@ Proof.
     by intro a; destruct (H a).
 Qed.
 
-Lemma not_forever [A: Type] (P: Stream A -> Prop):
+Lemma not_forever [A : Type] (P : Stream A -> Prop) :
   forall s, ~ Forever P s -> Eventually (fun s => ~ P s) s.
 Proof.
   intros s H. apply Classical_Prop.NNPP.
@@ -137,8 +137,8 @@ Proof.
   by intro; apply Classical_Prop.NNPP.
 Qed.
 
-Lemma stabilization [A: Type] [R: A -> A-> Prop] (HR: well_founded R)
-      [s]: progress R s -> exists x, Eventually (Forever (fun s => hd s = x)) s.
+Lemma stabilization [A : Type] [R : A -> A-> Prop] (HR : well_founded R)
+      [s] : progress R s -> exists x, Eventually (Forever (fun s => hd s = x)) s.
 Proof.
   intro Hprogress.
   apply Classical_Prop.NNPP.

--- a/theories/VLSM/Lib/Temporal.v
+++ b/theories/VLSM/Lib/Temporal.v
@@ -6,24 +6,24 @@ From Coq Require Import Streams Classical.
 
 Set Implicit Arguments.
 
-Inductive Eventually [A:Type] (P: Stream A -> Prop) : Stream A -> Prop :=
+Inductive Eventually [A: Type] (P: Stream A -> Prop) : Stream A -> Prop :=
 | ehere : forall s, P s -> Eventually P s
 | elater : forall s, Eventually P s -> forall a, Eventually P (Cons a s).
 
-CoInductive Forever [A:Type] (P: Stream A -> Prop) : Stream A -> Prop :=
+CoInductive Forever [A: Type] (P: Stream A -> Prop) : Stream A -> Prop :=
 | fcons : forall s, P s -> Forever P (tl s) -> Forever P s.
 
-Lemma fhere [A:Type] (P: Stream A -> Prop) : forall s, Forever P s -> P s.
+Lemma fhere [A: Type] (P: Stream A -> Prop) : forall s, Forever P s -> P s.
 Proof.
   by destruct 1.
 Qed.
 
-Lemma flater [A:Type] (P: Stream A -> Prop) : forall a s, Forever P (Cons a s) -> Forever P s.
+Lemma flater [A: Type] (P: Stream A -> Prop) : forall a s, Forever P (Cons a s) -> Forever P s.
 Proof.
   by inversion 1.
 Qed.
 
-Lemma Eventually_map [A B:Type] (f: A -> B) (P: Stream B -> Prop): forall s,
+Lemma Eventually_map [A B: Type] (f: A -> B) (P: Stream B -> Prop): forall s,
   Eventually P (Streams.map f s) <-> Eventually (fun s => P (Streams.map f s)) s.
 Proof.
   split.
@@ -39,7 +39,7 @@ Proof.
     + by rewrite unfold_Stream; constructor.
 Qed.
 
-Lemma Forever_map [A B:Type] (f: A -> B) (P: Stream B -> Prop): forall s,
+Lemma Forever_map [A B: Type] (f: A -> B) (P: Stream B -> Prop): forall s,
   Forever P (Streams.map f s) <-> Forever (fun s => P (Streams.map f s)) s.
 Proof.
   split; revert s.
@@ -53,10 +53,10 @@ Proof.
     by inversion 1; subst; constructor; [| apply lem].
 Qed.
 
-Definition progress [A:Type] (R: A -> A -> Prop) : Stream A -> Prop :=
+Definition progress [A: Type] (R: A -> A -> Prop) : Stream A -> Prop :=
   Forever (fun s => let x := hd s in let a := hd (tl s) in a = x \/ R a x).
 
-Lemma not_eventually [A:Type] (P: Stream A -> Prop):
+Lemma not_eventually [A: Type] (P: Stream A -> Prop):
   forall s, ~ Eventually P s -> Forever (fun s => ~ P s) s.
 Proof.
   cofix not_eventually.
@@ -66,7 +66,7 @@ Proof.
   - by apply not_eventually; contradict H; constructor.
 Qed.
 
-Lemma forever_impl [A:Type] (P Q : Stream A -> Prop):
+Lemma forever_impl [A: Type] (P Q : Stream A -> Prop):
   forall s, Forever (fun s => P s -> Q s) s -> Forever P s -> Forever Q s.
 Proof.
   cofix forever_impl.
@@ -75,7 +75,7 @@ Proof.
   by constructor; auto.
 Qed.
 
-Lemma eventually_impl [A:Type] (P Q : Stream A -> Prop):
+Lemma eventually_impl [A: Type] (P Q : Stream A -> Prop):
   forall s, Forever (fun s => P s -> Q s) s -> Eventually P s -> Eventually Q s.
 Proof.
   induction 2.
@@ -83,14 +83,14 @@ Proof.
   - by apply flater in H; apply elater, IHEventually.
 Qed.
 
-Lemma forever_tauto [A:Type] (P: Stream A -> Prop):
+Lemma forever_tauto [A: Type] (P: Stream A -> Prop):
   (forall s, P s) -> forall s, Forever P s.
 Proof.
   cofix forever_tauto.
   by destruct s; constructor; auto.
 Qed.
 
-Lemma use_eventually [A:Type] (P Q : Stream A -> Prop):
+Lemma use_eventually [A: Type] (P Q : Stream A -> Prop):
   forall s, Eventually P s -> Forever Q s ->
             exists s', P s' /\ Forever Q s'.
 Proof.
@@ -99,7 +99,7 @@ Proof.
   - by inversion 1; subst; itauto.
 Qed.
 
-Lemma refutation [A:Type] [R:A -> A-> Prop] (HR: well_founded R)
+Lemma refutation [A: Type] [R: A -> A-> Prop] (HR: well_founded R)
       [s]: ~ Forever (fun s => Eventually (fun x => R (hd x) (hd s)) s) s.
 Proof.
   remember (hd s) as x.
@@ -114,8 +114,8 @@ Proof.
   by eapply H0; eauto.
 Qed.
 
-Lemma forall_forever: forall [A B:Type] (P: A -> Stream B -> Prop) [s: Stream B],
-    (forall (a:A), Forever (P a) s) -> Forever (fun s => forall a, P a s) s.
+Lemma forall_forever: forall [A B: Type] (P: A -> Stream B -> Prop) [s: Stream B],
+    (forall (a: A), Forever (P a) s) -> Forever (fun s => forall a, P a s) s.
 Proof.
   intros A B P.
   cofix forall_forever.
@@ -127,7 +127,7 @@ Proof.
     by intro a; destruct (H a).
 Qed.
 
-Lemma not_forever [A:Type] (P: Stream A -> Prop):
+Lemma not_forever [A: Type] (P: Stream A -> Prop):
   forall s, ~ Forever P s -> Eventually (fun s => ~ P s) s.
 Proof.
   intros s H. apply Classical_Prop.NNPP.
@@ -137,7 +137,7 @@ Proof.
   by intro; apply Classical_Prop.NNPP.
 Qed.
 
-Lemma stabilization [A:Type] [R:A -> A-> Prop] (HR: well_founded R)
+Lemma stabilization [A: Type] [R: A -> A-> Prop] (HR: well_founded R)
       [s]: progress R s -> exists x, Eventually (Forever (fun s => hd s = x)) s.
 Proof.
   intro Hprogress.

--- a/theories/VLSM/Lib/Temporal.v
+++ b/theories/VLSM/Lib/Temporal.v
@@ -57,7 +57,7 @@ Definition progress [A:Type] (R: A -> A -> Prop) : Stream A -> Prop :=
   Forever (fun s => let x := hd s in let a := hd (tl s) in a = x \/ R a x).
 
 Lemma not_eventually [A:Type] (P: Stream A -> Prop):
-  forall s, ~Eventually P s -> Forever (fun s => ~ P s) s.
+  forall s, ~ Eventually P s -> Forever (fun s => ~ P s) s.
 Proof.
   cofix not_eventually.
   destruct s.
@@ -128,7 +128,7 @@ Proof.
 Qed.
 
 Lemma not_forever [A:Type] (P: Stream A -> Prop):
-  forall s, ~Forever P s -> Eventually (fun s => ~ P s) s.
+  forall s, ~ Forever P s -> Eventually (fun s => ~ P s) s.
 Proof.
   intros s H. apply Classical_Prop.NNPP.
   contradict H.

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -178,12 +178,12 @@ Lemma count_predecessors_zero
 Proof.
   unfold count_predecessors.
   induction l; [done |].
-  inversion_clear HPl as [|? ? HPa HPl0].
+  inversion_clear HPl as [| ? ? HPa HPl0].
   specialize (IHl0 HPl0).
   apply Exists_cons.
   rewrite filter_cons.
   destruct (decide (precedes a a)); [by contradict p; apply precedes_irreflexive |].
-  assert ({ l0=[] }+{l0 <> [] }) by (destruct l0; clear; [left|right]; congruence).
+  assert ({ l0=[] }+{l0 <> [] }) by (destruct l0; clear; [left | right]; congruence).
   destruct H as [? | Hl0]; [subst l0 |]; [by left |].
   specialize (IHl0 Hl0).
   apply Exists_exists in IHl0.
@@ -481,7 +481,7 @@ Proof.
     rewrite <- Heql'. rewrite <- H0. intro Hlen.
     specialize (IHn Hlen).
     split; intros x Hx; rewrite elem_of_cons in Hx;
-      destruct Hx as [Heq|Hinx]; try (subst x).
+      destruct Hx as [Heq | Hinx]; try (subst x).
     + by right; apply IHn; left.
     + destruct (decide (x = min)); try subst x.
       * by left.
@@ -612,7 +612,7 @@ Proof.
     }
     destruct l1 as [| _min l1]; inversion Heq; [by subst |].
     subst _min.
-    destruct (decide (a ∈ l')) as [i|i].
+    destruct (decide (a ∈ l')) as [i | i].
     - apply (IHn i l1 l2 Ha2 H4).
     - assert (Hmina : min = a).
       destruct (decide (min = a0)).

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -445,7 +445,7 @@ Fixpoint top_sort_n
   (l : list A)
   : list A
   :=
-  match n,l with
+  match n, l with
   | 0, _ => []
   | _, [] => []
   | S n', a :: l' =>

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -52,7 +52,7 @@ Fixpoint min_predecessors
   :=
   match remainder with
   | [] => min
-  | h:: t =>
+  | h :: t =>
     if decide (count_predecessors h < count_predecessors min)
     then min_predecessors t h
     else min_predecessors t min
@@ -687,7 +687,7 @@ Proof.
   intros contra.
   specialize (Htop max a contra).
 
-  assert (Hinmax: max ∈ l) by (apply maximal_element_in; itauto).
+  assert (Hinmax : max ∈ l) by (apply maximal_element_in; itauto).
   assert (Hinatop : a ∈ top_sort l) by (apply Hseteq; itauto).
   apply elem_of_list_split in Hinatop.
   destruct Hinatop as [prefA [sufA HeqA]].

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -183,7 +183,7 @@ Proof.
   apply Exists_cons.
   rewrite filter_cons.
   destruct (decide (precedes a a)); [by contradict p; apply precedes_irreflexive |].
-  assert ({ l0=[] }+{l0 <> [] }) by (destruct l0;clear;[left|right];congruence).
+  assert ({ l0=[] }+{l0 <> [] }) by (destruct l0; clear; [left|right]; congruence).
   destruct H as [? | Hl0]; [subst l0 |]; [by left |].
   specialize (IHl0 Hl0).
   apply Exists_exists in IHl0.
@@ -194,7 +194,7 @@ Proof.
     specialize (Hall HPl0 x Hin).
     match goal with |- ?X = 0  => cut (X <= 0) end.
     lia.
-    rewrite <- Hlen;clear Hlen.
+    rewrite <- Hlen; clear Hlen.
     apply filter_length_fn.
     revert HPl0.
     intro.

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -148,8 +148,7 @@ Proof.
   exact
     (StrictOrder_Asymmetric Hso
       (exist P a Ha) (exist P b Hb)
-      Hab Hba
-    ).
+      Hab Hba).
 Qed.
 
 Lemma precedes_transitive
@@ -164,8 +163,7 @@ Proof.
   exact
     (RelationClasses.StrictOrder_Transitive
       (exist P a Ha) (exist P b Hb) (exist P c Hc)
-      Hab Hbc
-    ).
+      Hab Hbc).
 Qed.
 
 (**

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -52,7 +52,7 @@ Fixpoint min_predecessors
   :=
   match remainder with
   | [] => min
-  | h::t =>
+  | h:: t =>
     if decide (count_predecessors h < count_predecessors min)
     then min_predecessors t h
     else min_predecessors t min

--- a/theories/VLSM/Lib/TraceClassicalProperties.v
+++ b/theories/VLSM/Lib/TraceClassicalProperties.v
@@ -41,7 +41,7 @@ end.
 
 (** ** Using midpoints to show the right associativity of the append property *)
 
-CoFixpoint midp (p0 p1: trace -> Prop) tr0 tr1 (h: followsT (appendT p0 p1) tr0 tr1) : trace :=
+CoFixpoint midp (p0 p1 : trace -> Prop) tr0 tr1 (h : followsT (appendT p0 p1) tr0 tr1) : trace :=
 match followsT_dec h with
 | inl (existT tr (exist a (conj _ (conj _ H)))) =>
   let: exist x _ := constructive_indefinite_description _ H in x
@@ -50,7 +50,7 @@ match followsT_dec h with
 end.
 
 Lemma midpointT_midp :
-  forall (p0 p1: trace -> Prop) tr0 tr1 (h : followsT (appendT p0 p1) tr0 tr1),
+  forall (p0 p1 : trace -> Prop) tr0 tr1 (h : followsT (appendT p0 p1) tr0 tr1),
     midpointT h (midp h).
 Proof.
 cofix CIH.
@@ -63,7 +63,7 @@ dependent inversion h; subst.
     (followsT_delay a b f) tr tr' f a b (midp f)).
 Qed.
 
-Lemma appendT_assoc_R: forall p1 p2 p3,
+Lemma appendT_assoc_R : forall p1 p2 p3,
  forall tr : trace, (appendT p1 (appendT p2 p3)) tr -> (appendT (appendT p1 p2)  p3) tr.
 Proof.
 move => p1 p2 p3 tr0 [tr1 [h1 h2]].
@@ -73,7 +73,7 @@ exists (midp h2); split.
 - exact: (midpointT_after (midpointT_midp h2)).
 Qed.
 
-Lemma AppendT_assoc_R: forall (p1 p2 p3 : propT), (p1 *** p2 *** p3) =>> (p1 *** p2) *** p3.
+Lemma AppendT_assoc_R : forall (p1 p2 p3 : propT), (p1 *** p2 *** p3) =>> (p1 *** p2) *** p3.
 Proof.
 move => [f1 hf1] [f2 hf2] [f3 hf3] tr0 /= h1.
 exact: appendT_assoc_R.

--- a/theories/VLSM/Lib/TraceProperties.v
+++ b/theories/VLSM/Lib/TraceProperties.v
@@ -208,7 +208,7 @@ exist _ (notT f) (notT_setoidT hf).
 Definition satisfyT (p : propT) : trace -> Prop :=
 fun tr => let: exist f0 h0 := p in f0 tr.
 
-Program Definition ExT {T: Type} (p: T -> propT) : propT :=
+Program Definition ExT {T : Type} (p : T -> propT) : propT :=
 exist _ (fun tr => exists x, satisfyT (p x) tr) _.
 Next Obligation.
 Proof.
@@ -242,32 +242,32 @@ move => f0 f1 h0 h1 tr0 [h2 | h2] tr1 h3.
 - by right; apply: h1 _ h2 _ h3.
 Qed.
 
-Definition OrT (p1 p2: propT) : propT :=
+Definition OrT (p1 p2 : propT) : propT :=
 let: exist f0 h0 := p1 in
 let: exist f1 h1 := p2 in
 exist _ (fun tr => f0 tr \/ f1 tr) (orT_setoidT h0 h1).
 
 #[local] Infix "orT" := OrT (at level 60, right associativity).
 
-Definition propT_imp (p1 p2: propT) : Prop :=
+Definition propT_imp (p1 p2 : propT) : Prop :=
 forall tr, satisfyT p1 tr -> satisfyT p2 tr.
 
 #[local] Infix "=>>" := propT_imp (at level 60, right associativity).
 
-Lemma propT_imp_conseq_L: forall p0 p1 q, p0 =>> p1 -> p1 =>> q -> p0 =>> q.
+Lemma propT_imp_conseq_L : forall p0 p1 q, p0 =>> p1 -> p1 =>> q -> p0 =>> q.
 Proof.
 move => [p0 hp0] [p1 hp1] [q hq] h0 h1 tr0 /= h2.
 exact/h1/h0.
 Qed.
 
-Lemma propT_imp_conseq_R: forall p q0 q1,
+Lemma propT_imp_conseq_R : forall p q0 q1,
  q0 =>> q1 -> p =>> q0 -> p =>> q1.
 Proof.
 move => [p hp] [q0 hq0] [q1 hq1] h0 h1 tr0 /= h2.
 exact/h0/h1.
 Qed.
 
-Lemma propT_imp_andT: forall p q0 q1,
+Lemma propT_imp_andT : forall p q0 q1,
  p =>> q0 -> p =>> q1 -> p =>> (q0 andT q1).
 Proof.
 move => [p hp] [q0 hq0] [q1 hq1] h0 h1 tr0 /= h2. split.
@@ -296,7 +296,7 @@ Proof.
 by move => [f1 hf1] [f2 hf2] tr /= h1; left.
 Qed.
 
-Lemma OrT_right: forall p1 p2, p2 =>> (p1 orT p2).
+Lemma OrT_right : forall p1 p2, p2 =>> (p1 orT p2).
 Proof.
 by move => [f1 hf1] [f2 hf2] tr /= h1; right.
 Qed.
@@ -309,15 +309,15 @@ Definition ttA : propA := fun a => True.
 
 Definition ffA : propA := fun a => False.
 
-Definition propA_imp (u1 u2: propA) : Prop := forall a, u1 a -> u2 a.
+Definition propA_imp (u1 u2 : propA) : Prop := forall a, u1 a -> u2 a.
 
 #[local] Infix "->>" := propA_imp (at level 60, right associativity).
 
-Definition andA (u1 u2: propA) : propA := fun a => u1 a /\ u2 a.
+Definition andA (u1 u2 : propA) : propA := fun a => u1 a /\ u2 a.
 
 #[local] Infix "andA" := andA (at level 60, right associativity).
 
-Definition exA {T : Type} (u: T -> propA) : propA :=
+Definition exA {T : Type} (u : T -> propA) : propA :=
 fun st => exists x, u x st.
 
 (** ** Singleton property *)
@@ -341,15 +341,15 @@ move => u v huv tr0 [a [h0 h1]]; invs h1.
 exact/nil_singletonT/huv.
 Qed.
 
-Lemma singletonT_nil: forall u a, singletonT u (Tnil a) -> u a.
+Lemma singletonT_nil : forall u a, singletonT u (Tnil a) -> u a.
 Proof. by move => u st [a [h0 h1]]; invs h1. Qed.
 
-Definition SingletonT (u: propA) : propT :=
+Definition SingletonT (u : propA) : propT :=
 exist _ (singletonT u) (@singletonT_setoidT u).
 
 #[local] Notation "[| p |]" := (SingletonT p) (at level 80).
 
-Lemma SingletonT_cont: forall u v, u ->> v -> [| u |] =>> [| v |].
+Lemma SingletonT_cont : forall u v, u ->> v -> [| u |] =>> [| v |].
 Proof.
 move => u v h0 tr0 [a [h1 h2]]; invs h2.
 exact/nil_singletonT/h0.
@@ -367,7 +367,7 @@ move => u a b h.
 by exists a; split; [apply: h | apply: bisim_refl].
 Qed.
 
-Lemma dupT_cont: forall (u0 u1: propA) b,
+Lemma dupT_cont : forall (u0 u1 : propA) b,
  u0 ->> u1 -> forall tr, dupT u0 b tr -> dupT u1 b tr.
 Proof.
 move => u0 u1 b hu tr [a [h0 h1]]; invs h1; invs H1.
@@ -386,7 +386,7 @@ exist _ (dupT u b) (@dupT_setoidT u b).
 
 #[local] Notation "<< p ; b >>" := (DupT p b) (at level 80).
 
-Lemma DupT_cont: forall u v b, u ->> v -> <<u; b>> =>> <<v; b>>.
+Lemma DupT_cont : forall u v b, u ->> v -> <<u; b>> =>> <<v; b>>.
 Proof.
 move => u v b h0 tr0 /=.
 exact: dupT_cont.
@@ -404,14 +404,14 @@ CoInductive followsT (p : trace -> Prop) : trace -> trace -> Prop :=
    hd tr = a ->
    p tr ->
    followsT p (Tnil a) tr
-| followsT_delay: forall a b tr tr',
+| followsT_delay : forall a b tr tr',
    followsT p tr tr' ->
    followsT p (Tcons a b tr) (Tcons a b tr').
 
-Lemma followsT_hd: forall p tr0 tr1, followsT p tr0 tr1 -> hd tr0 = hd tr1.
+Lemma followsT_hd : forall p tr0 tr1, followsT p tr0 tr1 -> hd tr0 = hd tr1.
 Proof. by move => p tr0 tr1 h0; invs h0. Qed.
 
-Definition followsT_dec : forall p tr0 tr1 (h: followsT p tr0 tr1),
+Definition followsT_dec : forall p tr0 tr1 (h : followsT p tr0 tr1),
  { tr & { a | tr0 = Tnil a /\ hd tr = a /\ p tr } } +
  { tr & { tr' & { a & { b | tr0 = Tcons a b tr /\ tr1 = Tcons a b tr' /\ followsT p tr tr'} } } }.
 Proof.
@@ -423,7 +423,7 @@ move => p [a | a b tr0] tr1 h.
 Defined.
 
 Lemma followsT_setoidT :
-  forall (p : trace -> Prop) (hp: forall tr0, p tr0 -> forall tr1, bisim tr0 tr1 -> p tr1),
+  forall (p : trace -> Prop) (hp : forall tr0, p tr0 -> forall tr1, bisim tr0 tr1 -> p tr1),
   forall tr0 tr1, followsT p tr0 tr1 ->
   forall tr2, bisim tr0 tr2 -> forall tr3, bisim tr1 tr3 ->
     followsT p tr2 tr3.
@@ -446,8 +446,8 @@ move => p. cofix CIH. move =>  tr tr0 h0 tr1 h1; invs h0; invs h1.
 - exact: (followsT_delay a b (CIH _ _ H _ H4)).
 Qed.
 
-Lemma followsT_setoidT_R : forall (p: trace -> Prop)
- (hp: forall tr0, p tr0 -> forall tr1, bisim tr0 tr1 -> p tr1),
+Lemma followsT_setoidT_R : forall (p : trace -> Prop)
+ (hp : forall tr0, p tr0 -> forall tr1, bisim tr0 tr1 -> p tr1),
  forall tr tr0, followsT p tr tr0 ->
  forall tr1, bisim tr0 tr1 -> followsT p tr tr1.
 Proof.
@@ -468,7 +468,7 @@ move => p q hpq. cofix CIH. move => tr0 tr1 h0; invs h0.
 - exact/followsT_delay/CIH.
 Qed.
 
-Lemma followsT_singletonT: forall u tr0 tr1,
+Lemma followsT_singletonT : forall u tr0 tr1,
  followsT (singletonT u) tr0 tr1 -> bisim tr0 tr1.
 Proof.
 move => u. cofix CIH. move => tr0 tr1 h0; invs h0.
@@ -477,7 +477,7 @@ move => u. cofix CIH. move => tr0 tr1 h0; invs h0.
 - exact/bisim_cons/CIH.
 Qed.
 
-Lemma followsT_singleton_andA_L: forall u0 u1 tr0,
+Lemma followsT_singleton_andA_L : forall u0 u1 tr0,
  followsT (singletonT (u0 andA u1)) tr0 tr0 ->
  followsT (singletonT u0) tr0 tr0.
 Proof.
@@ -491,7 +491,7 @@ move => u0 u1. cofix CIH. case.
   exact/followsT_delay/CIH.
 Qed.
 
-Lemma followsT_singleton_andA_R: forall u0 u1 tr0,
+Lemma followsT_singleton_andA_R : forall u0 u1 tr0,
  followsT (singletonT (u0 andA u1)) tr0 tr0 ->
  followsT (singletonT u1) tr0 tr0.
 Proof.
@@ -505,7 +505,7 @@ move => u0 u1. cofix CIH. case.
   exact/followsT_delay/CIH.
 Qed.
 
-Lemma singletonT_andA_followsT: forall u v tr,
+Lemma singletonT_andA_followsT : forall u v tr,
  followsT (singletonT u) tr tr -> followsT (singletonT v) tr tr ->
  followsT (singletonT (u andA v)) tr tr.
 Proof.
@@ -531,7 +531,7 @@ Qed.
   a prefix for which [p1] holds, and [p2] holds for the suffix.
 *)
 
-Definition appendT (p1 p2: trace -> Prop) : trace -> Prop :=
+Definition appendT (p1 p2 : trace -> Prop) : trace -> Prop :=
 fun tr => exists tr', p1 tr' /\ followsT p2 tr' tr.
 
 #[local] Infix "*+*" := appendT (at level 60, right associativity).
@@ -549,7 +549,7 @@ move => tr0 tr1 h0; invs h0.
 - exact/followsT_delay/CIH.
 Qed.
 
-Lemma appendT_cont_L : forall (p0 p1 q: trace -> Prop),
+Lemma appendT_cont_L : forall (p0 p1 q : trace -> Prop),
  (forall tr, p0 tr -> p1 tr) ->
  forall tr, (appendT p0 q tr) -> (appendT p1 q tr).
 Proof.
@@ -557,7 +557,7 @@ move => p0 p1 q hp tr.
 exact: (@appendT_cont _ _ q q hp _).
 Qed.
 
-Lemma appendT_cont_R: forall (p q0 q1: trace -> Prop),
+Lemma appendT_cont_R : forall (p q0 q1 : trace -> Prop),
 (forall tr, q0 tr -> q1 tr) ->
 forall tr, (appendT p q0 tr) -> (appendT p q1 tr).
 Proof.
@@ -565,7 +565,7 @@ move => p q0 q1 hq tr.
 exact: (@appendT_cont p p _ _ _ hq).
 Qed.
 
-Lemma appendT_setoidT: forall (p0 p1: trace -> Prop),
+Lemma appendT_setoidT : forall (p0 p1 : trace -> Prop),
  setoidT p1 -> setoidT (appendT p0 p1).
 Proof.
 move => p0 p1 hp1 tr0 h0 tr1 h1.
@@ -573,7 +573,7 @@ move: h0 => [tr2 [h0 h2]]. exists tr2; split; first by apply: h0.
 exact: (followsT_setoidT_R hp1 h2 h1).
 Qed.
 
-Lemma followsT_followsT: forall p q tr0 tr1 tr2, followsT p tr0 tr1 ->
+Lemma followsT_followsT : forall p q tr0 tr1 tr2, followsT p tr0 tr1 ->
  followsT q tr1 tr2 -> followsT (p *+* q) tr0 tr2.
 Proof.
 move => p q. cofix CIH. case.
@@ -595,7 +595,7 @@ move => tr0 tr1 tr2 h1 h2; invs h2.
 - invs h1. exact: followsT_delay _ _ (CIH _ _ _ H4 H).
 Qed.
 
-Lemma appendT_finalTA: forall (p q : trace -> Prop) tr0 tr1,
+Lemma appendT_finalTA : forall (p q : trace -> Prop) tr0 tr1,
  p tr0 -> q tr1 -> finalTA tr0 (hd tr1) ->
  (p *+* q) (tr0 +++ tr1).
 Proof.
@@ -608,14 +608,14 @@ move: {hp} tr0 tr1 hq hfin. cofix CIH. case.
   exact/followsT_delay/CIH.
 Qed.
 
-Definition AppendT (p1 p2: propT) : propT :=
+Definition AppendT (p1 p2 : propT) : propT :=
 let: exist f0 h0 := p1 in
 let: exist f1 h1 := p2 in
 exist _ (appendT f0 f1) (appendT_setoidT h1).
 
 #[local] Infix "***" := AppendT (at level 60, right associativity).
 
-Lemma AppendT_assoc_L: forall p1 p2 p3, ((p1 *** p2) *** p3) =>> (p1 *** p2 *** p3).
+Lemma AppendT_assoc_L : forall p1 p2 p3, ((p1 *** p2) *** p3) =>> (p1 *** p2 *** p3).
 Proof.
 move => [f1 hf1] [f2 hf2] [f3 hf3] tr0 /= h1.
 exact: appendT_assoc_L.
@@ -629,7 +629,7 @@ apply: (appendT_cont _ _ h2).
 - exact: h1.
 Qed.
 
-Lemma AppendT_cont_L: forall p1 p2 q, p1 =>> p2 -> (p1 *** q) =>> (p2 *** q).
+Lemma AppendT_cont_L : forall p1 p2 q, p1 =>> p2 -> (p1 *** q) =>> (p2 *** q).
 Proof.
 move => [p1 hp1] [p2 hp2] [q hq] h0 tr0 /=.
 exact: appendT_cont_L.
@@ -641,7 +641,7 @@ move => [q hq] [p1 hp1] [p2 hp2] h0 tr0 /= h1.
 exact: (@appendT_cont q q p1 p2).
 Qed.
 
-Lemma AppendT_ttA: forall p, p =>> (p *** [| ttA |]).
+Lemma AppendT_ttA : forall p, p =>> (p *** [| ttA |]).
 Proof.
 move => [f hp] tr0 /= h0.
 exists tr0; split => //.
@@ -689,7 +689,7 @@ invs h0; invs h1; move: H1 => [a [hv h0]]; invs h0 => /=.
 exact: nil_singletonT.
 Qed.
 
-Lemma andA_AppendT: forall u v, [| u andA v |] =>> [| u |] *** [| v |].
+Lemma andA_AppendT : forall u v, [| u andA v |] =>> [| u |] *** [| v |].
 Proof.
 move => u v tr0 [a [[hu hv] h0]]; invs h0.
 exists (Tnil a); split; first by apply: nil_singletonT.
@@ -697,7 +697,7 @@ apply: followsT_nil => //.
 exact: nil_singletonT.
 Qed.
 
-Lemma SingletonT_AppendT: forall v p, ([| v |] *** p) =>> p.
+Lemma SingletonT_AppendT : forall v p, ([| v |] *** p) =>> p.
 Proof.
 by move => v [p hp] tr0 /= [tr1 [[a [h0 h2]] h1]]; invs h1; invs h2.
 Qed.
@@ -708,7 +708,7 @@ move => p.
 exact: SingletonT_AppendT.
 Qed.
 
-Lemma implies_ttA_AppendT: forall p, p =>> [| ttA |] *** p.
+Lemma implies_ttA_AppendT : forall p, p =>> [| ttA |] *** p.
 Proof.
 move => [p hp] tr0 /= htr0.
 exists (Tnil (hd tr0)); split.
@@ -716,14 +716,14 @@ exists (Tnil (hd tr0)); split.
 - exact: followsT_nil.
 Qed.
 
-Lemma appendT_singletonT: forall p (hp: setoidT p) u tr,
+Lemma appendT_singletonT : forall p (hp : setoidT p) u tr,
  appendT p (singletonT u) tr -> p tr.
 Proof.
 move => p hp u tr0 [tr1 [h1 h2]].
 exact: (hp _ h1 _ (followsT_singletonT h2)).
 Qed.
 
-Lemma AppendT_Singleton: forall p v, (p *** [| v |]) =>> p.
+Lemma AppendT_Singleton : forall p v, (p *** [| v |]) =>> p.
 Proof.
 move => [p hp] v tr0 /=.
 exact: appendT_singletonT.
@@ -735,7 +735,7 @@ move => p.
 exact: AppendT_Singleton.
 Qed.
 
-Lemma implies_AppendT_ttA: forall p, p =>> p *** [| ttA |].
+Lemma implies_AppendT_ttA : forall p, p =>> p *** [| ttA |].
 Proof.
 move => [p hp] tr0 /= htr0.
 exists tr0; split => //.
@@ -746,7 +746,7 @@ case => [a | a b tr0].
 - exact/followsT_delay/CIH.
 Qed.
 
-Lemma TtT_AppendT_idem: (TtT *** TtT) =>> TtT.
+Lemma TtT_AppendT_idem : (TtT *** TtT) =>> TtT.
 Proof. by []. Qed.
 
 Lemma AppendT_FiniteT_idem : (FiniteT *** FiniteT) =>> FiniteT.
@@ -764,7 +764,7 @@ exists (Tnil (hd tr0)); split.
 - exact: followsT_nil.
 Qed.
 
-Lemma FiniteT_SingletonT: forall u, (FiniteT *** [| u |]) =>> FiniteT.
+Lemma FiniteT_SingletonT : forall u, (FiniteT *** [| u |]) =>> FiniteT.
 Proof.
 move => u tr /= [tr1 [h0 h1]].
 exact: (finiteT_setoidT h0 (followsT_singletonT h1)).
@@ -779,7 +779,7 @@ move => a b tr1 HinfT; invs HinfT.
 exact/followsT_delay/CIH.
 Qed.
 
-Lemma AppendT_implies_InfiniteT: (TtT *** [| ffA |]) =>> InfiniteT.
+Lemma AppendT_implies_InfiniteT : (TtT *** [| ffA |]) =>> InfiniteT.
 Proof.
 move => tr0 [tr1 [_ h1]] /=.
 move: tr0 tr1 h1; cofix CIH => tr0 tr1 h1; invs h1.
@@ -797,7 +797,7 @@ CoInductive iterT (p : trace -> Prop) : trace -> Prop :=
    followsT (iterT p) tr tr0 ->
    iterT p tr0.
 
-Lemma iterT_setoidT : forall p (hp: setoidT p), setoidT (iterT p).
+Lemma iterT_setoidT : forall p (hp : setoidT p), setoidT (iterT p).
 Proof.
 move => p hp. cofix CIH.
 have h0 : forall tr, setoidT (followsT (iterT p) tr).
@@ -810,7 +810,7 @@ move => tr0 h1 tr1 h2; invs h1.
 - exact: iterT_loop H (h0 _ _ H0 _ h2).
 Qed.
 
-Lemma iterT_cont: forall (p0 p1 : trace -> Prop),
+Lemma iterT_cont : forall (p0 p1 : trace -> Prop),
  (forall tr, p0 tr -> p1 tr) ->
  forall tr, iterT p0 tr -> iterT p1 tr.
 Proof.
@@ -823,7 +823,7 @@ move => tr0 h0; invs h0; first by apply: iterT_stop.
 exact: iterT_loop (hp _ H)  (h _ _ H0).
 Qed.
 
-Lemma iterT_appendT_dupT: forall (u : propA) p b tr,
+Lemma iterT_appendT_dupT : forall (u : propA) p b tr,
  u (hd tr) -> iterT (appendT p (dupT u b)) tr ->
  followsT (singletonT u) tr tr.
 Proof.
@@ -849,20 +849,20 @@ move => [p hp] [q hq] h0 tr0 /=.
 exact: (iterT_cont (fun tr => h0 tr)).
 Qed.
 
-Lemma iterT_split_1: forall p tr, iterT p tr -> (singletonT ttA tr) \/ (appendT p (iterT p) tr).
+Lemma iterT_split_1 : forall p tr, iterT p tr -> (singletonT ttA tr) \/ (appendT p (iterT p) tr).
 Proof.
 move => p tr h0; invs h0.
 - by left; apply: nil_singletonT.
 - by right; exists tr0.
 Qed.
 
-Lemma IterT_unfold_0: forall p, IterT p =>> ([| ttA |] orT (p *** IterT p)).
+Lemma IterT_unfold_0 : forall p, IterT p =>> ([| ttA |] orT (p *** IterT p)).
 Proof.
 move => [p hp] tr0 /= h0.
 exact: iterT_split_1 h0.
 Qed.
 
-Lemma iterT_split_2: forall tr p,
+Lemma iterT_split_2 : forall tr p,
  (singletonT ttA tr) \/ (appendT p (iterT p) tr) -> iterT p tr.
 Proof.
 move => tr p [[a [h0 h1]] | [tr0 [h0 h1]]].
@@ -898,7 +898,7 @@ move => [p hp] tr /= h0.
 exact: iterT_unfold_1 h0.
 Qed.
 
-Lemma IterT_unfold_2: forall p, ([| ttA |] orT (IterT p *** p)) =>> IterT p.
+Lemma IterT_unfold_2 : forall p, ([| ttA |] orT (IterT p *** p)) =>> IterT p.
 Proof.
 move => [p hp] tr0 /= [[a [_ h0]] | H].
 - invs h0. exact: iterT_stop.
@@ -969,7 +969,7 @@ Qed.
 Definition lastA (p : trace -> Prop) : propA :=
 fun a => exists tr, p tr /\ finalTA tr a.
 
-Lemma lastA_cont: forall (p q : trace -> Prop),
+Lemma lastA_cont : forall (p q : trace -> Prop),
  (forall tr, p tr -> q tr) ->
  lastA p ->> lastA q.
 Proof.
@@ -1089,7 +1089,7 @@ match tr with
 | Tcons a b' tr' => Tcons a b' (lastdup tr' b)
 end.
 
-Lemma lastdup_hd: forall tr b, hd tr = hd (lastdup tr b).
+Lemma lastdup_hd : forall tr b, hd tr = hd (lastdup tr b).
 Proof.
 by case => [a b | a b tr b0]; rewrite [lastdup _ _]trace_destr.
 Qed.
@@ -1144,13 +1144,13 @@ CoInductive midpointT
    p0 tr ->
    followsT p1 tr tr1 ->
    midpointT h tr
-| midpointT_delay : forall tr2 tr3 (h1: followsT (appendT p0 p1) tr2 tr3) (a : A) (b: B) tr',
+| midpointT_delay : forall tr2 tr3 (h1 : followsT (appendT p0 p1) tr2 tr3) (a : A) (b : B) tr',
    tr0 = Tcons a b tr2 ->
    tr1 = Tcons a b tr3 ->
    @midpointT p0 p1 tr2 tr3 h1 tr' ->
    midpointT h (Tcons a b tr').
 
-Lemma midpointT_before: forall p0 p1 tr0 tr1 (h: followsT (appendT p0 p1) tr0 tr1) tr',
+Lemma midpointT_before : forall p0 p1 tr0 tr1 (h : followsT (appendT p0 p1) tr0 tr1) tr',
  midpointT h tr' -> followsT p0 tr0 tr'.
 Proof.
 cofix CIH. dependent inversion h; subst.
@@ -1163,7 +1163,7 @@ cofix CIH. dependent inversion h; subst.
   exact: followsT_delay _ _ (CIH _ _ _ _ h1 _ _).
 Qed.
 
-Lemma midpointT_after: forall p0 p1 tr0 tr1 (h: followsT (appendT p0 p1) tr0 tr1) tr',
+Lemma midpointT_after : forall p0 p1 tr0 tr1 (h : followsT (appendT p0 p1) tr0 tr1) tr',
  midpointT h tr' -> followsT p1 tr' tr1.
 Proof.
 cofix CIH. dependent inversion h; subst => tr0 hm.

--- a/theories/VLSM/Lib/TraceProperties.v
+++ b/theories/VLSM/Lib/TraceProperties.v
@@ -349,7 +349,7 @@ exist _ (singletonT u) (@singletonT_setoidT u).
 
 #[local] Notation "[| p |]" := (SingletonT p) (at level 80).
 
-Lemma SingletonT_cont : forall u v, u ->> v -> [| u |] =>> [| v |].
+Lemma SingletonT_cont : forall u v, u ->> v -> [|u|] =>> [|v|].
 Proof.
 move => u v h0 tr0 [a [h1 h2]]; invs h2.
 exact/nil_singletonT/h0.
@@ -386,7 +386,7 @@ exist _ (dupT u b) (@dupT_setoidT u b).
 
 #[local] Notation "<< p ; b >>" := (DupT p b) (at level 80).
 
-Lemma DupT_cont : forall u v b, u ->> v -> <<u; b>> =>> <<v; b>>.
+Lemma DupT_cont : forall u v b, u ->> v -> <<u;b>> =>> <<v;b>>.
 Proof.
 move => u v b h0 tr0 /=.
 exact: dupT_cont.
@@ -641,7 +641,7 @@ move => [q hq] [p1 hp1] [p2 hp2] h0 tr0 /= h1.
 exact: (@appendT_cont q q p1 p2).
 Qed.
 
-Lemma AppendT_ttA : forall p, p =>> (p *** [| ttA |]).
+Lemma AppendT_ttA : forall p, p =>> (p *** [|ttA|]).
 Proof.
 move => [f hp] tr0 /= h0.
 exists tr0; split => //.
@@ -651,14 +651,14 @@ case => [a | a b tr0].
 - exact/followsT_delay/CIH.
 Qed.
 
-Lemma SingletonT_DupT_AppendT_andA_DupT : forall u v b, ([| u |] *** <<v; b>>) =>> <<u andA v; b>>.
+Lemma SingletonT_DupT_AppendT_andA_DupT : forall u v b, ([|u|] *** <<v;b>>) =>> <<u andA v;b>>.
 Proof.
 move => u v b tr0 [tr1 [[a [h0 h2]] h1]] /=; invs h2; invs h1.
 move: H1 => [a [h1 h2]]; invs h2; invs H1.
 exact: dupT_Tcons.
 Qed.
 
-Lemma DupT_andA_AppendT_SingletonT_DupT : forall u v b, <<u andA v; b>> =>> ([| u |] *** <<v; b>>).
+Lemma DupT_andA_AppendT_SingletonT_DupT : forall u v b, <<u andA v;b>> =>> ([|u|] *** <<v;b>>).
 Proof.
 move => u v b tr0 [a [[hu hv] h1]]; invs h1; invs H1.
 exists (Tnil a); split; first by apply: nil_singletonT.
@@ -666,7 +666,7 @@ apply: followsT_nil => //.
 exact: dupT_Tcons.
 Qed.
 
-Lemma DupT_andA_AppendT_SingletonT : forall u v b, <<u andA v; b>> =>> <<u; b>> *** [| v |].
+Lemma DupT_andA_AppendT_SingletonT : forall u v b, <<u andA v;b>> =>> <<u;b>> *** [|v|].
 Proof.
 move => u v b tr0 [a [[hu hv] h0]]; invs h0; invs H1.
 exists (Tcons a b (Tnil a)); split.
@@ -675,21 +675,21 @@ exists (Tcons a b (Tnil a)); split.
   exact: nil_singletonT.
 Qed.
 
-Lemma DupT_AppendT_SingletonT_andA_DupT : forall u v b, (<<u; b>> *** [| v |]) =>> <<u andA v; b>>.
+Lemma DupT_AppendT_SingletonT_andA_DupT : forall u v b, (<<u;b>> *** [|v|]) =>> <<u andA v;b>>.
 Proof.
 move => u v b tr0 [tr1 [[a [hu h0]] h1]].
 invs h0; invs H1; invs h1; invs H3; move: H1 => [a [hv h0]]; invs h0 => /=.
 exact: dupT_Tcons.
 Qed.
 
-Lemma AppendT_andA : forall u v, ([| u |] *** [| v |]) =>> [| u andA v |].
+Lemma AppendT_andA : forall u v, ([|u|] *** [|v|]) =>> [|u andA v|].
 Proof.
 move => u v tr0 [tr1 [[a [hu h0]] h1]].
 invs h0; invs h1; move: H1 => [a [hv h0]]; invs h0 => /=.
 exact: nil_singletonT.
 Qed.
 
-Lemma andA_AppendT : forall u v, [| u andA v |] =>> [| u |] *** [| v |].
+Lemma andA_AppendT : forall u v, [|u andA v|] =>> [|u|] *** [|v|].
 Proof.
 move => u v tr0 [a [[hu hv] h0]]; invs h0.
 exists (Tnil a); split; first by apply: nil_singletonT.
@@ -697,18 +697,18 @@ apply: followsT_nil => //.
 exact: nil_singletonT.
 Qed.
 
-Lemma SingletonT_AppendT : forall v p, ([| v |] *** p) =>> p.
+Lemma SingletonT_AppendT : forall v p, ([|v|] *** p) =>> p.
 Proof.
 by move => v [p hp] tr0 /= [tr1 [[a [h0 h2]] h1]]; invs h1; invs h2.
 Qed.
 
-Lemma ttA_AppendT_implies : forall p, ([| ttA |] *** p) =>> p.
+Lemma ttA_AppendT_implies : forall p, ([|ttA|] *** p) =>> p.
 Proof.
 move => p.
 exact: SingletonT_AppendT.
 Qed.
 
-Lemma implies_ttA_AppendT : forall p, p =>> [| ttA |] *** p.
+Lemma implies_ttA_AppendT : forall p, p =>> [|ttA|] *** p.
 Proof.
 move => [p hp] tr0 /= htr0.
 exists (Tnil (hd tr0)); split.
@@ -723,19 +723,19 @@ move => p hp u tr0 [tr1 [h1 h2]].
 exact: (hp _ h1 _ (followsT_singletonT h2)).
 Qed.
 
-Lemma AppendT_Singleton : forall p v, (p *** [| v |]) =>> p.
+Lemma AppendT_Singleton : forall p v, (p *** [|v|]) =>> p.
 Proof.
 move => [p hp] v tr0 /=.
 exact: appendT_singletonT.
 Qed.
 
-Lemma AppendT_ttA_implies : forall p, (p *** [| ttA |]) =>> p.
+Lemma AppendT_ttA_implies : forall p, (p *** [|ttA|]) =>> p.
 Proof.
 move => p.
 exact: AppendT_Singleton.
 Qed.
 
-Lemma implies_AppendT_ttA : forall p, p =>> p *** [| ttA |].
+Lemma implies_AppendT_ttA : forall p, p =>> p *** [|ttA|].
 Proof.
 move => [p hp] tr0 /= htr0.
 exists tr0; split => //.
@@ -764,13 +764,13 @@ exists (Tnil (hd tr0)); split.
 - exact: followsT_nil.
 Qed.
 
-Lemma FiniteT_SingletonT : forall u, (FiniteT *** [| u |]) =>> FiniteT.
+Lemma FiniteT_SingletonT : forall u, (FiniteT *** [|u|]) =>> FiniteT.
 Proof.
 move => u tr /= [tr1 [h0 h1]].
 exact: (finiteT_setoidT h0 (followsT_singletonT h1)).
 Qed.
 
-Lemma InfiniteT_implies_AppendT : InfiniteT =>> (TtT *** [| ffA |]).
+Lemma InfiniteT_implies_AppendT : InfiniteT =>> (TtT *** [|ffA|]).
 Proof.
 move => tr0 [a b tr1] HinfT /=.
 exists (Tcons a b tr1); split => {tr0} //.
@@ -779,7 +779,7 @@ move => a b tr1 HinfT; invs HinfT.
 exact/followsT_delay/CIH.
 Qed.
 
-Lemma AppendT_implies_InfiniteT : (TtT *** [| ffA |]) =>> InfiniteT.
+Lemma AppendT_implies_InfiniteT : (TtT *** [|ffA|]) =>> InfiniteT.
 Proof.
 move => tr0 [tr1 [_ h1]] /=.
 move: tr0 tr1 h1; cofix CIH => tr0 tr1 h1; invs h1.
@@ -856,7 +856,7 @@ move => p tr h0; invs h0.
 - by right; exists tr0.
 Qed.
 
-Lemma IterT_unfold_0 : forall p, IterT p =>> ([| ttA |] orT (p *** IterT p)).
+Lemma IterT_unfold_0 : forall p, IterT p =>> ([|ttA|] orT (p *** IterT p)).
 Proof.
 move => [p hp] tr0 /= h0.
 exact: iterT_split_1 h0.
@@ -870,7 +870,7 @@ move => tr p [[a [h0 h1]] | [tr0 [h0 h1]]].
 - exact: iterT_loop h0 h1.
 Qed.
 
-Lemma IterT_fold_0 : forall p, ([| ttA |] orT (p *** IterT p)) =>> IterT p.
+Lemma IterT_fold_0 : forall p, ([|ttA|] orT (p *** IterT p)) =>> IterT p.
 Proof.
 move => [p hp] tr0 /=.
 exact: iterT_split_2.
@@ -898,14 +898,14 @@ move => [p hp] tr /= h0.
 exact: iterT_unfold_1 h0.
 Qed.
 
-Lemma IterT_unfold_2 : forall p, ([| ttA |] orT (IterT p *** p)) =>> IterT p.
+Lemma IterT_unfold_2 : forall p, ([|ttA|] orT (IterT p *** p)) =>> IterT p.
 Proof.
 move => [p hp] tr0 /= [[a [_ h0]] | H].
 - invs h0. exact: iterT_stop.
 - exact: iterT_unfold_1 H.
 Qed.
 
-Lemma stop_IterT : forall p, [| ttA |] =>> IterT p.
+Lemma stop_IterT : forall p, [|ttA|] =>> IterT p.
 Proof.
 move => [p hp] /= t0 [x [_ h0]]; invs h0 => /=.
 exact: iterT_stop.
@@ -950,7 +950,7 @@ Lemma IterT_IterT : forall p, (IterT p *** IterT p) =>> IterT p.
 Proof. move => [p hp] tr /=. exact: iterT_iterT. Qed.
 
 Lemma IterT_DupT : forall v b,
- ([| v |] *** (IterT (TtT *** <<v; b>>))) =>> (TtT *** [| v |]).
+ ([|v|] *** (IterT (TtT *** <<v;b>>))) =>> (TtT *** [|v|]).
 Proof.
 move => v b tr0 [tr1 [[a [h0 h2]] h1]]; invs h2; invs h1 => /=.
 exists tr0. split => //.
@@ -987,12 +987,12 @@ move => [f hf] [g hg] /= h0.
 exact/lastA_cont/h0.
 Qed.
 
-Lemma LastA_SingletonT_fold : forall u, LastA ([| u |]) ->> u.
+Lemma LastA_SingletonT_fold : forall u, LastA ([|u|]) ->> u.
 Proof.
 by move => u a [tr0 [[st1 [h1 h3]] h2]]; invs h3; invs h2.
 Qed.
 
-Lemma LastA_SingletonT_unfold : forall u, u ->> LastA ([| u |]).
+Lemma LastA_SingletonT_unfold : forall u, u ->> LastA ([|u|]).
 Proof.
 move => u a h0.
 exists (Tnil a); split.
@@ -1009,7 +1009,7 @@ move: h1 tr h2; elim => {tr0 a} [a | a b a' tr0 Hfinal IH] tr h0; invs h0.
 - exact: IH _ H1.
 Qed.
 
-Lemma LastA_AppendA : forall p v, LastA (p *** [| v |]) ->> v.
+Lemma LastA_AppendA : forall p v, LastA (p *** [|v|]) ->> v.
 Proof.
 move => [p hp] v /= a [tr [[tr' [_ h0]] h1]].
 move: h1 tr' h0; elim => {tr a} [a | a b a' tr Hfinal IH] tr0 h0; invs h0.
@@ -1018,7 +1018,7 @@ move: h1 tr' h0; elim => {tr a} [a | a b a' tr Hfinal IH] tr0 h0; invs h0.
 - exact: IH _ H1.
 Qed.
 
-Lemma LastA_andA : forall p u, ((LastA p) andA u) ->> LastA (p *** [| u |]).
+Lemma LastA_andA : forall p u, ((LastA p) andA u) ->> LastA (p *** [|u|]).
 Proof.
 move => [p hp] u a [[tr0 [h2 h3]] h1].
 exists tr0. split => //. exists tr0. split => //.
@@ -1028,7 +1028,7 @@ move: {h2} tr0 a h3 h1. cofix CIH. move => tr0 a h0; invs h0 => h0.
 Qed.
 
 Lemma LastA_IterA : forall v b p,
- LastA ([| v |] *** (IterT (p *** <<v; b>>))) ->> v.
+ LastA ([|v|] *** (IterT (p *** <<v;b>>))) ->> v.
 Proof.
 move => v b p a h0.
 have h1: p =>> TtT by [].
@@ -1038,7 +1038,7 @@ exact: LastA_AppendA.
 Qed.
 
 Lemma IterT_LastA_DupT : forall v b,
- (<<v; b>> *** (IterT (TtT *** <<v; b>>))) =>> (TtT *** [| v |]).
+ (<<v;b>> *** (IterT (TtT *** <<v;b>>))) =>> (TtT *** [|v|]).
 Proof.
 move => v b tr0 [tr1 [[a [h0 h2]] h1]].
 invs h2; invs H1; invs h1; invs H3 => /=.
@@ -1055,7 +1055,7 @@ move: tr' h0 H1. cofix CIH. move => tr0 h0 h1; invs h1.
 Qed.
 
 Lemma LastA_LastA : forall p q,
- (LastA ([| LastA p |] *** q)) ->> (LastA (p *** q)).
+ (LastA ([|LastA p|] *** q)) ->> (LastA (p *** q)).
 Proof.
 move => [p hp] [q hq] a /= [tr1 [[tr0 [[tr2 [h0 h3]] h2]] h1]]; invs h3; invs h2.
 move: h0 => [tr2 [h0 h2]].
@@ -1075,7 +1075,7 @@ exists (tr2 +++ tr1). split.
 Qed.
 
 Lemma SingletonT_andA_AppendT : forall u v,
- (v andA u) ->> LastA ([| v |] *** [| u |]).
+ (v andA u) ->> LastA ([|v|] *** [|u|]).
 Proof.
 move => u v a [h0 h1].
 exists (Tnil a); split; last by apply: finalTA_nil.
@@ -1118,7 +1118,7 @@ move => tr a b1; elim => {tr a} [a | a1 b2 a2 tr Hfinal IH].
 Qed.
 
 Lemma LastA_DupT : forall p u b,
- LastA (p *** [| u |]) ->> LastA (p *** <<u; b>>).
+ LastA (p *** [|u|]) ->> LastA (p *** <<u;b>>).
 Proof.
 move => [p hp] u b a [tr0 [[tr1 [h0 h2]] h1]].
 exists (lastdup tr0 b); split; last by apply: finalTA_lastdup.

--- a/theories/VLSM/Lib/TraceProperties.v
+++ b/theories/VLSM/Lib/TraceProperties.v
@@ -58,7 +58,7 @@ Lemma infiniteT_trace_append :
 Proof.
 cofix CIH.
 move => tr Htr.
-case => [a|a b tr']; first by rewrite trace_append_nil.
+case => [a | a b tr']; first by rewrite trace_append_nil.
 rewrite trace_append_cons.
 exact/infiniteT_delay/CIH.
 Qed.
@@ -67,7 +67,7 @@ Lemma trace_append_infiniteT :
  forall tr, infiniteT tr -> forall tr', infiniteT (tr +++ tr').
 Proof.
 cofix CIH.
-case => [a|a b tr0] Hinf; inversion Hinf => tr'; subst.
+case => [a | a b tr0] Hinf; inversion Hinf => tr'; subst.
 rewrite trace_append_cons.
 exact/infiniteT_delay/CIH.
 Qed.
@@ -83,7 +83,7 @@ Inductive finiteT : trace -> Prop :=
 
 Lemma finiteT_setoidT : setoidT finiteT.
 Proof.
-move => tr1; elim => [a|a b tr1' Hfin IH] tr2 h0; invs h0.
+move => tr1; elim => [a | a b tr1' Hfin IH] tr2 h0; invs h0.
 - exact: finiteT_nil.
 - exact/finiteT_delay/IH.
 Qed.
@@ -100,7 +100,7 @@ Proof. by inversion h. Defined.
 Lemma finiteT_bisim_eq : forall tr,
  finiteT tr -> forall tr', bisim tr tr' -> tr = tr'.
 Proof.
-move => tr; elim => [a tr'|a b tr0 Hfin IH tr'] Hbis; invs Hbis => //.
+move => tr; elim => [a tr' | a b tr0 Hfin IH tr'] Hbis; invs Hbis => //.
 by rewrite (IH _ H3).
 Qed.
 
@@ -109,14 +109,14 @@ Qed.
 Lemma finiteT_infiniteT_not : forall tr,
  finiteT tr -> infiniteT tr -> False.
 Proof.
-by move => tr; elim => [a|a b tr' Hfin IH] Hinf; inversion Hinf.
+by move => tr; elim => [a | a b tr' Hfin IH] Hinf; inversion Hinf.
 Qed.
 
 Lemma not_finiteT_infiniteT : forall tr,
  ~ finiteT tr -> infiniteT tr.
 Proof.
 cofix CIH.
-case => [a|a b tr] Hfin; first by case: Hfin; apply: finiteT_nil.
+case => [a | a b tr] Hfin; first by case: Hfin; apply: finiteT_nil.
 apply: infiniteT_delay.
 apply: CIH => Hinf.
 case: Hfin.
@@ -141,14 +141,14 @@ Inductive finalTB : trace -> B -> Prop :=
 
 Lemma finalTA_finiteT : forall tr a, finalTA tr a -> finiteT tr.
 Proof.
-move => tr a; elim => [a1|a1 b a2 tr' Hfinal IH].
+move => tr a; elim => [a1 | a1 b a2 tr' Hfinal IH].
 - exact: finiteT_nil.
 - exact/finiteT_delay/IH.
 Qed.
 
 Lemma finalTB_finiteT : forall tr b, finalTB tr b -> finiteT tr.
 Proof.
-move => tr b; elim => [a1 b1 a2|a1 b1 b2 a2 Hfin IH].
+move => tr b; elim => [a1 b1 a2 | a1 b1 b2 a2 Hfin IH].
 - exact/finiteT_delay/finiteT_nil.
 - exact: finiteT_delay.
 Qed.
@@ -163,7 +163,7 @@ Lemma finiteT_finalTA : forall tr (h : finiteT tr),
  finalTA tr (finalA h).
 Proof.
 refine (fix IH tr h {struct h} := _).
-case: tr h => [a|a b tr] h; dependent inversion h => /=.
+case: tr h => [a | a b tr] h; dependent inversion h => /=.
 - exact: finalTA_nil.
 - exact: finalTA_delay.
 Qed.
@@ -172,7 +172,7 @@ Lemma finalTA_hd_append_trace : forall tr0 a,
  finalTA tr0 a -> forall tr1, hd tr1 = a ->
  hd (tr0 +++ tr1) = hd tr0.
 Proof.
-by move => tr a; elim => {tr a} [a tr <-|a b a' tr Hfinal IH tr'] //=.
+by move => tr a; elim => {tr a} [a tr <- | a b a' tr Hfinal IH tr'] //=.
 Qed.
 
 (** ** Basic trace properties and connectives *)
@@ -237,7 +237,7 @@ Lemma orT_setoidT : forall f0 f1,
  setoidT f0 -> setoidT f1 ->
  setoidT (fun tr => f0 tr \/ f1 tr).
 Proof.
-move => f0 f1 h0 h1 tr0 [h2|h2] tr1 h3.
+move => f0 f1 h0 h1 tr0 [h2 | h2] tr1 h3.
 - by left; apply: h0 _ h2 _ h3.
 - by right; apply: h1 _ h2 _ h3.
 Qed.
@@ -349,7 +349,7 @@ exist _ (singletonT u) (@singletonT_setoidT u).
 
 #[local] Notation "[| p |]" := (SingletonT p) (at level 80).
 
-Lemma SingletonT_cont: forall u v, u ->> v -> [|u|] =>> [|v|].
+Lemma SingletonT_cont: forall u v, u ->> v -> [| u |] =>> [| v |].
 Proof.
 move => u v h0 tr0 [a [h1 h2]]; invs h2.
 exact/nil_singletonT/h0.
@@ -364,7 +364,7 @@ Lemma dupT_Tcons : forall (u : propA) a b,
  u a -> dupT u b (Tcons a b (Tnil a)).
 Proof.
 move => u a b h.
-by exists a; split; [apply: h|apply: bisim_refl].
+by exists a; split; [apply: h | apply: bisim_refl].
 Qed.
 
 Lemma dupT_cont: forall (u0 u1: propA) b,
@@ -415,9 +415,9 @@ Definition followsT_dec : forall p tr0 tr1 (h: followsT p tr0 tr1),
  { tr & { a | tr0 = Tnil a /\ hd tr = a /\ p tr } } +
  { tr & { tr' & { a & { b | tr0 = Tcons a b tr /\ tr1 = Tcons a b tr' /\ followsT p tr tr'} } } }.
 Proof.
-move => p [a|a b tr0] tr1 h.
+move => p [a | a b tr0] tr1 h.
 - by left; exists tr1, a; inversion h.
-- case: tr1 h => [a0|a0 b0 tr1] h.
+- case: tr1 h => [a0 | a0 b0 tr1] h.
   + by left; exists (Tnil a); exists a; inversion h.
   + by right; exists tr0, tr1, a, b; inversion h.
 Defined.
@@ -518,7 +518,7 @@ Qed.
 
 Lemma followsT_ttA : forall tr, followsT (singletonT ttA) tr tr.
 Proof.
-cofix CIH. case => [a|a b tr0].
+cofix CIH. case => [a | a b tr0].
 - apply: followsT_nil => //.
   exact: nil_singletonT.
 - exact/followsT_delay/CIH.
@@ -641,24 +641,24 @@ move => [q hq] [p1 hp1] [p2 hp2] h0 tr0 /= h1.
 exact: (@appendT_cont q q p1 p2).
 Qed.
 
-Lemma AppendT_ttA: forall p, p =>> (p *** [|ttA|]).
+Lemma AppendT_ttA: forall p, p =>> (p *** [| ttA |]).
 Proof.
 move => [f hp] tr0 /= h0.
 exists tr0; split => //.
 move: {h0 hp} tr0. cofix CIH.
-case => [a|a b tr0].
+case => [a | a b tr0].
 - exact/followsT_nil/nil_singletonT.
 - exact/followsT_delay/CIH.
 Qed.
 
-Lemma SingletonT_DupT_AppendT_andA_DupT : forall u v b, ([|u|] *** <<v; b>>) =>> <<u andA v; b>>.
+Lemma SingletonT_DupT_AppendT_andA_DupT : forall u v b, ([| u |] *** <<v; b>>) =>> <<u andA v; b>>.
 Proof.
 move => u v b tr0 [tr1 [[a [h0 h2]] h1]] /=; invs h2; invs h1.
 move: H1 => [a [h1 h2]]; invs h2; invs H1.
 exact: dupT_Tcons.
 Qed.
 
-Lemma DupT_andA_AppendT_SingletonT_DupT : forall u v b, <<u andA v; b>> =>> ([|u|] *** <<v; b>>).
+Lemma DupT_andA_AppendT_SingletonT_DupT : forall u v b, <<u andA v; b>> =>> ([| u |] *** <<v; b>>).
 Proof.
 move => u v b tr0 [a [[hu hv] h1]]; invs h1; invs H1.
 exists (Tnil a); split; first by apply: nil_singletonT.
@@ -666,7 +666,7 @@ apply: followsT_nil => //.
 exact: dupT_Tcons.
 Qed.
 
-Lemma DupT_andA_AppendT_SingletonT : forall u v b, <<u andA v; b>> =>> <<u; b>> *** [|v|].
+Lemma DupT_andA_AppendT_SingletonT : forall u v b, <<u andA v; b>> =>> <<u; b>> *** [| v |].
 Proof.
 move => u v b tr0 [a [[hu hv] h0]]; invs h0; invs H1.
 exists (Tcons a b (Tnil a)); split.
@@ -675,21 +675,21 @@ exists (Tcons a b (Tnil a)); split.
   exact: nil_singletonT.
 Qed.
 
-Lemma DupT_AppendT_SingletonT_andA_DupT : forall u v b, (<<u; b>> *** [|v|]) =>> <<u andA v; b>>.
+Lemma DupT_AppendT_SingletonT_andA_DupT : forall u v b, (<<u; b>> *** [| v |]) =>> <<u andA v; b>>.
 Proof.
 move => u v b tr0 [tr1 [[a [hu h0]] h1]].
 invs h0; invs H1; invs h1; invs H3; move: H1 => [a [hv h0]]; invs h0 => /=.
 exact: dupT_Tcons.
 Qed.
 
-Lemma AppendT_andA : forall u v, ([|u|] *** [|v|]) =>> [|u andA v|].
+Lemma AppendT_andA : forall u v, ([| u |] *** [| v |]) =>> [| u andA v |].
 Proof.
 move => u v tr0 [tr1 [[a [hu h0]] h1]].
 invs h0; invs h1; move: H1 => [a [hv h0]]; invs h0 => /=.
 exact: nil_singletonT.
 Qed.
 
-Lemma andA_AppendT: forall u v, [|u andA v|] =>> [|u|] *** [|v|].
+Lemma andA_AppendT: forall u v, [| u andA v |] =>> [| u |] *** [| v |].
 Proof.
 move => u v tr0 [a [[hu hv] h0]]; invs h0.
 exists (Tnil a); split; first by apply: nil_singletonT.
@@ -697,18 +697,18 @@ apply: followsT_nil => //.
 exact: nil_singletonT.
 Qed.
 
-Lemma SingletonT_AppendT: forall v p, ([|v|] *** p) =>> p.
+Lemma SingletonT_AppendT: forall v p, ([| v |] *** p) =>> p.
 Proof.
 by move => v [p hp] tr0 /= [tr1 [[a [h0 h2]] h1]]; invs h1; invs h2.
 Qed.
 
-Lemma ttA_AppendT_implies : forall p, ([|ttA|] *** p) =>> p.
+Lemma ttA_AppendT_implies : forall p, ([| ttA |] *** p) =>> p.
 Proof.
 move => p.
 exact: SingletonT_AppendT.
 Qed.
 
-Lemma implies_ttA_AppendT: forall p, p =>> [|ttA|] *** p.
+Lemma implies_ttA_AppendT: forall p, p =>> [| ttA |] *** p.
 Proof.
 move => [p hp] tr0 /= htr0.
 exists (Tnil (hd tr0)); split.
@@ -723,24 +723,24 @@ move => p hp u tr0 [tr1 [h1 h2]].
 exact: (hp _ h1 _ (followsT_singletonT h2)).
 Qed.
 
-Lemma AppendT_Singleton: forall p v, (p *** [|v|]) =>> p.
+Lemma AppendT_Singleton: forall p v, (p *** [| v |]) =>> p.
 Proof.
 move => [p hp] v tr0 /=.
 exact: appendT_singletonT.
 Qed.
 
-Lemma AppendT_ttA_implies : forall p, (p *** [|ttA|]) =>> p.
+Lemma AppendT_ttA_implies : forall p, (p *** [| ttA |]) =>> p.
 Proof.
 move => p.
 exact: AppendT_Singleton.
 Qed.
 
-Lemma implies_AppendT_ttA: forall p, p =>> p *** [|ttA|].
+Lemma implies_AppendT_ttA: forall p, p =>> p *** [| ttA |].
 Proof.
 move => [p hp] tr0 /= htr0.
 exists tr0; split => //.
 move: {hp htr0} tr0. cofix CIH.
-case => [a|a b tr0].
+case => [a | a b tr0].
 - apply: followsT_nil => //.
   exact: nil_singletonT.
 - exact/followsT_delay/CIH.
@@ -752,7 +752,7 @@ Proof. by []. Qed.
 Lemma AppendT_FiniteT_idem : (FiniteT *** FiniteT) =>> FiniteT.
 Proof.
 move => tr0 [tr1 [Hfin Hfol]].
-elim: Hfin tr0 Hfol => [a tr0'|a b tr1' h0 IH tr0] Hfol; invs Hfol => //.
+elim: Hfin tr0 Hfol => [a tr0' | a b tr1' h0 IH tr0] Hfol; invs Hfol => //.
 exact/finiteT_delay/IH.
 Qed.
 
@@ -764,13 +764,13 @@ exists (Tnil (hd tr0)); split.
 - exact: followsT_nil.
 Qed.
 
-Lemma FiniteT_SingletonT: forall u, (FiniteT *** [|u|]) =>> FiniteT.
+Lemma FiniteT_SingletonT: forall u, (FiniteT *** [| u |]) =>> FiniteT.
 Proof.
 move => u tr /= [tr1 [h0 h1]].
 exact: (finiteT_setoidT h0 (followsT_singletonT h1)).
 Qed.
 
-Lemma InfiniteT_implies_AppendT : InfiniteT =>> (TtT *** [|ffA|]).
+Lemma InfiniteT_implies_AppendT : InfiniteT =>> (TtT *** [| ffA |]).
 Proof.
 move => tr0 [a b tr1] HinfT /=.
 exists (Tcons a b tr1); split => {tr0} //.
@@ -779,7 +779,7 @@ move => a b tr1 HinfT; invs HinfT.
 exact/followsT_delay/CIH.
 Qed.
 
-Lemma AppendT_implies_InfiniteT: (TtT *** [|ffA|]) =>> InfiniteT.
+Lemma AppendT_implies_InfiniteT: (TtT *** [| ffA |]) =>> InfiniteT.
 Proof.
 move => tr0 [tr1 [_ h1]] /=.
 move: tr0 tr1 h1; cofix CIH => tr0 tr1 h1; invs h1.
@@ -856,7 +856,7 @@ move => p tr h0; invs h0.
 - by right; exists tr0.
 Qed.
 
-Lemma IterT_unfold_0: forall p, IterT p =>> ([|ttA|] orT (p *** IterT p)).
+Lemma IterT_unfold_0: forall p, IterT p =>> ([| ttA |] orT (p *** IterT p)).
 Proof.
 move => [p hp] tr0 /= h0.
 exact: iterT_split_1 h0.
@@ -865,12 +865,12 @@ Qed.
 Lemma iterT_split_2: forall tr p,
  (singletonT ttA tr) \/ (appendT p (iterT p) tr) -> iterT p tr.
 Proof.
-move => tr p [[a [h0 h1]]|[tr0 [h0 h1]]].
+move => tr p [[a [h0 h1]] | [tr0 [h0 h1]]].
 - invs h1. exact: iterT_stop.
 - exact: iterT_loop h0 h1.
 Qed.
 
-Lemma IterT_fold_0 : forall p, ([|ttA|] orT (p *** IterT p)) =>> IterT p.
+Lemma IterT_fold_0 : forall p, ([| ttA |] orT (p *** IterT p)) =>> IterT p.
 Proof.
 move => [p hp] tr0 /=.
 exact: iterT_split_2.
@@ -882,7 +882,7 @@ move => p tr [tr0 [h0 h1]].
 move: tr0 tr h0 h1. cofix CIH.
 move => tr0 tr1 h0 h1; invs h0.
 - invs h1. apply: (iterT_loop H1). move: {H1} tr1. cofix CIH0.
-  case => [a|a b tr0]; first by apply: followsT_nil => //; apply: iterT_stop.
+  case => [a | a b tr0]; first by apply: followsT_nil => //; apply: iterT_stop.
   exact/followsT_delay/CIH0.
 - apply: (iterT_loop H). move: {H} tr tr0 tr1 H0 h1. cofix CIH0.
   move => tr0 tr1 tr2 h0 h1; invs h0.
@@ -898,14 +898,14 @@ move => [p hp] tr /= h0.
 exact: iterT_unfold_1 h0.
 Qed.
 
-Lemma IterT_unfold_2: forall p, ([|ttA|] orT (IterT p *** p)) =>> IterT p.
+Lemma IterT_unfold_2: forall p, ([| ttA |] orT (IterT p *** p)) =>> IterT p.
 Proof.
-move => [p hp] tr0 /= [[a [_ h0]]|H].
+move => [p hp] tr0 /= [[a [_ h0]] | H].
 - invs h0. exact: iterT_stop.
 - exact: iterT_unfold_1 H.
 Qed.
 
-Lemma stop_IterT : forall p, [|ttA|] =>> IterT p.
+Lemma stop_IterT : forall p, [| ttA |] =>> IterT p.
 Proof.
 move => [p hp] /= t0 [x [_ h0]]; invs h0 => /=.
 exact: iterT_stop.
@@ -922,7 +922,7 @@ Proof.
 move => p tr0 h0.
 exists tr0; split => //.
 move: {h0} tr0. cofix CIH.
-case => [a|a b tr0].
+case => [a | a b tr0].
 - apply: followsT_nil => //. exact: iterT_stop.
 - exact/followsT_delay/CIH.
 Qed.
@@ -950,7 +950,7 @@ Lemma IterT_IterT : forall p, (IterT p *** IterT p) =>> IterT p.
 Proof. move => [p hp] tr /=. exact: iterT_iterT. Qed.
 
 Lemma IterT_DupT : forall v b,
- ([|v|] *** (IterT (TtT *** <<v; b>>))) =>> (TtT *** [|v|]).
+ ([| v |] *** (IterT (TtT *** <<v; b>>))) =>> (TtT *** [| v |]).
 Proof.
 move => v b tr0 [tr1 [[a [h0 h2]] h1]]; invs h2; invs h1 => /=.
 exists tr0. split => //.
@@ -987,12 +987,12 @@ move => [f hf] [g hg] /= h0.
 exact/lastA_cont/h0.
 Qed.
 
-Lemma LastA_SingletonT_fold : forall u, LastA ([|u|]) ->> u.
+Lemma LastA_SingletonT_fold : forall u, LastA ([| u |]) ->> u.
 Proof.
 by move => u a [tr0 [[st1 [h1 h3]] h2]]; invs h3; invs h2.
 Qed.
 
-Lemma LastA_SingletonT_unfold : forall u, u ->> LastA ([|u|]).
+Lemma LastA_SingletonT_unfold : forall u, u ->> LastA ([| u |]).
 Proof.
 move => u a h0.
 exists (Tnil a); split.
@@ -1003,22 +1003,22 @@ Qed.
 Lemma lastA_appendA : forall p q a, lastA (appendT p q) a -> lastA q a.
 Proof.
 move => p q a [tr0 [[tr [_ h2]] h1]].
-move: h1 tr h2; elim => {tr0 a} [a|a b a' tr0 Hfinal IH] tr h0; invs h0.
+move: h1 tr h2; elim => {tr0 a} [a | a b a' tr0 Hfinal IH] tr h0; invs h0.
 - exists (Tnil a). by split; last by apply: finalTA_nil.
 - exists (Tcons a b tr0). by split; last by apply: finalTA_delay.
 - exact: IH _ H1.
 Qed.
 
-Lemma LastA_AppendA : forall p v, LastA (p *** [|v|]) ->> v.
+Lemma LastA_AppendA : forall p v, LastA (p *** [| v |]) ->> v.
 Proof.
 move => [p hp] v /= a [tr [[tr' [_ h0]] h1]].
-move: h1 tr' h0; elim => {tr a} [a|a b a' tr Hfinal IH] tr0 h0; invs h0.
+move: h1 tr' h0; elim => {tr a} [a | a b a' tr Hfinal IH] tr0 h0; invs h0.
 - by move: H0 => [a0 [h0 h1]]; invs h1.
 - by move: H0 => [a0 [_ h0]]; invs h0.
 - exact: IH _ H1.
 Qed.
 
-Lemma LastA_andA : forall p u, ((LastA p) andA u) ->> LastA (p *** [|u|]).
+Lemma LastA_andA : forall p u, ((LastA p) andA u) ->> LastA (p *** [| u |]).
 Proof.
 move => [p hp] u a [[tr0 [h2 h3]] h1].
 exists tr0. split => //. exists tr0. split => //.
@@ -1028,7 +1028,7 @@ move: {h2} tr0 a h3 h1. cofix CIH. move => tr0 a h0; invs h0 => h0.
 Qed.
 
 Lemma LastA_IterA : forall v b p,
- LastA ([|v|] *** (IterT (p *** <<v; b>>))) ->> v.
+ LastA ([| v |] *** (IterT (p *** <<v; b>>))) ->> v.
 Proof.
 move => v b p a h0.
 have h1: p =>> TtT by [].
@@ -1038,7 +1038,7 @@ exact: LastA_AppendA.
 Qed.
 
 Lemma IterT_LastA_DupT : forall v b,
- (<<v; b>> *** (IterT (TtT *** <<v; b>>))) =>> (TtT *** [|v|]).
+ (<<v; b>> *** (IterT (TtT *** <<v; b>>))) =>> (TtT *** [| v |]).
 Proof.
 move => v b tr0 [tr1 [[a [h0 h2]] h1]].
 invs h2; invs H1; invs h1; invs H3 => /=.
@@ -1055,19 +1055,19 @@ move: tr' h0 H1. cofix CIH. move => tr0 h0 h1; invs h1.
 Qed.
 
 Lemma LastA_LastA : forall p q,
- (LastA ([|LastA p|] *** q)) ->> (LastA (p *** q)).
+ (LastA ([| LastA p |] *** q)) ->> (LastA (p *** q)).
 Proof.
 move => [p hp] [q hq] a /= [tr1 [[tr0 [[tr2 [h0 h3]] h2]] h1]]; invs h3; invs h2.
 move: h0 => [tr2 [h0 h2]].
 exists (tr2 +++ tr1). split.
 - exists tr2. split => //.
   move: {h0 h1} tr2 h2. cofix CIH.
-  case => [a0|a0 b tr0] h0.
+  case => [a0 | a0 b tr0] h0.
   + rewrite trace_append_nil. apply: followsT_nil => //. by invs h0.
   + invs h0. rewrite trace_append_cons.
     exact/followsT_delay/CIH.
 - move => {H1 h0}; move h0: (hd tr1) h2 => a0 h2.
-  move: h2 tr1 h0 h1; elim => {tr2 a0} [a0|a0 b a1 tr2 Hfinal IH] tr0 h0 h1.
+  move: h2 tr1 h0 h1; elim => {tr2 a0} [a0 | a0 b a1 tr2 Hfinal IH] tr0 h0 h1.
   + by rewrite trace_append_nil.
   + rewrite trace_append_cons.
     apply: finalTA_delay.
@@ -1075,7 +1075,7 @@ exists (tr2 +++ tr1). split.
 Qed.
 
 Lemma SingletonT_andA_AppendT : forall u v,
- (v andA u) ->> LastA ([|v|] *** [|u|]).
+ (v andA u) ->> LastA ([| v |] *** [| u |]).
 Proof.
 move => u v a [h0 h1].
 exists (Tnil a); split; last by apply: finalTA_nil.
@@ -1091,7 +1091,7 @@ end.
 
 Lemma lastdup_hd: forall tr b, hd tr = hd (lastdup tr b).
 Proof.
-by case => [a b|a b tr b0]; rewrite [lastdup _ _]trace_destr.
+by case => [a b | a b tr b0]; rewrite [lastdup _ _]trace_destr.
 Qed.
 
 Lemma followsT_dupT : forall u tr b,
@@ -1110,7 +1110,7 @@ Qed.
 Lemma finalTA_lastdup : forall tr a b,
  finalTA tr a -> finalTA (lastdup tr b) a.
 Proof.
-move => tr a b1; elim => {tr a} [a|a1 b2 a2 tr Hfinal IH].
+move => tr a b1; elim => {tr a} [a | a1 b2 a2 tr Hfinal IH].
 - rewrite [lastdup _ _]trace_destr /=.
   apply: finalTA_delay. exact: finalTA_nil.
 - rewrite [lastdup _ _]trace_destr /=.
@@ -1118,7 +1118,7 @@ move => tr a b1; elim => {tr a} [a|a1 b2 a2 tr Hfinal IH].
 Qed.
 
 Lemma LastA_DupT : forall p u b,
- LastA (p *** [|u|]) ->> LastA (p *** <<u; b>>).
+ LastA (p *** [| u |]) ->> LastA (p *** <<u; b>>).
 Proof.
 move => [p hp] u b a [tr0 [[tr1 [h0 h2]] h1]].
 exists (lastdup tr0 b); split; last by apply: finalTA_lastdup.
@@ -1158,7 +1158,7 @@ cofix CIH. dependent inversion h; subst.
   invs hm; invs H; invs a0; invs H; invs h.
   apply: followsT_nil => //.
   by inversion H1.
-- subst; move => [a0|a0 b0 tr0] hm; first by inversion hm.
+- subst; move => [a0 | a0 b0 tr0] hm; first by inversion hm.
   invs hm; try invs H; invs H2; invs H3.
   exact: followsT_delay _ _ (CIH _ _ _ _ h1 _ _).
 Qed.

--- a/theories/VLSM/Lib/TraceProperties.v
+++ b/theories/VLSM/Lib/TraceProperties.v
@@ -386,7 +386,7 @@ exist _ (dupT u b) (@dupT_setoidT u b).
 
 #[local] Notation "<< p ; b >>" := (DupT p b) (at level 80).
 
-Lemma DupT_cont: forall u v b, u ->> v -> <<u;b>> =>> <<v;b>>.
+Lemma DupT_cont: forall u v b, u ->> v -> <<u; b>> =>> <<v; b>>.
 Proof.
 move => u v b h0 tr0 /=.
 exact: dupT_cont.
@@ -651,14 +651,14 @@ case => [a|a b tr0].
 - exact/followsT_delay/CIH.
 Qed.
 
-Lemma SingletonT_DupT_AppendT_andA_DupT : forall u v b, ([|u|] *** <<v;b>>) =>> <<u andA v;b>>.
+Lemma SingletonT_DupT_AppendT_andA_DupT : forall u v b, ([|u|] *** <<v; b>>) =>> <<u andA v; b>>.
 Proof.
 move => u v b tr0 [tr1 [[a [h0 h2]] h1]] /=; invs h2; invs h1.
 move: H1 => [a [h1 h2]]; invs h2; invs H1.
 exact: dupT_Tcons.
 Qed.
 
-Lemma DupT_andA_AppendT_SingletonT_DupT : forall u v b, <<u andA v;b>> =>> ([|u|] *** <<v;b>>).
+Lemma DupT_andA_AppendT_SingletonT_DupT : forall u v b, <<u andA v; b>> =>> ([|u|] *** <<v; b>>).
 Proof.
 move => u v b tr0 [a [[hu hv] h1]]; invs h1; invs H1.
 exists (Tnil a); split; first by apply: nil_singletonT.
@@ -666,7 +666,7 @@ apply: followsT_nil => //.
 exact: dupT_Tcons.
 Qed.
 
-Lemma DupT_andA_AppendT_SingletonT : forall u v b, <<u andA v;b>> =>> <<u;b>> *** [|v|].
+Lemma DupT_andA_AppendT_SingletonT : forall u v b, <<u andA v; b>> =>> <<u; b>> *** [|v|].
 Proof.
 move => u v b tr0 [a [[hu hv] h0]]; invs h0; invs H1.
 exists (Tcons a b (Tnil a)); split.
@@ -675,7 +675,7 @@ exists (Tcons a b (Tnil a)); split.
   exact: nil_singletonT.
 Qed.
 
-Lemma DupT_AppendT_SingletonT_andA_DupT : forall u v b, (<<u;b>> *** [|v|]) =>> <<u andA v;b>>.
+Lemma DupT_AppendT_SingletonT_andA_DupT : forall u v b, (<<u; b>> *** [|v|]) =>> <<u andA v; b>>.
 Proof.
 move => u v b tr0 [tr1 [[a [hu h0]] h1]].
 invs h0; invs H1; invs h1; invs H3; move: H1 => [a [hv h0]]; invs h0 => /=.
@@ -950,7 +950,7 @@ Lemma IterT_IterT : forall p, (IterT p *** IterT p) =>> IterT p.
 Proof. move => [p hp] tr /=. exact: iterT_iterT. Qed.
 
 Lemma IterT_DupT : forall v b,
- ([|v|] *** (IterT (TtT *** <<v;b>>))) =>> (TtT *** [|v|]).
+ ([|v|] *** (IterT (TtT *** <<v; b>>))) =>> (TtT *** [|v|]).
 Proof.
 move => v b tr0 [tr1 [[a [h0 h2]] h1]]; invs h2; invs h1 => /=.
 exists tr0. split => //.
@@ -1028,7 +1028,7 @@ move: {h2} tr0 a h3 h1. cofix CIH. move => tr0 a h0; invs h0 => h0.
 Qed.
 
 Lemma LastA_IterA : forall v b p,
- LastA ([|v|] *** (IterT (p *** <<v;b>>))) ->> v.
+ LastA ([|v|] *** (IterT (p *** <<v; b>>))) ->> v.
 Proof.
 move => v b p a h0.
 have h1: p =>> TtT by [].
@@ -1038,7 +1038,7 @@ exact: LastA_AppendA.
 Qed.
 
 Lemma IterT_LastA_DupT : forall v b,
- (<<v;b>> *** (IterT (TtT *** <<v;b>>))) =>> (TtT *** [|v|]).
+ (<<v; b>> *** (IterT (TtT *** <<v; b>>))) =>> (TtT *** [|v|]).
 Proof.
 move => v b tr0 [tr1 [[a [h0 h2]] h1]].
 invs h2; invs H1; invs h1; invs H3 => /=.
@@ -1118,7 +1118,7 @@ move => tr a b1; elim => {tr a} [a|a1 b2 a2 tr Hfinal IH].
 Qed.
 
 Lemma LastA_DupT : forall p u b,
- LastA (p *** [|u|]) ->> LastA (p *** <<u;b>>).
+ LastA (p *** [|u|]) ->> LastA (p *** <<u; b>>).
 Proof.
 move => [p hp] u b a [tr0 [[tr1 [h0 h2]] h1]].
 exists (lastdup tr0 b); split; last by apply: finalTA_lastdup.

--- a/theories/VLSM/Lib/Traces.v
+++ b/theories/VLSM/Lib/Traces.v
@@ -31,13 +31,13 @@ match tr with
 | Tcons a b tr0 => a
 end.
 
-Definition trace_decompose (tr: trace): trace :=
+Definition trace_decompose (tr : trace) : trace :=
 match tr with
 | Tnil a => Tnil a
 | Tcons a b tr' => Tcons a b tr'
 end.
 
-Lemma trace_destr: forall tr, tr = trace_decompose tr.
+Lemma trace_destr : forall tr, tr = trace_decompose tr.
 Proof. by case. Qed.
 
 (** ** Bisimulations between traces *)
@@ -71,12 +71,12 @@ case => [a | a b tr1] tr2 tr0 Hbs Hbs'; invs Hbs; invs Hbs'; first exact: bisim_
 exact: (bisim_cons _ _ (CIH _ _ _ H3 H4)).
 Qed.
 
-Lemma bisim_hd: forall tr0 tr1, bisim tr0 tr1 -> hd tr0 = hd tr1.
+Lemma bisim_hd : forall tr0 tr1, bisim tr0 tr1 -> hd tr0 = hd tr1.
 Proof. by move => tr0 tr1 []. Qed.
 
 (** ** Appending traces to one another *)
 
-CoFixpoint trace_append (tr tr': trace): trace :=
+CoFixpoint trace_append (tr tr' : trace) : trace :=
 match tr with
 | Tnil a => tr'
 | Tcons a b tr0 => Tcons a b (trace_append tr0 tr')

--- a/theories/VLSM/Lib/Traces.v
+++ b/theories/VLSM/Lib/Traces.v
@@ -52,14 +52,14 @@ CoInductive bisim : trace -> trace -> Prop :=
 Lemma bisim_refl : forall tr, bisim tr tr.
 Proof.
 cofix CIH.
-case => [a|a b tr]; first exact: bisim_nil.
+case => [a | a b tr]; first exact: bisim_nil.
 exact/bisim_cons/CIH.
 Qed.
 
 Lemma bisim_sym : forall tr1 tr2, bisim tr1 tr2 -> bisim tr2 tr1.
 Proof.
 cofix CIH.
-case => [a|a b tr1] tr2 Hbs; invs Hbs; first exact: bisim_nil.
+case => [a | a b tr1] tr2 Hbs; invs Hbs; first exact: bisim_nil.
 exact/bisim_cons/CIH.
 Qed.
 
@@ -67,7 +67,7 @@ Lemma bisim_trans : forall tr1 tr2 tr3,
  bisim tr1 tr2 -> bisim tr2 tr3 -> bisim tr1 tr3.
 Proof.
 cofix CIH.
-case => [a|a b tr1] tr2 tr0 Hbs Hbs'; invs Hbs; invs Hbs'; first exact: bisim_nil.
+case => [a | a b tr1] tr2 tr0 Hbs Hbs'; invs Hbs; invs Hbs'; first exact: bisim_nil.
 exact: (bisim_cons _ _ (CIH _ _ _ H3 H4)).
 Qed.
 


### PR DESCRIPTION
This is the same stuff as in https://github.com/runtimeverification/casper-cbc-proofs/pull/510, except this time I also added a script to the `scripts/` directory which can semi-automatically fix the kinds of lexical issues that are handled in this PR.