### PR TITLE
Export `elem_of_dec_slow` from Preamble

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -424,7 +424,6 @@ Proof.
     }
     specialize (valid_generated_state_message X _ _ Hs0 _ _ Hs0) as Hgen.
     unfold non_byzantine in Hi.
-    pose proof (Hdec := elem_of_dec_slow (H6 := H6)).
     rewrite elem_of_elements, elem_of_difference in Hi.
     apply not_and_r in Hi as [Hi | Hi];
       [by elim Hi; apply elem_of_list_to_set, elem_of_enum |].
@@ -680,7 +679,6 @@ Proof.
       eapply message_dependencies_are_sufficient in Hiom.
       revert Hiom.
       rewrite elem_of_elements, elem_of_difference in Hi.
-      pose proof (Hdec := elem_of_dec_slow (C := Ci)).
       apply not_and_r in Hi as [Hi | Hi];
         [by elim Hi; apply elem_of_list_to_set; apply elem_of_enum |].
       apply dec_stable in Hi.

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -155,7 +155,6 @@ Proof.
     by specialize (Hsent _ _ (conj Hpre_pre Hinit)).
   - specialize (proj1 Hemit) as [i [Hi Hsigned]].
     subst.
-    pose @elem_of_dec_slow.
     destruct (decide (i ∈ byzantine)).
     + unfold channel_authenticated_message in Hsigned.
       rewrite Hsender0 in Hsigned.
@@ -448,7 +447,6 @@ Proof.
       unfold channel_authenticated_message in Hauth
       ; rewrite Hsender in Hauth.
       apply Some_inj in Hauth; subst _i_im.
-      pose @elem_of_dec_slow.
       destruct (decide (i_im ∈ byzantine_vs)) as [Hi_im | Hni_im]; [done |].
       contradict H_i_im.
       apply elem_of_elements, elem_of_difference; cbn.

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -976,7 +976,6 @@ Proof.
       | left Hdec => left _
       | right Hdec => right _
       end).
-  - by apply elem_of_dec_slow.
   - by rewrite <- full_message_dependencies_happens_before.
   - by rewrite <- full_message_dependencies_happens_before.
 Qed.

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -90,8 +90,7 @@ Proof.
     intros a.
     split; intros Ha.
     - by set_solver.
-    - destruct (@decide (a ∈ Y)).
-      apply elem_of_dec_slow.
+    - destruct (decide (a ∈ Y)).
       + by apply elem_of_union; left; itauto.
       + by apply elem_of_union; right; set_solver.
   }

--- a/theories/VLSM/Lib/Preamble.v
+++ b/theories/VLSM/Lib/Preamble.v
@@ -38,6 +38,9 @@ end.
 
 Notation decide_eq := (fun x y => decide (x = y)).
 
+(** For some reason, this instance is not exported by stdpp. *)
+#[export] Existing Instance elem_of_dec_slow.
+
 (** ** Lemmas about transitive closure *)
 
 Lemma transitive_tc_idempotent `(Transitive A R) :


### PR DESCRIPTION
For some reason this instance was not exported by stdpp, which caused us to frequently write things like `pose @elem_of_dec_slow` or `apply elem_of_dec_slow`.