### PR TITLE
Remove redundant imports

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FunctionalExtensionality.
-From VLSM.Lib Require Import Preamble StdppListFinSet FinFunExtras ListExtras.
+From VLSM.Lib Require Import Preamble StdppListFinSet.
 From VLSM.Core Require Import VLSM MessageDependencies ProjectionTraces VLSMProjections.
 From VLSM.Core Require Import Composition SubProjectionTraces ByzantineTraces.
 From VLSM.Core Require Import Validator Equivocation EquivocationProjections.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -1,9 +1,9 @@
 From stdpp Require Import prelude finite.
 From Coq Require Import FunctionalExtensionality Reals.
-From VLSM.Lib Require Import Preamble StdppListSet FinSetExtras ListSetExtras ListFinSetExtras.
+From VLSM.Lib Require Import Preamble FinSetExtras ListFinSetExtras.
 From VLSM.Lib Require Import Measurable RealsExtras.
 From VLSM.Core Require Import VLSM MessageDependencies VLSMProjections Composition ProjectionTraces.
-From VLSM.Core Require Import SubProjectionTraces AnnotatedVLSM Validator Equivocation.
+From VLSM.Core Require Import SubProjectionTraces AnnotatedVLSM Equivocation.
 From VLSM.Core Require Import ByzantineTraces.FixedSetByzantineTraces.
 From VLSM.Core Require Import Equivocation.FixedSetEquivocation.
 From VLSM.Core Require Import Equivocation.LimitedMessageEquivocation.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From Coq Require Import FinFun FunctionalExtensionality.
 From stdpp Require Import prelude finite.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet.
+From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM VLSMProjections Composition Validator ProjectionTraces.
 From VLSM.Core Require Import SubProjectionTraces Equivocation Equivocation.NoEquivocation.
 

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun RIneq.
-From VLSM.Lib Require Import Preamble StdppListSet ListSetExtras FinSetExtras.
+From VLSM.Lib Require Import Preamble FinSetExtras.
 From VLSM.Lib Require Import RealsExtras Measurable.
 From VLSM.Core Require Import VLSM VLSMProjections MessageDependencies Composition Equivocation.
 From VLSM.Core Require Import Equivocation.FixedSetEquivocation.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -1,6 +1,6 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From VLSM.Lib Require Import Preamble StdppListSet.
+From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM MessageDependencies VLSMProjections Composition Equivocation.
 From VLSM.Core Require Import Equivocation.FixedSetEquivocation ProjectionTraces SubProjectionTraces.
 

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -1,6 +1,6 @@
 From stdpp Require Import prelude.
 From Coq Require Import Reals.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras FinSetExtras.
+From VLSM.Lib Require Import Preamble ListExtras ListSetExtras FinSetExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition.
 From VLSM.Core Require Import SubProjectionTraces MessageDependencies Equivocation.
 From VLSM.Core Require Import NoEquivocation FixedSetEquivocation TraceWiseEquivocation.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun Reals Lra.
-From VLSM.Lib Require Import Preamble StdppListSet ListSetExtras Measurable RealsExtras FinSetExtras.
+From VLSM.Lib Require Import Preamble Measurable RealsExtras FinSetExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition AnnotatedVLSM.
 From VLSM.Core Require Import Equivocation Equivocation.TraceWiseEquivocation MessageDependencies.
 From VLSM.Core Require Import Equivocation.NoEquivocation Equivocation.LimitedMessageEquivocation.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -1,5 +1,5 @@
 From stdpp Require Import prelude.
-From VLSM.Lib Require Import Preamble ListExtras.
+From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM VLSMProjections Equivocators.Equivocators.
 
 (** * VLSM Projecting Equivocator Traces *)

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -1,6 +1,6 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListFinSetExtras.
+From VLSM.Lib Require Import Preamble ListExtras ListFinSetExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.
 From VLSM.Core Require Import SubProjectionTraces Equivocation EquivocationProjections.
 

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -1,6 +1,5 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From VLSM.Lib Require Import ListExtras.
 From VLSM.Core Require Import VLSM.
 
 (** * VLSM Plans *)

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -1,7 +1,7 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import EquationsExtras.
-From VLSM.Lib Require Import Preamble ListSetExtras ListExtras.
+From VLSM.Lib Require Import Preamble ListSetExtras.
 From VLSM.Core Require Import VLSM Composition VLSMEmbedding.
 
 (** * Traceable VLSMs
@@ -752,7 +752,7 @@ Proof.
       rewrite Heq in Hind.
     eapply composite_tv_state_destructor_preserves_not_in_indices_initial in Hinitial as Hinitials;
       [| done..].
-    destruct_list_last suf suf' last_suf Heqsuf; subst suf; simplify_list_eq;
+    ListExtras.destruct_list_last suf suf' last_suf Heqsuf; subst suf; simplify_list_eq;
       [| by eapply Hind].
     assert (destination item0 = s') as ->
       by (eapply composite_tv_state_destructor_destination, elem_of_list_lookup_2; done).

--- a/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
+++ b/theories/VLSM/Core/TraceableVLSM/MinimalEquivocationTrace.v
@@ -1,7 +1,6 @@
 From stdpp Require Import prelude finite.
-From VLSM.Lib Require Import EquationsExtras.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet StdppExtras ListSetExtras NatExtras.
-From VLSM.Core Require Import VLSM Composition VLSMEmbedding.
+From VLSM.Lib Require Import Preamble ListExtras StdppListSet StdppExtras NatExtras.
+From VLSM.Core Require Import VLSM Composition.
 From VLSM.Core Require Import Equivocation MessageDependencies TraceableVLSM.
 
 (** * Minimally-equivocating traces

--- a/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
@@ -1,6 +1,6 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From VLSM.Lib Require Import Preamble ListExtras StreamExtras StreamFilters StdppExtras.
+From VLSM.Lib Require Import Preamble StreamExtras StreamFilters StdppExtras.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMPartialProjection.
 
 (** * VLSM Stuttering Embeddings

--- a/theories/VLSM/Lib/ListFinSetExtras.v
+++ b/theories/VLSM/Lib/ListFinSetExtras.v
@@ -1,6 +1,6 @@
 From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
 From stdpp Require Import prelude.
-From VLSM.Lib Require Import Preamble StdppExtras StdppListFinSet.
+From VLSM.Lib Require Import Preamble StdppListFinSet.
 
 Section sec_defs.
 

--- a/theories/VLSM/Lib/Measurable.v
+++ b/theories/VLSM/Lib/Measurable.v
@@ -1,6 +1,6 @@
 From stdpp Require Import prelude.
 From Coq Require Import Reals Lra.
-From VLSM.Lib Require Import Preamble ListExtras StdppListSet ListSetExtras StdppListFinSet.
+From VLSM.Lib Require Import Preamble ListExtras StdppListSet StdppListFinSet.
 
 (** * Measure-related definitions and lemmas *)
 


### PR DESCRIPTION
These minimizations were obtained by calling the appropriate absolutize imports and minimize import scripts and noticing which imports were removed.