### PR TITLE
remove itauto tactic notation that was incorporated upstream

### DIFF
--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import ListExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Validator Composition.

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FunctionalExtensionality.
 From VLSM.Lib Require Import Preamble StdppListFinSet.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude finite.
 From Coq Require Import Streams FunctionalExtensionality Eqdep_dec.
 From VLSM.Lib Require Import Preamble ListExtras.

--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import EquationsExtras.
 From VLSM.Lib Require Import Preamble StdppExtras.

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From Coq Require Import FunctionalExtensionality Reals.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import Preamble Measurable FinSetExtras RealsExtras ListExtras.

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From Coq Require Import FunctionalExtensionality.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import Preamble ListExtras StdppExtras.

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From Coq Require Import FunctionalExtensionality.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import Preamble StdppExtras StdppListSet.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From Coq Require Import Streams Rdefinitions.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import Preamble ListExtras StdppListSet StdppExtras.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From Coq Require Import FinFun FunctionalExtensionality.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import Preamble.

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun RIneq.
 From VLSM.Lib Require Import Preamble FinSetExtras.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM MessageDependencies VLSMProjections Composition Equivocation.

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From Coq Require Import Reals.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble StdppExtras StdppListFinSet FinSetExtras.

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun Rdefinitions.
 From VLSM.Lib Require Import Preamble ListExtras StdppListSet Measurable.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsComposition.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun FunctionalExtensionality Reals.
 From VLSM.Lib Require Import Preamble ListSetExtras StdppExtras.

--- a/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/Composition/EquivocatorsCompositionProjections.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From Coq Require Import FinFun FunctionalExtensionality.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import Preamble ListExtras StdppListSet.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import Preamble ListExtras StdppListSet.
 From VLSM.Core Require Import VLSM VLSMProjections Composition Equivocation.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/FixedEquivocationSimulation.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces SubProjectionTraces.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedEquivocationSimulation.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From Coq Require Import FinFun Reals.
 From VLSM.Lib Require Import StdppListSet RealsExtras Measurable FinSetExtras.

--- a/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/Composition/LimitedEquivocation/LimitedStateEquivocation.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun Reals Lra.
 From VLSM.Lib Require Import Preamble Measurable RealsExtras FinSetExtras.

--- a/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude finite.
 From Coq Require Import FinFun Program.
 From VLSM.Lib Require Import Preamble ListExtras.

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From Coq Require Import Eqdep Fin FunctionalExtensionality.
 From VLSM.Lib Require Import Preamble.

--- a/theories/VLSM/Core/Equivocators/MessageProperties.v
+++ b/theories/VLSM/Core/Equivocators/MessageProperties.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble StdppListSet.
 From VLSM.Lib Require Import ListSetExtras FinExtras.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras ListFinSetExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM.
 

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble StdppExtras.
 From VLSM.Core Require Import VLSM Composition VLSMProjections Validator.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From Coq Require Import FunctionalExtensionality Lia.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import Preamble ListExtras StdppListSet StdppExtras StdppListFinSet.

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import EquationsExtras.
 From VLSM.Lib Require Import Preamble ListSetExtras.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From Coq Require Import Streams.
 From VLSM.Lib Require Import Preamble ListExtras StreamExtras.

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From Coq Require Import FunctionalExtensionality.
 From VLSM.Core Require Import VLSM.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras StreamExtras StreamFilters.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMTotalProjection.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMInclusion VLSMProjections.VLSMEmbedding.
 

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMEmbedding VLSMProjections.VLSMTotalProjection.
 

--- a/theories/VLSM/Core/VLSMProjections/VLSMPartialProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMPartialProjection.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM.

--- a/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble StreamExtras StreamFilters StdppExtras.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMPartialProjection.

--- a/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras StreamExtras StreamFilters StdppExtras.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMPartialProjection.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM VLSMProjections Composition.
 

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble.
 

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import finite.
 From Coq Require Import FinFun.
 From VLSM.Lib Require Import Preamble.

--- a/theories/VLSM/Lib/ListFinSetExtras.v
+++ b/theories/VLSM/Lib/ListFinSetExtras.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble StdppListFinSet.
 

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras StdppExtras StdppListSet.
 

--- a/theories/VLSM/Lib/SortedLists.v
+++ b/theories/VLSM/Lib/SortedLists.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From Coq Require Import Sorting.
 From VLSM.Lib Require Import Preamble ListExtras ListSetExtras.

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras.
 

--- a/theories/VLSM/Lib/StdppListFinSet.v
+++ b/theories/VLSM/Lib/StdppListFinSet.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 
 (** * Finite set implementation of a list set interface *)

--- a/theories/VLSM/Lib/StdppListSet.v
+++ b/theories/VLSM/Lib/StdppListSet.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 
 Section sec_fst_defs.

--- a/theories/VLSM/Lib/Temporal.v
+++ b/theories/VLSM/Lib/Temporal.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From Coq Require Import Streams Classical.
 

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -1,4 +1,4 @@
-From Cdcl Require Import Itauto. #[local] Tactic Notation "itauto" := itauto auto.
+From Cdcl Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras ListSetExtras StdppListSet StdppExtras.
 


### PR DESCRIPTION
We dropped support for Coq 8.15, where this was needed to have `itauto` as drop-in replacement for `tauto`.