### PR TITLE
Remove some uses of `Existing Instance`

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -362,8 +362,6 @@ Proof.
       by case_decide; [rewrite sub_IM_state_update_neq |].
 Qed.
 
-Existing Instance elem_of_dec_slow.
-
 (**
   Considering a trace with the [fixed_byzantine_trace_alt_prop]erty for a
   set <<byzantine>> of indices of bounded weight, its subtrace corresponding to

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -204,8 +204,6 @@ Proof.
     by intros [(-> & -> & m2 & Hrecv & Hadr & Hincomp) |]; econstructor.
 Qed.
 
-#[local] Existing Instance list_exist_dec.
-
 #[export]
 Instance local_equivocators_full_obs_dec : RelDecision local_equivocators_full_obs.
 Proof.
@@ -213,7 +211,11 @@ Proof.
   induction ol using addObservation'_rec.
   - by right; inversion 1.
   - apply (Decision_iff (iff_Symmetric _ _ (lefo_alt _ _ _))).
-    by typeclasses eauto.
+    apply Decision_or; [| done].
+    apply Decision_and; [done |].
+    apply Decision_and; [by typeclasses eauto |].
+    apply list_exist_dec.
+    by intro; typeclasses eauto.
 Defined.
 
 Definition local_equivocators_full (s : State) : Address -> Prop :=

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -307,7 +307,7 @@ Context
   `{RelDecision _ _ is_equivocating_tracewise_no_has_been_sent}
   .
 
-#[local] Program Instance equivocation_dec_tracewise
+#[export] Program Instance equivocation_dec_tracewise
   : BasicEquivocation (composite_state IM) validator Cv threshold :=
   {
     state_validators := fun _ => list_to_set (enum validator);

--- a/theories/VLSM/Lib/NeList.v
+++ b/theories/VLSM/Lib/NeList.v
@@ -51,8 +51,6 @@ Inductive ne_list_equiv `{Equiv A} : Equiv (ne_list A) :=
 | ne_one_equiv x y : x ≡ y -> nel_singl x ≡ nel_singl y
 | ne_cons_equiv x y l k : x ≡ y -> l ≡ k -> x ::: l ≡ y ::: k.
 
-#[export] Existing Instance ne_list_equiv.
-
 Definition ne_list_to_list {A} (nel : ne_list A) : list A :=
   ne_list_foldr cons [] nel.
 

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -415,8 +415,6 @@ Class StrictlyComparable (X : Type) : Type :=
 }.
 #[global] Hint Mode StrictlyComparable ! : typeclass_instances.
 
-#[export] Existing Instance compare_strictorder.
-
 Definition comparable `(R : relation A) : relation A :=
   fun x y => exists c, CompSpec (=) R x y c.
 


### PR DESCRIPTION
I always found the command `Existing Instance` suspicious - I think you shouldn't need to use it. It turns out we can get rid of quite a few of them while keeping everything working just like before.