### PR TITLE
Make `vmachine` a coercion

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -266,7 +266,7 @@ Qed.
 Lemma pre_loaded_with_all_messages_alt_incl
     : VLSM_incl PreLoaded Alt1.
 Proof.
-  apply (basic_VLSM_incl (vmachine PreLoaded) (vmachine Alt1))
+  apply (basic_VLSM_incl PreLoaded Alt1)
   ; intro; intros; [done | | | apply H].
   - by apply alt_proj_option_valid_message.
   - exists (lifted_alt_state s).

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -402,7 +402,7 @@ Lemma constraint_free_incl
   (constraint : composite_label -> composite_state  * option message -> Prop)
   : VLSM_incl (composite_vlsm constraint) free_composite_vlsm.
 Proof.
-  by apply basic_VLSM_strong_incl; firstorder.
+  by apply basic_VLSM_strong_incl; do 2 (red; cbn); firstorder.
 Qed.
 
 Lemma composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages
@@ -1590,7 +1590,12 @@ Definition composite_valid_transition_item
 
 Lemma composite_valid_transition_reachable_iff l s1 iom s2 oom :
   CompositeValidTransition l s1 iom s2 oom <-> ValidTransition RFree l s1 iom s2 oom.
-Proof. by firstorder. Qed.
+Proof.
+  split; [by intros []; constructor |].
+  intros []; constructor.
+  - by apply vt_valid.
+  - by apply vt_transition.
+Qed.
 
 Inductive CompositeValidTransitionNext (s1 s2 : composite_state IM) : Prop :=
 | composite_transition_next : forall l iom oom,

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -367,7 +367,7 @@ Proof.
     + by cbn; split; inversion 1; [| constructor].
   - apply Morphisms_Prop.and_iff_morphism.
     + by split; apply UMO_reachable_impl; inversion 1; subst; [| constructor].
-    + by firstorder.
+    + by cbn; firstorder.
 Qed.
 
 Lemma ELMOComponent_message_dependencies_full_node_condition :

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -416,7 +416,7 @@ Context
 
 (** The VLSM [Mi] embeds into [RMi]. *)
 Lemma VLSM_incl_Mi_RMi :
-  VLSM_incl_part (vmachine Mi) (vmachine RMi).
+  VLSM_incl_part Mi RMi.
 Proof.
   by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
@@ -583,7 +583,7 @@ Lemma input_valid_transition_size_Mi :
 Proof.
   intros s1 s2 iom oom lbl Hivt.
   eapply input_valid_transition_size_RMi.
-  by apply (@VLSM_incl_input_valid_transition _ Mi (vmachine Mi) (vmachine RMi))
+  by apply (@VLSM_incl_input_valid_transition _ Mi Mi RMi)
   ; eauto using VLSM_incl_Mi_RMi.
 Qed.
 
@@ -596,7 +596,7 @@ Lemma finite_valid_trace_from_to_size_Mi :
 Proof.
   intros s1 s2 tr Hfvt.
   eapply finite_valid_trace_from_to_size_RMi.
-  by apply (@VLSM_incl_finite_valid_trace_from_to _ Mi (vmachine Mi) (vmachine RMi))
+  by apply (@VLSM_incl_finite_valid_trace_from_to _ Mi Mi RMi)
   ; eauto using VLSM_incl_Mi_RMi.
 Qed.
 
@@ -608,7 +608,7 @@ Lemma input_valid_transition_deterministic_conv_Mi :
 Proof.
   intros s1 s2 f iom1 iom2 oom1 oom2 lbl1 lbl2 Hivt1 Hivt2.
   by eapply input_valid_transition_deterministic_conv_RMi
-  ; apply (@VLSM_incl_input_valid_transition _ Mi (vmachine Mi) (vmachine RMi))
+  ; apply (@VLSM_incl_input_valid_transition _ Mi Mi RMi)
   ; eauto using VLSM_incl_Mi_RMi.
 Qed.
 

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -305,7 +305,7 @@ Context
   transport them to [Ui].
 *)
 Lemma VLSM_incl_Ui_Ri :
-  VLSM_incl_part (vmachine Ui) (vmachine Ri).
+  VLSM_incl_part Ui Ri.
 Proof.
   by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
@@ -474,7 +474,7 @@ Lemma input_valid_transition_size_Ui :
 Proof.
   intros s1 s2 iom oom lbl Hivt.
   eapply input_valid_transition_size_Ri.
-  by apply (@VLSM_incl_input_valid_transition _ Ui (vmachine Ui) (vmachine Ri))
+  by apply (@VLSM_incl_input_valid_transition _ Ui Ui Ri)
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -487,7 +487,7 @@ Lemma finite_valid_trace_from_to_size_Ui :
 Proof.
   intros s1 s2 tr Hfvt.
   eapply finite_valid_trace_from_to_size_Ri.
-  by apply (@VLSM_incl_finite_valid_trace_from_to _ Ui (vmachine Ui) (vmachine Ri))
+  by apply (@VLSM_incl_finite_valid_trace_from_to _ Ui Ui Ri)
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -497,7 +497,7 @@ Lemma finite_valid_trace_from_to_inv_Ui :
 Proof.
   intros s tr Hfvt.
   eapply finite_valid_trace_from_to_inv_Ri.
-  by apply (@VLSM_incl_finite_valid_trace_from_to _ Ui (vmachine Ui) (vmachine Ri))
+  by apply (@VLSM_incl_finite_valid_trace_from_to _ Ui Ui Ri)
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -535,7 +535,7 @@ Lemma input_valid_transition_deterministic_conv_Ui :
 Proof.
   intros s1 s2 f iom1 iom2 oom1 oom2 lbl1 lbl2 Hivt1 Hivt2.
   by eapply input_valid_transition_deterministic_conv_Ri
-  ; apply (@VLSM_incl_input_valid_transition _ Ui (vmachine Ui) (vmachine Ri))
+  ; apply (@VLSM_incl_input_valid_transition _ Ui Ui Ri)
   ; eauto using VLSM_incl_Ui_Ri.
 Qed.
 
@@ -1603,7 +1603,7 @@ Proof.
   intros us Hvsp.
   apply all_pre_traces_to_valid_state_are_valid; [typeclasses eauto | done |].
   apply finite_valid_trace_from_to_UMO_state2trace_RUMO.
-  eapply (@VLSM_incl_valid_state _ UMO (vmachine UMO) (vmachine RUMO)); [| done].
+  eapply (@VLSM_incl_valid_state _ UMO UMO RUMO); [| done].
   by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -406,7 +406,7 @@ Record oracle_stepwise_props
 {
   oracle_no_inits :
     forall (s : vstate vlsm),
-      initial_state_prop (VLSMMachine := vmachine vlsm) s ->
+      @initial_state_prop _ _ vlsm s ->
       forall (m : message), ~ oracle s m;
   oracle_step_update :
     forall (l : label _) (s : state _) (im : option message) (s' : state _) (om : option message),
@@ -962,7 +962,7 @@ Context
        no_traces_have_message_prop vlsm selector (fun m s => ~ oracle m s) s m).
 
 Lemma oracle_no_inits_from_trace :
-  forall (s : vstate vlsm), initial_state_prop (VLSMMachine := vmachine vlsm) s ->
+  forall (s : vstate vlsm), @initial_state_prop _ _ vlsm s ->
                            forall m, ~ oracle s m.
 Proof.
   intros s Hinit m Horacle.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -92,7 +92,7 @@ Qed.
 Lemma fixed_equivocation_vlsm_composition_incl_preloaded_free
   : VLSM_incl fixed_equivocation_vlsm_composition (pre_loaded_with_all_messages_vlsm Free).
 Proof.
-  apply VLSM_incl_trans with (vmachine Free).
+  apply VLSM_incl_trans with Free.
   - by apply fixed_equivocation_vlsm_composition_incl_free.
   - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -218,7 +218,7 @@ Proof.
   }
   assert (StrongFixedinclPreFree : VLSM_incl StrongFixed PreFree).
   {
-    apply VLSM_incl_trans with (vmachine Free).
+    apply VLSM_incl_trans with Free.
     - by apply (constraint_free_incl IM (strong_fixed_equivocation_constraint IM equivocators)).
     - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
@@ -261,7 +261,7 @@ Qed.
 Lemma Fixed_incl_Limited : VLSM_incl Fixed Limited.
 Proof.
   destruct (Fixed_eq_StrongFixed IM equivocators) as [Heq _].
-  apply VLSM_incl_trans with (vmachine StrongFixed).
+  apply VLSM_incl_trans with StrongFixed.
   - by apply Heq.
   - by apply StrongFixed_incl_Limited.
 Qed.

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -309,7 +309,7 @@ Proof.
   end.
   apply VLSM_eq_sym in Heq.
   match type of Heq with
-  | VLSM_eq _ ?v => apply VLSM_eq_trans with (vmachine v)
+  | VLSM_eq _ ?v => apply VLSM_eq_trans with v
   end
   ; [done |].
   specialize (constraint_subsumption_incl IM) as Hincl.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
@@ -244,7 +244,7 @@ Lemma equivocators_no_equivocations_vlsm_incl_PreFree :
     equivocators_no_equivocations_vlsm
     (pre_loaded_with_all_messages_vlsm equivocators_free_vlsm).
 Proof.
-  apply VLSM_incl_trans with (vmachine equivocators_free_vlsm).
+  apply VLSM_incl_trans with equivocators_free_vlsm.
   apply equivocators_no_equivocations_vlsm_incl_equivocators_free.
   by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.

--- a/theories/VLSM/Core/Equivocators/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocation.v
@@ -158,7 +158,7 @@ Lemma equivocators_fixed_equivocations_vlsm_incl_PreFree :
   VLSM_incl equivocators_fixed_equivocations_vlsm
     (pre_loaded_with_all_messages_vlsm (free_composite_vlsm equivocator_IM)).
 Proof.
-  apply VLSM_incl_trans with (vmachine (free_composite_vlsm equivocator_IM)).
+  apply VLSM_incl_trans with (free_composite_vlsm equivocator_IM).
   - by apply equivocators_fixed_equivocations_vlsm_incl_free.
   - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
@@ -647,7 +647,7 @@ Proof.
 
   assert (Htr_Pre : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) is tr).
   { revert Htr. apply VLSM_incl_finite_valid_trace.
-    apply VLSM_incl_trans with (vmachine FreeE);
+    apply VLSM_incl_trans with FreeE;
     [| by apply vlsm_incl_pre_loaded_with_all_messages_vlsm].
     apply equivocators_fixed_equivocations_vlsm_incl_free.
   }
@@ -784,7 +784,7 @@ Proof.
   }
   assert (Htr_free : finite_valid_trace  (pre_loaded_with_all_messages_vlsm FreeE) is tr).
   { revert Htr.  apply VLSM_incl_finite_valid_trace.
-    apply VLSM_incl_trans with (vmachine FreeE)
+    apply VLSM_incl_trans with FreeE
     ; [by apply equivocators_fixed_equivocations_vlsm_incl_free |].
     by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
@@ -801,7 +801,7 @@ Proof.
     (finite_trace_last is pre) ([item] ++ suf)).
   {
     revert Hsuf; apply VLSM_incl_finite_valid_trace_from.
-    apply VLSM_incl_trans with (vmachine FreeE)
+    apply VLSM_incl_trans with FreeE
     ; [by apply equivocators_fixed_equivocations_vlsm_incl_free |].
     by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
@@ -937,7 +937,7 @@ Proof.
     finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE) (destination item) suf).
   {
     revert Hsuf. apply VLSM_incl_finite_valid_trace_from.
-    apply VLSM_incl_trans with (vmachine FreeE).
+    apply VLSM_incl_trans with FreeE.
     - by apply equivocators_fixed_equivocations_vlsm_incl_free.
     - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
   }
@@ -1130,7 +1130,7 @@ Proof.
   assert (Htr'pre : finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm FreeE) is s tr).
   {
     revert Htr; apply VLSM_incl_finite_valid_trace_init_to.
-    apply VLSM_incl_trans with (vmachine FreeE).
+    apply VLSM_incl_trans with FreeE.
     - by apply (constraint_free_incl (equivocator_IM IM)
         (equivocators_fixed_equivocations_constraint IM (elements equivocating))).
     - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -446,7 +446,7 @@ Lemma proj_pre_loaded_with_all_messages_incl
   (PreLoaded := pre_loaded_with_all_messages_vlsm (IM j))
   : VLSM_incl Xj PreLoaded.
 Proof.
-  apply (basic_VLSM_incl (vmachine Xj) (vmachine PreLoaded)); intro; intros.
+  apply (basic_VLSM_incl Xj PreLoaded); intro; intros.
   - done.
   - by apply initial_message_is_valid.
   - by unfold vvalid; cbn; eapply (projection_valid_implies_valid IM), Hv.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -405,7 +405,7 @@ Definition finite_trace_sub_projection_app
 
 Lemma X_incl_Pre : VLSM_incl X Pre.
 Proof.
-  apply VLSM_incl_trans with (vmachine (free_composite_vlsm IM)).
+  apply VLSM_incl_trans with (free_composite_vlsm IM).
   - by apply (constraint_free_incl IM constraint).
   - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
@@ -484,12 +484,12 @@ Proof.
   spec Hincl; [done |].
   match goal with
   |- context [pre_loaded_vlsm ?v _] =>
-    apply VLSM_incl_trans with (vmachine (pre_loaded_with_all_messages_vlsm v))
+    apply VLSM_incl_trans with (pre_loaded_with_all_messages_vlsm v)
   end; [| apply Hincl].
   clear Hincl.
   match goal with
   |- context [pre_loaded_with_all_messages_vlsm ?v] =>
-    apply VLSM_incl_trans with (vmachine (pre_loaded_vlsm v (fun m => True)))
+    apply VLSM_incl_trans with (pre_loaded_vlsm v (fun m => True))
   end.
   - match goal with
     |- context [pre_loaded_vlsm ?v _] =>

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -94,7 +94,7 @@ Definition decidable_initial_messages_prop
 Record VLSM (message : Type) : Type := mk_vlsm
 {
   vtype :> VLSMType message;
-  vmachine : VLSMMachine vtype;
+  vmachine :> VLSMMachine vtype;
 }.
 
 Arguments vtype [message] v.
@@ -107,7 +107,7 @@ Definition pre_loaded_vlsm
   (initial : message -> Prop)
   : VLSM message
   :=
-  {| vmachine := VLSMMachine_pre_loaded_with_messages (vmachine X) initial |}.
+  {| vmachine := VLSMMachine_pre_loaded_with_messages X initial |}.
 
 Section sec_traces.
 
@@ -389,15 +389,15 @@ Context
 
 Definition vstate := state vlsm.
 Definition vlabel := label vlsm.
-Definition vinitial_state_prop := @initial_state_prop _ _ (vmachine vlsm).
-Definition vinitial_state := @initial_state _ _ (vmachine vlsm).
-Definition vinitial_message_prop := @initial_message_prop _ _ (vmachine vlsm).
-Definition voption_initial_message_prop := @option_initial_message_prop _ _ (vmachine vlsm).
-Definition vinitial_message := @initial_message _ _ (vmachine vlsm).
-Definition vs0 := @inhabitant _ (@s0 _ _ (vmachine vlsm)).
-Definition vdecidable_initial_messages_prop := @decidable_initial_messages_prop _ _ (vmachine vlsm).
-Definition vtransition := @transition _ _ (vmachine vlsm).
-Definition vvalid := @valid _ _ (vmachine vlsm).
+Definition vinitial_state_prop := @initial_state_prop _ _ vlsm.
+Definition vinitial_state := @initial_state _ _ vlsm.
+Definition vinitial_message_prop := @initial_message_prop _ _ vlsm.
+Definition voption_initial_message_prop := @option_initial_message_prop _ _ vlsm.
+Definition vinitial_message := @initial_message _ _ vlsm.
+Definition vs0 := @inhabitant _ (@s0 _ _ vlsm).
+Definition vdecidable_initial_messages_prop := @decidable_initial_messages_prop _ _ vlsm.
+Definition vtransition := @transition _ _ vlsm.
+Definition vvalid := @valid _ _ vlsm.
 Definition vtransition_item := @transition_item _ vlsm.
 Definition vTrace := @Trace _ vlsm.
 
@@ -2513,7 +2513,7 @@ Definition pre_loaded_with_all_messages_vlsm_machine
   :=
   {| initial_state_prop := vinitial_state_prop X
    ; initial_message_prop := fun message => True
-   ; s0 := @s0 _ _ (vmachine X)
+   ; s0 := @s0 _ _ X
    ; transition := vtransition X
    ; valid := vvalid X
   |}.

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -85,7 +85,7 @@ Proof.
   }
   split.
   - constructor; intros.
-    apply (proj1 (VLSM_incl_finite_traces_characterization (vmachine X) (vmachine Y)) H) in H0.
+    apply (proj1 (VLSM_incl_finite_traces_characterization X Y) H) in H0.
     replace (pre_VLSM_embedding_finite_trace_project _ _ _ _ trX) with trX; [done |].
     by apply Hid.
   - intro Hproject. apply VLSM_incl_finite_traces_characterization.


### PR DESCRIPTION
This PR is analogous to #218, but there are a few differences:
- I left explicit uses of `vmachine` in the notations `VLSM_incl` and `VLSM_eq`
- I had to fix some proofs here and there.