### PR TITLE
Refactor `VLSM_eq`

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -488,7 +488,7 @@ Qed.
 Lemma fixed_non_byzantine_pre_loaded_eq
   : VLSM_eq fixed_non_byzantine_projection pre_loaded_fixed_non_byzantine_vlsm'.
 Proof.
-  apply VLSM_eq_incl_iff. split.
+  split.
   - by apply fixed_non_byzantine_pre_loaded_incl.
   - by apply pre_loaded_fixed_non_byzantine_incl.
 Qed.
@@ -760,7 +760,6 @@ Qed.
 Lemma fixed_non_byzantine_eq_fixed_non_equivocating_from_initial
   : VLSM_eq PreNonByzantine FixedNonEquivocating.
 Proof.
-  apply VLSM_eq_incl_iff.
   split.
   - by apply fixed_non_byzantine_incl_fixed_non_equivocating_from_initial.
   - by apply fixed_non_equivocating_incl_fixed_non_byzantine.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -706,11 +706,11 @@ Lemma free_valid_preloaded_lifts_can_be_emitted
 Proof.
   intros.
   eapply VLSM_incl_can_emit.
-  - by eapply VLSM_eq_proj2, (vlsm_is_pre_loaded_with_False free_composite_vlsm).
+  - by eapply (vlsm_is_pre_loaded_with_False free_composite_vlsm).
   - eapply valid_preloaded_lifts_can_be_emitted; [| done].
     intros dm Hdm.
     eapply VLSM_incl_valid_message.
-    + by apply VLSM_eq_proj1, (vlsm_is_pre_loaded_with_False free_composite_vlsm).
+    + by apply (vlsm_is_pre_loaded_with_False free_composite_vlsm).
     + by cbv; itauto.
     + by apply Hdeps.
 Qed.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -696,7 +696,7 @@ Lemma Equivocators_Fixed_Strong_eq base_s
       (equivocators_composition_for_directly_observed IM equivocators base_s)
       (equivocators_composition_for_sent IM equivocators base_s).
 Proof.
-  apply VLSM_eq_incl_iff. split.
+  split.
   - by apply Equivocators_Fixed_Strong_incl.
   - by apply Equivocators_Strong_Fixed_incl.
 Qed.
@@ -723,7 +723,7 @@ Qed.
 
 Lemma Fixed_eq_StrongFixed : VLSM_eq Fixed StrongFixed.
 Proof.
-  apply VLSM_eq_incl_iff. split.
+  split.
   - by apply Fixed_incl_StrongFixed.
   - by apply StrongFixed_incl_Fixed.
 Qed.
@@ -1015,7 +1015,6 @@ Lemma strong_fixed_equivocation_vlsm_composition_no_equivocators
   : VLSM_eq (strong_fixed_equivocation_vlsm_composition IM (@empty Ci _))
       (composite_vlsm IM (composite_no_equivocations IM)).
 Proof.
-  apply VLSM_eq_incl_iff.
   split.
   - apply constraint_subsumption_incl.
     apply preloaded_constraint_subsumption_stronger.

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -260,9 +260,7 @@ Qed.
 
 Lemma Fixed_incl_Limited : VLSM_incl Fixed Limited.
 Proof.
-  specialize (Fixed_eq_StrongFixed IM equivocators)
-    as Heq.
-  apply VLSM_eq_proj1 in Heq.
+  destruct (Fixed_eq_StrongFixed IM equivocators) as [Heq _].
   apply VLSM_incl_trans with (machine StrongFixed).
   - by apply Heq.
   - by apply StrongFixed_incl_Limited.

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -283,7 +283,7 @@ Lemma msg_dep_strong_fixed_equivocation_eq
       (composite_vlsm IM msg_dep_fixed_set_equivocation_constraint)
       (composite_vlsm IM (strong_fixed_equivocation_constraint IM equivocators)).
 Proof.
-  apply VLSM_eq_incl_iff; split.
+  split.
   - by apply msg_dep_strong_fixed_equivocation_incl.
   - by apply strong_msg_dep_fixed_equivocation_incl.
 Qed.
@@ -418,7 +418,7 @@ Lemma full_node_fixed_equivocation_eq
       (composite_vlsm IM full_node_fixed_set_equivocation_constraint)
       (composite_vlsm IM (fixed_equivocation_constraint IM equivocators)).
 Proof.
-  apply VLSM_eq_incl_iff; split.
+  split.
   - apply full_node_fixed_equivocation_incl; [done |].
     by apply channel_authentication_sender_safety.
   - by apply fixed_full_node_equivocation_incl.

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -344,7 +344,7 @@ Qed.
 Lemma full_node_msg_dep_limited_equivocation_vlsm_eq :
   VLSM_eq FullNodeLimited Limited.
 Proof.
-  apply VLSM_eq_incl_iff; split.
+  split.
   - by apply full_node_msg_dep_limited_equivocation_vlsm_incl.
   - by apply msg_dep_full_node_limited_equivocation_vlsm_incl.
 Qed.

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -269,17 +269,19 @@ Proof.
   |- VLSM_incl (pre_loaded_vlsm ?v _) _ =>
     specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True v) as Hprev
   end.
-  apply VLSM_eq_incl_iff in Hprev. apply proj2 in Hprev.
+  destruct Hprev as [_ Hprev].
   match type of Hprev with
   | VLSM_incl (mk_vlsm ?m) _ => apply VLSM_incl_trans with m
-  end
-  ; [by apply pre_loaded_vlsm_incl |].
-  match type of Hprev with
-  | VLSM_incl _ (mk_vlsm ?m) => apply VLSM_incl_trans with m
-  end
-  ; [done |].
-  unfold free_composite_vlsm; cbn.
-  by apply preloaded_constraint_subsumption_incl.
+  end.
+  - cbn; clear Hprev.
+    by apply (@pre_loaded_vlsm_incl message
+      (composite_vlsm IM no_equivocations_additional_constraint_with_pre_loaded)).
+  - match type of Hprev with
+    | VLSM_incl _ (mk_vlsm ?m) => apply VLSM_incl_trans with m
+    end
+    ; [done |].
+    unfold free_composite_vlsm; cbn.
+    by apply preloaded_constraint_subsumption_incl.
 Qed.
 
 End sec_seeded_composite_vlsm_no_equivocation_definition.

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -151,11 +151,9 @@ Qed.
 Lemma preloaded_eq_no_equivocations
   : VLSM_eq (pre_loaded_with_all_messages_vlsm X) X.
 Proof.
-  specialize preloaded_incl_no_equivocations.
-  specialize (vlsm_incl_pre_loaded_with_all_messages_vlsm X).
-  clear -X. destruct X as [T [S M]].
-  intros Hincl Hincl'.
-  by apply VLSM_eq_incl_iff.
+  split.
+  - by apply preloaded_incl_no_equivocations.
+  - by apply (vlsm_incl_pre_loaded_with_all_messages_vlsm X).
 Qed.
 
 End sec_no_equivocation_invariants.
@@ -314,7 +312,6 @@ Proof.
   | VLSM_eq _ ?v => apply VLSM_eq_trans with (machine v)
   end
   ; [done |].
-  apply VLSM_eq_incl_iff.
   specialize (constraint_subsumption_incl IM) as Hincl.
   unfold no_equivocations_additional_constraint_with_pre_loaded.
   by split; apply Hincl; intros l [s [m |]] Hpv; apply Hpv.

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -1044,11 +1044,11 @@ Lemma equivocator_state_project_valid_message
 Proof.
   destruct om as [m |]; [| by apply option_valid_message_None].
   specialize (vlsm_is_pre_loaded_with_False_initial_message equivocator_vlsm) as Hinit.
-  apply (VLSM_incl_valid_message (VLSM_eq_proj1 (vlsm_is_pre_loaded_with_False equivocator_vlsm)))
+  apply (VLSM_incl_valid_message (proj1 (vlsm_is_pre_loaded_with_False equivocator_vlsm)))
     in Hom; [| done].
   apply preloaded_with_equivocator_state_project_valid_message in Hom.
   specialize (vlsm_is_pre_loaded_with_False_initial_message_rev X) as Hinit_rev.
-  by apply (VLSM_incl_valid_message (VLSM_eq_proj2 (vlsm_is_pre_loaded_with_False X))) in Hom
+  by apply (VLSM_incl_valid_message (proj2 (vlsm_is_pre_loaded_with_False X))) in Hom
   ; destruct X.
 Qed.
 

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -914,19 +914,19 @@ Lemma equivocator_vlsm_trace_project_valid
     end.
 Proof.
   apply (VLSM_incl_finite_valid_trace_from_to
-    (VLSM_eq_proj1 (vlsm_is_pre_loaded_with_False equivocator_vlsm))) in Hbtr.
+    (proj1 (vlsm_is_pre_loaded_with_False equivocator_vlsm))) in Hbtr.
   specialize (preloaded_with_equivocator_vlsm_trace_project_valid _ _ _ _ Hbtr _ _ Hj)
     as [tr [di [Hbtr_pr Hdi]]].
   eexists _, _; split; [done |].
   destruct di as [sn | i].
   - destruct Hdi as [Hsn Htr].
     split; [done |].
-    apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj2
+    apply (VLSM_incl_finite_valid_trace_from_to (proj2
       (vlsm_is_pre_loaded_with_False X))) in Htr.
     by clear -Htr; destruct X.
   - destruct Hdi as [s [Hpr_bs_i Htr]].
     eexists; split; [done |].
-    apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj2 (vlsm_is_pre_loaded_with_False X)))
+    apply (VLSM_incl_finite_valid_trace_from_to (proj2 (vlsm_is_pre_loaded_with_False X)))
       in Htr.
     by clear -Htr; destruct X.
 Qed.
@@ -956,7 +956,7 @@ Lemma preloaded_equivocator_vlsm_trace_project_valid
       finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm X) s ej tr
     end.
 Proof.
-  apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj1
+  apply (VLSM_incl_finite_valid_trace_from_to (proj1
     (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True equivocator_vlsm))) in Hbtr.
   specialize (preloaded_with_equivocator_vlsm_trace_project_valid _ _ _ _ Hbtr _ _ Hj)
     as [tr [di [Hbtr_pr Hdi]]].
@@ -964,12 +964,12 @@ Proof.
   destruct di as [sn | i].
   - destruct Hdi as [Hsn Htr].
     split; [done |].
-    apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj2
+    apply (VLSM_incl_finite_valid_trace_from_to (proj2
       (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True X))) in Htr.
     by clear -Htr; destruct X.
   - destruct Hdi as [s [Hpr_bs_i Htr]].
     eexists; split; [done |].
-    apply (VLSM_incl_finite_valid_trace_from_to (VLSM_eq_proj2
+    apply (VLSM_incl_finite_valid_trace_from_to (proj2
       (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True X))) in Htr.
     by clear -Htr; destruct X.
 Qed.

--- a/theories/VLSM/Core/Equivocators/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocation.v
@@ -1394,7 +1394,6 @@ Qed.
 
 Lemma equivocators_fixed_equivocations_all_eq : VLSM_eq XE NE.
 Proof.
-  apply VLSM_eq_incl_iff.
   split.
   - apply constraint_subsumption_incl.
     apply preloaded_constraint_subsumption_stronger.

--- a/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
@@ -261,7 +261,7 @@ Proof.
       apply (VLSM_eq_valid_state HeqXE) in Hstate_valid.
       apply (VLSM_eq_valid_state HeqX) in HtrX.
       intros m Hsent.
-      apply (VLSM_incl_valid_message (VLSM_eq_proj1 HeqXE)); [by left |].
+      apply (VLSM_incl_valid_message (proj1 HeqXE)); [by left |].
       by apply (fixed_equivocating_messages_sent_by_non_equivocating_are_valid eqv_state_s).
     }
     specialize (Hreplay eqv_state_s).

--- a/theories/VLSM/Core/Equivocators/LimitedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/LimitedEquivocationSimulation.v
@@ -103,7 +103,7 @@ Lemma limited_equivocators_finite_valid_trace_init_to_rev
 Proof.
   destruct HtrX as (equivocating & Hlimited & HtrX).
   eapply VLSM_incl_finite_valid_trace, valid_trace_add_default_last in HtrX
-  ; [| by eapply VLSM_eq_proj1, Fixed_eq_StrongFixed].
+  ; [| by eapply Fixed_eq_StrongFixed].
   eapply fixed_equivocators_finite_valid_trace_init_to_rev in HtrX
     as (is & s & tr & His & Hs & Htr & Hptr & Houtput); [| done].
   exists is, s, tr; split_and?; try itauto.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -515,7 +515,7 @@ Qed.
 Definition pre_loaded_with_all_messages_validator_component_proj_incl
   (Hvalidator : component_projection_validator_prop)
   : VLSM_incl (pre_loaded_with_all_messages_vlsm (IM j)) Xj :=
-  VLSM_eq_proj1 (pre_loaded_with_all_messages_validator_component_proj_eq Hvalidator).
+  proj1 (pre_loaded_with_all_messages_validator_component_proj_eq Hvalidator).
 
 End sec_fixed_projection.
 

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -53,7 +53,7 @@ Qed.
 Lemma composite_vlsm_induced_projection_composition_iff :
   VLSM_eq X (composite_vlsm composite_vlsm_induced_projection constraint).
 Proof.
-  apply VLSM_eq_incl_iff; split.
+  split.
   - apply basic_VLSM_strong_incl; [| | by intro..].
     + by intros s Hs i; specialize (Hs i).
     + intros ? (i & [im Him] & <-).

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -500,7 +500,7 @@ Proof.
     |- context [pre_loaded_with_all_messages_vlsm ?v] =>
       specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True v) as Hincl
     end.
-    by apply VLSM_eq_incl_iff, proj2 in Hincl.
+    by destruct Hincl.
 Qed.
 
 (**

--- a/theories/VLSM/Core/VLSMProjections.v
+++ b/theories/VLSM/Core/VLSMProjections.v
@@ -241,7 +241,7 @@ Lemma VLSM_projection_eq_trans
   (ProjXY : VLSM_projection X Y project_labelXY project_stateXY)
   (ProjYZ : VLSM_eq Y Z)
   : VLSM_projection X Z project_labelXY project_stateXY.
-Proof. by apply VLSM_projection_incl_trans; [| apply VLSM_eq_proj1]. Qed.
+Proof. by apply VLSM_projection_incl_trans; [| apply ProjYZ]. Qed.
 
 Lemma VLSM_embedding_eq_trans
   {message}
@@ -255,7 +255,7 @@ Lemma VLSM_embedding_eq_trans
   (ProjXY : VLSM_embedding X Y project_labelXY project_stateXY)
   (ProjYZ : VLSM_eq Y Z)
   : VLSM_embedding X Z project_labelXY project_stateXY.
-Proof. by apply VLSM_embedding_incl_trans; [| apply VLSM_eq_proj1]. Qed.
+Proof. by apply VLSM_embedding_incl_trans; [| apply ProjYZ]. Qed.
 
 Lemma VLSM_eq_projection_trans
   {message}
@@ -269,7 +269,7 @@ Lemma VLSM_eq_projection_trans
   (project_stateYZ : vstate Y -> vstate Z)
   (ProjYZ : VLSM_projection Y Z project_labelYZ project_stateYZ)
   : VLSM_projection X Z project_labelYZ project_stateYZ.
-Proof. by apply VLSM_incl_projection_trans; [apply VLSM_eq_proj1 |]. Qed.
+Proof. by apply VLSM_incl_projection_trans; [apply ProjXY |]. Qed.
 
 Lemma VLSM_eq_embedding_trans
   {message}
@@ -283,6 +283,6 @@ Lemma VLSM_eq_embedding_trans
   (project_stateYZ : vstate Y -> vstate Z)
   (ProjYZ : VLSM_embedding Y Z project_labelYZ project_stateYZ)
   : VLSM_embedding X Z project_labelYZ project_stateYZ.
-Proof. by apply VLSM_incl_embedding_trans; [apply VLSM_eq_proj1 |]. Qed.
+Proof. by apply VLSM_incl_embedding_trans; [apply ProjXY |]. Qed.
 
 End sec_transitivity_props.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -19,10 +19,8 @@ Context
 
 Definition VLSM_eq_part
   (MX MY : VLSMMachine vtype)
-  (X := mk_vlsm MX) (Y := mk_vlsm MY)
-  :=
-  forall t : Trace,
-    valid_trace_prop X t <-> valid_trace_prop Y t .
+  (X := mk_vlsm MX) (Y := mk_vlsm MY) : Prop :=
+    VLSM_incl X Y /\ VLSM_incl Y X.
 
 #[local] Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
 
@@ -298,8 +296,6 @@ Qed.
 Lemma vlsm_is_pre_loaded_with_False
   : VLSM_eq X (pre_loaded_vlsm X (fun m => False)).
 Proof.
-  destruct X as (T, M). intro Hpp.
-  apply VLSM_eq_incl_iff.
   by cbn; split; apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -72,24 +72,12 @@ Context
 
 (** VLSM equality specialized to finite trace. *)
 
-Lemma VLSM_eq_proj1 : VLSM_incl X Y.
-Proof.
-  by apply Hincl.
-Qed.
-
-Lemma VLSM_eq_proj2 : VLSM_incl Y X.
-Proof.
-  by apply Hincl.
-Qed.
-
 Lemma VLSM_eq_finite_valid_trace
   (s : vstate X)
   (tr : list (vtransition_item X))
   : finite_valid_trace X s tr <-> finite_valid_trace Y s tr.
 Proof.
-  split.
-  - by apply (VLSM_incl_finite_valid_trace VLSM_eq_proj1).
-  - by apply (VLSM_incl_finite_valid_trace VLSM_eq_proj2).
+  by split; apply VLSM_incl_finite_valid_trace, Hincl.
 Qed.
 
 Lemma VLSM_eq_finite_valid_trace_init_to
@@ -98,27 +86,21 @@ Lemma VLSM_eq_finite_valid_trace_init_to
   : finite_valid_trace_init_to X s f tr <->
     finite_valid_trace_init_to Y s f tr.
 Proof.
-  split.
-  - by apply (VLSM_incl_finite_valid_trace_init_to VLSM_eq_proj1).
-  - by apply (VLSM_incl_finite_valid_trace_init_to VLSM_eq_proj2).
+  by split; apply VLSM_incl_finite_valid_trace_init_to, Hincl.
 Qed.
 
 Lemma VLSM_eq_valid_state
   (s : vstate X)
   : valid_state_prop X s <-> valid_state_prop Y s.
 Proof.
-  split.
-  - by apply (VLSM_incl_valid_state VLSM_eq_proj1).
-  - by apply (VLSM_incl_valid_state VLSM_eq_proj2).
+  by split; apply VLSM_incl_valid_state, Hincl.
 Qed.
 
 Lemma VLSM_eq_initial_state
   (is : vstate X)
   : vinitial_state_prop X is <-> vinitial_state_prop Y is.
 Proof.
-  split.
-  - by apply (VLSM_incl_initial_state VLSM_eq_proj1).
-  - by apply (VLSM_incl_initial_state VLSM_eq_proj2).
+  by split; apply VLSM_incl_initial_state, Hincl.
 Qed.
 
 Lemma VLSM_eq_finite_valid_trace_from
@@ -127,9 +109,7 @@ Lemma VLSM_eq_finite_valid_trace_from
   : finite_valid_trace_from X s tr <->
     finite_valid_trace_from Y s tr.
 Proof.
-  split.
-  - by apply (VLSM_incl_finite_valid_trace_from VLSM_eq_proj1).
-  - by apply (VLSM_incl_finite_valid_trace_from VLSM_eq_proj2).
+  by split; apply VLSM_incl_finite_valid_trace_from, Hincl.
 Qed.
 
 Lemma VLSM_eq_finite_valid_trace_from_to
@@ -137,18 +117,14 @@ Lemma VLSM_eq_finite_valid_trace_from_to
   (tr : list (vtransition_item X))
   : finite_valid_trace_from_to X s f tr <-> finite_valid_trace_from_to Y s f tr.
 Proof.
-  split.
-  - by apply (VLSM_incl_finite_valid_trace_from_to VLSM_eq_proj1).
-  - by apply (VLSM_incl_finite_valid_trace_from_to VLSM_eq_proj2).
+  by split; apply VLSM_incl_finite_valid_trace_from_to, Hincl.
 Qed.
 
 Lemma VLSM_eq_in_futures
   (s1 s2 : vstate X)
   : in_futures X s1 s2 <-> in_futures Y s1 s2.
 Proof.
-  split.
-  - by apply (VLSM_incl_in_futures VLSM_eq_proj1).
-  - by apply (VLSM_incl_in_futures VLSM_eq_proj2).
+  by split; apply VLSM_incl_in_futures, Hincl.
 Qed.
 
 Lemma VLSM_eq_input_valid_transition
@@ -156,18 +132,14 @@ Lemma VLSM_eq_input_valid_transition
   input_valid_transition X l (s, im) (s', om) <->
   input_valid_transition Y l (s, im) (s', om).
 Proof.
-  split.
-  - by apply (VLSM_incl_input_valid_transition VLSM_eq_proj1).
-  - by apply (VLSM_incl_input_valid_transition VLSM_eq_proj2).
+  by split; apply @VLSM_incl_input_valid_transition, Hincl.
 Qed.
 
 Lemma VLSM_eq_input_valid
   : forall l s im,
   input_valid X l (s, im) <-> input_valid Y l (s, im).
 Proof.
-  split.
-  - by apply (VLSM_incl_input_valid VLSM_eq_proj1).
-  - by apply (VLSM_incl_input_valid VLSM_eq_proj2).
+  by split; apply @VLSM_incl_input_valid, Hincl.
 Qed.
 
 Lemma VLSM_eq_can_produce
@@ -175,18 +147,14 @@ Lemma VLSM_eq_can_produce
   (om : option message)
   : option_can_produce X s om <-> option_can_produce Y s om.
 Proof.
-  split.
-  - by apply (VLSM_incl_can_produce VLSM_eq_proj1).
-  - by apply (VLSM_incl_can_produce VLSM_eq_proj2).
+  by split; apply VLSM_incl_can_produce, Hincl.
 Qed.
 
 Lemma VLSM_eq_can_emit
   (m : message)
   : can_emit X m <-> can_emit Y m.
 Proof.
-  split.
-  - by apply (VLSM_incl_can_emit VLSM_eq_proj1).
-  - by apply (VLSM_incl_can_emit VLSM_eq_proj2).
+  by split; apply VLSM_incl_can_emit, Hincl.
 Qed.
 
 Lemma VLSM_eq_infinite_valid_trace_from
@@ -194,26 +162,20 @@ Lemma VLSM_eq_infinite_valid_trace_from
   : infinite_valid_trace_from X s ls <->
     infinite_valid_trace_from Y s ls.
 Proof.
-  split.
-  - by apply (VLSM_incl_infinite_valid_trace_from VLSM_eq_proj1).
-  - by apply (VLSM_incl_infinite_valid_trace_from VLSM_eq_proj2).
+  by split; apply VLSM_incl_infinite_valid_trace_from, Hincl.
 Qed.
 
 Lemma VLSM_eq_infinite_valid_trace
   s ls
   : infinite_valid_trace X s ls <-> infinite_valid_trace Y s ls.
 Proof.
-  split.
-  - by apply (VLSM_incl_infinite_valid_trace VLSM_eq_proj1).
-  - by apply (VLSM_incl_infinite_valid_trace VLSM_eq_proj2).
+  by split; apply VLSM_incl_infinite_valid_trace, Hincl.
 Qed.
 
 Lemma VLSM_eq_valid_trace
   : forall t, valid_trace_prop X t <-> valid_trace_prop Y t.
 Proof.
-  split.
-  - by apply (VLSM_incl_valid_trace VLSM_eq_proj1).
-  - by apply (VLSM_incl_valid_trace VLSM_eq_proj2).
+  by split; apply VLSM_incl_valid_trace, Hincl.
 Qed.
 
 End sec_VLSM_eq_properties.
@@ -263,7 +225,7 @@ Lemma pre_loaded_with_all_messages_eq_validating_pre_loaded_vlsm
   : VLSM_eq (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X P).
 Proof.
   split; cbn;
-    [| apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages].
+    [| by apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages].
   apply basic_VLSM_incl.
   - by intro; intros **.
   - by intros l s m Hv _ _; eapply Hvalidating.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -24,12 +24,6 @@ Definition VLSM_eq_part
 
 #[local] Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
 
-Lemma VLSM_eq_incl_iff
-  (MX MY : VLSMMachine vtype)
-  (X := mk_vlsm MX) (Y := mk_vlsm MY)
-  : VLSM_eq X Y <-> VLSM_incl X Y /\ VLSM_incl Y X.
-Proof. by firstorder. Qed.
-
 End sec_VLSM_equality.
 
 Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
@@ -80,12 +74,12 @@ Context
 
 Lemma VLSM_eq_proj1 : VLSM_incl X Y.
 Proof.
-  by apply VLSM_eq_incl_iff in Hincl; apply Hincl.
+  by apply Hincl.
 Qed.
 
 Lemma VLSM_eq_proj2 : VLSM_incl Y X.
 Proof.
-  by apply VLSM_eq_incl_iff in Hincl; apply Hincl.
+  by apply Hincl.
 Qed.
 
 Lemma VLSM_eq_finite_valid_trace
@@ -238,7 +232,7 @@ Lemma pre_loaded_vlsm_with_valid_eq
   (QimpliesValid : forall m, Q m -> valid_message_prop (pre_loaded_vlsm X P) m)
   : VLSM_eq (pre_loaded_vlsm X (fun m => P m \/ Q m)) (pre_loaded_vlsm X P).
 Proof.
-  apply VLSM_eq_incl_iff; split; cbn.
+  split; cbn.
   - by apply pre_loaded_vlsm_incl_relaxed; itauto.
   - by apply pre_loaded_vlsm_incl; itauto.
 Qed.
@@ -247,7 +241,7 @@ Lemma pre_loaded_vlsm_idem
   (P : message -> Prop)
   : VLSM_eq (pre_loaded_vlsm (pre_loaded_vlsm X P) P) (pre_loaded_vlsm X P).
 Proof.
-  apply VLSM_eq_incl_iff; split; cbn.
+  split; cbn.
   - by apply pre_loaded_vlsm_idem_l.
   - by apply pre_loaded_vlsm_idem_r.
 Qed.
@@ -255,7 +249,7 @@ Qed.
 Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True
   : VLSM_eq (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun m => True)).
 Proof.
-  apply VLSM_eq_incl_iff; split; cbn.
+  split; cbn.
   - by apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_l.
   - by apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_r.
 Qed.
@@ -268,7 +262,7 @@ Lemma pre_loaded_with_all_messages_eq_validating_pre_loaded_vlsm
       valid_message_prop (pre_loaded_vlsm X P) m)
   : VLSM_eq (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X P).
 Proof.
-  apply VLSM_eq_incl_iff; split; cbn;
+  split; cbn;
     [| apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages].
   apply basic_VLSM_incl.
   - by intro; intros **.
@@ -300,7 +294,7 @@ Lemma pre_loaded_with_all_messages_vlsm_idem :
     (pre_loaded_with_all_messages_vlsm (pre_loaded_with_all_messages_vlsm X))
     (pre_loaded_with_all_messages_vlsm X).
 Proof.
-  apply VLSM_eq_incl_iff; split; cbn.
+  split; cbn.
   - by apply pre_loaded_with_all_messages_vlsm_idem_l.
   - by apply pre_loaded_with_all_messages_vlsm_idem_r.
 Qed.
@@ -310,7 +304,6 @@ Lemma vlsm_is_pre_loaded_with_False_valid_state_message s om :
   valid_state_message_prop (pre_loaded_vlsm X (fun m => False)) s om.
 Proof.
   pose proof vlsm_is_pre_loaded_with_False as Heq.
-  apply VLSM_eq_incl_iff in Heq.
   destruct X as (T, M); simpl in *.
   by split; (apply VLSM_incl_valid_state_message; [| cbv; tauto]); apply Heq.
 Qed.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -22,8 +22,6 @@ Definition VLSM_eq_part
   (X := mk_vlsm MX) (Y := mk_vlsm MY) : Prop :=
     VLSM_incl X Y /\ VLSM_incl Y X.
 
-#[local] Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
-
 End sec_VLSM_equality.
 
 Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
@@ -209,7 +207,7 @@ Proof.
 Qed.
 
 Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True
-  : VLSM_eq (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun m => True)).
+  : VLSM_eq (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun _ => True)).
 Proof.
   split; cbn.
   - by apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_l.
@@ -234,19 +232,19 @@ Proof.
 Qed.
 
 Lemma vlsm_is_pre_loaded_with_False
-  : VLSM_eq X (pre_loaded_vlsm X (fun m => False)).
+  : VLSM_eq X (pre_loaded_vlsm X (fun _ => False)).
 Proof.
   by cbn; split; apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
 Lemma vlsm_is_pre_loaded_with_False_initial_message
-  : strong_embedding_initial_message_preservation X (pre_loaded_vlsm X (fun m => False)).
+  : strong_embedding_initial_message_preservation X (pre_loaded_vlsm X (fun _ => False)).
 Proof.
   by intros m Hm; left.
 Qed.
 
 Lemma vlsm_is_pre_loaded_with_False_initial_message_rev
-  : strong_embedding_initial_message_preservation (pre_loaded_vlsm X (fun m => False)) X.
+  : strong_embedding_initial_message_preservation (pre_loaded_vlsm X (fun _ => False)) X.
 Proof.
   by intros m [Hm | Hfalse].
 Qed.
@@ -263,7 +261,7 @@ Qed.
 
 Lemma vlsm_is_pre_loaded_with_False_valid_state_message s om :
   valid_state_message_prop X s om <->
-  valid_state_message_prop (pre_loaded_vlsm X (fun m => False)) s om.
+  valid_state_message_prop (pre_loaded_vlsm X (fun _ => False)) s om.
 Proof.
   pose proof vlsm_is_pre_loaded_with_False as Heq.
   destruct X as (T, M); simpl in *.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -24,22 +24,6 @@ Definition VLSM_eq_part
 
 #[local] Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
 
-Lemma VLSM_eq_incl_l
-  (MX MY : VLSMMachine vtype)
-  (X := mk_vlsm MX) (Y := mk_vlsm MY)
-  : VLSM_eq X Y -> VLSM_incl X Y.
-Proof.
-  by intros Heq t Hxt; apply Heq.
-Qed.
-
-Lemma VLSM_eq_incl_r
-  (MX MY : VLSMMachine vtype)
-  (X := mk_vlsm MX) (Y := mk_vlsm MY)
-  : VLSM_eq X Y -> VLSM_incl Y X.
-Proof.
-  by intros Heq t Hyt; apply Heq.
-Qed.
-
 Lemma VLSM_eq_incl_iff
   (MX MY : VLSMMachine vtype)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -480,7 +480,7 @@ Lemma projection_induced_validator_eq
     induced_validator_transition_consistency_Some X2 TY label_project state_project)
   : VLSM_eq X1 X2 -> VLSM_eq XY1 XY2.
 Proof.
-  intro Heq; apply VLSM_eq_incl_iff; split.
+  intro Heq; split.
   - by apply (projection_induced_validator_incl MX1 MX2); [.. | apply VLSM_eq_proj1].
   - by apply (projection_induced_validator_incl MX2 MX1); [.. | apply VLSM_eq_proj2].
 Qed.
@@ -662,7 +662,7 @@ Qed.
 Lemma pre_loaded_with_all_messages_validator_proj_eq
   : VLSM_eq PreY Xi.
 Proof.
-  apply VLSM_eq_incl_iff; split.
+  split.
   - by apply pre_loaded_with_all_messages_validator_proj_incl.
   - by apply induced_validator_incl_preloaded_with_all_messages.
 Qed.
@@ -846,7 +846,7 @@ Lemma preloaded_composite_vlsm_induced_projection_validator_iff
       (pre_loaded_vlsm composite_vlsm_induced_projection_validator P)
       (pre_loaded_vlsm (composite_vlsm_induced_validator IM constraint i) P).
 Proof.
-  apply VLSM_eq_incl_iff; split; cbn; apply basic_VLSM_strong_incl.
+  split; cbn; apply basic_VLSM_strong_incl.
   - intros s Hs; cbn in *; red.
     exists (lift_to_composite_state' IM i s).
     split; [by state_update_simpl |].

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -481,8 +481,8 @@ Lemma projection_induced_validator_eq
   : VLSM_eq X1 X2 -> VLSM_eq XY1 XY2.
 Proof.
   intro Heq; split.
-  - by apply (projection_induced_validator_incl MX1 MX2); [.. | apply VLSM_eq_proj1].
-  - by apply (projection_induced_validator_incl MX2 MX1); [.. | apply VLSM_eq_proj2].
+  - by apply (projection_induced_validator_incl MX1 MX2); [.. | apply Heq].
+  - by apply (projection_induced_validator_incl MX2 MX1); [.. | apply Heq].
 Qed.
 
 End sec_projection_induced_validator_incl.


### PR DESCRIPTION
The goal of this PR is to change the definition of `VLSM_eq X Y` to `VLSM_incl X Y /\ VLSM_incl Y X` and remove all redundancies that result from this.