### PR TITLE
Switch to GH Runner based deps updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: 'Update dependents'
         env:
-          GITHUB_TOKEN: ${{ secrets.JENKINS_DEVOPS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
         run: |
           set -x
           version="${GITHUB_SHA}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - update-deps
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v3
       - name: 'Update dependents'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,21 +5,22 @@ on:
       - master
 
 jobs:
+
   release:
     name: 'Publish Release'
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v3
-
       - name: 'Update dependents'
         env:
-          JENKINS_DEVOPS_TOKEN: ${{ secrets.JENKINS_DEVOPS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.JENKINS_DEVOPS_TOKEN }}
         run: |
-          curl --fail 'https://ci.runtimeverification.com/jenkins/buildByToken/buildWithParameters' \
-            --data job=Devops/master \
-            --data token=$JENKINS_DEVOPS_TOKEN \
-            --data UPDATE_DEPS=true \
-            --data UPDATE_DEPS_REPO=runtimeverification/vlsm \
-            --data UPDATE_DEPS_VERSION="$(git rev-parse HEAD)"
+          set -x
+          version="${GITHUB_SHA}"
+          curl --fail                                                          \
+            -X POST                                                            \
+            -H "Accept: application/vnd.github+json"                           \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}"                         \
+            -H "X-GitHub-Api-Version: 2022-11-28"                              \
+            https://api.github.com/repos/runtimeverification/devops/dispatches \
+            -d '{"event_type":"on-demand-test","client_payload":{"repo":"runtimeverification/vlsm","version":"'${VERSION}'"}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: 'Checkout code'
+      - name: 'Check out code'
         uses: actions/checkout@v3
       - name: 'Update dependents'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: 'Checkout code'
+        uses: actions/checkout@v3
       - name: 'Update dependents'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -24,4 +26,4 @@ jobs:
             -H "Authorization: Bearer ${GITHUB_TOKEN}"                         \
             -H "X-GitHub-Api-Version: 2022-11-28"                              \
             https://api.github.com/repos/runtimeverification/devops/dispatches \
-            -d '{"event_type":"on-demand-test","client_payload":{"repo":"runtimeverification/vlsm","version":"'${VERSION}'"}}'
+            -d '{"event_type":"on-demand-test","client_payload":{"repo":"runtimeverification/vlsm","version":"'${version}'"}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - update-deps
 
 jobs:
 


### PR DESCRIPTION
This switches us from using the Jenkins-based dependency updater to using the GH Runner based updater.