### PR TITLE
Remove module FinExtras, this time for good

### DIFF
--- a/theories/VLSM/Lib/FinExtras.v
+++ b/theories/VLSM/Lib/FinExtras.v
@@ -1,3 +1,0 @@
-From stdpp Require Import prelude.
-
-(** * Finite type utility definitions and lemmas *)


### PR DESCRIPTION
I'm sorry for this embarrassing situation, but it seems after deleting everything from FinExtras, I forgot to delete the module itself...