### PR TITLE
Refactor `list_annotate` and `filter annotate`

### DIFF
--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -550,7 +550,7 @@ match l with
   end
 end.
 
-Definition filter_annotate_length
+Lemma filter_annotate_length
   {A : Type}
   (P : A -> Prop)
   {Pdec : forall a : A, Decision (P a)}

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -453,10 +453,10 @@ Lemma elem_of_list_annotate_forget
 Proof.
   induction l.
   - by inversion Hin.
-  - rewrite list_annotate_unroll, elem_of_cons in Hin.
-    destruct Hin as [-> | Hin].
+  - cbn in Hin.
+    apply elem_of_cons in Hin as [-> | Hin].
     + by left.
-    + by right; apply (IHl (Forall_tl Hs)).
+    + by right; apply (IHl (Forall_inv_tail Hs)).
 Qed.
 
 Lemma elem_of_list_annotate


### PR DESCRIPTION
The definitions of these two functions were quite hairy, as they required to reprove some standard library lemmas and end them with `Defined` instead of `Qed`. I refactored both functions to be defined more directly, which allows us to delete these duplicated lemmas.