### PR TITLE
Remove some v-notations

### DIFF
--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1103,7 +1103,7 @@ Context
   .
 
 Lemma composite_decidable_initial_message
-  (Hdec_init : forall i, vdecidable_initial_messages_prop (IM i))
+  (Hdec_init : forall i, decidable_initial_messages_prop (IM i))
   : decidable_initial_messages_prop (composite_vlsm_machine IM constraint).
 Proof.
   intro m. simpl. unfold composite_initial_message_prop.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -184,7 +184,7 @@ Proof. by intros i; destruct (vs0 (IM i)). Defined.
 *)
 Definition composite_initial_message_prop (m : message) : Prop
   :=
-    exists (n : index) (mi : vinitial_message (IM n)), proj1_sig mi = m.
+    exists (n : index) (mi : initial_message (IM n)), proj1_sig mi = m.
 
 Definition option_composite_initial_message_prop : option message -> Prop
   := from_option composite_initial_message_prop True.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1387,7 +1387,7 @@ Definition computable_messages_oracle_rel_dec
 
 Lemma ComputableSentMessages_initial_state_empty
   `{!ComputableSentMessages vlsm}
-  (s : vinitial_state vlsm)
+  (s : initial_state vlsm)
   : sent_messages_set (proj1_sig s) = [].
 Proof.
   by eapply computable_messages_oracle_initial_state_empty;
@@ -1426,7 +1426,7 @@ Proof. done. Qed.
 
 Lemma ComputableReceivedMessages_initial_state_empty
   `{!ComputableReceivedMessages vlsm}
-  (s : vinitial_state vlsm)
+  (s : initial_state vlsm)
   : received_messages_set (proj1_sig s) = [].
 Proof.
   by eapply computable_messages_oracle_initial_state_empty;

--- a/theories/VLSM/Core/Equivocators/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocation.v
@@ -300,7 +300,7 @@ Context
   (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM (elements equivocating))
   (X : VLSM message := fixed_equivocation_vlsm_composition IM equivocating)
   (FreeE : VLSM message := free_composite_vlsm (equivocator_IM IM))
-  (Hdec_init : forall i, vdecidable_initial_messages_prop (IM i))
+  (Hdec_init : forall i, decidable_initial_messages_prop (IM i))
   (Free := free_composite_vlsm IM)
   (index_equivocating_prop : index -> Prop := sub_index_prop (elements equivocating))
   (equivocating_index : Type := sub_index (elements equivocating))

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -394,7 +394,6 @@ Definition vinitial_state := @initial_state _ _ vlsm.
 Definition vinitial_message_prop := @initial_message_prop _ _ vlsm.
 Definition vinitial_message := @initial_message _ _ vlsm.
 Definition vs0 := @inhabitant _ (@s0 _ _ vlsm).
-Definition vdecidable_initial_messages_prop := @decidable_initial_messages_prop _ _ vlsm.
 Definition vtransition := @transition _ _ vlsm.
 Definition vvalid := @valid _ _ vlsm.
 Definition vtransition_item := @transition_item _ vlsm.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -62,6 +62,7 @@ Class VLSMMachine {message : Type} (T : VLSMType message) : Type :=
 *)
 Arguments Build_VLSMMachine _ _ & _ _ _ _ _.
 
+Arguments initial_state {message T} _.
 Arguments initial_message {message T} _.
 
 Definition option_initial_message_prop
@@ -392,7 +393,6 @@ Context
 Definition vstate := state vlsm.
 Definition vlabel := label vlsm.
 Definition vinitial_state_prop := @initial_state_prop _ _ vlsm.
-Definition vinitial_state := @initial_state _ _ vlsm.
 Definition vinitial_message_prop := @initial_message_prop _ _ vlsm.
 Definition vs0 := @inhabitant _ (@s0 _ _ vlsm).
 Definition vtransition := @transition _ _ vlsm.
@@ -851,7 +851,7 @@ Qed.
 Lemma valid_state_prop_iff :
   forall s' : state X,
     valid_state_prop s'
-    <-> (exists is : vinitial_state X, s' = proj1_sig is)
+    <-> (exists is : initial_state X, s' = proj1_sig is)
       \/ exists (l : label X) (som : state X * option message) (om' : option message),
         input_valid_transition l som (s', om').
 Proof.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -62,6 +62,8 @@ Class VLSMMachine {message : Type} (T : VLSMType message) : Type :=
 *)
 Arguments Build_VLSMMachine _ _ & _ _ _ _ _.
 
+Arguments initial_message {message T} _, {message} _ _.
+
 Definition option_initial_message_prop
   {message : Type} {T : VLSMType message} {M : VLSMMachine T}
   : option message -> Prop := from_option initial_message_prop True.
@@ -392,7 +394,6 @@ Definition vlabel := label vlsm.
 Definition vinitial_state_prop := @initial_state_prop _ _ vlsm.
 Definition vinitial_state := @initial_state _ _ vlsm.
 Definition vinitial_message_prop := @initial_message_prop _ _ vlsm.
-Definition vinitial_message := @initial_message _ _ vlsm.
 Definition vs0 := @inhabitant _ (@s0 _ _ vlsm).
 Definition vtransition := @transition _ _ vlsm.
 Definition vvalid := @valid _ _ vlsm.
@@ -893,7 +894,7 @@ Qed.
 Lemma valid_message_prop_iff :
   forall m' : message,
     valid_message_prop m'
-    <-> (exists im : vinitial_message X, m' = proj1_sig im)
+    <-> (exists im : initial_message X, m' = proj1_sig im)
       \/ exists (l : label X) (som : state X * option message) (s' : state X),
         input_valid_transition l som (s', Some m').
 Proof.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -392,7 +392,6 @@ Definition vlabel := label vlsm.
 Definition vinitial_state_prop := @initial_state_prop _ _ vlsm.
 Definition vinitial_state := @initial_state _ _ vlsm.
 Definition vinitial_message_prop := @initial_message_prop _ _ vlsm.
-Definition voption_initial_message_prop := @option_initial_message_prop _ _ vlsm.
 Definition vinitial_message := @initial_message _ _ vlsm.
 Definition vs0 := @inhabitant _ (@s0 _ _ vlsm).
 Definition vdecidable_initial_messages_prop := @decidable_initial_messages_prop _ _ vlsm.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -62,7 +62,7 @@ Class VLSMMachine {message : Type} (T : VLSMType message) : Type :=
 *)
 Arguments Build_VLSMMachine _ _ & _ _ _ _ _.
 
-Arguments initial_message {message T} _, {message} _ _.
+Arguments initial_message {message T} _.
 
 Definition option_initial_message_prop
   {message : Type} {T : VLSMType message} {M : VLSMMachine T}


### PR DESCRIPTION
It's time to start removing the various definitions from `VLSM.v` that start with "v" (like `vstate`, `vlabel`, `vtransition`, etc.). I decided to start with the least used ones, as they are the easiest to remove.

In this PR, I remove:
- `voption_initial_message_prop`
- `vinitial_message`
- `vdecidable_initial_messages_prop`
- `vinitial_state`