### PR TITLE
Remove `vinitial_message_prop`

### DIFF
--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -71,7 +71,7 @@ Definition annotated_transition
 
 Definition annotated_vlsm_machine : VLSMMachine annotated_type :=
   {| initial_state_prop := fun s : state annotated_type => annotated_initial_state_prop s
-  ; initial_message_prop := fun m : message => vinitial_message_prop X m
+  ; initial_message_prop := fun m : message => initial_message_prop X m
   ; valid := annotated_valid
   ; transition := annotated_transition
   |}.

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -93,7 +93,7 @@ Definition fixed_byzantine_IM : index -> VLSM message :=
   update_IM IM byzantine (fun i => emit_any_signed_message_vlsm A sender (` i)).
 
 Lemma fixed_byzantine_IM_no_initial_messages
-  : forall i m, ~ vinitial_message_prop (fixed_byzantine_IM i) m.
+  : forall i m, ~ initial_message_prop (fixed_byzantine_IM i) m.
 Proof.
   unfold fixed_byzantine_IM, update_IM. simpl.
   intros i m Hm.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -804,7 +804,7 @@ Qed.
 
 Lemma lift_to_composite_initial_message_preservation :
   forall (i : index),
-      forall m, vinitial_message_prop (IM i) m ->
+      forall m, initial_message_prop (IM i) m ->
       composite_initial_message_prop m.
 Proof. by intros i m Hm; exists i, (exist _ _ Hm). Qed.
 
@@ -1109,7 +1109,7 @@ Proof.
   intro m. simpl. unfold composite_initial_message_prop.
   apply
     (Decision_iff
-      (P := List.Exists (fun i => vinitial_message_prop (IM i) m) (enum index))).
+      (P := List.Exists (fun i => initial_message_prop (IM i) m) (enum index))).
   - rewrite <- exists_finite.
     split; intros [i Hm]; exists i.
     + by exists (exist _ _ Hm).
@@ -1529,7 +1529,7 @@ Proof.
     simpl in Hi. subst im.
     cbn. unfold composite_initial_message_prop.
     left. exists i.
-    assert (Hm : vinitial_message_prop (IM2 i) m).
+    assert (Hm : initial_message_prop (IM2 i) m).
     + by eapply same_VLSM_initial_message_preservation; eauto.
     + by exists (exist _ m Hm).
 Qed.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1980,7 +1980,7 @@ Definition sender_nontriviality_prop : Prop :=
   sender m = Some v.
 
 Definition no_initial_messages_in_IM_prop : Prop :=
-  forall i m, ~ vinitial_message_prop (IM i) m.
+  forall i m, ~ initial_message_prop (IM i) m.
 
 Lemma composite_no_initial_valid_messages_emitted_by_sender
     (can_emit_signed : channel_authentication_prop)

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -922,7 +922,7 @@ Qed.
 *)
 Lemma EquivPreloadedBase_Fixed_weak_embedding
   (no_initial_messages_for_equivocators :
-    forall i m, i ∈ equivocators -> ~ vinitial_message_prop (IM i) m)
+    forall i m, i ∈ equivocators -> ~ initial_message_prop (IM i) m)
   : VLSM_weak_embedding EquivPreloadedBase Fixed
       (lift_sub_label IM (elements equivocators)) (lift_sub_state_to IM (elements equivocators) base_s).
 Proof.

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -589,7 +589,7 @@ Definition equivocator_vlsm_machine
   : VLSMMachine equivocator_type
   :=
   {|  initial_state_prop := equivocator_initial_state_prop
-   ;  initial_message_prop := vinitial_message_prop X
+   ;  initial_message_prop := @initial_message_prop _ _ X
    ;  transition := equivocator_transition
    ;  valid := equivocator_valid
   |}.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
@@ -513,8 +513,8 @@ Qed.
 
 Lemma equivocators_initial_message
   (m : message)
-  (Hem : vinitial_message_prop equivocators_free_vlsm m)
-  : vinitial_message_prop Free m.
+  (Hem : initial_message_prop equivocators_free_vlsm m)
+  : initial_message_prop Free m.
 Proof.
   destruct Hem as [eqv [emi Hem]].
   by exists eqv, emi.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -1729,8 +1729,8 @@ Context
 
 Lemma seeded_equivocators_initial_message
   (m : message)
-  (Hem : vinitial_message_prop SeededXE m)
-  : vinitial_message_prop SeededX m.
+  (Hem : initial_message_prop SeededXE m)
+  : initial_message_prop SeededX m.
 Proof.
   destruct Hem as [[eqv [emi Hem]] | Hseed].
   - by left; exists eqv, emi.

--- a/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
@@ -45,7 +45,7 @@ Context {message : Type}
   .
 
 Lemma no_initial_messages_in_sub_IM
-  : forall i m, ~ vinitial_message_prop (sub_IM IM (elements equivocating) i) m.
+  : forall i m, ~ initial_message_prop (sub_IM IM (elements equivocating) i) m.
 Proof.
   intros [i Hi] m Hinit.
   by apply (no_initial_messages_in_IM i m).
@@ -344,7 +344,7 @@ Proof.
     hypothesis and conclusion is done to fit the applied lemma.
   *)
   assert (no_initial_messages_in_XE :
-    forall m, ~ vinitial_message_prop (pre_loaded_vlsm XE (fun _ => False)) m).
+    forall m, ~ initial_message_prop (pre_loaded_vlsm XE (fun _ => False)) m).
   { intros m [[i [[mi Hmi] Him]] | Hseeded]; [| done].
     by elim (no_initial_messages_in_IM i mi).
   }
@@ -406,7 +406,7 @@ Lemma no_equivocating_equivocators_finite_valid_trace_init_to_rev
     finite_trace_last_output trX = finite_trace_last_output tr.
 Proof.
   assert (no_initial_messages_in_XE :
-    forall m, ~ vinitial_message_prop (pre_loaded_vlsm XE (fun _ => False)) m).
+    forall m, ~ initial_message_prop (pre_loaded_vlsm XE (fun _ => False)) m).
   {
     intros m [[i [[mi Hmi] Him]] | Hseeded]; [| done].
     by elim (no_initial_messages_in_IM i mi).

--- a/theories/VLSM/Core/Equivocators/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/FullReplayTraces.v
@@ -531,7 +531,7 @@ Proof.
 Qed.
 
 Lemma lift_initial_message
-  : forall m, vinitial_message_prop SeededXE m -> valid_message_prop SeededCE m.
+  : forall m, initial_message_prop SeededXE m -> valid_message_prop SeededCE m.
 Proof.
   intros m [Hinit | Hseeded].
   - apply initial_message_is_valid. destruct Hinit as [[i Hi] Hinit].

--- a/theories/VLSM/Core/Equivocators/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/SimulatingFree.v
@@ -58,7 +58,7 @@ Definition last_in_trace_except_from
 Definition zero_descriptor_constraint_lifting_prop : Prop :=
   forall
     es (Hes : valid_state_prop CE es)
-    om (Hom : sent_except_from (equivocator_IM IM) (vinitial_message_prop CE) es om)
+    om (Hom : sent_except_from (equivocator_IM IM) (@initial_message_prop _ _ CE) es om)
     eqv li,
     constraintE (existT eqv (ContinueWith 0 li)) (es, om).
 
@@ -81,14 +81,14 @@ Definition replayable_message_prop : Prop :=
     eqv_msg_is eqv_msg_s eqv_msg_tr
     (Hmsg_trace : finite_valid_trace_init_to CE eqv_msg_is eqv_msg_s eqv_msg_tr)
     iom
-    (Hfinal_msg : last_in_trace_except_from (vinitial_message_prop CE) eqv_msg_tr iom)
+    (Hfinal_msg : last_in_trace_except_from (@initial_message_prop _ _ CE) eqv_msg_tr iom)
     l
     (HcX : constraintX l (s, iom)),
     exists eqv_msg_tr lst_msg_tr,
       finite_valid_trace_from_to CE eqv_state_s lst_msg_tr eqv_msg_tr /\
       equivocators_total_trace_project IM eqv_msg_tr = [] /\
       equivocators_total_state_project IM lst_msg_tr = s /\
-      sent_except_from (equivocator_IM IM) (vinitial_message_prop CE) lst_msg_tr iom.
+      sent_except_from (equivocator_IM IM) (@initial_message_prop _ _ CE) lst_msg_tr iom.
 
 (**
   The main result of this section, showing that every trace of the

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -127,7 +127,7 @@ Proof. by apply tc_reflect. Qed.
   [valid_message_prop]erty.
 *)
 Lemma msg_dep_reflects_validity
-  (no_initial_messages_in_X : forall m, ~ vinitial_message_prop X m)
+  (no_initial_messages_in_X : forall m, ~ initial_message_prop X m)
   (P : message -> Prop)
   (Hreflects : forall dm m, msg_dep_rel dm m -> P m -> P dm)
   : forall dm m, msg_dep_rel dm m ->

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -57,7 +57,7 @@ Proof.
   - apply basic_VLSM_strong_incl; [| | by intro..].
     + by intros s Hs i; specialize (Hs i).
     + intros ? (i & [im Him] & <-).
-      assert (Him' : vinitial_message_prop (composite_vlsm_induced_projection i) im) by (left; done).
+      assert (Him' : initial_message_prop (composite_vlsm_induced_projection i) im) by (left; done).
       by exists i, (exist _ _ Him').
   - apply basic_VLSM_incl.
     + by intros s Hs i; specialize (Hs i).

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -63,7 +63,7 @@ Class VLSMMachine {message : Type} (T : VLSMType message) : Type :=
 Arguments Build_VLSMMachine _ _ & _ _ _ _ _.
 
 Arguments initial_state {message T} _.
-Arguments initial_message_prop {message T} _, {message T _}.
+Arguments initial_message_prop {message T} _ _, {message T _} _.
 Arguments initial_message {message T} _.
 
 Definition option_initial_message_prop

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -63,6 +63,7 @@ Class VLSMMachine {message : Type} (T : VLSMType message) : Type :=
 Arguments Build_VLSMMachine _ _ & _ _ _ _ _.
 
 Arguments initial_state {message T} _.
+Arguments initial_message_prop {message T} _, {message T _}.
 Arguments initial_message {message T} _.
 
 Definition option_initial_message_prop
@@ -393,7 +394,6 @@ Context
 Definition vstate := state vlsm.
 Definition vlabel := label vlsm.
 Definition vinitial_state_prop := @initial_state_prop _ _ vlsm.
-Definition vinitial_message_prop := @initial_message_prop _ _ vlsm.
 Definition vs0 := @inhabitant _ (@s0 _ _ vlsm).
 Definition vtransition := @transition _ _ vlsm.
 Definition vvalid := @valid _ _ vlsm.
@@ -503,7 +503,7 @@ Qed.
 
 Lemma initial_message_is_valid
   (m : message)
-  (Hinitial : vinitial_message_prop X m) :
+  (Hinitial : initial_message_prop X m) :
   valid_message_prop m.
 Proof.
   exists (proj1_sig (vs0 X)).
@@ -826,7 +826,7 @@ Qed.
 
 Lemma emitted_messages_are_valid_iff
   (m : message)
-  : valid_message_prop m <-> vinitial_message_prop X m \/ can_emit m.
+  : valid_message_prop m <-> initial_message_prop X m \/ can_emit m.
 Proof.
   split.
   - intros [s Hm].
@@ -2758,7 +2758,7 @@ Lemma same_VLSM_initial_state_preservation s1
 Proof. by subst. Qed.
 
 Lemma same_VLSM_initial_message_preservation m
-  : vinitial_message_prop X1 m -> vinitial_message_prop X2 m.
+  : initial_message_prop X1 m -> initial_message_prop X2 m.
 Proof. by subst. Qed.
 
 End sec_same_VLSM.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -214,12 +214,12 @@ Definition weak_embedding_initial_message_preservation : Prop :=
   forall (l : vlabel X) (s : vstate X) (m : message)
     (Hv : input_valid X l (s, Some m))
     (HsY : valid_state_prop Y (state_project s))
-    (HmX : vinitial_message_prop X m),
+    (HmX : initial_message_prop X m),
     valid_message_prop Y m.
 
 Definition strong_embedding_initial_message_preservation : Prop :=
   forall m : message,
-    vinitial_message_prop X m -> vinitial_message_prop Y m.
+    initial_message_prop X m -> initial_message_prop Y m.
 
 Lemma strong_embedding_initial_message_preservation_weaken
   : strong_embedding_initial_message_preservation ->

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -801,7 +801,7 @@ Definition composite_vlsm_induced_projection_validator_machine
   : VLSMMachine (IM i) :=
 {|
   initial_state_prop := vinitial_state_prop (IM i);
-  initial_message_prop := vinitial_message_prop (IM i);
+  initial_message_prop := @initial_message_prop _ _ (IM i);
   s0 := populate (vs0 (IM i));
   transition :=  vtransition (IM i);
   valid := composite_vlsm_induced_projection_valid;
@@ -815,7 +815,7 @@ Definition pre_composite_vlsm_induced_projection_validator : VLSM message :=
 
 Lemma preloaded_composite_vlsm_induced_projection_validator_iff
   (P : message -> Prop)
-  (Hinits : forall m,  vinitial_message_prop (IM i) m -> P m)
+  (Hinits : forall m,  initial_message_prop (IM i) m -> P m)
   : VLSM_eq
       (pre_loaded_vlsm composite_vlsm_induced_projection_validator P)
       (pre_loaded_vlsm (composite_vlsm_induced_validator IM constraint i) P).
@@ -872,7 +872,7 @@ Proof.
 Qed.
 
 Lemma composite_vlsm_induced_projection_validator_iff
-  (Hno_inits : forall m, ~ vinitial_message_prop (IM i) m)
+  (Hno_inits : forall m, ~ initial_message_prop (IM i) m)
   : VLSM_eq
       composite_vlsm_induced_projection_validator
       (composite_vlsm_induced_validator IM constraint i).


### PR DESCRIPTION
I removed `vinitial_message_prop` and replaced it with direct uses of `initial_message_prop`. For the latter, I set the implicit argument handling as

```coq
Arguments initial_message_prop {message T} _ _, {message T _} _.
```

This means we can write both `initial_message_prop vlsm m` (explicitly giving the `vlsm`) and `initial_message_prop m` (keeping the `vlsm` implicit).