### PR TITLE
add Ctauto module for Itauto with possibility of classical reasoning

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -4,6 +4,7 @@
 -arg -w -arg -deprecated-tacopt-without-locality
 
 theories/VLSM/Lib/Itauto.v
+theories/VLSM/Lib/Ctauto.v
 theories/VLSM/Lib/SsrExport.v
 theories/VLSM/Lib/Preamble.v
 theories/VLSM/Lib/EquationsExtras.v

--- a/theories/VLSM/Lib/Ctauto.v
+++ b/theories/VLSM/Lib/Ctauto.v
@@ -1,9 +1,10 @@
 From Cdcl Require Export Itauto.
 
-(** * Constructive Itauto tactic *)
+(** * Classical Itauto tactic *)
 
 Ltac gen_conflicts tac :=
   intros; unfold not in *; unfold iff in *;
+  cdcl_nnpp; unfold not;
   (cdcl_conflicts tac).
 
 Tactic Notation "itauto" tactic(tac) :=


### PR DESCRIPTION
Also, add basic documentation. The `Ctauto` module is useful downstream. This provides a small abstraction layer for upcoming changes to the Itauto plugin: https://gitlab.inria.fr/fbesson/itauto/-/commit/c532a62e9a975215975f49bb0358a1a56ac4cc7d