### PR TITLE
New free composition

### DIFF
--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -264,7 +264,7 @@ Proof.
     unfold annotated_composite_label_project, composite_project_label; cbn.
     case_decide; [| congruence].
     subst _i; cbn; inversion_clear 1.
-    by intros (s, ann) om (_ & _ & [Hv _] & _) _ _.
+    by intros (s, ann) om (_ & _ & Hv & _) _ _.
   - intros [_i _li] li.
     unfold annotated_composite_label_project, composite_project_label; cbn.
     case_decide; [| congruence].

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -189,7 +189,7 @@ Proof.
   apply basic_VLSM_strong_incl.
   - by intros s Hincl; apply fixed_non_byzantine_projection_initial_state_preservation.
   - by intros.
-  - by split; [eapply induced_sub_projection_valid_preservation |].
+  - by intros l **; cbn; eapply induced_sub_projection_valid_preservation.
   - intros l s om s' om'; cbn.
     (* an ugly trick to get the forward direction from an iff (<->) lemma *)
     by eapply proj1; rapply @induced_sub_projection_transition_preservation.
@@ -568,7 +568,7 @@ Proof.
   {
     intro i.
     revert Hs.
-    apply valid_state_project_preloaded_to_preloaded.
+    by apply valid_state_project_preloaded_to_preloaded_free.
   }
   apply elem_of_elements, elem_of_difference in HAv as [_ HAv].
   destruct Hstrong_v as [(i & Hi & Hsent) | Hemitted].
@@ -702,8 +702,8 @@ Lemma preloaded_non_byzantine_vlsm_lift
       (lift_sub_state IM (elements selection_complement)).
 Proof.
   apply basic_VLSM_strong_embedding; [| | | done].
-  - intros l s om [Hv _].
-    by split; [apply lift_sub_valid |].
+  - intros l s om [Hv _]; cbn.
+    by apply lift_sub_valid.
   - by intro; intros; rapply lift_sub_transition.
   - by intro; intros; apply (lift_sub_state_initial IM).
 Qed.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -380,8 +380,11 @@ Definition free_composite_vlsm : VLSM message :=
   constraint.
 *)
 
+Definition free_constraint : composite_label -> composite_state * option message -> Prop :=
+  fun _ _ => True.
+
 Lemma free_composite_vlsm_spec :
-  VLSM_eq free_composite_vlsm (composite_vlsm (fun _ _ => True)).
+  VLSM_eq free_composite_vlsm (composite_vlsm free_constraint).
 Proof.
   split.
   - apply (VLSM_incl_embedding_iff); cbn.
@@ -1172,7 +1175,7 @@ Definition binary_IM
   end.
 
 Definition binary_free_composition : VLSM message :=
-  composite_vlsm binary_IM (fun _ _ => True).
+  composite_vlsm binary_IM (free_constraint binary_IM).
 
 End sec_binary_free_composition.
 

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1510,6 +1510,14 @@ Proof.
   by intros m [s' [l _]]; elim (empty_composition_no_label l).
 Qed.
 
+Lemma pre_loaded_empty_free_composition_no_emit
+  (seed : message -> Prop)
+  (PreX := pre_loaded_vlsm (free_composite_vlsm IM) seed)
+  : forall m, ~ can_emit PreX m.
+Proof.
+  by intros m [s' [l _]]; elim (empty_composition_no_label l).
+Qed.
+
 Lemma pre_loaded_with_all_empty_composition_no_emit
   : forall m, ~ can_emit (pre_loaded_with_all_messages_vlsm X) m.
 Proof.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1096,9 +1096,8 @@ Definition binary_IM
   | false => M2
   end.
 
-Definition binary_free_composition
-  : VLSM message
-  := free_composite_vlsm binary_IM.
+Definition binary_free_composition : VLSM message :=
+  composite_vlsm binary_IM (fun _ _ => True).
 
 End sec_binary_free_composition.
 

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1521,56 +1521,72 @@ Lemma relevant_components
   finite_valid_plan_from (composite_vlsm _ (free_constraint IM)) s' a /\
   (forall (i : index), i ∈ li -> (res' i) = res i).
 Proof.
-  induction a using rev_ind; cbn in *; [by auto using finite_valid_plan_empty |].
-  apply finite_valid_plan_from_app_iff in Hpr as [Hrem Hsingle].
-  spec IHa.
-  {
-    remember (List.map (@projT1 _ (fun n : index => label (IM n))) (List.map label_a a)) as small.
-    transitivity a_indices; [| done].
-    unfold a_indices.
-    intros e H; simpl.
-    rewrite 2 map_app, elem_of_app.
-    by itauto.
-  }
-  spec IHa; [done |].
-  destruct IHa as [IHapr IHaind].
+  induction a using rev_ind.
+  - by split; [apply finite_valid_plan_empty |].
+  - simpl in *.
+    apply finite_valid_plan_from_app_iff in Hpr.
+    destruct Hpr as [Hrem Hsingle].
 
-  specialize (relevant_components_one
-    (snd (apply_plan (composite_vlsm _ (free_constraint IM)) s a))
-    (snd (apply_plan (composite_vlsm _ (free_constraint IM)) s' a))) as Hrel.
-  spec Hrel; [by apply apply_plan_last_valid; itauto |].
-  specialize (Hrel x); simpl in *.
-  spec Hrel.
-  {
-    specialize (IHaind (projT1 (label_a x))).
-    symmetry.
-    apply IHaind.
-    specialize (Hincl (projT1 (label_a x))).
-    apply Hincl.
-    unfold a_indices.
-    by rewrite 2 map_app, elem_of_app; right; left.
-  }
-  specialize (Hrel Hsingle).
-  destruct Hrel as [Hrelpr Hrelind].
-  split; [by apply finite_valid_plan_from_app_iff; split |].
-  intros i Hi.
-  rewrite !apply_plan_app.
-  destruct (apply_plan (composite_vlsm IM (free_constraint IM)) s' a) as [tra' sa'] eqn: eq_as'.
-  destruct (apply_plan (composite_vlsm IM (free_constraint IM)) s a) as [tra sa] eqn: eq_as.
-  simpl in *.
-  destruct (apply_plan (composite_vlsm IM (free_constraint IM)) sa [x]) as [trx sx] eqn: eq_xsa.
-  destruct (apply_plan (composite_vlsm IM (free_constraint IM)) sa' [x]) as [trx' sx'] eqn: eq_xsa'.
-  simpl in *.
-  destruct (decide (i = (projT1 (label_a x)))); [by rewrite e |].
+    spec IHa. {
+      remember (List.map (@projT1 _ (fun n : index => label (IM n))) (List.map label_a a)) as small.
+      transitivity a_indices; [| done].
+      unfold a_indices.
+      intros e H; simpl.
+      rewrite 2 map_app, elem_of_app.
+      by itauto.
+    }
 
-  apply (f_equal snd) in eq_xsa, eq_xsa'.
-  replace sx' with (snd (composite_apply_plan IM sa' [x])).
-  replace sx with (snd (composite_apply_plan IM sa [x])).
-  specialize (irrelevant_components_one sa x i n) as Hdiff.
-  specialize (irrelevant_components_one sa' x i n) as Hdiff0.
-  setoid_rewrite Hdiff.
-  setoid_rewrite Hdiff0.
-  by apply IHaind.
+    spec IHa; [done |].
+
+    destruct IHa as [IHapr IHaind].
+
+    specialize (relevant_components_one
+      (snd (apply_plan (composite_vlsm _ (free_constraint IM)) s a))
+      (snd (apply_plan (composite_vlsm _ (free_constraint IM)) s' a))) as Hrel.
+
+    spec Hrel; [by apply apply_plan_last_valid; itauto |].
+
+    specialize (Hrel x); simpl in *.
+
+    spec Hrel. {
+      specialize (IHaind (projT1 (label_a x))).
+      symmetry.
+      apply IHaind.
+      specialize (Hincl (projT1 (label_a x))).
+      apply Hincl.
+      unfold a_indices.
+      by rewrite 2 map_app, elem_of_app; right; left.
+    }
+    specialize (Hrel Hsingle).
+    destruct Hrel as [Hrelpr Hrelind].
+    split.
+    + by apply finite_valid_plan_from_app_iff; split.
+    + intros i Hi.
+      specialize (IHaind i Hi).
+      specialize (Heq i Hi).
+      rewrite !apply_plan_app.
+      simpl in *.
+      destruct (apply_plan (composite_vlsm IM (free_constraint IM)) s' a) as [tra' sa'] eqn: eq_as'.
+      destruct (apply_plan (composite_vlsm IM (free_constraint IM)) s a) as [tra sa] eqn: eq_as.
+      simpl in *.
+      destruct (apply_plan (composite_vlsm IM (free_constraint IM)) sa [x]) as [trx sx] eqn: eq_xsa.
+      destruct (apply_plan (composite_vlsm IM (free_constraint IM)) sa' [x]) as [trx' sx'] eqn: eq_xsa'.
+      simpl in *.
+      destruct (decide (i = (projT1 (label_a x)))).
+      * by rewrite e.
+      * specialize (irrelevant_components_one sa) as Hdiff.
+        specialize (Hdiff x i n).
+
+        specialize (irrelevant_components_one sa') as Hdiff0.
+        specialize (Hdiff0 x i n).
+        simpl in *.
+        apply (f_equal snd) in eq_xsa.
+        apply (f_equal snd) in eq_xsa'.
+
+        replace sx' with (snd (composite_apply_plan IM sa' [x])).
+        replace sx with (snd (composite_apply_plan IM sa [x])).
+        setoid_rewrite Hdiff.
+        by setoid_rewrite Hdiff0.
 Qed.
 
 Lemma relevant_components_free

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -360,34 +360,34 @@ Qed.
 
 (** ** Free VLSM composition
 
-  The [free_constraint] is defined to be [True] for all inputs.
-  Thus, the [free_composite_vlsm] is the [composite_vlsm] using the
-  [free_constraint].
+  The [free_composite_vlsm] is like [composite_vlsm], but without any additional
+  validity constraints.
 *)
 
-Definition free_constraint
-  (l : composite_label)
-  (som : composite_state * option message)
-  : Prop
-  := True.
+Definition free_composite_vlsm_machine : VLSMMachine composite_type :=
+{|
+  initial_state_prop := composite_initial_state_prop;
+  initial_message_prop := composite_initial_message_prop;
+  transition := composite_transition;
+  valid := composite_valid;
+|}.
 
-Definition free_composite_vlsm : VLSM message
-  := composite_vlsm free_constraint.
+Definition free_composite_vlsm : VLSM message :=
+  mk_vlsm free_composite_vlsm_machine.
 
 Lemma lift_to_composite_VLSM_embedding j
   : VLSM_embedding (IM j) free_composite_vlsm (lift_to_composite_label j)
       (lift_to_composite_state' j).
 Proof.
   apply basic_VLSM_strong_embedding; intro; intros.
-  - split; [| done].
-    cbn; unfold lift_to_composite_state'.
+  - cbn; unfold lift_to_composite_state'.
     by rewrite state_update_eq.
   - cbn; unfold lift_to_composite_state' at 1.
     rewrite state_update_eq.
     replace (transition _ _ _) with (s', om').
     unfold lift_to_composite_state'.
     by rewrite state_update_twice.
-  - by apply composite_initial_state_prop_lift.
+  - by cbn; apply composite_initial_state_prop_lift.
   - by exists j, (exist _ _ H).
 Qed.
 
@@ -612,7 +612,7 @@ Lemma preloaded_constraint_free_incl
       (pre_loaded_with_all_messages_vlsm (composite_vlsm constraint))
       (pre_loaded_with_all_messages_vlsm free_composite_vlsm).
 Proof.
-  by apply preloaded_constraint_subsumption_incl.
+  by apply basic_VLSM_strong_incl; do 2 (red; cbn); firstorder.
 Qed.
 
 (*
@@ -640,14 +640,13 @@ Lemma lift_to_composite_generalized_preloaded_VLSM_embedding
 Proof.
   apply basic_VLSM_embedding_preloaded_with; intro; intros.
   - by apply PimpliesQ.
-  - split; cbn; [| done].
-    by unfold lift_to_composite_state'; rewrite state_update_eq.
+  - by cbn; unfold lift_to_composite_state'; rewrite state_update_eq.
   - cbn; unfold lift_to_composite_state' at 1.
     rewrite state_update_eq.
     replace (transition (IM j) l _) with (s', om').
     unfold lift_to_composite_state'.
     by rewrite state_update_twice.
-  - by apply composite_initial_state_prop_lift.
+  - by cbn; apply composite_initial_state_prop_lift.
   - by exists j, (exist _ _ H).
 Qed.
 
@@ -659,8 +658,8 @@ Lemma lift_to_composite_preloaded_VLSM_embedding (j : index) :
     (lift_to_composite_state' j).
 Proof.
   apply basic_VLSM_embedding_preloaded.
-  - intro; intros. split; [| done].
-    unfold lift_to_composite_state'; cbn.
+  - intro; intros.
+    cbn; unfold lift_to_composite_state'; cbn.
     by rewrite state_update_eq.
   - intro; intros; cbn.
     cbn; unfold lift_to_composite_state' at 1.
@@ -668,7 +667,7 @@ Proof.
     replace (transition l _) with (s', om').
     unfold lift_to_composite_state'.
     by rewrite state_update_twice.
-  - by intros s H; apply composite_initial_state_prop_lift.
+  - by  intros s H; cbn; apply composite_initial_state_prop_lift.
 Qed.
 
 (**
@@ -769,8 +768,9 @@ Lemma pre_composite_free_update_state_with_initial
   : valid_state_prop (pre_loaded_vlsm free_composite_vlsm P) (state_update s i si).
 Proof.
   induction Hs using valid_state_prop_ind.
-  - by apply initial_state_is_valid, composite_update_initial_state_with_initial.
-  - destruct Ht as [[Hps [Hom [Hv _]]] Ht]; cbn in Ht, Hv.
+  - apply initial_state_is_valid; cbn.
+    by apply composite_update_initial_state_with_initial.
+  - destruct Ht as [[Hps [Hom Hv]] Ht]; cbn in Ht, Hv.
     destruct l as [j lj].
     destruct (transition _ _ _) as [sj' omj'] eqn: Htj.
     inversion_clear Ht.
@@ -818,11 +818,11 @@ Proof.
   intros i cs P Hvsp.
   apply basic_VLSM_weak_embedding.
   - intros l s om (_ & _ & Hv) _ _.
-    by split; [apply lift_to_composite_valid_preservation |].
-  - by inversion 1; apply lift_to_composite_transition_preservation.
+    by cbn; apply lift_to_composite_valid_preservation.
+  - by inversion 1; cbn; apply lift_to_composite_transition_preservation.
   - by intros s Hs; apply pre_composite_free_update_state_with_initial.
   - intros _ _ m _ _ [Hm | Hp]; apply initial_message_is_valid; [left | by right].
-    by eapply lift_to_composite_initial_message_preservation.
+    by cbn; eapply lift_to_composite_initial_message_preservation.
 Qed.
 
 Lemma lift_to_free_weak_embedding :
@@ -1149,7 +1149,6 @@ Lemma relevant_component_transition
 Proof.
   split_and!; [done | by apply Hiv |].
   cbn in Hiv |- *.
-  unfold constrained_composite_valid, composite_valid, free_constraint in Hiv |- *.
   destruct l.
   simpl in i.
   unfold i in Heq.
@@ -1170,13 +1169,9 @@ Lemma relevant_component_transition2
   let (dest', output') := transition Free l (s', input) in
   output = output' /\ (dest i) = (dest' i).
 Proof.
-  destruct l as [x l]; simpl.
-  simpl in i.
-  unfold i in Heq.
-  rewrite Heq.
+  destruct l as [x l]; simpl in i |- *.
+  unfold i in Heq; rewrite Heq.
   destruct (transition (IM x) l (s' x, input)).
-  split; [done |].
-  unfold i.
   by state_update_simpl.
 Qed.
 
@@ -1193,8 +1188,7 @@ Lemma relevant_components_one
   (res' i) = res i.
 Proof.
   simpl.
-  unfold finite_valid_plan_from in *.
-  unfold apply_plan, _apply_plan in *.
+  unfold finite_valid_plan_from, apply_plan, _apply_plan in *.
   destruct ai; simpl in *.
   match goal with
   |- context [let (_, _) := let (_, _) := ?t in _ in _] =>
@@ -1206,26 +1200,20 @@ Proof.
   end.
   inversion Hpr; subst.
   split.
-  - assert (Ht' : input_valid_transition Free label_a (s', input_a) (c, o)). {
+  - assert (Ht' : input_valid_transition Free label_a (s', input_a) (c, o)).
+    {
       unfold input_valid_transition in *.
       destruct Ht as [Hpr_valid Htrans].
       by apply relevant_component_transition with (s' := s') in Hpr_valid; itauto.
     }
-
     apply finite_valid_trace_from_extend; [| done].
     apply finite_valid_trace_from_empty.
     by apply input_valid_transition_destination in Ht'.
-  - simpl.
-    specialize (relevant_component_transition2 s s' label_a input_a) as Hrel.
-    simpl in Hrel. unfold i in Heq. specialize (Hrel Heq Hprs').
-    match type of Hrel with
-    | let (_, _) := ?t in _ => replace t with (c0, o0) in Hrel
-    end.
-    match type of Hrel with
-    | let (_, _) := ?t in _ => replace t with (c, o) in Hrel
-    end.
-    unfold i.
-    by itauto.
+  - specialize (relevant_component_transition2 s s' label_a input_a Heq Hprs') as Hrel.
+    cbn in *.
+    repeat case_match.
+    unfold i; cbn in *.
+    by itauto congruence.
 Qed.
 
 (**
@@ -1315,76 +1303,55 @@ Lemma relevant_components
   finite_valid_plan_from Free s' a /\
   (forall (i : index), i ∈ li -> (res' i) = res i).
 Proof.
-  induction a using rev_ind.
-  - by split; [apply finite_valid_plan_empty |].
-  - simpl in *.
-    apply finite_valid_plan_from_app_iff in Hpr.
-    destruct Hpr as [Hrem Hsingle].
+  induction a using rev_ind; cbn in *; [by auto using finite_valid_plan_empty |].
+  apply finite_valid_plan_from_app_iff in Hpr as [Hrem Hsingle].
+  spec IHa.
+  {
+    remember (List.map (@projT1 _ (fun n : index => label (IM n))) (List.map label_a a)) as small.
+    transitivity a_indices; [| done].
+    unfold a_indices.
+    intros e H; simpl.
+    rewrite 2 map_app, elem_of_app.
+    by itauto.
+  }
+  spec IHa; [done |].
+  destruct IHa as [IHapr IHaind].
 
-    spec IHa. {
-      remember (List.map (@projT1 _ (fun n : index => label (IM n))) (List.map label_a a)) as small.
-      transitivity a_indices; [| done].
-      unfold a_indices.
-      intros e H; simpl.
-      rewrite 2 map_app, elem_of_app.
-      by itauto.
-    }
+  specialize (relevant_components_one (snd (apply_plan Free s a))
+    (snd (apply_plan Free s' a))) as Hrel.
+  spec Hrel; [by apply apply_plan_last_valid; itauto |].
+  specialize (Hrel x); simpl in *.
+  spec Hrel.
+  {
+    specialize (IHaind (projT1 (label_a x))).
+    symmetry.
+    apply IHaind.
+    specialize (Hincl (projT1 (label_a x))).
+    apply Hincl.
+    unfold a_indices.
+    by rewrite 2 map_app, elem_of_app; right; left.
+  }
+  specialize (Hrel Hsingle).
+  destruct Hrel as [Hrelpr Hrelind].
+  split; [by apply finite_valid_plan_from_app_iff; split |].
+  intros i Hi.
+  rewrite !apply_plan_app.
+  destruct (apply_plan Free s' a) as [tra' sa'] eqn: eq_as'.
+  destruct (apply_plan Free s a) as [tra sa] eqn: eq_as.
+  simpl in *.
+  destruct (apply_plan Free sa [x]) as [trx sx] eqn: eq_xsa.
+  destruct (apply_plan Free sa' [x]) as [trx' sx'] eqn: eq_xsa'.
+  simpl in *.
+  destruct (decide (i = (projT1 (label_a x)))); [by rewrite e |].
 
-    spec IHa; [done |].
-
-    destruct IHa as [IHapr IHaind].
-
-    specialize (relevant_components_one (snd (apply_plan Free s a))
-      (snd (apply_plan Free s' a))) as Hrel.
-
-    spec Hrel; [by apply apply_plan_last_valid; itauto |].
-
-    specialize (Hrel x); simpl in *.
-
-    spec Hrel. {
-      specialize (IHaind (projT1 (label_a x))).
-      symmetry.
-      apply IHaind.
-      specialize (Hincl (projT1 (label_a x))).
-      apply Hincl.
-      unfold a_indices.
-      by rewrite 2 map_app, elem_of_app; right; left.
-    }
-
-    specialize (Hrel Hsingle).
-    destruct Hrel as [Hrelpr Hrelind].
-    split.
-    + by apply finite_valid_plan_from_app_iff; split.
-    + intros i Hi.
-      specialize (IHaind i Hi).
-      specialize (Heq i Hi).
-      rewrite !apply_plan_app.
-      simpl in *.
-      destruct (apply_plan Free s' a)
-        as (tra', sa') eqn: eq_as'.
-      destruct (apply_plan Free s a)
-        as (tra, sa) eqn: eq_as.
-      simpl in *.
-      destruct (apply_plan Free sa [x])
-        as (trx, sx) eqn: eq_xsa.
-      destruct (apply_plan Free sa' [x])
-        as (trx', sx') eqn: eq_xsa'.
-      simpl in *.
-      destruct (decide (i = (projT1 (label_a x)))).
-      * by rewrite e.
-      * specialize (irrelevant_components_one sa) as Hdiff.
-        specialize (Hdiff x i n).
-
-        specialize (irrelevant_components_one sa') as Hdiff0.
-        specialize (Hdiff0 x i n).
-        simpl in *.
-        apply (f_equal snd) in eq_xsa.
-        apply (f_equal snd) in eq_xsa'.
-
-        replace sx' with (snd (composite_apply_plan IM sa' [x])).
-        replace sx with (snd (composite_apply_plan IM sa [x])).
-        setoid_rewrite Hdiff.
-        by setoid_rewrite Hdiff0.
+  apply (f_equal snd) in eq_xsa, eq_xsa'.
+  replace sx' with (snd (composite_apply_plan IM sa' [x])).
+  replace sx with (snd (composite_apply_plan IM sa [x])).
+  specialize (irrelevant_components_one sa x i n) as Hdiff.
+  specialize (irrelevant_components_one sa' x i n) as Hdiff0.
+  setoid_rewrite Hdiff.
+  setoid_rewrite Hdiff0.
+  by apply IHaind.
 Qed.
 
 End sec_composite_plan_properties.
@@ -1523,10 +1490,10 @@ Proof.
     destruct HmX as [[i [[im Him] Hi]] | Hseed]; [| by right].
     simpl in Hi. subst im.
     cbn. unfold composite_initial_message_prop.
-    left. exists i.
-    assert (Hm : initial_message_prop (IM2 i) m).
-    + by eapply same_VLSM_initial_message_preservation; eauto.
-    + by exists (exist _ m Hm).
+    left; exists i.
+    unshelve esplit.
+    + by exists m; eapply same_VLSM_initial_message_preservation; eauto.
+    + done.
 Qed.
 
 End sec_pre_loaded_constrained.
@@ -1538,20 +1505,21 @@ Lemma same_IM_preloaded_free_embedding
     same_IM_label_rew
     same_IM_state_rew.
 Proof.
-  constructor.
-  intros s1 tr1 Htr1.
-  specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True
-    (free_composite_vlsm IM1)) as Heq1.
-  apply (VLSM_eq_finite_valid_trace Heq1) in Htr1.
-  clear Heq1.
-  specialize (same_IM_embedding (free_constraint IM1) (free_constraint IM2))
-    as Hproj.
-  spec Hproj; [done |].
-  specialize (Hproj (fun _ => True)).
-  apply (VLSM_embedding_finite_valid_trace Hproj) in Htr1.
-  specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True
-    (free_composite_vlsm IM2)) as Heq2.
-  by apply (VLSM_eq_finite_valid_trace Heq2).
+  apply basic_VLSM_embedding; intros l **.
+  - destruct l; cbn.
+    unfold same_VLSM_label_rew, same_IM_state_rew.
+    destruct (Heq x); cbn.
+    by destruct Hv as [Hs [Hom Hv]].
+  - destruct H as [_ H], l as [i li]; revert H; cbn.
+    destruct (transition (IM1 i) _ _) as [si'1 _om'] eqn: Ht1.
+    unfold same_IM_state_rew at 1.
+    erewrite same_VLSM_transition_preservation; [| done].
+    inversion 1; subst; clear H.
+    f_equal; extensionality j.
+    unfold same_IM_state_rew at 2.
+    by destruct (decide (i = j)); subst; state_update_simpl.
+  - by intros i; apply same_VLSM_initial_state_preservation.
+  - by apply initial_message_is_valid.
 Qed.
 
 End sec_same_IM_embedding.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -587,6 +587,16 @@ Proof.
   - by apply preloaded_constraint_subsumption_input_valid.
 Qed.
 
+Lemma preloaded_constraint_subsumption_incl_free :
+  VLSM_incl
+    (pre_loaded_with_all_messages_vlsm X1)
+    (pre_loaded_with_all_messages_vlsm free_composite_vlsm).
+Proof.
+  apply basic_VLSM_incl; intro; intros; [done | | | apply H].
+  - by apply initial_message_is_valid.
+  - by apply Hv.
+Qed.
+
 Lemma weak_constraint_subsumption_weakest
   (Hsubsumption : input_valid_constraint_subsumption constraint1 constraint2)
   : weak_input_valid_constraint_subsumption constraint1 constraint2.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -375,6 +375,23 @@ Definition free_composite_vlsm_machine : VLSMMachine composite_type :=
 Definition free_composite_vlsm : VLSM message :=
   mk_vlsm free_composite_vlsm_machine.
 
+(**
+  [free_composite_vlsm] is equivalent to a [composite_vlsm] with a trivial
+  constraint.
+*)
+
+Lemma free_composite_vlsm_spec :
+  VLSM_eq free_composite_vlsm (composite_vlsm (fun _ _ => True)).
+Proof.
+  split.
+  - apply (VLSM_incl_embedding_iff); cbn.
+    by apply basic_VLSM_strong_embedding; red; cbn.
+  - apply (VLSM_incl_embedding_iff); cbn.
+    apply basic_VLSM_strong_embedding; red; cbn; [| done..].
+    unfold constrained_composite_valid.
+    by itauto.
+Qed.
+
 Lemma lift_to_composite_VLSM_embedding j
   : VLSM_embedding (IM j) free_composite_vlsm (lift_to_composite_label j)
       (lift_to_composite_state' j).

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -395,6 +395,35 @@ Proof.
     by itauto.
 Qed.
 
+Lemma preloaded_free_composite_vlsm_spec :
+  forall (initial : message -> Prop),
+    VLSM_eq
+      (pre_loaded_vlsm free_composite_vlsm initial)
+      (pre_loaded_vlsm (composite_vlsm free_constraint) initial).
+Proof.
+  split.
+  - apply (VLSM_incl_embedding_iff); cbn.
+    by apply basic_VLSM_strong_embedding; red; cbn.
+  - apply (VLSM_incl_embedding_iff); cbn.
+    apply basic_VLSM_strong_embedding; red; cbn; [| done..].
+    unfold constrained_composite_valid.
+    by itauto.
+Qed.
+
+Lemma preloaded_with_all_messages_free_composite_vlsm_spec :
+  VLSM_eq
+    (pre_loaded_with_all_messages_vlsm free_composite_vlsm)
+    (pre_loaded_with_all_messages_vlsm (composite_vlsm free_constraint)).
+Proof.
+  split.
+  - apply (VLSM_incl_embedding_iff); cbn.
+    by apply basic_VLSM_strong_embedding; red; cbn.
+  - apply (VLSM_incl_embedding_iff); cbn.
+    apply basic_VLSM_strong_embedding; red; cbn; [| done..].
+    unfold constrained_composite_valid.
+    by itauto.
+Qed.
+
 Lemma lift_to_composite_VLSM_embedding j
   : VLSM_embedding (IM j) free_composite_vlsm (lift_to_composite_label j)
       (lift_to_composite_state' j).

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -636,15 +636,6 @@ Qed.
 
 End sec_constraint_subsumption.
 
-Lemma preloaded_constraint_free_incl
-  (constraint : composite_label -> composite_state  * option message -> Prop) :
-    VLSM_incl
-      (pre_loaded_with_all_messages_vlsm (composite_vlsm constraint))
-      (pre_loaded_with_all_messages_vlsm free_composite_vlsm).
-Proof.
-  by apply basic_VLSM_strong_incl; do 2 (red; cbn); firstorder.
-Qed.
-
 (*
   TODO(traiansf): There are many places where, because the lemma below
   was missing, it was either reproved locally, or multiple VLSM_incl_
@@ -657,7 +648,7 @@ Lemma constraint_preloaded_free_incl
 Proof.
   eapply VLSM_incl_trans.
   - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
-  - by apply preloaded_constraint_free_incl.
+  - by apply preloaded_constraint_subsumption_incl_free.
 Qed.
 
 Lemma preloaded_free_incl :

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1616,7 +1616,6 @@ Proof.
   }
   spec IHa; [done |].
   destruct IHa as [IHapr IHaind].
-
   specialize (relevant_components_one_free (snd (apply_plan Free s a))
     (snd (apply_plan Free s' a))) as Hrel.
   spec Hrel; [by apply apply_plan_last_valid; itauto |].
@@ -1643,7 +1642,6 @@ Proof.
   destruct (apply_plan Free sa' [x]) as [trx' sx'] eqn: eq_xsa'.
   simpl in *.
   destruct (decide (i = (projT1 (label_a x)))); [by rewrite e |].
-
   apply (f_equal snd) in eq_xsa, eq_xsa'.
   replace sx' with (snd (composite_apply_plan IM sa' [x])).
   replace sx with (snd (composite_apply_plan IM sa [x])).

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -660,6 +660,14 @@ Proof.
   - by apply preloaded_constraint_free_incl.
 Qed.
 
+Lemma preloaded_free_incl :
+  VLSM_incl free_composite_vlsm (pre_loaded_with_all_messages_vlsm free_composite_vlsm).
+Proof.
+  eapply VLSM_incl_trans.
+  - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  - by apply VLSM_incl_refl.
+Qed.
+
 Lemma lift_to_composite_generalized_preloaded_VLSM_embedding
   (P Q : message -> Prop)
   (PimpliesQ : forall m, P m -> Q m)
@@ -1140,6 +1148,22 @@ Proof.
   exists (s2 (projT1 l)).
   exists (s1 (projT1 l), oim), (projT2 l).
   by eapply input_valid_transition_preloaded_project_active.
+Qed.
+
+Lemma can_emit_free_composite_project
+  {message} `{EqDecision V} {IM : V -> VLSM message}
+  (X := free_composite_vlsm IM)
+  (m : message)
+  (Hemit : can_emit (pre_loaded_with_all_messages_vlsm X) m)
+  : exists (j : V), can_emit (pre_loaded_with_all_messages_vlsm (IM j)) m.
+Proof.
+  apply can_emit_iff in Hemit.
+  destruct Hemit as [s2 [(s1, oim) [l Ht]]].
+  exists (projT1 l).
+  apply can_emit_iff.
+  exists (s2 (projT1 l)).
+  exists (s1 (projT1 l), oim), (projT2 l).
+  by eapply input_valid_transition_preloaded_project_active_free.
 Qed.
 
 Section sec_binary_free_composition.

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -1673,7 +1673,7 @@ Proof.
   cbn; intros s a Hs.
   apply Morphisms_Prop.ex_iff_morphism; intro m.
   assert (forall k : index, UMO_reachable full_node (s k))
-    by (intro; eapply ELMO_full_node_reachable, valid_state_project_preloaded_to_preloaded; done).
+    by (intro; eapply ELMO_full_node_reachable, valid_state_project_preloaded_to_preloaded_free; done).
   setoid_rewrite <- full_node_messages_iff_rec_obs; [| done].
   setoid_rewrite <- ELMO_CHBO_in_messages; [| done].
   (* firstorder works here but is slow *)
@@ -1753,8 +1753,9 @@ Proof.
   {
     apply Forall_forall; intros item Hitem m Hobs.
     eapply directly_observed_valid; [done |].
+      
     eapply EquivocationProjections.VLSM_incl_has_been_directly_observed_reflect;
-      [by apply preloaded_constraint_free_incl | |].
+      [by apply preloaded_constraint_subsumption_incl_free | |].
     - by generalize Hs; apply VLSM_incl_valid_state, vlsm_incl_pre_loaded_with_all_messages_vlsm.
     - eapply has_been_directly_observed_examine_one_trace; [done |].
       by apply Exists_exists; eexists; cbn; eauto.
@@ -1769,7 +1770,7 @@ Proof.
       clear Hall_not_heavy Hall_input_valid.
     split; [| by apply Htr_min]; clear Htr_min.
     apply (extend_right_finite_trace_from_to _ IHHtr).
-    destruct Ht as [(Hs_pre & _ & [Hv _]) Ht].
+    destruct Ht as [(Hs_pre & _ & Hy) Ht].
     repeat split; [| | done | | done].
     + by apply valid_trace_last_pstate in IHHtr.
     + by destruct iom; [apply Hmsg_valid | apply option_valid_message_None].
@@ -1912,7 +1913,7 @@ Proof.
   exists m; repeat split; [| done].
   destruct Hobs as [k Hobs]; exists k.
   apply full_node_messages_iff_rec_obs; [| by apply elem_of_messages].
-  by eapply ELMO_full_node_reachable, valid_state_project_preloaded_to_preloaded.
+  by eapply ELMO_full_node_reachable, valid_state_project_preloaded_to_preloaded_free.
 Qed.
 
 Lemma ELMO_equivocating_validators_step_update_Send
@@ -2524,11 +2525,11 @@ Proof.
     }
     apply elem_of_messages in Hm as [Hsnd |]; [| done].
     cbn in Hsnd; eapply reachable_sent_messages_adr in Hsnd; cycle 1.
-    + by eapply valid_state_project_preloaded_to_preloaded.
+    + by eapply valid_state_project_preloaded_to_preloaded_free.
     + by congruence.
   - intros [j Hsnd].
     cbn in Hsnd; eapply reachable_sent_messages_adr in Hsnd as Hsnd_adr;
-      [| by eapply valid_state_project_preloaded_to_preloaded].
+      [| by eapply valid_state_project_preloaded_to_preloaded_free].
     rewrite Hm0_adr in Hsnd_adr.
     eapply inj in Hsnd_adr; [| done]; subst j.
     eapply ELMOComponent_sizeState_of_ram_trace_output in Hitem;

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -997,7 +997,7 @@ Proof.
   intros m [s' IH].
   inversion IH; subst; [by inversion Hom as [j []]; inversion x |].
   destruct l as [k []], om as [m' |];
-    destruct Hv as [Hv _]; inversion Hv; subst; clear Hv;
+    inversion Hv; subst; clear Hv;
     inversion Ht; subst; clear Ht.
   unfold addObservationToMessage; cbn; red.
   remember (s k <+> MkObservation Send (MkMessage (s k))) as sk'.
@@ -1019,7 +1019,7 @@ Proof.
   intros m mr Hvalid [sm IH1] [smr IH2].
   inversion IH1; subst; [by inversion Hom as [j []]; inversion x |].
   destruct l as [k []], om as [m' |];
-    destruct Hv as [Hv _]; inversion Hv; subst; clear Hv;
+    inversion Hv; subst; clear Hv;
     inversion Ht; subst; clear Ht.
   exists (state_update M s k (s k <+> MkObservation Receive mr <+>
     MkObservation Send (MkMessage (s k <+> MkObservation Receive mr)))).
@@ -1134,7 +1134,7 @@ Proof.
         by apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True MO)).
     + replace us with (state_update M us i (us i)) at 2 by (state_update_simpl; done).
       apply lift_to_RMO_finite_valid_trace_from_to; [done |].
-      apply (valid_state_project_preloaded_to_preloaded _ _ _ us i) in Hvsp as Hvsp'.
+      apply (valid_state_project_preloaded_to_preloaded_free _ _ us i) in Hvsp as Hvsp'.
       apply valid_state_has_trace in Hvsp' as (s & tr & [Hfvt Hinit]).
       replace s with (MkState [] (idx i)) in *; cycle 1.
       * by inversion Hinit; destruct s; cbn in *; subst.
@@ -1160,11 +1160,17 @@ Proof.
             (lift_to_MO_state (fun j : index => MkState [] (idx j)) i s')
             (lift_to_MO_trace (fun j : index => MkState [] (idx j)) i tr)) in Heqftl.
   apply valid_trace_forget_last, first_transition_valid in Hfvt; cbn in *.
-  destruct Hfvt as [[Hvps [Hovmp [Hv1 Hv2]]] Ht']; cbn in Hv1, Hv2.
+  destruct Hfvt as [[Hvps [Hovmp Hv]] Ht']; cbn in Hv.
   unfold lift_to_MO_trace in Heqftl; cbn in Heqftl.
   rewrite <- pre_VLSM_embedding_finite_trace_last, Hlast in Heqftl.
-  exists ftl; split; [| done].
-  by rewrite Heqftl; state_update_simpl.
+  exists ftl; split; [by rewrite Heqftl; state_update_simpl |].
+  split_and!; [| | done].
+  - eapply VLSM_incl_valid_state; [| by apply Hvps].
+    by apply free_composite_vlsm_spec.
+  - destruct Hovmp as [ss Hvsmp].
+    exists ss.
+    apply VLSM_incl_valid_state_message; [| by do 2 red | done].
+    by apply free_composite_vlsm_spec.
 Qed.
 
 (** *** Equivocation *)

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -1584,7 +1584,7 @@ Proof.
           (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True UMO)).
     + replace us with (state_update U us i (us i)) at 2 by (state_update_simpl; done).
       apply lift_to_RUMO_finite_valid_trace_from_to; [done |].
-      apply (valid_state_project_preloaded_to_preloaded _ _ _ us i) in Hvsp as Hvsp'.
+      apply (valid_state_project_preloaded_to_preloaded_free _ _ us i) in Hvsp as Hvsp'.
       apply valid_state_has_trace in Hvsp' as (s & tr & [Hfvt Hinit]).
       replace s with (MkState [] (idx i)) in *; cycle 1.
       * by inversion Hinit; destruct s; cbn in *; subst.
@@ -1601,7 +1601,7 @@ Lemma finite_valid_trace_from_to_UMO_state2trace_UMO :
       finite_valid_trace_init_to UMO (``(vs0 UMO)) us (UMO_state2trace us).
 Proof.
   intros us Hvsp.
-  apply all_pre_traces_to_valid_state_are_valid; [typeclasses eauto | done |].
+  apply all_pre_traces_to_valid_state_are_valid_free; [typeclasses eauto | done |].
   apply finite_valid_trace_from_to_UMO_state2trace_RUMO.
   eapply (@VLSM_incl_valid_state _ UMO UMO RUMO); [| done].
   by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -2347,6 +2347,19 @@ Proof.
   by eapply sent_valid; [| exists i].
 Qed.
 
+Lemma preloaded_messages_sent_from_component_of_valid_state_are_valid_free
+  (seed : message -> Prop)
+  (X := pre_loaded_vlsm (free_composite_vlsm IM) seed)
+  (s : composite_state IM)
+  (Hs : valid_state_prop X s)
+  (i : index)
+  (m : message)
+  (Hsent : has_been_sent (IM i) (s i) m) :
+  valid_message_prop X m.
+Proof.
+  by eapply sent_valid; [| exists i].
+Qed.
+
 Lemma messages_received_from_component_of_valid_state_are_valid
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
@@ -2364,6 +2377,19 @@ Lemma preloaded_messages_received_from_component_of_valid_state_are_valid
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (seed : message -> Prop)
   (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
+  (s : composite_state IM)
+  (Hs : valid_state_prop X s)
+  (i : index)
+  (m : message)
+  (Hreceived : has_been_received (IM i) (s i) m)
+  : valid_message_prop X m.
+Proof.
+  by eapply received_valid; [| exists i].
+Qed.
+
+Lemma preloaded_messages_received_from_component_of_valid_state_are_valid_free
+  (seed : message -> Prop)
+  (X := pre_loaded_vlsm (free_composite_vlsm IM) seed)
   (s : composite_state IM)
   (Hs : valid_state_prop X s)
   (i : index)
@@ -2461,6 +2487,25 @@ Proof.
     + by eapply preloaded_messages_received_from_component_of_valid_state_are_valid.
     + by eapply preloaded_messages_sent_from_component_of_valid_state_are_valid.
   - eapply valid_state_project_preloaded_to_preloaded.
+    eapply VLSM_incl_valid_state; [| done].
+    by apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
+Qed.
+
+Lemma preloaded_free_composite_directly_observed_valid
+  (seed : message -> Prop)
+  (X := pre_loaded_vlsm (free_composite_vlsm IM) seed)
+  (s : composite_state IM)
+  (Hs : valid_state_prop X s)
+  (m : message)
+  (Hobserved : composite_has_been_directly_observed s m)
+  : valid_message_prop X m.
+Proof.
+  destruct Hobserved as [i Hobserved].
+  apply (has_been_directly_observed_sent_received_iff (IM i)) in Hobserved.
+  - destruct Hobserved as [Hreceived | Hsent].
+    + by eapply preloaded_messages_received_from_component_of_valid_state_are_valid_free.
+    + by eapply preloaded_messages_sent_from_component_of_valid_state_are_valid_free.
+  - eapply valid_state_project_preloaded_to_preloaded_free.
     eapply VLSM_incl_valid_state; [| done].
     by apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
 Qed.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1960,6 +1960,16 @@ Proof.
   by intros l; specialize (Hstep l); destruct l.
 Qed.
 
+Lemma free_composite_has_been_directly_observed_stepwise_props :
+  oracle_stepwise_props (vlsm := free_composite_vlsm IM) item_sends_or_receives
+    composite_has_been_directly_observed.
+Proof.
+  destruct (free_composite_stepwise_props (fun i =>
+    has_been_directly_observed_stepwise_props (IM i))) as [Hinits Hstep].
+  split; [done |].
+  by intros l; specialize (Hstep l); destruct l.
+Qed.
+
 Definition composite_HasBeenDirectlyObservedCapability_from_stepwise
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
@@ -2077,6 +2087,29 @@ Proof.
   intros [[i [[mi Hmi] _]] | [(s, om) [(i, l) [s' Ht]]]]
   ; [by contradict Hmi; apply no_initial_messages_in_IM |].
   apply (VLSM_incl_input_valid_transition (constraint_preloaded_free_incl IM _)) in Ht.
+  apply pre_loaded_with_all_messages_projection_input_valid_transition_eq
+    with (j := i) in Ht; [| done]; cbn in Ht.
+  specialize (can_emit_signed i m).
+  spec can_emit_signed; [by eexists _, _, _ |].
+  unfold channel_authenticated_message in can_emit_signed.
+  destruct (sender m) as [v |] eqn: Hsender; [| by inversion can_emit_signed].
+  apply Some_inj in can_emit_signed.
+  by exists v; subst; unfold can_emit; eauto.
+Qed.
+
+Lemma free_composite_no_initial_valid_messages_emitted_by_sender
+  (can_emit_signed : channel_authentication_prop)
+  (no_initial_messages_in_IM : no_initial_messages_in_IM_prop)
+  (X := free_composite_vlsm IM)
+  : forall (m : message), valid_message_prop X m ->
+    exists v, sender m = Some v /\
+      can_emit (pre_loaded_with_all_messages_vlsm (IM (A v))) m.
+Proof.
+  intro m.
+  rewrite emitted_messages_are_valid_iff.
+  intros [[i [[mi Hmi] _]] | [(s, om) [(i, l) [s' Ht]]]]
+  ; [by contradict Hmi; apply no_initial_messages_in_IM |].
+  apply (VLSM_incl_input_valid_transition (preloaded_free_incl IM)) in Ht.
   apply pre_loaded_with_all_messages_projection_input_valid_transition_eq
     with (j := i) in Ht; [| done]; cbn in Ht.
   specialize (can_emit_signed i m).

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1649,8 +1649,7 @@ Lemma composite_stepwise_props
   : oracle_stepwise_props (vlsm := X) composite_message_selector composite_oracle.
 Proof.
   split.
-  - (* initial states not claim *)
-    intros s Hs m [i Horacle].
+  - intros s Hs m [i Horacle].
     revert Horacle.
     apply (oracle_no_inits (stepwise_props i)).
     by apply Hs.
@@ -1685,11 +1684,9 @@ Lemma free_composite_stepwise_props :
   oracle_stepwise_props (vlsm := free_composite_vlsm IM) composite_message_selector composite_oracle.
 Proof.
   split.
-  - (* initial states not claim *)
-    intros s Hs m [i Horacle].
+  - intros s Hs m [i Horacle].
     revert Horacle.
-    apply (oracle_no_inits (stepwise_props i)).
-    by apply Hs.
+    by apply (oracle_no_inits (stepwise_props i)).
   - (* step update property *)
     intros l s im s' om Hproto msg.
     destruct l as [i li].
@@ -1712,9 +1709,8 @@ Proof.
     + intros [Hnow | [j Hbefore]].
       * by exists i; apply Hproto; left.
       * exists j.
-        destruct (Hsj j) as [Hunchanged | ->].
-        -- by rewrite <- Hunchanged.
-        -- by apply Hproto; right.
+        destruct (Hsj j) as [<- | ->]; [done |].
+        by apply Hproto; right.
 Qed.
 
 Lemma oracle_component_selected_previously
@@ -1799,8 +1795,6 @@ Qed.
     composite_has_been_sent
     composite_has_been_sent_dec
     (composite_has_been_sent_stepwise_props constraint).
-
-(** Analogous stuff for [free_composite_vlsm]. *)
 
 Lemma free_composite_has_been_sent_stepwise_props
   (X := free_composite_vlsm IM)
@@ -2949,9 +2943,8 @@ Context
   within it must be valid, thus the trace itself is valid.
 *)
 Lemma all_pre_traces_to_valid_state_are_valid
-  s
+  (s is : state PreX) (tr : list (transition_item PreX))
   (Hs : valid_state_prop X s)
-  is tr
   (Htr : finite_valid_trace_init_to PreX is s tr)
   : finite_valid_trace_init_to X is s tr.
 Proof.
@@ -2966,9 +2959,8 @@ Proof.
 Qed.
 
 Lemma all_pre_traces_to_valid_state_are_valid_free
-  s
+  (s is : state PreY) (tr : list (transition_item PreY))
   (Hs : valid_state_prop Y s)
-  is tr
   (Htr : finite_valid_trace_init_to PreY is s tr)
   : finite_valid_trace_init_to Y is s tr.
 Proof.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -311,7 +311,7 @@ Qed.
 
 Definition preloaded_Fixed_incl_Preloaded :
   VLSM_incl (pre_loaded_with_all_messages_vlsm Fixed) (pre_loaded_with_all_messages_vlsm Free) :=
-    preloaded_constraint_free_incl _ _.
+    preloaded_constraint_subsumption_incl_free _ _.
 
 Definition StrongFixed_incl_Free : VLSM_incl StrongFixed Free := constraint_free_incl _ _.
 

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -928,7 +928,7 @@ Lemma EquivPreloadedBase_Fixed_weak_embedding
 Proof.
   apply basic_VLSM_weak_embedding.
   - intros l s om Hv HsY HomY. split.
-    + destruct Hv as [_ [_ [Hv _]]]; revert Hv; destruct l as (i, li).
+    + destruct Hv as [_ [_ Hv]]; revert Hv; destruct l as (i, li).
       destruct_dec_sig i j Hj Heq; subst i; cbn; unfold sub_IM; cbn.
       by rewrite lift_sub_state_to_eq with (Hi := Hj).
     + destruct om as [m |]; [| done]; cbn.

--- a/theories/VLSM/Core/Equivocation/FullNode.v
+++ b/theories/VLSM/Core/Equivocation/FullNode.v
@@ -122,7 +122,7 @@ Proof.
   apply node_generated_without_further_equivocation_weaken; [done | | done].
   revert Hs.
   apply VLSM_incl_valid_state.
-  by apply preloaded_constraint_free_incl.
+  by apply preloaded_constraint_subsumption_incl_free.
 Qed.
 
 End sec_full_node_constraint.

--- a/theories/VLSM/Core/Equivocation/MinimalEquivocationTrace.v
+++ b/theories/VLSM/Core/Equivocation/MinimalEquivocationTrace.v
@@ -217,7 +217,7 @@ Proof.
   exists s, item, m, s_j, item_j, m_j; constructor; [done.. |]; constructor.
   apply head_Some_elem_of in Hdestruct_j as H_destruct_j.
   eapply composite_tv_state_destructor_index in H_destruct_j as Hlj.
-  apply input_valid_transition_preloaded_project_active in Htj as Htj'.
+  apply input_valid_transition_preloaded_project_active_free in Htj as Htj'.
   eapply composite_tv_state_destructor_destination in H_destruct_j as Hdestination_j; [| done].
   destruct item_j, l as [_j lj]; cbn in *; subst _j destination.
   destruct (decide (i = j)).
@@ -242,7 +242,7 @@ Proof.
     + by eexists s_j, _; constructor; [done.. | constructor 3].
     + apply Some_inj in H_output as <-.
       contradict n.
-      apply input_valid_transition_preloaded_project_active in Hti as Hti'; cbn in Hti'.
+      apply input_valid_transition_preloaded_project_active_free in Hti as Hti'; cbn in Hti'.
       specialize (Hchannel i m_j) as Hchannel_i.
       spec Hchannel_i; [by eexists _, _, _ |].
       specialize (Hchannel j m_j) as Hchannel_j.
@@ -289,7 +289,8 @@ Program Definition initial_indices
   @filter _ _ _ (fun i => initial_state_prop (IM i) (s i)) _ is.
 Next Obligation.
 Proof.
-  by intros; eapply traceable_vlsm_initial_state_dec, valid_state_project_preloaded_to_preloaded.
+  by intros; eapply traceable_vlsm_initial_state_dec,
+    valid_state_project_preloaded_to_preloaded_free.
 Qed.
 
 (**
@@ -604,7 +605,7 @@ Proof.
   cut (output item <> Some m).
   {
     intro.
-    destruct (composite_has_been_sent_stepwise_props IM (free_constraint IM)) as [_].
+    destruct (free_composite_has_been_sent_stepwise_props IM) as [_].
     rewrite oracle_step_update by done; cbn.
     by intros [].
   }

--- a/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepFixedSetEquivocation.v
@@ -122,7 +122,7 @@ Lemma single_equivocator_projection s j
       (sub_state_element_project IM equivocators j Hj).
 Proof.
   apply basic_VLSM_projection.
-  - intros [sub_i li] lY HlX_pr sX om (_ & _ & HvX & _) HsY _; revert HvX.
+  - intros [sub_i li] lY HlX_pr sX om (_ & _ & HvX) HsY _; revert HvX.
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
     unfold sub_label_element_project in HlX_pr; cbn in HlX_pr.
     case_decide as Heqij; [| congruence].
@@ -219,7 +219,7 @@ Proof.
       by apply no_initial_messages_in_IM.
     }
     destruct Hemit as ((sX, iom) & (sub_i, li) & sX' & HtX).
-    eapply (preloaded_composite_directly_observed_valid _ _ _ sX').
+    eapply (preloaded_free_composite_directly_observed_valid _ _ sX').
     + by eapply input_valid_transition_destination.
     + exists sub_i; destruct_dec_sig sub_i i Hi Heqsub_i; subst.
       eapply message_dependencies_are_necessary; [| done].

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -388,7 +388,7 @@ Lemma equivocating_messages_are_equivocator_emitted
 Proof.
   eapply (VLSM_incl_can_emit (vlsm_incl_pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)))
       in Him.
-  apply can_emit_composite_project in Him as [j Him].
+  apply can_emit_free_composite_project in Him as [j Him].
   apply Hchannel in Him as Hsender.
   unfold channel_authenticated_message in Hsender.
   destruct (sender im) as [v |] eqn: Heq_sender; [| by inversion Hsender].
@@ -635,7 +635,7 @@ Proof.
   - subst msg.
     eapply VLSM_incl_can_emit in Hemitted
     ; [| apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages].
-    apply can_emit_composite_project in Hemitted as [sub_eqv Hemitted].
+    apply can_emit_free_composite_project in Hemitted as [sub_eqv Hemitted].
     destruct_dec_sig sub_eqv _eqv H_eqv Heqsub_eqv; subst.
     unfold sub_IM in Hemitted; cbn in Hemitted.
     eapply Hsender_safety in Hemitted; [| done]; subst.
@@ -648,7 +648,7 @@ Proof.
         by eapply sent_by_non_equivocating_are_directly_observed.
       - eapply VLSM_incl_can_emit in Hemitted_msg
         ; [| apply pre_loaded_vlsm_incl_pre_loaded_with_all_messages].
-        apply can_emit_composite_project in Hemitted_msg as [sub_i Hemitted_msg].
+        apply can_emit_free_composite_project in Hemitted_msg as [sub_i Hemitted_msg].
         destruct_dec_sig sub_i i Hi Heqsub_i; subst.
         eapply Hsender_safety in Hemitted_msg; [| done].
         cbn in Hemitted_msg; subst.

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -258,6 +258,9 @@ Definition composite_no_equivocation_vlsm_with_pre_loaded
   :=
   pre_loaded_vlsm (composite_vlsm IM no_equivocations_additional_constraint_with_pre_loaded) seed.
 
+Definition free_composite_no_equivocation_vlsm_with_pre_loaded : VLSM message :=
+  pre_loaded_vlsm (free_composite_vlsm IM) seed.
+
 Lemma seeded_no_equivocation_incl_preloaded :
   VLSM_incl composite_no_equivocation_vlsm_with_pre_loaded
     (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)).

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -279,7 +279,7 @@ Proof.
     end
     ; [done |].
     unfold free_composite_vlsm; cbn.
-    by apply preloaded_constraint_subsumption_incl.
+    by apply preloaded_constraint_subsumption_incl_free.
 Qed.
 
 End sec_seeded_composite_vlsm_no_equivocation_definition.

--- a/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/TraceWiseEquivocation.v
@@ -211,7 +211,7 @@ Proof.
     intros.
     erewrite <- oracle_initial_trace_update
       with (vlsm := free_composite_vlsm IM); cycle 1.
-    - by apply composite_has_been_sent_stepwise_props.
+    - by apply free_composite_has_been_sent_stepwise_props.
     - done.
     - by eapply has_been_sent_iff_by_sender.
   }

--- a/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/WitnessedEquivocation.v
@@ -605,7 +605,7 @@ Proof.
     in Hs as Hpre_s.
   apply preloaded_has_strong_trace_witnessing_equivocation_prop in Hpre_s.
   destruct Hpre_s as [is [tr [Htr Hwitness]]].
-  apply (all_pre_traces_to_valid_state_are_valid IM) in Htr
+  apply (all_pre_traces_to_valid_state_are_valid_free IM) in Htr
   ; [| done].
   by exists is, tr.
 Qed.
@@ -652,8 +652,8 @@ Context
   (Hsender_safety : sender_safety_alt_prop IM A sender :=
     channel_authentication_sender_safety IM A sender can_emit_signed)
   (Free_has_sender :=
-    composite_no_initial_valid_messages_have_sender IM A sender
-      can_emit_signed no_initial_messages_in_IM (free_constraint IM))
+    free_composite_no_initial_valid_messages_have_sender IM A sender
+      can_emit_signed no_initial_messages_in_IM)
   (equivocating_validators :=
     equivocating_validators (BasicEquivocation := Htracewise_BasicEquivocation))
   .
@@ -689,14 +689,15 @@ Proof.
   ; [by elim (no_initial_messages_in_IM _v _im) |].
   apply (VLSM_incl_can_emit (vlsm_incl_pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)))
     in Hiom.
-  apply can_emit_composite_project in Hiom as [_v Hiom].
+  apply can_emit_free_composite_project in Hiom as [_v Hiom].
   specialize (Hsender_safety _ _ Hsender _ Hiom) as Heq_v. simpl in Heq_v.
   subst _v.
   eapply message_dependencies_are_sufficient in Hiom.
   unfold pre_loaded_free_equivocating_vlsm_composition, free_equivocating_vlsm_composition.
   specialize
     (@lift_to_composite_generalized_preloaded_VLSM_embedding
-      message (sub_index (elements (C := Ci) (fin_sets.set_map A (equivocating_validators sf)))) _ (sub_IM IM (elements(fin_sets.set_map A (equivocating_validators sf))))
+      message (sub_index (elements (C := Ci) (fin_sets.set_map A (equivocating_validators sf)))) _
+        (sub_IM IM (elements(fin_sets.set_map A (equivocating_validators sf))))
       (fun msg : message => msg ∈ message_dependencies m)
       (composite_has_been_directly_observed IM s))
     as Hproj.
@@ -757,7 +758,7 @@ Proof.
     }
     clear IHHtr.
     apply (extend_right_finite_trace_from_to _ Htr_sf).
-    destruct Ht as [(Hs & Hiom & Hv & _) Ht].
+    destruct Ht as [(Hs & Hiom & Hv) Ht].
     apply finite_valid_trace_from_to_last_pstate in Htr_sf as Hs'.
     specialize
       (Heqv

--- a/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
@@ -234,7 +234,7 @@ Proof.
   apply basic_VLSM_incl.
   - by cbv; intros s Hn n; specialize (Hn n); split_and!; itauto.
   - by intro; intros; apply initial_message_is_valid.
-  - by split; [apply Hv |].
+  - by intros l s om Hiv _ _; apply Hiv.
   - by destruct 1.
 Qed.
 

--- a/theories/VLSM/Core/Equivocators/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocation.v
@@ -150,7 +150,7 @@ Qed.
 Lemma equivocators_fixed_equivocations_vlsm_incl_free
   : VLSM_incl equivocators_fixed_equivocations_vlsm (free_composite_vlsm equivocator_IM).
 Proof.
-  by apply constraint_subsumption_incl.
+  by apply constraint_free_incl.
 Qed.
 
 (** Inclusion into the preloaded free composition. *)
@@ -558,12 +558,11 @@ Proof.
       ; [done |].
       assert
         (Hs_free : valid_state_prop FreeE (finite_trace_last is tr')).
-      { destruct Hs as [_om Hs].
-        apply (constraint_subsumption_valid_state_message_preservation (equivocator_IM IM))
-          with (constraint2 := free_constraint (equivocator_IM IM))
-          in Hs as Hs_free
-          ; [| done].
-        by exists _om.
+      {
+        destruct Hs as [_om Hs].
+        exists _om.
+        eapply VLSM_incl_valid_state_message; [by apply free_composite_vlsm_spec | by do 2 red |].
+        by eapply constraint_subsumption_valid_state_message_preservation.
       }
       specialize
         (specialized_proper_sent_rev FreeE _ Hs_free _ Hno_equiv) as Hall.
@@ -619,7 +618,12 @@ Lemma free_equivocators_valid_trace_project
     equivocators_state_project IM final_descriptors final_state = final_stateX /\
     finite_valid_trace (free_composite_vlsm IM) isX trX.
 Proof.
-  by apply _equivocators_valid_trace_project.
+  destruct (_equivocators_valid_trace_project final_descriptors is tr Hproper Htr
+    (free_constraint IM)) as (trX & idesc & Hex); [done.. |].
+  exists trX, idesc.
+  split_and!; [by itauto.. |].
+  apply (@VLSM_incl_finite_valid_trace _ _ (composite_vlsm IM (free_constraint IM))); [| by itauto].
+  by apply free_composite_vlsm_spec.
 Qed.
 
 (**
@@ -715,7 +719,7 @@ Proof.
   ; [| by congruence].
   destruct item. simpl in *.
   apply first_transition_valid in Hpre_item_free. simpl in Hpre_item_free.
-  destruct Hpre_item_free as [[_ [_ [Hv _]]] Ht].
+  destruct Hpre_item_free as [[_ [_ Hv]] Ht].
   destruct l as [x l].
   cbn in *.
   destruct (equivocator_transition (IM x) l _) as [si' om'] eqn: Hti.

--- a/theories/VLSM/Core/Equivocators/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/FullReplayTraces.v
@@ -60,10 +60,11 @@ Proof.
     by apply lift_sub_valid, Hv.
   - by intros [_ Ht]; revert Ht; apply lift_sub_transition.
   - by intros; apply (lift_sub_state_initial equivocator_IM).
-  - intros; destruct HmX as [Hinit | Hseeded]; [| by apply Hseed].
-    apply initial_message_is_valid.
-    destruct Hinit as [i Him].
-    by exists (proj1_sig i).
+  - intros; destruct HmX as [Hinit | Hseeded].
+    + apply initial_message_is_valid.
+      destruct Hinit as [i Him].
+      by exists (proj1_sig i).
+    + by eapply VLSM_incl_valid_message; [apply free_composite_vlsm_spec | do 2 red | apply Hseed].
 Qed.
 
 (**
@@ -572,7 +573,7 @@ End sec_pre_loaded_constrained_projection.
 
 Lemma SeededXE_PreFreeE_weak_embedding
   (full_replay_state : composite_state equivocator_IM)
-  (Hfull_replay_state : valid_state_prop PreFreeE  full_replay_state)
+  (Hfull_replay_state : valid_state_prop PreFreeE full_replay_state)
   : VLSM_weak_embedding SeededXE PreFreeE
       (lift_equivocators_sub_label_to full_replay_state)
       (lift_equivocators_sub_state_to full_replay_state).
@@ -581,10 +582,17 @@ Proof.
   intros sX trX HtrX.
   specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True FreeE) as Heq.
   apply (VLSM_eq_finite_valid_trace_from Heq).
-  revert sX trX HtrX.
-  apply lift_equivocators_sub_weak_projection; [done | | | done].
+  eapply (lift_equivocators_sub_weak_projection (free_constraint _) (fun _ => True)) in HtrX; cycle 1.
+  - done.
   - by intros; apply initial_message_is_valid; right.
-  - by apply (VLSM_eq_valid_state Heq) in Hfull_replay_state.
+  - apply (VLSM_eq_valid_state Heq) in Hfull_replay_state.
+    apply (VLSM_incl_valid_state (MX := pre_loaded_vlsm FreeE (fun _ => True))); [| done].
+    by apply preloaded_free_composite_vlsm_spec.
+  - done.
+  - apply (@VLSM_incl_finite_valid_trace_from _ _ (pre_loaded_vlsm
+      (composite_vlsm equivocator_IM (free_constraint _)) (fun _ => True))); [| done].
+    eapply VLSM_incl_trans; [| by apply Heq].
+    by apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
 Qed.
 
 Lemma PreFreeSubE_PreFreeE_weak_embedding
@@ -595,14 +603,16 @@ Lemma PreFreeSubE_PreFreeE_weak_embedding
       (lift_equivocators_sub_state_to full_replay_state).
 Proof.
   apply basic_VLSM_weak_embedding; intros ? *.
-  - by split; [apply lift_equivocators_sub_valid; apply Hv |].
+  - by intros; apply lift_equivocators_sub_valid, Hv.
   - by intro Ht; apply lift_equivocators_sub_transition; apply Ht.
   - intros.
     rewrite <- replayed_initial_state_from_lift; [| done].
     apply finite_valid_trace_last_pstate.
     specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True FreeE) as Heq.
     apply (VLSM_eq_finite_valid_trace_from Heq).
+    eapply VLSM_incl_finite_valid_trace_from; [by apply preloaded_free_composite_vlsm_spec |].
     apply replayed_initial_state_from_valid; [done | | done].
+    eapply VLSM_incl_valid_state; [by apply preloaded_free_composite_vlsm_spec |].
     by apply (VLSM_eq_valid_state Heq).
   - by intros; apply any_message_is_valid_in_preloaded.
 Qed.
@@ -648,7 +658,9 @@ Proof.
   simpl. rewrite (lift_equivocators_sub_state_to_sub _ _ _ Hi).
   subst. unfold SubProjectionTraces.sub_IM in Hsent. cbn in Hsent |-*.
   apply equivocator_state_append_sent_right; [.. | done].
-  - by apply Hfull_replay_state_pr.
+  - apply Hfull_replay_state_pr.
+    eapply VLSM_incl_valid_state; [| done].
+    by apply preloaded_with_all_messages_free_composite_vlsm_spec.
   - by apply (Hs_pr (dexist i Hi) Hs).
 Qed.
 

--- a/theories/VLSM/Core/Equivocators/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/LimitedStateEquivocation.v
@@ -90,7 +90,7 @@ Definition equivocators_limited_equivocations_vlsm
 Lemma equivocators_limited_equivocations_vlsm_incl_free
   : VLSM_incl equivocators_limited_equivocations_vlsm FreeE.
 Proof.
-  by apply constraint_subsumption_incl.
+  by apply constraint_free_incl.
 Qed.
 
 (** Inclusion in the preloaded free composition. *)

--- a/theories/VLSM/Core/Equivocators/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/SimulatingFree.v
@@ -348,7 +348,7 @@ Proof.
     rewrite
       (equivocators_total_trace_project_replayed_trace_from
         IM (enum index) eqv_state_s).
-    repeat split; simpl.
+    repeat split. simpl.
     destruct Hfinal_msg as [Hfinal_msg | Hinitial]; [| by right].
     left.
     apply valid_trace_first_pstate in Hmsg_trace_full_replay as Hfst.
@@ -359,6 +359,7 @@ Proof.
     specialize (@has_been_sent_examine_one_trace _ FreeE _ _ _ _ (conj Happ His_s) im)
       as Hrew.
     unfold has_been_sent in Hrew; cbn in Hrew; apply Hrew.
+
     apply Exists_app. right.
     destruct_list_last eqv_msg_tr eqv_msg_tr' itemX Heqv_msg_tr
     ; [by inversion Hfinal_msg |].
@@ -398,8 +399,10 @@ Lemma equivocators_finite_valid_trace_init_to_rev
 Proof.
   specialize (vlsm_is_pre_loaded_with_False Free) as Heq.
   apply (VLSM_eq_finite_valid_trace_init_to Heq) in HtrX.
-  specialize (seeded_equivocators_finite_valid_trace_init_to_rev
-    IM (fun m => False) no_initial_messages_in_IM _ _ _ HtrX)
+  specialize
+    (seeded_equivocators_finite_valid_trace_init_to_rev
+      IM (fun m => False) no_initial_messages_in_IM
+      _ _ _ HtrX)
     as [is [His [s [Hs [tr [Htr_pr [Htr Houtput]]]]]]].
   exists is; split; [done |].
   exists s; split; [done |].
@@ -419,7 +422,7 @@ Proof.
   apply strong_constraint_subsumption_strongest.
   subst.
   clear.
-  intros l [s om] Hc.
+  intros l (s, om) Hc.
   split; [| done].
   destruct om as [m |]; [| done].
   by apply proj1 in Hc.

--- a/theories/VLSM/Core/Equivocators/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/SimulatingFree.v
@@ -39,8 +39,6 @@ Context
   (CE := pre_loaded_vlsm (composite_vlsm (equivocator_IM IM) constraintE) seed)
   (FreeE := free_composite_vlsm (equivocator_IM IM))
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
-  (CX_free := pre_loaded_vlsm (free_composite_vlsm IM) seed)
-  (CE_free := pre_loaded_vlsm (free_composite_vlsm (equivocator_IM IM)) seed)
   .
 
 Definition last_in_trace_except_from
@@ -245,8 +243,6 @@ Context {message : Type}
   (seed : message -> Prop)
   (SeededXE : VLSM message :=
     composite_no_equivocation_vlsm_with_pre_loaded (equivocator_IM IM) (free_constraint _) seed)
-  (SeededXE_free : VLSM message :=
-    free_composite_no_equivocation_vlsm_with_pre_loaded (equivocator_IM IM) seed)
   (Free := free_composite_vlsm IM)
   (SeededFree := pre_loaded_vlsm Free seed)
   .

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -2,7 +2,7 @@ From VLSM.Lib Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.
-From VLSM.Core Require Import SubProjectionTraces Equivocation EquivocationProjections. 
+From VLSM.Core Require Import SubProjectionTraces Equivocation EquivocationProjections.
 
 (** * VLSM Message Dependencies
 

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -300,10 +300,12 @@ Context
   .
 
 Definition binary_free_composition_fst : VLSM message :=
-  pre_composite_vlsm_induced_projection_validator (binary_IM M1 M2) (fun _ _ => True) first.
+  pre_composite_vlsm_induced_projection_validator (binary_IM M1 M2)
+    (free_constraint (binary_IM M1 M2)) first.
 
 Definition binary_free_composition_snd : VLSM message :=
-  pre_composite_vlsm_induced_projection_validator (binary_IM M1 M2) (fun _ _ => True) second.
+  pre_composite_vlsm_induced_projection_validator (binary_IM M1 M2)
+    (free_constraint (binary_IM M1 M2)) second.
 
 End sec_binary_free_composition_projections.
 

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -225,8 +225,7 @@ Lemma pre_loaded_with_all_messages_projection_input_valid_transition_neq
   (Hi : i <> projT1 l)
   : s1 i = s2 i.
 Proof.
-  destruct Ht as [[Hs1 [Hom1 [Hv _]]] Ht].
-  simpl in Hv. simpl in Ht. cbn in Ht.
+  destruct Ht as [[Hs1 [Hom1 Hv]] Ht]; cbn in Hv, Ht.
   destruct l as [il l].
   destruct (transition _ _ _) as (si', om') eqn: Htj.
   inversion Ht; subst; clear Ht.
@@ -301,10 +300,10 @@ Context
   .
 
 Definition binary_free_composition_fst : VLSM message :=
-  pre_composite_vlsm_induced_projection_validator (binary_IM M1 M2) (free_constraint _) first.
+  pre_composite_vlsm_induced_projection_validator (binary_IM M1 M2) (fun _ _ => True) first.
 
 Definition binary_free_composition_snd : VLSM message :=
-  pre_composite_vlsm_induced_projection_validator (binary_IM M1 M2) (free_constraint _) second.
+  pre_composite_vlsm_induced_projection_validator (binary_IM M1 M2) (fun _ _ => True) second.
 
 End sec_binary_free_composition_projections.
 

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -473,14 +473,8 @@ Lemma Xj_incl_Pre_Sub_Free
 Proof.
   subst Xj.
   unfold composite_no_equivocation_vlsm_with_pre_loaded.
-  specialize
-    (preloaded_constraint_subsumption_incl sub_IM
-      (no_equivocations_additional_constraint_with_pre_loaded sub_IM
-        (free_constraint sub_IM)
-        seed)
-      (free_constraint sub_IM))
-    as Hincl.
-  spec Hincl; [done |].
+  pose proof (Hincl := preloaded_constraint_subsumption_incl_free sub_IM
+    (no_equivocations_additional_constraint_with_pre_loaded sub_IM (free_constraint sub_IM) seed)).
   match goal with
   |- context [pre_loaded_vlsm ?v _] =>
     apply VLSM_incl_trans with (pre_loaded_with_all_messages_vlsm v)
@@ -831,7 +825,6 @@ Proof.
   simpl in Hl.
   destruct (decide _); [by congruence |].
   inversion Hl. subst lY. clear Hl.
-  split; [| done].
   cbn in Hv |- *.
   unfold remove_equivocating_state_project.
   by rewrite lift_sub_state_to_neq; [apply Hv |].
@@ -958,8 +951,7 @@ Lemma PreSubFree_PreFree_weak_embedding :
     (lift_sub_label IM equivocators) (lift_sub_state_to IM equivocators base_s).
 Proof.
   apply basic_VLSM_weak_embedding.
-  - split; [| done].
-    by apply lift_sub_to_valid, Hv.
+  - by red; intros; by apply lift_sub_to_valid, Hv.
   - intros l s om s' om' Hv.
     by apply lift_sub_to_transition, Hv.
   - by apply preloaded_lift_sub_state_to_initial_state.
@@ -1134,8 +1126,7 @@ Lemma lift_sub_incl_embedding :
     lift_sub_incl_label lift_sub_incl_state.
 Proof.
   apply basic_VLSM_strong_embedding; intro; intros.
-  - by split; [apply lift_sub_incl_valid, H |].
-
+  - by apply lift_sub_incl_valid, H.
   - by apply lift_sub_incl_transition.
   - by apply lift_sub_incl_state_initial.
   - by apply lift_sub_incl_message_initial.
@@ -1150,7 +1141,7 @@ Lemma lift_sub_incl_preloaded_embedding
       lift_sub_incl_label lift_sub_incl_state.
 Proof.
   apply basic_VLSM_embedding_preloaded_with; [done | ..]; intro; intros.
-  - by split; [apply lift_sub_incl_valid, H |].
+  - by apply lift_sub_incl_valid, H.
   - by apply lift_sub_incl_transition.
   - by apply lift_sub_incl_state_initial.
   - by apply lift_sub_incl_message_initial.
@@ -1557,11 +1548,10 @@ Lemma preloaded_sub_element_embedding
   : VLSM_embedding PrePXj PreQSubFree sub_element_label sub_element_state.
 Proof.
   apply basic_VLSM_embedding_preloaded_with; [done | ..].
-  - intros l s om Hv.
-    split; [cbn | done].
-    by rewrite sub_element_state_eq with (H_j := Hj).
+  - intros l s om Hv; cbn.
+    by rewrite sub_element_state_eq.
   - intros l s om s' om'; cbn.
-    rewrite sub_element_state_eq with (H_j := Hj).
+    rewrite sub_element_state_eq.
     intro Ht; replace (transition _ _ _) with (s', om'); f_equal.
     extensionality sub_i.
     destruct_dec_sig sub_i i Hi Heqsub_i; subst.
@@ -1721,9 +1711,8 @@ Lemma lift_sub_free_preloaded_with_embedding
   : VLSM_embedding (pre_loaded_vlsm SubFree seed) (pre_loaded_vlsm Free seed)
     (lift_sub_label IM indices) (lift_sub_state IM indices).
 Proof.
-  apply (basic_VLSM_embedding_preloaded_with SubFree Free seed seed); intro; intros.
-  - done.
-  - by split; [apply lift_sub_valid, H |].
+  apply (basic_VLSM_embedding_preloaded_with SubFree Free seed seed); intro; intros; [done | ..].
+  - by cbn; apply lift_sub_valid, H.
   - by rapply lift_sub_transition.
   - by apply (lift_sub_state_initial IM).
   - by apply (lift_sub_message_initial IM indices).
@@ -1833,10 +1822,10 @@ Context
   If a sub-composition [can_emit] a message then its sender must be one of
   the components of the sub-composition.
 *)
-Lemma sub_no_indices_no_can_emit (P : message -> Prop)
-  : forall m, ~ can_emit (pre_loaded_vlsm (free_composite_vlsm sub_IM) P) m.
+Lemma sub_no_indices_no_can_emit (P : message -> Prop) :
+  forall m, ~ can_emit (pre_loaded_vlsm (free_composite_vlsm sub_IM) P) m.
 Proof.
-  apply pre_loaded_empty_composition_no_emit, elem_of_nil_inv.
+  apply pre_loaded_empty_free_composition_no_emit, elem_of_nil_inv.
   by intro sub_i; destruct_dec_sig sub_i i Hi Heqsub_i; subst; inversion Hi.
 Qed.
 

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -243,7 +243,7 @@ Proof.
   eapply (VLSM_weak_embedding_input_valid_transition
            (lift_to_preloaded_free_weak_embedding IM i s' Hs')).
   eapply @tv_state_destructor_transition; [done | | done].
-  by eapply valid_state_project_preloaded_to_preloaded.
+  by eapply valid_state_project_preloaded_to_preloaded_free.
 Qed.
 
 Lemma composite_tv_state_destructor_index  :
@@ -281,9 +281,9 @@ Proof.
   - replace (state_destructor i (s i))
       with (@nil (transition_item (IM i) * state (IM i))); [done |].
     symmetry; apply tv_state_destructor_initial; [| done].
-    by eapply valid_state_project_preloaded_to_preloaded.
+    by eapply valid_state_project_preloaded_to_preloaded_free.
   - apply tv_state_destructor_initial.
-    + by eapply valid_state_project_preloaded_to_preloaded.
+    + by eapply valid_state_project_preloaded_to_preloaded_free.
     + by eapply fmap_nil_inv.
 Qed.
 
@@ -313,7 +313,7 @@ Proof.
   - apply composite_state_update_size_monotone.
     state_update_simpl.
     eapply tv_state_destructor_size; [done | | done].
-    by eapply valid_state_project_preloaded_to_preloaded.
+    by eapply valid_state_project_preloaded_to_preloaded_free.
   - by rewrite state_update_twice, state_update_id.
 Qed.
 


### PR DESCRIPTION
The purpose of this PR is to change the definition of `free_composite_vlsm` from the current one (which is `composite_vlsm` with a constraint that is always true) to a new, standalone one which is equivalent to the old one but not definitionally equal. The ultimate purpose is to be able to define constrained composition using `constrained_vlsm` and free composition.

Changes to the definition of `free_composite_vlsm` can be seen at the beginning of Compostion.v. These changes made it necessary to fix failing proofs that were touching `free_composite_vlsm` in more or less the entire codebase. The fixes are of various kinds:
- Simple proof refactorings: since the constraint in `free_composite_vlsm` is no longer `something /\ True` but just `something`, a use of `split` had to be removed from many proofs, and intro-patterns like `... & Hv & _ ...` had to be cut to just `... & Hv & ...`. Also `cbn` had to be inserted here and there, and various other ad-hoc fixes were needed in many places.
- Proof refactorings with glue: in some proofs I had to insert uses of equivalence between `free_composite_vlsm` and `composite_vlsm` with free constraint.
- Complex proof refactorings: I was not able to fix some proofs and had to reprove them from scratch. I think the main example of this is `same_IM_preloaded_free_embedding` in Composition.v
- Some new lemmas had to be proved. These are mainly specifications of `free_composite_vlsm` that relate it with `composite_vlsm` with a free constraint, and they live in Composition.v
- Some lemmas dealing with `composite_vlsm` had to be copy-pasted and adjusted to work for `free_composite_vlsm`. These are mainly the ones that have `_free` or `free_composite_` in their names. They live mostly in Composition.v, but there's also plenty of them in Equivocation.v. I will eventually work to remove them in a future PR, after the new definition of constrained composition is merged.