### PR TITLE
Make `vtype` a coercion

### DIFF
--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -96,11 +96,11 @@ Lemma annotate_trace_item_project
   (k : annotated_state -> list (@transition_item _ annotated_type))
   (sa : annotated_state)
   : pre_VLSM_embedding_finite_trace_project
-      annotated_type (vtype X) id original_state
+      annotated_type X id original_state
       (annotate_trace_item item k sa)
       = item ::
         pre_VLSM_embedding_finite_trace_project
-            annotated_type (vtype X) id original_state
+            annotated_type X id original_state
             (k {| original_state := destination item;
                   state_annotation := annotated_transition_state (l item) (sa, input item) |}).
 Proof.
@@ -158,7 +158,7 @@ Proof. by apply annotate_trace_from_last_original_state. Qed.
 
 Lemma annotate_trace_project is tr
   : pre_VLSM_embedding_finite_trace_project
-      annotated_type (vtype X) id original_state
+      annotated_type X id original_state
       (annotate_trace is tr)
       = tr.
 Proof.
@@ -289,7 +289,7 @@ Proof.
 Qed.
 
 Definition annotated_composite_induced_validator : VLSM message
-  := projection_induced_validator AnnotatedFree (vtype (IM i))
+  := projection_induced_validator AnnotatedFree (IM i)
     annotated_composite_label_project annotated_composite_state_project
     annotated_composite_label_lift annotated_composite_state_lift.
 

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -388,7 +388,7 @@ Lemma lift_fixed_byzantine_traces_to_limited
         (lift_sub_label IM (elements non_byzantine)) (lift_sub_state IM (elements non_byzantine))
         (finite_trace_sub_projection IM (elements non_byzantine) tr)))
   : finite_valid_trace Limited bs btr /\
-    state_annotation (@finite_trace_last _ (vtype Limited) bs btr) ⊆ byzantine_vs.
+    state_annotation (@finite_trace_last _ Limited bs btr) ⊆ byzantine_vs.
 Proof.
   subst non_byzantine.
   induction Hbyzantine using finite_valid_trace_rev_ind; [repeat split |].
@@ -473,7 +473,7 @@ Lemma msg_dep_validator_limited_non_equivocating_byzantine_traces_are_limited_no
       finite_trace_sub_projection IM (elements selection_complement) tr =
         finite_trace_sub_projection IM (elements selection_complement)
           (pre_VLSM_embedding_finite_trace_project
-            (vtype Limited) (composite_type IM) Datatypes.id original_state btr).
+            Limited (composite_type IM) Datatypes.id original_state btr).
 Proof.
   split.
   - intros (byzantine & Hlimited & Hbyzantine).

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -210,7 +210,7 @@ Definition lift_to_composite_transition_item
   (s : composite_state)
   (j : index)
   : vtransition_item (IM j) -> composite_transition_item :=
-  pre_VLSM_embedding_transition_item_project (vtype (IM j)) composite_type
+  pre_VLSM_embedding_transition_item_project (IM j) composite_type
     (lift_to_composite_label j) (lift_to_composite_state s j).
 
 (**

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -583,7 +583,7 @@ Lemma input_valid_transition_size_Mi :
 Proof.
   intros s1 s2 iom oom lbl Hivt.
   eapply input_valid_transition_size_RMi.
-  by apply (@VLSM_incl_input_valid_transition _ (vtype Mi) (vmachine Mi) (vmachine RMi))
+  by apply (@VLSM_incl_input_valid_transition _ Mi (vmachine Mi) (vmachine RMi))
   ; eauto using VLSM_incl_Mi_RMi.
 Qed.
 
@@ -596,7 +596,7 @@ Lemma finite_valid_trace_from_to_size_Mi :
 Proof.
   intros s1 s2 tr Hfvt.
   eapply finite_valid_trace_from_to_size_RMi.
-  by apply (@VLSM_incl_finite_valid_trace_from_to _ (vtype Mi) (vmachine Mi) (vmachine RMi))
+  by apply (@VLSM_incl_finite_valid_trace_from_to _ Mi (vmachine Mi) (vmachine RMi))
   ; eauto using VLSM_incl_Mi_RMi.
 Qed.
 
@@ -608,7 +608,7 @@ Lemma input_valid_transition_deterministic_conv_Mi :
 Proof.
   intros s1 s2 f iom1 iom2 oom1 oom2 lbl1 lbl2 Hivt1 Hivt2.
   by eapply input_valid_transition_deterministic_conv_RMi
-  ; apply (@VLSM_incl_input_valid_transition _ (vtype Mi) (vmachine Mi) (vmachine RMi))
+  ; apply (@VLSM_incl_input_valid_transition _ Mi (vmachine Mi) (vmachine RMi))
   ; eauto using VLSM_incl_Mi_RMi.
 Qed.
 

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -474,7 +474,7 @@ Lemma input_valid_transition_size_Ui :
 Proof.
   intros s1 s2 iom oom lbl Hivt.
   eapply input_valid_transition_size_Ri.
-  by apply (@VLSM_incl_input_valid_transition _ (vtype Ui) (vmachine Ui) (vmachine Ri))
+  by apply (@VLSM_incl_input_valid_transition _ Ui (vmachine Ui) (vmachine Ri))
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -487,7 +487,7 @@ Lemma finite_valid_trace_from_to_size_Ui :
 Proof.
   intros s1 s2 tr Hfvt.
   eapply finite_valid_trace_from_to_size_Ri.
-  by apply (@VLSM_incl_finite_valid_trace_from_to _ (vtype Ui) (vmachine Ui) (vmachine Ri))
+  by apply (@VLSM_incl_finite_valid_trace_from_to _ Ui (vmachine Ui) (vmachine Ri))
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -497,7 +497,7 @@ Lemma finite_valid_trace_from_to_inv_Ui :
 Proof.
   intros s tr Hfvt.
   eapply finite_valid_trace_from_to_inv_Ri.
-  by apply (@VLSM_incl_finite_valid_trace_from_to _ (vtype Ui) (vmachine Ui) (vmachine Ri))
+  by apply (@VLSM_incl_finite_valid_trace_from_to _ Ui (vmachine Ui) (vmachine Ri))
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -535,7 +535,7 @@ Lemma input_valid_transition_deterministic_conv_Ui :
 Proof.
   intros s1 s2 f iom1 iom2 oom1 oom2 lbl1 lbl2 Hivt1 Hivt2.
   by eapply input_valid_transition_deterministic_conv_Ri
-  ; apply (@VLSM_incl_input_valid_transition _ (vtype Ui) (vmachine Ui) (vmachine Ri))
+  ; apply (@VLSM_incl_input_valid_transition _ Ui (vmachine Ui) (vmachine Ri))
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -1603,7 +1603,7 @@ Proof.
   intros us Hvsp.
   apply all_pre_traces_to_valid_state_are_valid; [typeclasses eauto | done |].
   apply finite_valid_trace_from_to_UMO_state2trace_RUMO.
-  eapply (@VLSM_incl_valid_state _ (vtype UMO) (vmachine UMO) (vmachine RUMO)); [| done].
+  eapply (@VLSM_incl_valid_state _ UMO (vmachine UMO) (vmachine RUMO)); [| done].
   by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -180,7 +180,7 @@ Definition msg_dep_limited_equivocation_projection_validator_prop_alt :=
   coeqv_limited_equivocation_projection_validator_prop_alt IM threshold sender msg_dep_coequivocating_senders.
 
 Lemma msg_dep_annotate_trace_with_equivocators_project s tr
-  : pre_VLSM_embedding_finite_trace_project (vtype msg_dep_limited_equivocation_vlsm)
+  : pre_VLSM_embedding_finite_trace_project msg_dep_limited_equivocation_vlsm
     (composite_type IM) Datatypes.id original_state
     (msg_dep_annotate_trace_with_equivocators s tr) = tr.
 Proof. by apply (annotate_trace_project (free_composite_vlsm IM) Cv). Qed.
@@ -485,7 +485,7 @@ Lemma msg_dep_fixed_limited_equivocation_witnessed
     finite_valid_trace Fixed
       (original_state is)
       (pre_VLSM_embedding_finite_trace_project
-        (vtype Limited) (composite_type IM) Datatypes.id original_state
+        Limited (composite_type IM) Datatypes.id original_state
         tr).
 Proof.
   repeat split; [.. | by apply Htr].
@@ -504,7 +504,7 @@ Proof.
       by eapply coeqv_limited_equivocation_transition_state_annotation_incl, Ht.
     + apply finite_valid_trace_singleton.
       unfold input_valid_transition, input_valid.
-      change (map _ _) with (pre_VLSM_embedding_finite_trace_project (vtype Limited)
+      change (map _ _) with (pre_VLSM_embedding_finite_trace_project Limited
                               (composite_type IM) Datatypes.id original_state tr).
       rewrite <- pre_VLSM_embedding_finite_trace_last.
       assert (Hs : valid_state_prop
@@ -514,7 +514,7 @@ Proof.
         replace s with (finite_trace_last si tr) at 2
              by (apply valid_trace_get_last in Htr; done).
         rewrite (pre_VLSM_embedding_finite_trace_last
-                  (vtype Limited) (composite_type IM) Datatypes.id original_state si tr).
+                  Limited (composite_type IM) Datatypes.id original_state si tr).
         by apply finite_valid_trace_last_pstate.
       }
       destruct Ht as [[HLs [HLim HLv]] HLt].
@@ -579,7 +579,7 @@ Corollary msg_dep_fixed_limited_equivocation is tr
     fixed_limited_equivocation_prop IM threshold A
       (original_state is)
       (pre_VLSM_embedding_finite_trace_project
-        (vtype Limited) (composite_type IM) Datatypes.id original_state
+        Limited (composite_type IM) Datatypes.id original_state
         tr) (Ci := Ci) (Cv := Cv).
 Proof.
   intro Htr.
@@ -601,13 +601,13 @@ Lemma fixed_transition_preserves_annotation_equivocators
       (s, iom) (sf, oom))
   (Hsub_equivocators :
     state_annotation
-      (@finite_trace_last _ (vtype Limited)
+      (@finite_trace_last _ Limited
         {| original_state := is; state_annotation := `inhabitant |}
         (msg_dep_annotate_trace_with_equivocators IM full_message_dependencies sender is tr))
     ⊆ eqv_validators)
   : msg_dep_composite_transition_message_equivocators IM
       full_message_dependencies sender l
-      (@finite_trace_last _ (vtype Limited)
+      (@finite_trace_last _ Limited
         {| original_state := is; state_annotation := ∅ |}
         (annotate_trace_from (free_composite_vlsm IM)
           Cv
@@ -680,7 +680,7 @@ Proof.
   |- finite_valid_trace_from Limited ?is ?tr =>
     cut
       (finite_valid_trace_from Limited is tr /\
-        (state_annotation (@finite_trace_last _ (vtype Limited) is tr) ⊆ equivocators))
+        (state_annotation (@finite_trace_last _ Limited is tr) ⊆ equivocators))
   end
   ; [itauto |].
   induction Htr using finite_valid_trace_init_to_rev_strong_ind.

--- a/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
@@ -68,7 +68,7 @@ Lemma equivocator_state_append_initial_state_in_futures
         (equivocator_state_append base_s s).
 Proof.
   exists
-    [(@Build_transition_item _ (vtype (equivocator_vlsm X))
+    [(@Build_transition_item _ (equivocator_vlsm X)
       (Spawn (equivocator_state_zero s))
       None
       (equivocator_state_append base_s s)

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -52,8 +52,8 @@ Definition equivocator_type : VLSMType message :=
      label := EquivocatorLabel
   |}.
 
-Definition equivocator_state : Type := @state message equivocator_type.
-Definition equivocator_label : Type := @label message equivocator_type.
+Definition equivocator_state : Type := state equivocator_type.
+Definition equivocator_label : Type := label equivocator_type.
 
 (** The number of machine copies in the given state. *)
 Definition equivocator_state_n (es : equivocator_state) := S (projT1 es).

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -56,7 +56,7 @@ Definition equivocators_transition_item_project
       with
   | Some (Some item', deqv') =>
     Some
-      (Some (@Build_transition_item message (vtype Free)
+      (Some (@Build_transition_item message Free
         (existT eqv (l item'))
         (input item) sx (output item))
       , equivocator_descriptors_update eqv_descriptors eqv deqv')
@@ -1462,7 +1462,7 @@ Qed.
 Lemma equivocators_total_VLSM_projection_finite_trace_project
   {s tr}
   (Hpre_tr : finite_valid_trace_from PreFreeE s tr)
-  : @pre_VLSM_projection_finite_trace_project _ (vtype PreFreeE) _ equivocators_total_label_project
+  : @pre_VLSM_projection_finite_trace_project _ PreFreeE _ equivocators_total_label_project
       equivocators_total_state_project tr = equivocators_total_trace_project tr.
 Proof.
   induction tr using rev_ind; [done |].

--- a/theories/VLSM/Core/Equivocators/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocation.v
@@ -606,7 +606,7 @@ Lemma free_equivocators_valid_trace_project
   (final_descriptors : equivocator_descriptors IM)
   (is : composite_state (equivocator_IM IM))
   (tr : list (composite_transition_item (equivocator_IM IM)))
-  (final_state := @finite_trace_last _ (vtype XE) is tr)
+  (final_state := @finite_trace_last _ XE is tr)
   (Hproper : proper_fixed_equivocator_descriptors final_descriptors final_state)
   (Htr : finite_valid_trace XE is tr)
   : exists

--- a/theories/VLSM/Core/Equivocators/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/FullReplayTraces.v
@@ -300,7 +300,7 @@ Qed.
 
 Definition replayed_trace_from full_replay_state is tr :=
   replayed_initial_state_from full_replay_state is ++
-  pre_VLSM_embedding_finite_trace_project (vtype FreeSubE) (vtype FreeE)
+  pre_VLSM_embedding_finite_trace_project FreeSubE FreeE
     (lift_equivocators_sub_label_to full_replay_state)
     (lift_equivocators_sub_state_to full_replay_state) tr.
 

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -171,10 +171,10 @@ Context
   corresponding [type] and [transition].
 *)
 
-Definition vplan_item := (@plan_item _ (vtype X)).
+Definition vplan_item := (@plan_item _ X).
 Definition plan : Type := list vplan_item.
-Definition apply_plan := (@_apply_plan _ (vtype X) (vtransition X)).
-Definition trace_to_plan := (@_trace_to_plan _ (vtype X)).
+Definition apply_plan := (@_apply_plan _ X (vtransition X)).
+Definition trace_to_plan := (@_trace_to_plan _ X).
 Definition apply_plan_app
   (start : vstate X)
   (a a' : plan)
@@ -182,13 +182,13 @@ Definition apply_plan_app
     let (aitems, afinal) := apply_plan start a in
     let (a'items, a'final) := apply_plan afinal a' in
      (aitems ++ a'items, a'final)
-  := (@_apply_plan_app _ (vtype X) (vtransition X) start a a').
+  := (@_apply_plan_app _ X (vtransition X) start a a').
 Definition apply_plan_last
   (start : vstate X)
   (a : plan)
   (after_a := apply_plan start a)
   : finite_trace_last start (fst after_a) = snd after_a
-  := (@_apply_plan_last _ (vtype X) (vtransition X) start a).
+  := (@_apply_plan_last _ X (vtransition X) start a).
 
 (**
   A plan is valid w.r.t. a state if by applying it to that state we
@@ -357,7 +357,7 @@ Proof.
       setoid_rewrite Hlst in Ha. setoid_rewrite <- Heqsa in Ha.
       repeat constructor; [| done ..].
       exists out.
-      replace (@pair (@state message (vtype X)) (option message) dest out)
+      replace (@pair (@state message X) (option message) dest out)
         with (vtransition X label_a0 (sa, input_a0)).
       destruct Ha as [_oma Hsa].
       destruct Hinput_ai as [_s Hinput_a0].

--- a/theories/VLSM/Core/Plans.v
+++ b/theories/VLSM/Core/Plans.v
@@ -357,7 +357,7 @@ Proof.
       setoid_rewrite Hlst in Ha. setoid_rewrite <- Heqsa in Ha.
       repeat constructor; [| done ..].
       exists out.
-      replace (@pair (@state message X) (option message) dest out)
+      replace (@pair (state X) (option message) dest out)
         with (vtransition X label_a0 (sa, input_a0)).
       destruct Ha as [_oma Hsa].
       destruct Hinput_ai as [_s Hinput_a0].

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -109,7 +109,7 @@ Definition composite_transition_item_projection_from_eq
   : vtransition_item (IM j)
   :=
   let lj := eq_rect_r _ (projT2 (l item)) e in
-  @Build_transition_item _ (vtype (IM j)) lj (input item) (destination item j) (output item).
+  @Build_transition_item _ (IM j) lj (input item) (destination item j) (output item).
 
 Definition composite_transition_item_projection
   (item : composite_transition_item IM)
@@ -250,7 +250,7 @@ Lemma finite_trace_projection_list_in
   (itemX : composite_transition_item IM)
   (HitemX : itemX ∈ tr)
   (j := projT1 (l itemX)) :
-    @Build_transition_item _ (vtype (IM j)) (projT2 (l itemX)) (input itemX) (destination itemX j)
+    @Build_transition_item _ (IM j) (projT2 (l itemX)) (input itemX) (destination itemX j)
       (output itemX)
       ∈
     VLSM_projection_finite_trace_project (preloaded_component_projection IM j) tr.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -1682,7 +1682,7 @@ Qed.
 
 Definition induced_sub_element_projection constraint : VLSM message :=
   projection_induced_validator
-    (pre_induced_sub_projection IM (elements indices) constraint) (vtype (IM j))
+    (pre_induced_sub_projection IM (elements indices) constraint) (IM j)
     sub_label_element_project sub_state_element_project
     sub_element_label sub_element_state.
 

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -393,8 +393,8 @@ Context
 *)
 
 Definition machine := vmachine vlsm.
-Definition vstate := state (vtype vlsm).
-Definition vlabel := label (vtype vlsm).
+Definition vstate := state vlsm.
+Definition vlabel := label vlsm.
 Definition vinitial_state_prop := @initial_state_prop _ _ machine.
 Definition vinitial_state := @initial_state _ _ machine.
 Definition vinitial_message_prop := @initial_message_prop _ _ machine.
@@ -404,8 +404,8 @@ Definition vs0 := @inhabitant _ (@s0 _ _ machine).
 Definition vdecidable_initial_messages_prop := @decidable_initial_messages_prop _ _ machine.
 Definition vtransition := @transition _ _ machine.
 Definition vvalid := @valid _ _ machine.
-Definition vtransition_item := @transition_item _ (vtype vlsm).
-Definition vTrace := @Trace _ (vtype vlsm).
+Definition vtransition_item := @transition_item _ vlsm.
+Definition vTrace := @Trace _ vlsm.
 
 End sec_vlsm_projections.
 

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -42,34 +42,34 @@ Arguments label {_} _.
   and the [transition] function and [valid] predicate.
 *)
 
-Class VLSMMachine {message : Type} (vtype : VLSMType message) : Type :=
+Class VLSMMachine {message : Type} (T : VLSMType message) : Type :=
 {
-  initial_state_prop : state vtype -> Prop;
-  initial_state : Type := {s : state vtype | initial_state_prop s};
+  initial_state_prop : state T -> Prop;
+  initial_state : Type := {s : state T | initial_state_prop s};
   s0 : Inhabited initial_state;
   initial_message_prop : message -> Prop;
   initial_message : Type := {m : message | initial_message_prop m};
-  transition : label vtype -> state vtype * option message -> state vtype * option message;
-  valid : label vtype -> state vtype * option message -> Prop;
+  transition : label T -> state T * option message -> state T * option message;
+  valid : label T -> state T * option message -> Prop;
 }.
 
 (* The & is a "bidirectionality hint", so that typechecking
    a VLSMMachine record definition will try to use the expected
-   result type to determine [vtype] before typechecking the fields.
+   result type to determine <<T>> before typechecking the fields.
    Without this, the types of the values given for the fields would
    have to be written so they only mention the state and label type
-   in ways that can be matched with [state ?vtype] and [label ?vtype].
+   in ways that can be matched with [state ?T] and [label ?T].
 *)
 Arguments Build_VLSMMachine _ _ & _ _ _ _ _.
 
 Definition option_initial_message_prop
-  {message : Type} {vtype : VLSMType message} {vmachine : VLSMMachine vtype}
+  {message : Type} {T : VLSMType message} {vmachine : VLSMMachine T}
   : option message -> Prop := from_option initial_message_prop True.
 
 Definition VLSMMachine_pre_loaded_with_messages
-  {message : Type} {vtype : VLSMType message} (vmachine : VLSMMachine vtype)
+  {message : Type} {T : VLSMType message} (vmachine : VLSMMachine T)
   (initial : message -> Prop)
-  : VLSMMachine vtype
+  : VLSMMachine T
   :=
   {| initial_state_prop := @initial_state_prop _ _ vmachine
   ; initial_message_prop := fun m => @initial_message_prop _ _ vmachine  m \/ initial m
@@ -79,7 +79,7 @@ Definition VLSMMachine_pre_loaded_with_messages
   |}.
 
 Definition decidable_initial_messages_prop
-  {message : Type} {vtype : VLSMType message} (vmachine : VLSMMachine vtype)
+  {message : Type} {T : VLSMType message} (vmachine : VLSMMachine T)
   := forall m, Decision (initial_message_prop m).
 
 (** *** VLSM type definition

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -93,7 +93,7 @@ Definition decidable_initial_messages_prop
 
 Record VLSM (message : Type) : Type := mk_vlsm
 {
-  vtype : VLSMType message;
+  vtype :> VLSMType message;
   vmachine : VLSMMachine vtype;
 }.
 
@@ -2473,8 +2473,8 @@ Defined.
 
 Class TraceWithStart
   {message} {X : VLSM message}
-  (start : @state message (vtype X))
-  (trace_prop : list (transition_item (vtype X)) -> Prop)
+  (start : state X)
+  (trace_prop : list (transition_item X) -> Prop)
   : Prop :=
 {
   valid_trace_first_pstate :
@@ -2515,7 +2515,7 @@ Context
   .
 
 Definition pre_loaded_with_all_messages_vlsm_machine
-  : VLSMMachine (vtype X)
+  : VLSMMachine X
   :=
   {| initial_state_prop := vinitial_state_prop X
    ; initial_message_prop := fun message => True

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -278,7 +278,7 @@ Lemma VLSM_embedding_projection_type
   (X Y : VLSM message)
   (label_project : vlabel X -> vlabel Y)
   (state_project : vstate X -> vstate Y)
-  : VLSM_projection_type X (vtype Y) (Some ∘ label_project) state_project.
+  : VLSM_projection_type X Y (Some ∘ label_project) state_project.
 Proof.
   split; intros.
   destruct_list_last trX trX' lstX Heq; [done |].

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -14,11 +14,11 @@ Section sec_VLSM_equality.
 
 Context
   {message : Type}
-  {vtype : VLSMType message}
+  {T : VLSMType message}
   .
 
 Definition VLSM_eq_part
-  (MX MY : VLSMMachine vtype)
+  (MX MY : VLSMMachine T)
   (X := mk_vlsm MX) (Y := mk_vlsm MY) : Prop :=
     VLSM_incl X Y /\ VLSM_incl Y X.
 
@@ -28,8 +28,8 @@ Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
 
 Lemma VLSM_eq_refl
   {message : Type}
-  {vtype : VLSMType message}
-  (MX : VLSMMachine vtype)
+  {T : VLSMType message}
+  (MX : VLSMMachine T)
   (X := mk_vlsm MX)
   : VLSM_eq X X.
 Proof.
@@ -38,8 +38,8 @@ Qed.
 
 Lemma VLSM_eq_sym
   {message : Type}
-  {vtype : VLSMType message}
-  (MX MY : VLSMMachine vtype)
+  {T : VLSMType message}
+  (MX MY : VLSMMachine T)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_eq X Y -> VLSM_eq Y X.
 Proof.
@@ -48,8 +48,8 @@ Qed.
 
 Lemma VLSM_eq_trans
   {message : Type}
-  {vtype : VLSMType message}
-  (MX MY MZ : VLSMMachine vtype)
+  {T : VLSMType message}
+  (MX MY MZ : VLSMMachine T)
   (X := mk_vlsm MX) (Y := mk_vlsm MY) (Z := mk_vlsm MZ)
   : VLSM_eq X Y -> VLSM_eq Y Z -> VLSM_eq X Z.
 Proof.
@@ -61,8 +61,8 @@ Section sec_VLSM_eq_properties.
 (** ** VLSM equality properties *)
 
 Context
-  {message : Type} [vtype : VLSMType message]
-  [MX MY : VLSMMachine vtype]
+  {message : Type} [T : VLSMType message]
+  [MX MY : VLSMMachine T]
   (Hincl : VLSM_eq_part MX MY)
   (X := mk_vlsm MX)
   (Y := mk_vlsm MY)
@@ -141,7 +141,7 @@ Proof.
 Qed.
 
 Lemma VLSM_eq_can_produce
-  (s : state vtype)
+  (s : state T)
   (om : option message)
   : option_can_produce X s om <-> option_can_produce Y s om.
 Proof.

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -13,11 +13,11 @@ Section sec_VLSM_inclusion.
 
 Context
   {message : Type}
-  {vtype : VLSMType message}
+  {T : VLSMType message}
   .
 
 Definition VLSM_incl_part
-  (MX MY : VLSMMachine vtype)
+  (MX MY : VLSMMachine T)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   :=
   forall t : Trace,
@@ -26,7 +26,7 @@ Definition VLSM_incl_part
 #[local] Notation VLSM_incl X Y := (VLSM_incl_part (machine X) (machine Y)).
 
 Lemma VLSM_incl_refl
-  (MX : VLSMMachine vtype)
+  (MX : VLSMMachine T)
   (X := mk_vlsm MX)
   : VLSM_incl X X.
 Proof.
@@ -34,7 +34,7 @@ Proof.
 Qed.
 
 Lemma VLSM_incl_trans
-  (MX MY MZ : VLSMMachine vtype)
+  (MX MY MZ : VLSMMachine T)
   (X := mk_vlsm MX) (Y := mk_vlsm MY) (Z := mk_vlsm MZ)
   : VLSM_incl X Y -> VLSM_incl Y Z -> VLSM_incl X Z.
 Proof.
@@ -42,7 +42,7 @@ Proof.
 Qed.
 
 Lemma VLSM_incl_finite_traces_characterization
-  (MX MY : VLSMMachine vtype)
+  (MX MY : VLSMMachine T)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_incl X Y <->
     forall (s : vstate X)
@@ -74,7 +74,7 @@ Qed.
   label and state projection functions are identities.
 *)
 Lemma VLSM_incl_embedding_iff
-  (MX MY : VLSMMachine vtype)
+  (MX MY : VLSMMachine T)
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   : VLSM_incl X Y <-> VLSM_embedding X Y id id.
 Proof.
@@ -95,14 +95,14 @@ Proof.
 Qed.
 
 Definition VLSM_incl_is_embedding
-  {MX MY : VLSMMachine vtype}
+  {MX MY : VLSMMachine T}
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   (Hincl : VLSM_incl X Y)
   : VLSM_embedding X Y id id
   := proj1 (VLSM_incl_embedding_iff MX MY) Hincl.
 
 Lemma VLSM_incl_is_embedding_finite_trace_project
-  {MX MY : VLSMMachine vtype}
+  {MX MY : VLSMMachine T}
   (X := mk_vlsm MX) (Y := mk_vlsm MY)
   (Hincl : VLSM_incl X Y)
   : forall tr,
@@ -157,8 +157,8 @@ Section sec_VLSM_incl_properties.
 (** ** VLSM inclusion properties *)
 
 Context
-  {message : Type} [vtype : VLSMType message]
-  [MX MY : VLSMMachine vtype]
+  {message : Type} [T : VLSMType message]
+  [MX MY : VLSMMachine T]
   (Hincl : VLSM_incl_part MX MY)
   (X := mk_vlsm MX)
   (Y := mk_vlsm MY)
@@ -264,7 +264,7 @@ Proof.
 Qed.
 
 Lemma VLSM_incl_can_produce
-  (s : state vtype)
+  (s : state T)
   (om : option message)
   : option_can_produce X s om -> option_can_produce Y s om.
 Proof.

--- a/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
@@ -145,7 +145,7 @@ Context
   {X Y : VLSM message}
   (state_project : vstate X -> vstate Y)
   (transition_item_project : vtransition_item X -> list (vtransition_item Y))
-  (Hsimul : VLSM_stuttering_embedding_type X (vtype Y) state_project transition_item_project)
+  (Hsimul : VLSM_stuttering_embedding_type X Y state_project transition_item_project)
   .
 
 (**
@@ -193,7 +193,7 @@ Definition stuttering_embedding_input_valid_transition_item_validity : Prop :=
 Record VLSM_weak_stuttering_embedding : Prop :=
 {
   weak_stuttering_embedding_type :>
-    VLSM_stuttering_embedding_type X (vtype Y) state_project transition_item_project;
+    VLSM_stuttering_embedding_type X Y state_project transition_item_project;
   weak_stuttering_embedding_preserves_valid_trace :
     forall sX trX,
       finite_valid_trace_from X sX trX ->
@@ -203,7 +203,7 @@ Record VLSM_weak_stuttering_embedding : Prop :=
 Record VLSM_stuttering_embedding : Prop :=
 {
   stuttering_embedding_type :>
-    VLSM_stuttering_embedding_type X (vtype Y) state_project transition_item_project;
+    VLSM_stuttering_embedding_type X Y state_project transition_item_project;
   stuttering_embedding_preserves_valid_trace :
     forall sX trX,
       finite_valid_trace X sX trX -> finite_valid_trace Y (state_project sX) (trace_project trX);
@@ -683,7 +683,7 @@ Context
   .
 
 Lemma basic_VLSM_stuttering_embedding_type :
-  VLSM_stuttering_embedding_type X (vtype Y) state_project transition_item_project.
+  VLSM_stuttering_embedding_type X Y state_project transition_item_project.
 Proof.
   constructor; intros.
   by eapply finite_valid_trace_from_to_last, Htransition.

--- a/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
@@ -149,7 +149,7 @@ Record VLSM_projection_type
   (TY : VLSMType message)
   (label_project : vlabel X -> option (label TY))
   (state_project : vstate X -> state TY)
-  (trace_project := pre_VLSM_projection_finite_trace_project (vtype X) TY label_project state_project)
+  (trace_project := pre_VLSM_projection_finite_trace_project X TY label_project state_project)
   : Prop :=
 {
   final_state_project :
@@ -179,7 +179,7 @@ Context
   {label_project : vlabel X -> option (vlabel Y)}
   {state_project : vstate X -> vstate Y}
   (trace_project := pre_VLSM_projection_finite_trace_project _ _ label_project state_project)
-  (Hsimul : VLSM_projection_type X (vtype Y) label_project state_project)
+  (Hsimul : VLSM_projection_type X Y label_project state_project)
   .
 
 (**
@@ -255,7 +255,7 @@ Context
 *)
 Record VLSM_weak_projection : Prop :=
 {
-  weak_projection_type :> VLSM_projection_type X (vtype Y) label_project state_project;
+  weak_projection_type :> VLSM_projection_type X Y label_project state_project;
   weak_trace_project_preserves_valid_trace :
     forall sX trX,
       finite_valid_trace_from X sX trX ->
@@ -264,7 +264,7 @@ Record VLSM_weak_projection : Prop :=
 
 Record VLSM_projection : Prop :=
 {
-  projection_type :> VLSM_projection_type X (vtype Y) label_project state_project;
+  projection_type :> VLSM_projection_type X Y label_project state_project;
   trace_project_preserves_valid_trace :
     forall sX trX,
       finite_valid_trace X sX trX -> finite_valid_trace Y (state_project sX) (trace_project trX);
@@ -851,8 +851,8 @@ Context
   (Hvalid : weak_projection_valid_preservation X Y label_project state_project)
   (Htransition_Some : weak_projection_transition_preservation_Some X Y label_project state_project)
   (Htransition_None : weak_projection_transition_consistency_None _ _ label_project state_project)
-  (Htype : VLSM_projection_type X (vtype Y) label_project state_project :=
-    basic_VLSM_projection_type X (vtype Y) label_project state_project Htransition_None)
+  (Htype : VLSM_projection_type X Y label_project state_project :=
+    basic_VLSM_projection_type X Y label_project state_project Htransition_None)
   .
 
 Section sec_weak_projection.
@@ -905,7 +905,7 @@ Proof.
   apply finite_valid_trace_from_to_app_split, proj2 in Happ_pr.
   apply valid_trace_get_last in Hs as Heqs.
   apply valid_trace_forget_last, proj1 in Hs.
-  rewrite <- (final_state_project X (vtype Y) label_project state_project Htype)
+  rewrite <- (final_state_project X Y label_project state_project Htype)
     in Happ_pr by done.
   by apply valid_trace_forget_last in Happ_pr; subst.
 Qed.
@@ -968,14 +968,14 @@ Lemma basic_VLSM_projection_type_preloaded
   (label_project : vlabel X -> option (vlabel Y))
   (state_project : vstate X -> vstate Y)
   (Htransition_None : strong_projection_transition_consistency_None _ _ label_project state_project)
-  : VLSM_projection_type (pre_loaded_with_all_messages_vlsm X) (vtype Y) label_project state_project.
+  : VLSM_projection_type (pre_loaded_with_all_messages_vlsm X) Y label_project state_project.
 Proof.
   constructor.
   intros is tr Htr.
   induction Htr using finite_valid_trace_from_rev_ind
   ; [done |].
   rewrite (@pre_VLSM_projection_finite_trace_project_app _
-    (vtype (pre_loaded_with_all_messages_vlsm X)) (vtype Y) label_project state_project).
+    (pre_loaded_with_all_messages_vlsm X) Y label_project state_project).
   rewrite finite_trace_last_is_last.
   rewrite finite_trace_last_app, <- IHHtr.
   clear IHHtr.
@@ -1007,7 +1007,7 @@ Proof.
   induction HtrX using finite_valid_trace_rev_ind.
   - by constructor; apply initial_state_is_valid, Hstate.
   - rewrite (@pre_VLSM_projection_finite_trace_project_app _
-      (vtype (pre_loaded_with_all_messages_vlsm X)) (vtype Y) label_project state_project).
+      (pre_loaded_with_all_messages_vlsm X) Y label_project state_project).
     apply (finite_valid_trace_from_app_iff (pre_loaded_with_all_messages_vlsm Y)).
     split; [done |].
     simpl. unfold pre_VLSM_projection_transition_item_project.
@@ -1034,14 +1034,14 @@ Lemma basic_VLSM_projection_type_preloaded_with
   (label_project : vlabel X -> option (vlabel Y))
   (state_project : vstate X -> vstate Y)
   (Htransition_None : strong_projection_transition_consistency_None _ _ label_project state_project)
-  : VLSM_projection_type (pre_loaded_vlsm X P) (vtype Y) label_project state_project.
+  : VLSM_projection_type (pre_loaded_vlsm X P) Y label_project state_project.
 Proof.
   constructor.
   intros is tr Htr.
   induction Htr using finite_valid_trace_from_rev_ind
   ; [done |].
   rewrite (@pre_VLSM_projection_finite_trace_project_app
-    _ (vtype (pre_loaded_vlsm X P)) (vtype Y) label_project state_project).
+    _ (pre_loaded_vlsm X P) Y label_project state_project).
   rewrite finite_trace_last_is_last.
   rewrite finite_trace_last_app, <- IHHtr.
   clear IHHtr.
@@ -1074,7 +1074,7 @@ Proof.
   induction HtrX using finite_valid_trace_rev_ind.
   - by constructor; apply initial_state_is_valid, Hstate.
   - rewrite (@pre_VLSM_projection_finite_trace_project_app _
-      (vtype (pre_loaded_vlsm X P)) (vtype Y) label_project state_project).
+      (pre_loaded_vlsm X P) Y label_project state_project).
     apply (finite_valid_trace_from_app_iff (pre_loaded_vlsm Y Q)).
     split; [done |].
     simpl. unfold pre_VLSM_projection_transition_item_project.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -503,7 +503,7 @@ Context
   (Htransition_None : weak_projection_transition_consistency_None _ _ label_project state_project)
   (label_lift : vlabel Y -> vlabel X)
   (state_lift : vstate Y -> vstate X)
-  (Xi := pre_projection_induced_validator X (vtype Y)
+  (Xi := pre_projection_induced_validator X Y
           label_project state_project label_lift state_lift)
   (Hlabel_lift : induced_validator_label_lift_prop label_project label_lift)
   (Hstate_lift : induced_validator_state_lift_prop state_project state_lift)
@@ -701,12 +701,12 @@ Definition composite_project_label (l : composite_label IM)
   projection from a composition to a component.
 *)
 Definition composite_vlsm_induced_validator : VLSM message :=
-  projection_induced_validator X (vtype (IM i))
+  projection_induced_validator X (IM i)
     composite_project_label (fun s => s i)
     (lift_to_composite_label IM i) (lift_to_composite_state' IM i).
 
 Definition pre_composite_vlsm_induced_validator : VLSM message :=
-  pre_projection_induced_validator X (vtype (IM i))
+  pre_projection_induced_validator X (IM i)
     composite_project_label (fun s => s i)
     (lift_to_composite_label IM i) (lift_to_composite_state' IM i).
 
@@ -728,7 +728,7 @@ Lemma component_state_projection_lift
 Proof. by intros sj; apply state_update_eq. Qed.
 
 Lemma component_transition_projection_None
-  : weak_projection_transition_consistency_None X (vtype (IM i))
+  : weak_projection_transition_consistency_None X (IM i)
     composite_project_label (fun s : vstate X => s i).
 Proof.
   intros [j lj] HlX sX iom s'X oom [_ Ht]; cbn in Ht.
@@ -739,7 +739,7 @@ Proof.
 Qed.
 
 Lemma component_transition_projection_Some
-  : induced_validator_transition_consistency_Some X (vtype (IM i))
+  : induced_validator_transition_consistency_Some X (IM i)
     composite_project_label (fun s : vstate X => s i).
 Proof.
   intros [j1 lj1] [j2 lj2] lj; unfold composite_project_label; cbn.
@@ -824,7 +824,7 @@ Proof. by destruct siomi, Hcomposite as (s & <- & _ & _ & []). Qed.
   [composite_vlsm_induced_projection_valid].
 *)
 Definition composite_vlsm_induced_projection_validator_machine
-  : VLSMMachine (vtype (IM i)) :=
+  : VLSMMachine (IM i) :=
 {|
   initial_state_prop := vinitial_state_prop (IM i);
   initial_message_prop := vinitial_message_prop (IM i);


### PR DESCRIPTION
Besides making `vtype` a coercion, I made sure that this coercion is actually used everywhere (and `vtype` is explicitly used nowhere) and also made sure that variables named `vtype` were renamed to `T` to make things cleaner.

The script used to substitute `(vtype whatever)` -> `whatever`:

```bash
FILES=$(grep -l "vtype" $(find -name "*.v"))

sed -Ei "s/\(vtype ([a-zA-Z0-9'_]*)\)/\1/g" $FILES
sed -i 's/(vtype (IM i))/(IM i)/g' $FILES
sed -i 's/(vtype (IM j))/(IM j)/g' $FILES
```