### PR TITLE
Add group by option to make axioms

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -14,7 +14,7 @@ COQDOCHTMLFLAGS = --toc --toc-depth 3 --index indexpage --html -s \
   --interpolate --no-lib-name --parse-comments \
   --with-header resources/header.html --with-footer resources/footer.html
 
-GROUPBYMOD = "false"
+group_by_mod = "false"
 
 ALECTRYON = alectryon
 ALECTRYONDIR = docs/alectryon
@@ -32,7 +32,7 @@ coqdoc: $(DOCVOFILES) $(DOCVFILES) $(CSSFILES) $(JSFILES) $(HTMLFILES)
 .PHONY: coqdoc
 
 axioms: $(DOCVOFILES)
-	@scripts/axiom-diagnostics.sh "${COQLIBS}" "${path}" "${keep_tmp}" "${GROUPBYMOD}" 
+	@scripts/axiom-diagnostics.sh "${COQLIBS}" "${path}" "${keep_tmp}" "${group_by_mod}" 
 .PHONY: axioms
 
 RATIOS.md: $(DOCVFILES)

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -30,7 +30,7 @@ coqdoc: $(DOCVOFILES) $(DOCVFILES) $(CSSFILES) $(JSFILES) $(HTMLFILES)
 .PHONY: coqdoc
 
 axioms: $(DOCVOFILES)
-	@scripts/axiom-diagnostics.sh "${COQLIBS}" "${path}" "${keep_tmp}"
+	@scripts/axiom-diagnostics.sh "${GROUPBYMOD}" "${COQLIBS}" "${path}" "${keep_tmp}"
 .PHONY: axioms
 
 RATIOS.md: $(DOCVFILES)

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -14,6 +14,8 @@ COQDOCHTMLFLAGS = --toc --toc-depth 3 --index indexpage --html -s \
   --interpolate --no-lib-name --parse-comments \
   --with-header resources/header.html --with-footer resources/footer.html
 
+GROUPBYMOD = "false"
+
 ALECTRYON = alectryon
 ALECTRYONDIR = docs/alectryon
 ALECTRYONHTMLFLAGS = --frontend coqdoc --webpage-style windowed
@@ -30,7 +32,7 @@ coqdoc: $(DOCVOFILES) $(DOCVFILES) $(CSSFILES) $(JSFILES) $(HTMLFILES)
 .PHONY: coqdoc
 
 axioms: $(DOCVOFILES)
-	@scripts/axiom-diagnostics.sh "${GROUPBYMOD}" "${COQLIBS}" "${path}" "${keep_tmp}"
+	@scripts/axiom-diagnostics.sh "${COQLIBS}" "${path}" "${keep_tmp}" "${GROUPBYMOD}" 
 .PHONY: axioms
 
 RATIOS.md: $(DOCVFILES)

--- a/scripts/all-comment-ratio.sh
+++ b/scripts/all-comment-ratio.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-#| Paper           | Coq                              |
-#|:----------------|:---------------------------------|
+
 BASE=$(dirname $0)
 echo "| Comments size | Spec size | Comments-Spec Ratio | Spec-Comments Ratio | Filename |"
 echo "|:--------------|:----------|:--------------------|:--------------------|:---------|"

--- a/scripts/axiom-diagnostics.sh
+++ b/scripts/axiom-diagnostics.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
 
 
-if test -n "$4"
-then
-   GROUPBYFLAG=$4
-fi
-
 # If argument $1 is not present, print usage info and exit.
 if test -z "$1"
 then
@@ -13,7 +8,7 @@ then
   echo "make axioms"
   echo "make axioms path=path_to_source_directory"
   echo "make axioms path=path_to_source_directory keep_tmp=true"
-  echo "make axioms path=path_to_source_directory keep_tmp=true GROUPBYMOD=true"
+  echo "make axioms path=path_to_source_directory keep_tmp=true group_by_mod=true"
   exit
 fi
 
@@ -34,6 +29,12 @@ then
   keep_tmp=true
 else
   keep_tmp=false
+fi
+
+# If argument $4 is present then store it
+if test -n "$4"
+then
+   group_by_mod=$4
 fi
 
 # Create a temporary directory to hold intermediate results.
@@ -98,9 +99,9 @@ awk '{if (lastLine=="") {lastLine=$0;next} if ($0 ~ /Closed under the global con
 sed -r \
 -e '/PrimInt63/d' \
 -e '/Uint63/d' \
-`# If the user passed GROUPBYMOD=true then group the listings by module name.` \
+`# If the user passed group_by_mod=true then group the listings by module name.` \
 | \
-if [ "$GROUPBYFLAG" = "true" ]; then sed -E -e 's/\t/|/' -e '/^\|/!s/()\..*$//' | awk 'BEGIN {lastModule=""} {if ($0 ~ /^\|/) { data[lastModule][$0] = 1 } else { lastModule=$0 }} END {for (key in data) { print key; for (axiom in data[key]){ print "\t"axiom; } print "\n"; }}' | sed -E 's/\|//'; else tail -n +1; fi
+if [ "$group_by_mod" = "true" ]; then sed -E -e 's/\t/|/' -e '/^\|/!s/()\..*$//' | awk 'BEGIN {lastModule=""} {if ($0 ~ /^\|/) { data[lastModule][$0] = 1 } else { lastModule=$0 }} END {for (key in data) { print key; for (axiom in data[key]){ print "\t"axiom; } print "\n"; }}' | sed -E 's/\|//'; else tail -n +1; fi
 
 # Delete the temporary directory (unless user wants to keep it).
 if [ $keep_tmp == false ]


### PR DESCRIPTION
The options can be activated by passing GROUPBYMOD=true to the make axioms command, for example:
```bash
make GROUPBYMOD=true axioms
```

Obs. if group by module option is active the writing will no longer happen in real time. The contents will be dumpted at the end.