### PR TITLE
Remove a few lemmas

### DIFF
--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -2120,7 +2120,7 @@ Proof.
   }
   assert (Hincl : VLSM_incl ELMOProtocol ReachELMO) by apply constraint_preloaded_free_incl.
   destruct (decide (composite_has_been_sent ELMOComponent s m)) as [| Hnsnd];
-    [by eapply composite_sent_valid |].
+    [by eapply sent_valid |].
   destruct Hreceive as [[Hv Hc] Ht]; inversion Hv as [? ? Hrcv |]; subst; inversion Ht.
   assert (Hm_eqv : global_equivocators_simple s' (adr (state m))).
   {
@@ -3029,7 +3029,7 @@ Proof.
     symmetry in Heqs'i; destruct (Htransitions _ Heqs'i) as [Hvs'0 Hvt0];
     inversion Hvt0 as [? ? ? ? Hvt | ? ? ? ? Hvt].
   - repeat split; [done | | by apply Hvt..].
-    eapply composite_received_valid; [by apply Hs' |].
+    eapply received_valid; [by apply Hs' |].
     by eexists; eapply has_been_received_step_update; [| left].
   - by repeat split; [| apply option_valid_message_None | apply Hvt].
 Qed.

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -2260,19 +2260,6 @@ Proof.
   by eapply received_valid; [| exists i].
 Qed.
 
-Lemma composite_sent_valid
-  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (X := composite_vlsm IM constraint)
-  (s : composite_state IM)
-  (Hs : valid_state_prop X s)
-  (m : message)
-  (Hsent : composite_has_been_sent s m)
-  : valid_message_prop X m.
-Proof.
-  destruct Hsent as [i Hsent].
-  by apply messages_sent_from_component_of_valid_state_are_valid with s i.
-Qed.
-
 Lemma preloaded_composite_sent_valid
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (seed : message -> Prop)
@@ -2283,21 +2270,7 @@ Lemma preloaded_composite_sent_valid
   (Hsent : composite_has_been_sent s m)
   : valid_message_prop X m.
 Proof.
-  destruct Hsent as [i Hsent].
-  by apply preloaded_messages_sent_from_component_of_valid_state_are_valid with s i.
-Qed.
-
-Lemma composite_received_valid
-  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (X := composite_vlsm IM constraint)
-  (s : composite_state IM)
-  (Hs : valid_state_prop X s)
-  (m : message)
-  (Hreceived : composite_has_been_received s m)
-  : valid_message_prop X m.
-Proof.
-  destruct Hreceived as [i Hreceived].
-  by apply messages_received_from_component_of_valid_state_are_valid with s i.
+  by eapply sent_valid.
 Qed.
 
 Lemma preloaded_composite_received_valid
@@ -2310,8 +2283,7 @@ Lemma preloaded_composite_received_valid
   (Hreceived : composite_has_been_received s m)
   : valid_message_prop X m.
 Proof.
-  destruct Hreceived as [i Hreceived].
-  by apply preloaded_messages_received_from_component_of_valid_state_are_valid with s i.
+  by eapply received_valid.
 Qed.
 
 Lemma composite_directly_observed_valid
@@ -2800,7 +2772,7 @@ Proof.
   apply pre_traces_with_valid_inputs_are_valid in Htr; [done |].
   apply valid_trace_last_pstate in Htr as Hspre.
   intros.
-  eapply composite_received_valid; [done |].
+  eapply received_valid; [done |].
   specialize (proper_received _ s Hspre m) as Hproper.
   apply proj2 in Hproper. apply Hproper.
   apply has_been_received_consistency; [by typeclasses eauto | done |].

--- a/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
@@ -70,7 +70,7 @@ Proof.
   apply sent_by_non_equivocating_are_sent in Hm.
   pose proof (Hincl := StrongFixed_incl_Preloaded IM equivocating).
   apply (VLSM_incl_valid_state Hincl) in Hs.
-  apply (composite_sent_valid (equivocator_IM IM) _ _ Heqv_state_s).
+  eapply sent_valid; [done |].
   revert Hm; apply (VLSM_incl_valid_state HinclE) in Heqv_state_s.
   by specialize
     (VLSM_projection_has_been_sent_reflect

--- a/theories/VLSM/Core/Equivocators/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/LimitedStateEquivocation.v
@@ -190,7 +190,7 @@ Proof.
       + destruct iom as [m |]; [| by apply option_valid_message_None].
         destruct Hno_equiv as [Hsent | Hfalse]; [| done].
         simpl in Hsent.
-        by eapply composite_sent_valid.
+        by eapply sent_valid.
       + replace (composite_transition _ _ _) with (sf, oom).
         unfold state_has_fixed_equivocation.
         transitivity (elements (equivocating_validators sf)); [| done].


### PR DESCRIPTION
I noticed a few lemmas which were basically specialized versions of `sent_valid` and `received_valid`, so I removed them and inlined uses of `sent_valid`/`received_valid` in the proofs.