### PR TITLE
Generalization to allow distinct types for index and validator

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -1,6 +1,7 @@
 From stdpp Require Import prelude finite.
 From Coq Require Import FunctionalExtensionality Reals.
-From VLSM.Lib Require Import Preamble StdppListSet Measurable ListSetExtras RealsExtras ListFinSetExtras.
+From VLSM.Lib Require Import Preamble StdppListSet FinSetExtras ListSetExtras ListFinSetExtras.
+From VLSM.Lib Require Import Measurable RealsExtras.
 From VLSM.Core Require Import VLSM MessageDependencies VLSMProjections Composition ProjectionTraces.
 From VLSM.Core Require Import SubProjectionTraces AnnotatedVLSM Validator Equivocation.
 From VLSM.Core Require Import ByzantineTraces.FixedSetByzantineTraces.
@@ -158,8 +159,7 @@ Proof.
     + unfold channel_authenticated_message in Hsigned.
       rewrite Hsender0 in Hsigned.
       apply Some_inj in Hsigned; subst.
-      apply elem_of_map in e as (_v & HeqAv & H_v).
-      by eapply inj in HeqAv; [| done]; subst.
+      by revert e; apply elem_of_set_map_inj.
     + rewrite elem_of_elements in Hi.
       contradict Hi.
       apply elem_of_difference; split; [| done].
@@ -453,10 +453,7 @@ Proof.
       contradict H_i_im.
       apply elem_of_elements, elem_of_difference; cbn.
       split; [by apply elem_of_list_to_set, elem_of_enum |].
-      unfold byzantine; rewrite elem_of_map.
-      intros (v & HeqAv & Hv).
-      eapply inj in HeqAv; [| done].
-      by subst.
+      by contradict Hni_im; revert Hni_im; apply elem_of_set_map_inj.
 Qed.
 
 (**

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -1,7 +1,8 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun RIneq.
-From VLSM.Lib Require Import Preamble Measurable StdppListSet RealsExtras ListSetExtras.
+From VLSM.Lib Require Import Preamble StdppListSet ListSetExtras FinSetExtras.
+From VLSM.Lib Require Import RealsExtras Measurable.
 From VLSM.Core Require Import VLSM VLSMProjections MessageDependencies Composition Equivocation.
 From VLSM.Core Require Import Equivocation.FixedSetEquivocation.
 From VLSM.Core Require Import Equivocation.TraceWiseEquivocation.
@@ -244,9 +245,7 @@ Proof.
     by specialize (Hsent _ _ (conj Hpre_pre Hinit)).
   + apply (SubProjectionTraces.sub_can_emit_sender IM (elements equivocators)
       A sender Hsender_safety _ _ v), elem_of_elements in Hemit; [| done].
-    apply elem_of_map in Hemit as (_v & HeqAv & H_v).
-    eapply inj in HeqAv; [| done].
-    by subst.
+    by revert Hemit; apply elem_of_set_map_inj.
 Qed.
 
 Lemma StrongFixed_incl_Limited : VLSM_incl StrongFixed Limited.

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -123,15 +123,17 @@ Context
   {message index : Type}
   (IM : index -> VLSM message)
   (threshold : R)
-  `{ReachableThreshold index Ci threshold}
-  `{!finite.Finite index}
+  `{EqDecision index}
   `{forall i, HasBeenSentCapability (IM i)}
   `{forall i, HasBeenReceivedCapability (IM i)}
   (Free := free_composite_vlsm IM)
-  (sender : message -> option index)
-  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM id sender)}
-  (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) index Ci threshold
-    := equivocation_dec_tracewise IM threshold Datatypes.id sender)
+  `{finite.Finite validator}
+  `{ReachableThreshold validator Cv threshold}
+  (A : validator -> index)
+  (sender : message -> option validator)
+  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM A sender)}
+  (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) validator Cv threshold
+    := equivocation_dec_tracewise IM threshold A sender)
   .
 
 Existing Instance Htracewise_BasicEquivocation.
@@ -148,14 +150,14 @@ Definition tracewise_limited_equivocation_vlsm_composition : VLSM message :=
 
 Lemma full_node_limited_equivocation_valid_state_weight s
   : valid_state_prop tracewise_limited_equivocation_vlsm_composition s ->
-    LimitedEquivocationProp (Cv := Ci) IM threshold is_equivocating s.
+    LimitedEquivocationProp (Cv := Cv) IM threshold is_equivocating s.
 Proof.
   eapply limited_equivocation_valid_state; [done |].
   by intros; apply initial_state_not_is_equivocating_tracewise.
 Qed.
 
 Lemma tracewise_not_heavy_LimitedEquivocationProp_iff :
-  forall s, not_heavy s <-> LimitedEquivocationProp (Cv := Ci) IM threshold is_equivocating s.
+  forall s, not_heavy s <-> LimitedEquivocationProp (Cv := Cv) IM threshold is_equivocating s.
 Proof.
   intros; split.
   - by apply not_heavy_impl_LimitedEquivocationProp,
@@ -179,22 +181,27 @@ Context
   {message index : Type}
   (IM : index -> VLSM message)
   (threshold : R)
-  `{ReachableThreshold index Ci threshold}
+  `{FinSet index Ci}
   `{!finite.Finite index}
   `{forall i, HasBeenSentCapability (IM i)}
   `{forall i, HasBeenReceivedCapability (IM i)}
-  (equivocators : Ci)
   (Free := free_composite_vlsm IM)
+  `{finite.Finite validator}
+  `{ReachableThreshold validator Cv threshold}
+  (A : validator -> index)
+  `{! Inj (=) (=) A}
+  (sender : message -> option validator)
+  (eqv_validators : Cv)
+  (equivocators := fin_sets.set_map A eqv_validators : Ci)
+  (Hlimited : (sum_weights eqv_validators <= threshold)%R )
+  (Hsender_safety : sender_safety_alt_prop IM A sender)
+  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM A sender)}
   (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
   (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
-  (Hlimited : (sum_weights equivocators <= threshold)%R)
-  (sender : message -> option index)
-  (Hsender_safety : sender_safety_alt_prop IM (fun i => i) sender)
-  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
-  (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition (Ci := Ci) IM threshold sender)
-  (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) index Ci threshold
-    := equivocation_dec_tracewise IM threshold (fun i => i) sender)
+  (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition (Cv := Cv) IM threshold A sender)
+  (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) validator Cv threshold
+    := equivocation_dec_tracewise IM threshold A sender)
   (tracewise_not_heavy := not_heavy (1 := Htracewise_BasicEquivocation))
   (tracewise_equivocating_validators := equivocating_validators (1 := Htracewise_BasicEquivocation))
   .
@@ -203,7 +210,7 @@ Lemma StrongFixed_valid_state_not_heavy s
   (Hs : valid_state_prop StrongFixed s)
   : tracewise_not_heavy s.
 Proof.
-  cut (tracewise_equivocating_validators s ⊆ equivocators).
+  cut (tracewise_equivocating_validators s ⊆ eqv_validators).
   {
     intro Hincl; unfold tracewise_not_heavy, not_heavy.
     by etransitivity; [apply sum_weights_subseteq |].
@@ -235,8 +242,11 @@ Proof.
       by (exists i; done).
     apply (composite_proper_sent IM) in Hsent; [| done].
     by specialize (Hsent _ _ (conj Hpre_pre Hinit)).
-  + by apply (SubProjectionTraces.sub_can_emit_sender IM (elements equivocators)
-      (fun i => i) sender Hsender_safety _ _ v), elem_of_elements in Hemit.
+  + apply (SubProjectionTraces.sub_can_emit_sender IM (elements equivocators)
+      A sender Hsender_safety _ _ v), elem_of_elements in Hemit; [| done].
+    apply elem_of_map in Hemit as (_v & HeqAv & H_v).
+    eapply inj in HeqAv; [| done].
+    by subst.
 Qed.
 
 Lemma StrongFixed_incl_Limited : VLSM_incl StrongFixed Limited.
@@ -272,11 +282,16 @@ Section sec_has_limited_equivocation.
 *)
 
 Context
-  {message index : Type}
+  {message}
+  `{FinSet index Ci}
+  `{!finite.Finite index}
   (IM : index -> VLSM message)
   (threshold : R)
-  `{ReachableThreshold index Ci threshold}
-  `{!finite.Finite index}
+  `{finite.Finite validator}
+  `{ReachableThreshold validator Cv threshold}
+  (A : validator -> index)
+  `{!Inj (=) (=) A}
+  (sender : message -> option validator)
   `{forall i, HasBeenSentCapability (IM i)}
   `{forall i, HasBeenReceivedCapability (IM i)}
   .
@@ -286,16 +301,15 @@ Definition fixed_limited_equivocation_prop
   (tr : list (composite_transition_item IM))
   : Prop
   :=
-    exists equivocators : Ci,
+    exists equivocators : Cv,
       (sum_weights equivocators <= threshold)%R /\
-      finite_valid_trace (fixed_equivocation_vlsm_composition IM equivocators) s tr.
+      finite_valid_trace (fixed_equivocation_vlsm_composition (Ci := Ci) IM (fin_sets.set_map A equivocators)) s tr.
 
 Context
-  (sender : message -> option index)
   `{FinSet message Cm}
   (message_dependencies : message -> Cm)
-  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
-  (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition (Ci := Ci) IM threshold sender)
+  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM A sender)}
+  (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition (Cv := Cv) IM threshold A sender)
   .
 
 (**
@@ -303,12 +317,12 @@ Context
   composition using a [limited_equivocation_constraint].
 *)
 Lemma traces_exhibiting_limited_equivocation_are_valid
-  (Hsender_safety : sender_safety_alt_prop IM (fun i => i) sender)
+  (Hsender_safety : sender_safety_alt_prop IM A sender)
   : forall s tr, fixed_limited_equivocation_prop s tr -> finite_valid_trace Limited s tr.
 Proof.
   intros s tr [equivocators [Hlimited Htr]].
   eapply VLSM_incl_finite_valid_trace; [| done].
-  by apply Fixed_incl_Limited.
+  by eapply Fixed_incl_Limited.
 Qed.
 
 (**
@@ -317,16 +331,16 @@ Qed.
   the [fixed_limited_equivocation_prop]erty.
 *)
 Lemma traces_exhibiting_limited_equivocation_are_valid_rev
-  (Hke : WitnessedEquivocationCapability IM threshold id sender (Cv := Ci))
+  (Hke : WitnessedEquivocationCapability IM threshold A sender (Cv := Cv))
   `{!Irreflexive (msg_dep_happens_before message_dependencies)}
   `{forall i, MessageDependencies (IM i) message_dependencies}
   (Hfull : forall i, message_dependencies_full_node_condition_prop (IM i) message_dependencies)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
-  (can_emit_signed : channel_authentication_prop IM id sender)
-  (Htracewise_basic_equivocation : BasicEquivocation (composite_state IM) index Ci threshold
-    := equivocation_dec_tracewise IM threshold (fun i => i) sender)
-  (tracewise_not_heavy := not_heavy (1 := Htracewise_basic_equivocation) (Cv := Ci))
-  : forall is s tr, strong_trace_witnessing_equivocation_prop IM threshold id sender is tr (Cv := Ci) ->
+  (can_emit_signed : channel_authentication_prop IM A sender)
+  (Htracewise_basic_equivocation : BasicEquivocation (composite_state IM) validator Cv threshold
+    := equivocation_dec_tracewise IM threshold A sender)
+  (tracewise_not_heavy := not_heavy (1 := Htracewise_basic_equivocation) (Cv := Cv))
+  : forall is s tr, strong_trace_witnessing_equivocation_prop IM threshold A sender is tr (Cv := Cv) ->
     finite_valid_trace_init_to (free_composite_vlsm IM) is s tr ->
     tracewise_not_heavy s ->
     fixed_limited_equivocation_prop is tr.
@@ -344,13 +358,13 @@ Qed.
   have the [fixed_limited_equivocation_prop]erty.
 *)
 Lemma limited_traces_exhibiting_limited_equivocation_are_valid_rev
-  (Hke : WitnessedEquivocationCapability IM threshold id sender (Cv := Ci))
+  (Hke : WitnessedEquivocationCapability IM threshold A sender (Cv := Cv))
   `{!Irreflexive (msg_dep_happens_before message_dependencies)}
   `{forall i, MessageDependencies (IM i) message_dependencies}
   (Hfull : forall i, message_dependencies_full_node_condition_prop (IM i) message_dependencies)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
-  (can_emit_signed : channel_authentication_prop IM id sender)
-  : forall s tr, strong_trace_witnessing_equivocation_prop IM threshold id sender s tr (Cv := Ci) ->
+  (can_emit_signed : channel_authentication_prop IM A sender)
+  : forall s tr, strong_trace_witnessing_equivocation_prop IM threshold A sender s tr (Cv := Cv) ->
     finite_valid_trace Limited s tr -> fixed_limited_equivocation_prop s tr.
 Proof.
   intros s tr Hstrong Htr.
@@ -369,12 +383,12 @@ Qed.
 *)
 
 Lemma limited_valid_state_has_trace_exhibiting_limited_equivocation
-  (Hke : WitnessedEquivocationCapability IM threshold id sender (Cv := Ci))
+  (Hke : WitnessedEquivocationCapability IM threshold A sender (Cv := Cv))
   `{!Irreflexive (msg_dep_happens_before message_dependencies)}
   `{forall i, MessageDependencies (IM i) message_dependencies}
   (Hfull : forall i, message_dependencies_full_node_condition_prop (IM i) message_dependencies)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
-  (can_emit_signed : channel_authentication_prop IM id sender)
+  (can_emit_signed : channel_authentication_prop IM A sender)
   : forall s, valid_state_prop Limited s ->
     exists is tr, finite_trace_last is tr = s /\ fixed_limited_equivocation_prop is tr.
 Proof.
@@ -382,7 +396,7 @@ Proof.
   assert (Hfree_s : valid_state_prop (free_composite_vlsm IM) s)
     by (revert Hs; apply VLSM_incl_valid_state, constraint_free_incl).
   destruct
-    (free_has_strong_trace_witnessing_equivocation_prop IM threshold id sender _ s Hfree_s)
+    (free_has_strong_trace_witnessing_equivocation_prop IM threshold A sender _ s Hfree_s)
     as (is & tr & Htr & Heqv).
   exists is, tr.
   apply valid_trace_get_last in Htr as Hlst.

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -391,7 +391,7 @@ Proof.
   apply can_emit_composite_project in Him as [j Him].
   apply Hchannel in Him as Hsender.
   unfold channel_authenticated_message in Hsender.
-  destruct (sender im) as [v |] eqn:Heq_sender; [| by inversion Hsender].
+  destruct (sender im) as [v |] eqn: Heq_sender; [| by inversion Hsender].
   apply Some_inj in Hsender; cbn in Hsender; subst.
   exists v; subst; cbn.
   unfold msg_dep_message_equivocators, coeqv_message_equivocators,
@@ -447,8 +447,8 @@ Lemma message_equivocators_can_emit (s : vstate Limited) im
 Proof.
   eapply VLSM_embedding_can_emit.
   - unshelve apply equivocators_composition_for_directly_observed_index_incl_embedding with
-      (indices1 := fin_sets.set_map A (msg_dep_message_equivocators IM (Cv := Cv) full_message_dependencies sender
-        (original_state s) im)).
+      (indices1 := fin_sets.set_map A (msg_dep_message_equivocators IM (Cv := Cv)
+        full_message_dependencies sender (original_state s) im)).
     intros x; rewrite !elem_of_elements.
     by apply set_map_mono, union_subseteq_r.
   - destruct (equivocating_messages_are_equivocator_emitted _ _ HLemit Hnobserved)

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -1,7 +1,8 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From Coq Require Import Reals.
 From stdpp Require Import prelude.
-From VLSM.Lib Require Import Preamble ListExtras StdppListFinSet ListSetExtras Measurable StdppExtras.
+From VLSM.Lib Require Import Preamble StdppExtras StdppListFinSet FinSetExtras.
+From VLSM.Lib Require Import ListExtras ListSetExtras Measurable.
 From VLSM.Core Require Import VLSM AnnotatedVLSM MessageDependencies VLSMProjections Composition.
 From VLSM.Core Require Import Validator ProjectionTraces SubProjectionTraces Equivocation.
 From VLSM.Core Require Import Equivocation.FixedSetEquivocation.
@@ -637,10 +638,9 @@ Proof.
     apply can_emit_composite_project in Hemitted as [sub_eqv Hemitted].
     destruct_dec_sig sub_eqv _eqv H_eqv Heqsub_eqv; subst.
     unfold sub_IM in Hemitted; cbn in Hemitted.
-    eapply Hsender_safety in Hemitted; [| done].
-    apply elem_of_elements, elem_of_map in H_eqv as (eqv' & -> & Heqv').
-    eapply inj in Hemitted; [| done].
-    by subst.
+    eapply Hsender_safety in Hemitted; [| done]; subst.
+    apply elem_of_elements in H_eqv.
+    by revert H_eqv; apply elem_of_set_map_inj.
   - cut (strong_fixed_equivocation IM equivocators s msg).
     {
       intros [Hobserved | Hemitted_msg].
@@ -652,9 +652,8 @@ Proof.
         destruct_dec_sig sub_i i Hi Heqsub_i; subst.
         eapply Hsender_safety in Hemitted_msg; [| done].
         cbn in Hemitted_msg; subst.
-        apply elem_of_elements, elem_of_map in Hi as (_eqv & HeqA & H_eqv).
-        eapply inj in HeqA; [| done].
-        by subst.
+        apply elem_of_elements in Hi.
+        by revert Hi; apply elem_of_set_map_inj.
     }
     eapply msg_dep_happens_before_reflect
     ; [| by apply full_message_dependencies_happens_before | right]

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -1,6 +1,6 @@
 From stdpp Require Import prelude.
 From Coq Require Import Reals.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras.
+From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras FinSetExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition.
 From VLSM.Core Require Import SubProjectionTraces MessageDependencies Equivocation.
 From VLSM.Core Require Import NoEquivocation FixedSetEquivocation TraceWiseEquivocation.
@@ -627,7 +627,7 @@ End sec_witnessed_equivocation.
 Section sec_witnessed_equivocation_fixed_set.
 
 Context
-  {message}
+  {message : Type}
   `{FinSet index Ci}
   `{!finite.Finite index}
   (IM : index -> VLSM message)
@@ -709,7 +709,7 @@ Proof.
   }
   eapply VLSM_embedding_can_emit; [| done].
   unshelve eapply (Hproj (dexist (A v) _)).
-  by apply elem_of_elements, elem_of_map; eexists.
+  by apply elem_of_elements, elem_of_map_2.
 Qed.
 
 (** *** Main result of the section
@@ -749,9 +749,7 @@ Proof.
     { revert IHHtr.
       apply VLSM_incl_finite_valid_trace_from_to,
                fixed_equivocation_vlsm_composition_index_incl.
-      intro; rewrite !elem_of_elements, !elem_of_map.
-      intros (v & -> & Hv); eexists; split; [done |].
-      revert Hv.
+      apply elements_subseteq, set_map_subset.
       remember {| destination := sf |} as item.
       replace sf with (destination item) by (subst; done).
       eapply equivocating_validators_witness_monotonicity; [done |].

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -627,28 +627,32 @@ End sec_witnessed_equivocation.
 Section sec_witnessed_equivocation_fixed_set.
 
 Context
-  {message index : Type}
+  {message}
+  `{FinSet index Ci}
+  `{!finite.Finite index}
   (IM : index -> VLSM message)
   `{forall i, HasBeenSentCapability (IM i)}
   `{forall i, HasBeenReceivedCapability (IM i)}
   (threshold : R)
-  `{ReachableThreshold index Ci threshold}
-  `{!finite.Finite index}
+  `{finite.Finite validator}
+  `{ReachableThreshold validator Cv threshold}
+  (A : validator -> index)
+  (sender : message -> option validator)
   (Free := free_composite_vlsm IM)
-  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM Datatypes.id sender)}
-  (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) index Ci threshold
-    := equivocation_dec_tracewise IM threshold Datatypes.id sender)
+  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM A sender)}
+  (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) validator Cv threshold
+    := equivocation_dec_tracewise IM threshold A sender)
   `{FinSet message Cm}
   (message_dependencies : message -> Cm)
   `{!Irreflexive (msg_dep_happens_before message_dependencies)}
   `{forall i, MessageDependencies (IM i) message_dependencies}
   (Hfull : forall i, message_dependencies_full_node_condition_prop (IM i) message_dependencies)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
-  (can_emit_signed : channel_authentication_prop IM Datatypes.id sender)
-  (Hsender_safety : sender_safety_alt_prop IM Datatypes.id sender :=
-    channel_authentication_sender_safety IM Datatypes.id sender can_emit_signed)
+  (can_emit_signed : channel_authentication_prop IM A sender)
+  (Hsender_safety : sender_safety_alt_prop IM A sender :=
+    channel_authentication_sender_safety IM A sender can_emit_signed)
   (Free_has_sender :=
-    composite_no_initial_valid_messages_have_sender IM Datatypes.id sender
+    composite_no_initial_valid_messages_have_sender IM A sender
       can_emit_signed no_initial_messages_in_IM (free_constraint IM))
   (equivocating_validators :=
     equivocating_validators (BasicEquivocation := Htracewise_BasicEquivocation))
@@ -666,7 +670,7 @@ Existing Instance Htracewise_BasicEquivocation.
 Definition equivocating_validators_fixed_equivocation_constraint
   (s : composite_state IM)
   :=
-  fixed_equivocation_constraint IM (equivocating_validators s).
+  fixed_equivocation_constraint IM (Ci := Ci) (fin_sets.set_map A (equivocating_validators s)).
 
 Lemma equivocators_can_emit_free m
   (Hmsg : valid_message_prop Free m)
@@ -677,7 +681,7 @@ Lemma equivocators_can_emit_free m
   l s
   (Hv : composite_valid IM l (s, Some m))
   : can_emit
-    (equivocators_composition_for_directly_observed IM (equivocating_validators sf) s)
+    (equivocators_composition_for_directly_observed IM (Ci := Ci) (fin_sets.set_map A (equivocating_validators sf)) s)
     m.
 Proof.
   apply emitted_messages_are_valid_iff in Hmsg
@@ -692,7 +696,7 @@ Proof.
   unfold pre_loaded_free_equivocating_vlsm_composition, free_equivocating_vlsm_composition.
   specialize
     (@lift_to_composite_generalized_preloaded_VLSM_embedding
-      message (sub_index (elements(equivocating_validators sf))) _ (sub_IM IM (elements(equivocating_validators sf)))
+      message (sub_index (elements (C := Ci) (fin_sets.set_map A (equivocating_validators sf)))) _ (sub_IM IM (elements(fin_sets.set_map A (equivocating_validators sf))))
       (fun msg : message => msg ∈ message_dependencies m)
       (composite_has_been_directly_observed IM s))
     as Hproj.
@@ -703,9 +707,9 @@ Proof.
     apply (Hfull _ _ _ _ Hv) in Hdm.
     by exists i.
   }
-  apply elem_of_elements in Hequivocating_v.
-  specialize (Hproj (@dexist _ _ (fun v => sub_index_prop_dec (elements(equivocating_validators sf)) v) v Hequivocating_v)).
-  by apply (VLSM_embedding_can_emit Hproj).
+  eapply VLSM_embedding_can_emit; [| done].
+  unshelve eapply (Hproj (dexist (A v) _)).
+  by apply elem_of_elements, elem_of_map; eexists.
 Qed.
 
 (** *** Main result of the section
@@ -723,14 +727,14 @@ Qed.
 
 Lemma strong_witness_has_fixed_equivocation is s tr
   (Htr : finite_valid_trace_init_to (free_composite_vlsm IM) is s tr)
-  (Heqv : strong_trace_witnessing_equivocation_prop (Cv := Ci) IM threshold Datatypes.id sender is tr)
-  : finite_valid_trace_init_to (fixed_equivocation_vlsm_composition IM
-      (equivocating_validators s)) is s tr.
+  (Heqv : strong_trace_witnessing_equivocation_prop (Cv := Cv) IM threshold A sender is tr)
+  : finite_valid_trace_init_to (fixed_equivocation_vlsm_composition IM (Ci := Ci)
+      (fin_sets.set_map A (equivocating_validators s))) is s tr.
 Proof.
   split; [| by apply Htr].
   induction Htr using finite_valid_trace_init_to_rev_ind.
   - eapply (finite_valid_trace_from_to_empty (fixed_equivocation_vlsm_composition IM
-      (equivocating_validators si))).
+      (Ci := Ci) (fin_sets.set_map A (equivocating_validators si)))).
     by apply initial_state_is_valid.
   - spec IHHtr.
     { intros prefix. intros.
@@ -741,11 +745,13 @@ Proof.
       in Htr as Hpre_tr.
     assert
       (Htr_sf : finite_valid_trace_from_to
-        (fixed_equivocation_vlsm_composition IM (equivocating_validators sf)) si s tr).
+        (fixed_equivocation_vlsm_composition IM (Ci := Ci) (fin_sets.set_map A (equivocating_validators sf))) si s tr).
     { revert IHHtr.
       apply VLSM_incl_finite_valid_trace_from_to,
                fixed_equivocation_vlsm_composition_index_incl.
-      intro; rewrite !elem_of_elements.
+      intro; rewrite !elem_of_elements, !elem_of_map.
+      intros (v & -> & Hv); eexists; split; [done |].
+      revert Hv.
       remember {| destination := sf |} as item.
       replace sf with (destination item) by (subst; done).
       eapply equivocating_validators_witness_monotonicity; [done |].
@@ -753,7 +759,7 @@ Proof.
     }
     clear IHHtr.
     apply (extend_right_finite_trace_from_to _ Htr_sf).
-    destruct Ht as [[Hs [Hiom [Hv _]]] Ht].
+    destruct Ht as [(Hs & Hiom & Hv & _) Ht].
     apply finite_valid_trace_from_to_last_pstate in Htr_sf as Hs'.
     specialize
       (Heqv
@@ -805,7 +811,7 @@ Qed.
   [equivocating_validators_fixed_equivocation_constraint] induced by it.
 *)
 Lemma equivocating_validators_fixed_equivocation_characterization
-  (Hke : WitnessedEquivocationCapability IM threshold Datatypes.id sender (Cv := Ci))
+  (Hke : WitnessedEquivocationCapability IM threshold A sender (Cv := Cv))
   : forall s,
     valid_state_prop Free s ->
     valid_state_prop
@@ -813,7 +819,7 @@ Lemma equivocating_validators_fixed_equivocation_characterization
 Proof.
   intros s Hs.
   destruct
-    (free_has_strong_trace_witnessing_equivocation_prop IM threshold Datatypes.id sender _ s Hs)
+    (free_has_strong_trace_witnessing_equivocation_prop IM threshold A sender _ s Hs)
     as [is [tr [Htr Heqv]]].
   cut (finite_valid_trace_from_to (composite_vlsm IM
     (equivocating_validators_fixed_equivocation_constraint s)) is s tr).

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -185,6 +185,27 @@ Qed.
 
 End sec_equivocators_fixed_equivocations_vlsm.
 
+Lemma equivocators_fixed_equivocations_vlsm_subset_incl
+  {message : Type}
+  `{finite.Finite index}
+  (IM : index -> VLSM message)
+  `{forall i : index, HasBeenSentCapability (IM i)}
+  (equivocator_IM := equivocator_IM IM)
+  (equivocating1 equivocating2 : set index)
+  (Hincl : equivocating1 ⊆ equivocating2) :
+  VLSM_incl
+    (equivocators_fixed_equivocations_vlsm IM equivocating1)
+    (equivocators_fixed_equivocations_vlsm IM equivocating2).
+Proof.
+  apply constraint_subsumption_incl.
+  apply preloaded_constraint_subsumption_stronger,
+    strong_constraint_subsumption_strongest.
+  intros l (_s, om) [Hmsg Hfixed].
+  split; [done |].
+  unfold state_has_fixed_equivocation.
+  by set_solver.
+Qed.
+
 Section sec_fixed_equivocation_with_fullnode.
 
 (**

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
@@ -93,7 +93,7 @@ Context
 Lemma limited_equivocators_finite_valid_trace_init_to_rev
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   isX trX
-  (HtrX : fixed_limited_equivocation_prop (Ci := Ci) IM threshold isX trX)
+  (HtrX : fixed_limited_equivocation_prop (Ci := Ci) (Cv := Ci) IM threshold Datatypes.id isX trX)
   : exists is s tr,
       equivocators_total_state_project IM is = isX /\
       equivocators_total_state_project IM s = finite_trace_last isX trX /\
@@ -108,7 +108,17 @@ Proof.
     as (is & s & tr & His & Hs & Htr & Hptr & Houtput); [| done].
   exists is, s, tr; split_and?; try itauto.
   revert Hptr; apply VLSM_incl_finite_valid_trace_init_to.
-  by apply equivocators_Fixed_incl_Limited.
+  eapply VLSM_incl_trans; [| by apply equivocators_Fixed_incl_Limited].
+  apply constraint_subsumption_incl.
+  apply preloaded_constraint_subsumption_stronger,
+    strong_constraint_subsumption_strongest.
+  intros l (_s, om) [Hmsg Hfixed].
+  split; [done |].
+  unfold state_has_fixed_equivocation.
+  etransitivity; [done |].
+  intro v; rewrite !elem_of_elements.
+  intro Hv; apply elem_of_map in Hv as (? & ? & ?).
+  by subst.
 Qed.
 
 Section sec_equivocators_simulating_annotated_limited.
@@ -139,7 +149,7 @@ Lemma equivocators_limited_valid_trace_projects_to_annotated_limited_equivocatio
       finite_trace_last_output trX = finite_trace_last_output tr.
 Proof.
   apply valid_trace_get_last in HtrX as HeqsX.
-  eapply valid_trace_forget_last, msg_dep_fixed_limited_equivocation in HtrX; [| done ..].
+  eapply valid_trace_forget_last, @msg_dep_fixed_limited_equivocation in HtrX; [| done..].
   apply limited_equivocators_finite_valid_trace_init_to_rev in HtrX
      as (is & s & tr & His_pr & Hpr_s & Htr_pr & Htr & Houtput); [| done].
   exists is, s, tr; subst; split_and!; [done | | done | done |].
@@ -153,7 +163,7 @@ Context
   `{FinSet message Cm}
   (sender : message -> option index)
   `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
-  (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition IM (Ci := Ci) threshold sender)
+  (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition IM (Cv := Ci) threshold Datatypes.id sender)
   (message_dependencies : message -> Cm)
   .
 
@@ -176,8 +186,8 @@ Lemma limited_equivocators_valid_state_rev
 Proof.
   intros sX HsX.
   apply
-    (limited_valid_state_has_trace_exhibiting_limited_equivocation IM threshold
-      sender message_dependencies Hwitnessed_equivocation Hfull
+    (limited_valid_state_has_trace_exhibiting_limited_equivocation (Ci := Ci) IM threshold
+      Datatypes.id sender message_dependencies Hwitnessed_equivocation Hfull
       no_initial_messages_in_IM can_emit_signed)
     in HsX as (isX & trX & HsX & HtrX).
   apply limited_equivocators_finite_valid_trace_init_to_rev in HtrX

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
 From Coq Require Import FinFun Reals.
-From VLSM.Lib Require Import StdppListSet RealsExtras Measurable.
+From VLSM.Lib Require Import StdppListSet RealsExtras Measurable FinSetExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition AnnotatedVLSM.
 From VLSM.Core Require Import Equivocation MessageDependencies.
 From VLSM.Core Require Import Equivocation.TraceWiseEquivocation.
@@ -109,16 +109,8 @@ Proof.
   exists is, s, tr; split_and?; try itauto.
   revert Hptr; apply VLSM_incl_finite_valid_trace_init_to.
   eapply VLSM_incl_trans; [| by apply equivocators_Fixed_incl_Limited].
-  apply constraint_subsumption_incl.
-  apply preloaded_constraint_subsumption_stronger,
-    strong_constraint_subsumption_strongest.
-  intros l (_s, om) [Hmsg Hfixed].
-  split; [done |].
-  unfold state_has_fixed_equivocation.
-  etransitivity; [done |].
-  intro v; rewrite !elem_of_elements.
-  intro Hv; apply elem_of_map in Hv as (? & ? & ?).
-  by subst.
+  apply equivocators_fixed_equivocations_vlsm_subset_incl.
+  by set_solver.
 Qed.
 
 Section sec_equivocators_simulating_annotated_limited.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
@@ -5,7 +5,7 @@ From VLSM.Lib Require Import Preamble StdppListSet ListSetExtras Measurable Real
 From VLSM.Core Require Import VLSM VLSMProjections Composition AnnotatedVLSM.
 From VLSM.Core Require Import Equivocation Equivocation.TraceWiseEquivocation MessageDependencies.
 From VLSM.Core Require Import Equivocation.NoEquivocation Equivocation.LimitedMessageEquivocation.
-From VLSM.Core Require Import Equivocation.MsgDepLimitedEquivocation.
+From VLSM.Core Require Import FixedSetEquivocation MsgDepLimitedEquivocation.
 From VLSM.Core Require Import Equivocators.Equivocators.
 From VLSM.Core Require Import Equivocators.MessageProperties.
 From VLSM.Core Require Import Equivocators.Composition.EquivocatorsComposition.
@@ -218,7 +218,7 @@ Lemma equivocators_limited_valid_trace_projects_to_fixed_limited_equivocation
     proper_equivocator_descriptors initial_descriptors is /\
     equivocators_trace_project IM final_descriptors tr = Some (trX, initial_descriptors) /\
     equivocators_state_project final_descriptors final_state = final_stateX /\
-    fixed_limited_equivocation_prop (Ci := Ci) IM threshold isX trX.
+    fixed_limited_equivocation_prop (Cv := Ci) (Ci := Ci) IM threshold Datatypes.id isX trX.
 Proof.
   apply valid_trace_add_default_last in Htr as Hfixed_tr.
   apply equivocators_limited_valid_trace_is_fixed in Hfixed_tr.
@@ -228,17 +228,25 @@ Proof.
     (equivocating_validators (finite_trace_last is tr)) final_descriptors is tr) as Hpr.
   feed specialize Hpr; [| done |].
   - by eapply not_equivocating_equivocator_descriptors_proper_fixed.
-  - destruct Hpr as [trX [initial_descriptors [Hinitial_descriptors [Hpr [Hlst_pr Hpr_fixed]]]]].
+  - destruct Hpr as (trX & initial_descriptors & Hinitial_descriptors & Hpr & Hlst_pr & Hpr_fixed).
     exists trX, initial_descriptors.
-    repeat split; [by apply Hinitial_descriptors | done | done |].
+    split_and!; [by apply Hinitial_descriptors | done | done |].
     exists (equivocating_validators (finite_trace_last is tr)).
-    split; [| done].
-    apply valid_trace_add_default_last, valid_trace_last_pstate,
-      valid_state_limited_equivocation in Htr.
-    transitivity (equivocation_fault (finite_trace_last is tr)); [| done].
-    pose proof (@equivocating_indices_equivocating_validators _ _ _ _ IM
-     threshold _ _ _ _ _ _ _ _ _ _ _ H9).
-    by unfold equivocation_fault; apply sum_weights_subseteq.
+    split.
+    + apply valid_trace_add_default_last, valid_trace_last_pstate,
+        valid_state_limited_equivocation in Htr.
+      transitivity (equivocation_fault (finite_trace_last is tr)); [| done].
+      by unfold equivocation_fault; apply sum_weights_subseteq.
+    + revert Hpr_fixed.
+      apply VLSM_incl_finite_valid_trace, constraint_subsumption_incl.
+      apply preloaded_constraint_subsumption_stronger, strong_constraint_subsumption_strongest.
+      intros l (s, [m |]); [| done]; cbn.
+      intros [| Hemit]; [by left |].
+      right; revert Hemit.
+      unshelve eapply VLSM_embedding_can_emit, equivocators_composition_for_directly_observed_index_incl_embedding.
+      intro v; rewrite !elem_of_elements.
+      intro Hv; apply elem_of_map.
+      by exists v.
 Qed.
 
 Section sec_equivocators_projection_annotated_limited.
@@ -282,7 +290,8 @@ Proof.
   ; [| done].
   exists trX, initial_descriptors.
   cbn; split_and?; try itauto.
-  by eapply msg_dep_limited_fixed_equivocation.
+  eapply @msg_dep_limited_fixed_equivocation; [done | done | done | | done..].
+  typeclasses eauto.
 Qed.
 
 End sec_equivocators_projection_annotated_limited.
@@ -291,9 +300,9 @@ Section sec_equivocators_projection_constrained_limited.
 
 Context
   `{FinSet message Cm}
-  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM (fun i => i) sender)}
-  (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition IM (Ci := Ci) threshold sender)
-  (Hsender_safety : sender_safety_alt_prop IM (fun i => i) sender)
+  `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM Datatypes.id sender)}
+  (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition IM (Cv := Ci) threshold Datatypes.id sender)
+  (Hsender_safety : sender_safety_alt_prop IM Datatypes.id sender)
   (message_dependencies : message -> Cm)
   (Hfull : forall i, message_dependencies_full_node_condition_prop (IM i) message_dependencies)
   .
@@ -328,7 +337,7 @@ Proof.
       as [trX [initial_descriptors [Hinitial_descriptors [Hpr [Hlst_pr Hpr_limited]]]]].
   exists trX, initial_descriptors.
   repeat split; [done.. | |].
-  - by eapply traces_exhibiting_limited_equivocation_are_valid.
+  - by eapply @traces_exhibiting_limited_equivocation_are_valid; [| | typeclasses eauto | |].
   - by destruct Hpr_limited as [equivs Hpr_limited]; apply Hpr_limited.
 Qed.
 

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun Reals Lra.
-From VLSM.Lib Require Import Preamble StdppListSet ListSetExtras Measurable RealsExtras.
+From VLSM.Lib Require Import Preamble StdppListSet ListSetExtras Measurable RealsExtras FinSetExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition AnnotatedVLSM.
 From VLSM.Core Require Import Equivocation Equivocation.TraceWiseEquivocation MessageDependencies.
 From VLSM.Core Require Import Equivocation.NoEquivocation Equivocation.LimitedMessageEquivocation.
@@ -244,9 +244,8 @@ Proof.
       intros [| Hemit]; [by left |].
       right; revert Hemit.
       unshelve eapply VLSM_embedding_can_emit, equivocators_composition_for_directly_observed_index_incl_embedding.
-      intro v; rewrite !elem_of_elements.
-      intro Hv; apply elem_of_map.
-      by exists v.
+      apply elements_subseteq.
+      by intros v Hv; apply elem_of_map; eexists.
 Qed.
 
 Section sec_equivocators_projection_annotated_limited.
@@ -289,9 +288,8 @@ Proof.
       in Htr as (trX & initial_descriptors & Hinitial_descriptors & Hpr & Hlst_pr & Hpr_limited)
   ; [| done].
   exists trX, initial_descriptors.
-  cbn; split_and?; try itauto.
-  eapply @msg_dep_limited_fixed_equivocation; [done | done | done | | done..].
-  typeclasses eauto.
+  cbn; split_and!; [itauto.. |].
+  by eapply @msg_dep_limited_fixed_equivocation; [| | | typeclasses eauto |..].
 Qed.
 
 End sec_equivocators_projection_annotated_limited.

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -11,6 +11,10 @@ Context
 
 Section sec_general.
 
+Lemma elements_subseteq (X Y : C) :
+  X ⊆ Y -> elements X ⊆ elements Y.
+Proof. by set_solver. Qed.
+
 Lemma union_size_ge_size1
   (X Y : C) :
   size (X ∪ Y) >= size X.
@@ -208,5 +212,18 @@ Proof.
   simpl; subst fX.
   by apply fmap_length.
 Qed.
+
+Lemma elem_of_set_map_inj (f : A -> B) `{!Inj (=) (=) f} (a : A) (X : C) :
+  f a ∈@{D} fin_sets.set_map f X <-> a ∈ X.
+Proof.
+  intros; rewrite elem_of_map.
+  split; [| by eexists].
+  intros (_v & HeqAv & H_v).
+  eapply inj in HeqAv; [| done].
+  by subst.
+Qed.
+
+Lemma set_map_id (X : C) : X ≡ set_map id X.
+Proof. by set_solver. Qed.
 
 End sec_map.


### PR DESCRIPTION
To allow handling protocols such as ELMO, where the validator type (e.g., Address) is distinct than the component indexing type, we generalize the existing results about limited equivocation and limited byzantine behavior to support this distinction.