### PR TITLE
Change `Defined` to `Qed` for proofs

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -117,7 +117,7 @@ Lemma fixed_byzantine_IM_sender_safety :
 Proof.
   exact (channel_authentication_sender_safety fixed_byzantine_IM A sender
     fixed_byzantine_IM_preserves_channel_authentication).
-Defined.
+Qed.
 
 Definition message_as_byzantine_label
   (m : message)

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -552,7 +552,7 @@ Lemma has_been_sent_no_inits `{HasBeenSentCapability} :
     initial_state_prop vlsm s -> forall m : message, ~ has_been_sent s m.
 Proof.
   exact (oracle_no_inits _ _ (has_been_sent_stepwise_props)).
-Defined.
+Qed.
 
 Lemma has_been_sent_step_update `{HasBeenSentCapability} :
   forall (l : label _) (s : state _) (im : option message) (s' : state _) (om : option message),
@@ -561,7 +561,7 @@ Lemma has_been_sent_step_update `{HasBeenSentCapability} :
     has_been_sent s' msg <-> (om = Some msg \/ has_been_sent s msg).
 Proof.
   exact (oracle_step_update _ _ has_been_sent_stepwise_props).
-Defined.
+Qed.
 
 Definition has_been_sent_tracewise_prop
     (has_been_sent_pred : state_message_oracle) : Prop :=
@@ -729,7 +729,7 @@ Lemma has_been_received_no_inits `{HasBeenReceivedCapability} :
     initial_state_prop vlsm s -> forall m : message, ~ has_been_received s m.
 Proof.
   exact (oracle_no_inits _ _ has_been_received_stepwise_props).
-Defined.
+Qed.
 
 Lemma has_been_received_step_update `{HasBeenReceivedCapability} :
   forall [l : label _] [s : state _] [im : option message] [s' : state _] [om : option message],
@@ -738,7 +738,7 @@ Lemma has_been_received_step_update `{HasBeenReceivedCapability} :
     has_been_received s' msg <-> (im = Some msg \/ has_been_received s msg).
 Proof.
   exact (oracle_step_update _ _ has_been_received_stepwise_props).
-Defined.
+Qed.
 
 Definition has_been_received_tracewise_prop
   (has_been_received_pred : state_message_oracle) : Prop :=
@@ -1174,7 +1174,7 @@ Lemma has_been_directly_observed_no_inits `[HasBeenDirectlyObservedCapability me
     ~ has_been_directly_observed vlsm s m.
 Proof.
   exact (oracle_no_inits (has_been_directly_observed_stepwise_props vlsm)).
-Defined.
+Qed.
 
 Lemma has_been_directly_observed_step_update `{HasBeenDirectlyObservedCapability message vlsm} :
   forall l s im s' om,
@@ -1184,7 +1184,7 @@ Lemma has_been_directly_observed_step_update `{HasBeenDirectlyObservedCapability
     (im = Some msg \/ om = Some msg) \/ has_been_directly_observed vlsm s msg.
 Proof.
   exact (oracle_step_update (has_been_directly_observed_stepwise_props vlsm)).
-Defined.
+Qed.
 
 Lemma proper_directly_observed
   {message} (vlsm : VLSM message) `{HasBeenDirectlyObservedCapability message vlsm} :

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -317,7 +317,7 @@ Qed.
 Lemma StrongFixed_incl_Free : VLSM_incl StrongFixed Free.
 Proof.
   exact (constraint_free_incl _ _).
-Defined.
+Qed.
 
 Lemma StrongFixed_incl_Preloaded : VLSM_incl StrongFixed (pre_loaded_with_all_messages_vlsm Free).
 Proof.

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -240,7 +240,7 @@ Lemma VLSM_embedding_has_been_sent
     forall m, has_been_sent X s m -> has_been_sent Y (state_project s) m.
 Proof.
   exact (VLSM_weak_embedding_has_been_sent (VLSM_embedding_weaken Hsimul)).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_has_been_received
   `{HasBeenReceivedCapability message X}
@@ -249,7 +249,7 @@ Lemma VLSM_embedding_has_been_received
     forall m, has_been_received X s m -> has_been_received Y (state_project s) m.
 Proof.
   exact (VLSM_weak_embedding_has_been_received (VLSM_embedding_weaken Hsimul)).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_has_been_directly_observed
   `{HasBeenSentCapability message X}
@@ -260,7 +260,7 @@ Lemma VLSM_embedding_has_been_directly_observed
     forall m, has_been_directly_observed X s m -> has_been_directly_observed Y (state_project s) m.
 Proof.
   exact (VLSM_weak_embedding_has_been_directly_observed (VLSM_embedding_weaken Hsimul)).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_has_been_sent_reflect
   `{HasBeenSentCapability message X}
@@ -269,7 +269,7 @@ Lemma VLSM_embedding_has_been_sent_reflect
     forall m, has_been_sent Y (state_project s) m -> has_been_sent X s m.
 Proof.
   exact (VLSM_projection_has_been_sent_reflect  (VLSM_embedding_is_projection Hsimul)).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_has_been_received_reflect
   `{HasBeenReceivedCapability message X}
@@ -278,7 +278,7 @@ Lemma VLSM_embedding_has_been_received_reflect
     forall m, has_been_received Y (state_project s) m -> has_been_received X s m.
 Proof.
   exact (VLSM_projection_has_been_received_reflect  (VLSM_embedding_is_projection Hsimul)).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_has_been_directly_observed_reflect
   `{HasBeenSentCapability message X}
@@ -289,7 +289,7 @@ Lemma VLSM_embedding_has_been_directly_observed_reflect
     forall m, has_been_directly_observed Y (state_project s) m -> has_been_directly_observed X s m.
 Proof.
   exact (VLSM_projection_has_been_directly_observed_reflect (VLSM_embedding_is_projection Hsimul)).
-Defined.
+Qed.
 
 End sec_embedding_oracle.
 

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -1359,7 +1359,7 @@ Lemma destruct_equivocators_partial_trace_project
 Proof.
   exact (proj1 (equivocators_partial_trace_project_characterization
     final_descriptors sX trX sY trY) Hpr_tr).
-Defined.
+Qed.
 
 Lemma construct_equivocators_partial_trace_project
   {final_descriptors : equivocator_descriptors}
@@ -1374,7 +1374,7 @@ Lemma construct_equivocators_partial_trace_project
 Proof.
   exact (proj2 (equivocators_partial_trace_project_characterization
     final_descriptors sX trX sY trY) Hed).
-Defined.
+Qed.
 
 Lemma equivocators_partial_trace_project_extends_left
   (final_descriptors : equivocator_descriptors)

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -766,7 +766,7 @@ Lemma can_produce_valid
   : valid_state_message_prop s (Some m).
 Proof.
   exact (option_can_produce_valid s (Some m) Hm).
-Defined.
+Qed.
 
 Lemma option_can_produce_valid_iff
   (s : state X)
@@ -790,7 +790,7 @@ Lemma can_produce_valid_iff
     can_produce s m \/ initial_state_prop X s /\ initial_message_prop X m.
 Proof.
   exact (option_can_produce_valid_iff s (Some m)).
-Defined.
+Qed.
 
 Definition can_emit
   (m : message)

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -304,7 +304,7 @@ Lemma VLSM_weak_embedding_finite_trace_last :
     finite_trace_last (state_project sX) (VLSM_weak_embedding_finite_trace_project Hsimul trX).
 Proof.
   exact (pre_VLSM_embedding_finite_trace_last _ _ label_project state_project).
-Defined.
+Qed.
 
 Lemma VLSM_weak_embedding_finite_valid_trace_from :
   forall (s : state X) (tr : list (transition_item X)),
@@ -313,7 +313,7 @@ Lemma VLSM_weak_embedding_finite_valid_trace_from :
       (VLSM_weak_embedding_finite_trace_project Hsimul tr).
 Proof.
   exact (weak_full_trace_project_preserves_valid_trace _ _ _ _ Hsimul).
-Defined.
+Qed.
 
 (**
   Any [VLSM_embedding] determines a [VLSM_projection], allowing us
@@ -332,7 +332,7 @@ Lemma VLSM_weak_embedding_valid_state :
     valid_state_prop Y (state_project s).
 Proof.
   exact (VLSM_weak_projection_valid_state VLSM_weak_embedding_is_projection).
-Defined.
+Qed.
 
 Lemma VLSM_weak_embedding_finite_valid_trace_from_to :
   forall (s f : state X) (tr : list (transition_item X)),
@@ -341,14 +341,14 @@ Lemma VLSM_weak_embedding_finite_valid_trace_from_to :
       (VLSM_weak_embedding_finite_trace_project Hsimul tr).
 Proof.
   exact (VLSM_weak_projection_finite_valid_trace_from_to VLSM_weak_embedding_is_projection).
-Defined.
+Qed.
 
 Lemma VLSM_weak_embedding_in_futures :
   forall (s1 s2 : state X),
     in_futures X s1 s2 -> in_futures Y (state_project s1) (state_project s2).
 Proof.
   exact (VLSM_weak_projection_in_futures VLSM_weak_embedding_is_projection).
-Defined.
+Qed.
 
 Lemma VLSM_weak_embedding_input_valid_transition
   : forall l s im s' om,
@@ -432,7 +432,7 @@ Lemma VLSM_embedding_finite_trace_last :
     finite_trace_last (state_project sX) (VLSM_embedding_finite_trace_project Hsimul trX).
 Proof.
   exact (pre_VLSM_embedding_finite_trace_last _ _ label_project state_project).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_finite_valid_trace :
   forall (s : state X) (tr : list (transition_item X)),
@@ -440,7 +440,7 @@ Lemma VLSM_embedding_finite_valid_trace :
     finite_valid_trace Y (state_project s) (VLSM_embedding_finite_trace_project Hsimul tr).
 Proof.
   exact (full_trace_project_preserves_valid_trace _ _ _ _ Hsimul).
-Defined.
+Qed.
 
 (**
   Any [VLSM_embedding] determines a [VLSM_projection], allowing us
@@ -460,7 +460,7 @@ Lemma VLSM_embedding_finite_valid_trace_from :
     finite_valid_trace_from Y (state_project s) (VLSM_embedding_finite_trace_project Hsimul tr).
 Proof.
   exact (VLSM_projection_finite_valid_trace_from VLSM_embedding_is_projection).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_finite_valid_trace_init_to :
   forall (s f : state X) (tr : list (transition_item X)),
@@ -469,14 +469,14 @@ Lemma VLSM_embedding_finite_valid_trace_init_to :
       (VLSM_embedding_finite_trace_project Hsimul tr).
 Proof.
   exact (VLSM_projection_finite_valid_trace_init_to VLSM_embedding_is_projection).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_initial_state :
   forall (is : state X),
     initial_state_prop X is -> initial_state_prop Y (state_project is).
 Proof.
   exact (VLSM_projection_initial_state VLSM_embedding_is_projection).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_weaken
   : VLSM_weak_embedding X Y label_project state_project.
@@ -489,7 +489,7 @@ Lemma VLSM_embedding_valid_state :
     valid_state_prop Y (state_project s).
 Proof.
   exact (VLSM_weak_embedding_valid_state VLSM_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_finite_valid_trace_from_to :
   forall (s f : state X) (tr : list (transition_item X)),
@@ -498,14 +498,14 @@ Lemma VLSM_embedding_finite_valid_trace_from_to :
       (VLSM_embedding_finite_trace_project Hsimul tr).
 Proof.
   exact (VLSM_weak_embedding_finite_valid_trace_from_to VLSM_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_in_futures :
   forall (s1 s2 : state X),
     in_futures X s1 s2 -> in_futures Y (state_project s1) (state_project s2).
 Proof.
   exact (VLSM_weak_embedding_in_futures VLSM_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_input_valid_transition :
   forall l s im s' om,
@@ -513,7 +513,7 @@ Lemma VLSM_embedding_input_valid_transition :
     input_valid_transition Y (label_project l) (state_project s, im) (state_project s', om).
 Proof.
   exact (VLSM_weak_embedding_input_valid_transition VLSM_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_input_valid :
   forall l s im,
@@ -521,21 +521,21 @@ Lemma VLSM_embedding_input_valid :
     input_valid Y (label_project l) (state_project s, im).
 Proof.
   exact (VLSM_weak_embedding_input_valid VLSM_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_can_produce :
   forall (s : state X) (om : option message),
     option_can_produce X s om -> option_can_produce Y (state_project s) om.
 Proof.
   exact (VLSM_weak_embedding_can_produce VLSM_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_can_emit :
   forall (m : message),
     can_emit X m -> can_emit Y m.
 Proof.
   exact (VLSM_weak_embedding_can_emit VLSM_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_valid_message :
   strong_embedding_initial_message_preservation X Y ->
@@ -544,7 +544,7 @@ Lemma VLSM_embedding_valid_message :
 Proof.
   exact (fun Hinitial_valid_message =>
     VLSM_weak_embedding_valid_message VLSM_embedding_weaken Hinitial_valid_message).
-Defined.
+Qed.
 
 Definition VLSM_embedding_trace_project (t : Trace X) : Trace Y :=
   match t with
@@ -560,7 +560,7 @@ Lemma VLSM_embedding_infinite_valid_trace_from :
       (VLSM_embedding_infinite_trace_project Hsimul ls).
 Proof.
   exact (fun s ls => VLSM_weak_embedding_infinite_valid_trace_from VLSM_embedding_weaken s ls).
-Defined.
+Qed.
 
 Lemma VLSM_embedding_infinite_valid_trace
   s ls

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -101,7 +101,7 @@ Lemma VLSM_incl_is_embedding
     VLSM_incl X Y -> VLSM_embedding X Y id id.
 Proof.
   exact (proj1 (VLSM_incl_embedding_iff MX MY)).
-Defined.
+Qed.
 
 Lemma VLSM_incl_is_embedding_finite_trace_project
   {MX MY : VLSMMachine T}

--- a/theories/VLSM/Core/VLSMProjections/VLSMPartialProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMPartialProjection.v
@@ -99,7 +99,7 @@ Lemma VLSM_weak_partial_projection_finite_valid_trace_from :
     finite_valid_trace_from X sX trX -> finite_valid_trace_from Y sY trY.
 Proof.
   exact (weak_partial_trace_project_preserves_valid_trace _ _ _ Hsimul).
-Defined.
+Qed.
 
 Lemma VLSM_weak_partial_projection_valid_state
   : forall sX sY trY,
@@ -163,7 +163,7 @@ Lemma VLSM_partial_projection_finite_valid_trace :
     finite_valid_trace X sX trX -> finite_valid_trace Y sY trY.
 Proof.
   exact (partial_trace_project_preserves_valid_trace _ _ _ Hsimul).
-Defined.
+Qed.
 
 Lemma VLSM_partial_projection_finite_valid_trace_from
   : forall sX trX sY trY,
@@ -205,7 +205,7 @@ Lemma VLSM_partial_projection_valid_state :
     valid_state_prop X sX -> valid_state_prop Y sY.
 Proof.
   exact (VLSM_weak_partial_projection_valid_state VLSM_partial_projection_weaken).
-Defined.
+Qed.
 
 Lemma  VLSM_partial_projection_input_valid_transition :
   forall sX itemX sY itemY,
@@ -214,7 +214,7 @@ Lemma  VLSM_partial_projection_input_valid_transition :
     input_valid_transition Y (l itemY) (sY, input itemY) (destination itemY, output itemY).
 Proof.
   exact (VLSM_weak_partial_projection_input_valid_transition VLSM_partial_projection_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_partial_projection_input_valid :
   forall (sX : state X) (itemX : transition_item),
@@ -224,7 +224,7 @@ Lemma VLSM_partial_projection_input_valid :
       input_valid Y (l itemY) (sY, input itemY).
 Proof.
   exact (VLSM_weak_partial_projection_input_valid VLSM_partial_projection_weaken).
-Defined.
+Qed.
 
 End sec_partial_projection_properties.
 

--- a/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMStutteringEmbedding.v
@@ -56,7 +56,7 @@ Lemma pre_VLSM_stuttering_embedding_finite_trace_project_app :
       ++ pre_VLSM_stuttering_embedding_finite_trace_project l2.
 Proof.
   exact (mbind_app _).
-Defined.
+Qed.
 
 Lemma elem_of_pre_VLSM_stuttering_embedding_finite_trace_project :
   forall (trX : list (transition_item TX)) (itemY : transition_item TY),
@@ -261,7 +261,7 @@ Lemma elem_of_VLSM_weak_stuttering_embedding :
 Proof.
   exact (fun _ => elem_of_pre_VLSM_stuttering_embedding_finite_trace_project
     transition_item_project).
-Defined.
+Qed.
 
 Definition VLSM_weak_stuttering_embedding_infinite_trace_project
   (Hsimul : VLSM_weak_stuttering_embedding X Y state_project transition_item_project)
@@ -295,7 +295,7 @@ Lemma VLSM_weak_stuttering_embedding_finite_trace_project_app :
       ++ VLSM_weak_stuttering_embedding_finite_trace_project Hsimul l2.
 Proof.
   exact (pre_VLSM_stuttering_embedding_finite_trace_project_app transition_item_project).
-Defined.
+Qed.
 
 Lemma VLSM_weak_stuttering_embedding_finite_trace_last :
   forall sX trX,
@@ -306,7 +306,7 @@ Lemma VLSM_weak_stuttering_embedding_finite_trace_last :
     state_project (finite_trace_last sX trX).
 Proof.
   exact (pre_VLSM_stuttering_embedding_finite_trace_last _ _ _ _ Hsimul).
-Defined.
+Qed.
 
 Lemma VLSM_weak_stuttering_embedding_finite_valid_trace_from :
   forall sX trX,
@@ -315,7 +315,7 @@ Lemma VLSM_weak_stuttering_embedding_finite_valid_trace_from :
       (VLSM_weak_stuttering_embedding_finite_trace_project Hsimul trX).
 Proof.
   exact (weak_stuttering_embedding_preserves_valid_trace _ _ _ _ Hsimul).
-Defined.
+Qed.
 
 Lemma VLSM_weak_stuttering_embedding_infinite_valid_trace_from :
   forall sX trX (Hinf : InfinitelyOften (fun item => transition_item_project item <> []) trX),
@@ -441,7 +441,7 @@ Lemma elem_of_VLSM_stuttering_embedding :
 Proof.
   exact (fun _ => elem_of_pre_VLSM_stuttering_embedding_finite_trace_project
     transition_item_project).
-Defined.
+Qed.
 
 Definition VLSM_stuttering_embedding_infinite_trace_project
   (Hsimul : VLSM_stuttering_embedding X Y state_project transition_item_project)
@@ -475,7 +475,7 @@ Lemma VLSM_stuttering_embedding_finite_trace_project_app :
       ++ VLSM_stuttering_embedding_finite_trace_project Hsimul l2.
 Proof.
   exact (pre_VLSM_stuttering_embedding_finite_trace_project_app transition_item_project).
-Defined.
+Qed.
 
 Lemma VLSM_stuttering_embedding_finite_trace_last :
   forall sX trX,
@@ -485,7 +485,7 @@ Lemma VLSM_stuttering_embedding_finite_trace_last :
     state_project (finite_trace_last sX trX).
 Proof.
   exact (pre_VLSM_stuttering_embedding_finite_trace_last _ _ _ _ Hsimul).
-Defined.
+Qed.
 
 Lemma VLSM_stuttering_embedding_finite_valid_trace :
   forall sX trX,
@@ -493,7 +493,7 @@ Lemma VLSM_stuttering_embedding_finite_valid_trace :
       (VLSM_stuttering_embedding_finite_trace_project Hsimul trX).
 Proof.
   exact (stuttering_embedding_preserves_valid_trace _ _ _ _ Hsimul).
-Defined.
+Qed.
 
 (**
   Any [VLSM_stuttering_embedding] determines a [VLSM_partial_projection], allowing us
@@ -532,7 +532,7 @@ Lemma VLSM_stuttering_embedding_valid_state :
     valid_state_prop X sX -> valid_state_prop Y (state_project sX).
 Proof.
   exact (VLSM_weak_stuttering_embedding_valid_state VLSM_stuttering_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_stuttering_embedding_input_valid_transition_item :
   forall s item,
@@ -542,7 +542,7 @@ Lemma VLSM_stuttering_embedding_input_valid_transition_item :
 Proof.
   exact (VLSM_weak_stuttering_embedding_input_valid_transition_item
     VLSM_stuttering_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_stuttering_embedding_finite_valid_trace_from_to :
   forall sX s'X trX,
@@ -552,14 +552,14 @@ Lemma VLSM_stuttering_embedding_finite_valid_trace_from_to :
 Proof.
   exact (VLSM_weak_stuttering_embedding_finite_valid_trace_from_to
     VLSM_stuttering_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_stuttering_embedding_in_futures :
   forall s1 s2,
     in_futures X s1 s2 -> in_futures Y (state_project s1) (state_project s2).
 Proof.
   exact (VLSM_weak_stuttering_embedding_in_futures VLSM_stuttering_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_stuttering_embedding_infinite_valid_trace_from :
   forall sX trX (Hinf : InfinitelyOften _ trX),
@@ -569,7 +569,7 @@ Lemma VLSM_stuttering_embedding_infinite_valid_trace_from :
 Proof.
   exact (VLSM_weak_stuttering_embedding_infinite_valid_trace_from
     VLSM_stuttering_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_stuttering_embedding_infinite_finite_valid_trace_from :
   forall sX trX (Hfin : FinitelyManyBound _ trX),
@@ -579,7 +579,7 @@ Lemma VLSM_stuttering_embedding_infinite_finite_valid_trace_from :
 Proof.
   exact (VLSM_weak_stuttering_embedding_infinite_finite_valid_trace_from
     VLSM_stuttering_embedding_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_stuttering_embedding_initial_state :
   forall sX, initial_state_prop X sX -> initial_state_prop Y (state_project sX).

--- a/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
@@ -117,7 +117,7 @@ Lemma pre_VLSM_projection_finite_trace_project_app :
     pre_VLSM_projection_finite_trace_project l1 ++ pre_VLSM_projection_finite_trace_project l2.
 Proof.
   exact (map_option_app _).
-Defined.
+Qed.
 
 Lemma pre_VLSM_projection_finite_trace_project_app_rev :
   forall l l1' l2', pre_VLSM_projection_finite_trace_project l = l1' ++ l2' ->
@@ -126,21 +126,21 @@ Lemma pre_VLSM_projection_finite_trace_project_app_rev :
       pre_VLSM_projection_finite_trace_project l2 = l2'.
 Proof.
   exact (map_option_app_rev _).
-Defined.
+Qed.
 
 Lemma pre_VLSM_projection_finite_trace_project_elem_of_iff :
   forall trX itemY, itemY ∈ pre_VLSM_projection_finite_trace_project trX <->
     exists itemX, itemX ∈ trX /\ pre_VLSM_projection_transition_item_project itemX = Some itemY.
 Proof.
   exact (elem_of_map_option _).
-Defined.
+Qed.
 
 Lemma elem_of_pre_VLSM_projection_finite_trace_project :
   forall trX itemY, itemY ∈ pre_VLSM_projection_finite_trace_project trX <->
     exists itemX, itemX ∈ trX /\ pre_VLSM_projection_transition_item_project itemX = Some itemY.
 Proof.
   exact (elem_of_map_option _).
-Defined.
+Qed.
 
 Lemma pre_VLSM_projection_finite_trace_project_elem_of :
   forall itemX itemY,
@@ -410,7 +410,7 @@ Lemma VLSM_weak_projection_trace_project_app :
     VLSM_weak_projection_trace_project Hsimul l1 ++ VLSM_weak_projection_trace_project Hsimul l2.
 Proof.
   exact (pre_VLSM_projection_finite_trace_project_app _ _ label_project state_project).
-Defined.
+Qed.
 
 Lemma VLSM_weak_projection_trace_project_app_rev :
   forall l l1' l2', VLSM_weak_projection_trace_project Hsimul l = l1' ++ l2' ->
@@ -419,7 +419,7 @@ Lemma VLSM_weak_projection_trace_project_app_rev :
       VLSM_weak_projection_trace_project Hsimul l2 = l2'.
 Proof.
   exact (pre_VLSM_projection_finite_trace_project_app_rev _ _ label_project state_project).
-Defined.
+Qed.
 
 Lemma VLSM_weak_projection_finite_trace_last :
   forall sX trX,
@@ -428,7 +428,7 @@ Lemma VLSM_weak_projection_finite_trace_last :
       finite_trace_last (state_project sX) (VLSM_weak_projection_trace_project Hsimul trX).
 Proof.
   exact (final_state_project _ _ _ _ Hsimul).
-Defined.
+Qed.
 
 Lemma VLSM_weak_projection_finite_valid_trace_from :
   forall sX trX,
@@ -436,7 +436,7 @@ Lemma VLSM_weak_projection_finite_valid_trace_from :
       finite_valid_trace_from Y (state_project sX) (VLSM_weak_projection_trace_project Hsimul trX).
 Proof.
   exact (weak_trace_project_preserves_valid_trace _ _ _ _ Hsimul).
-Defined.
+Qed.
 
 Lemma VLSM_weak_projection_infinite_valid_trace_from
   : forall sX trX (Hinf : InfinitelyOften (VLSM_weak_projection_in Hsimul) trX),
@@ -599,7 +599,7 @@ Lemma VLSM_projection_finite_trace_project_app :
     VLSM_projection_finite_trace_project Hsimul l1 ++ VLSM_projection_finite_trace_project Hsimul l2.
 Proof.
   exact (pre_VLSM_projection_finite_trace_project_app _ _ label_project state_project).
-Defined.
+Qed.
 
 Lemma VLSM_projection_finite_trace_project_app_rev :
   forall l l1' l2',
@@ -610,7 +610,7 @@ Lemma VLSM_projection_finite_trace_project_app_rev :
       VLSM_projection_finite_trace_project Hsimul l2 = l2'.
 Proof.
   exact (pre_VLSM_projection_finite_trace_project_app_rev _ _ label_project state_project).
-Defined.
+Qed.
 
 Lemma VLSM_projection_finite_trace_project_in :
   forall itemX itemY,
@@ -620,7 +620,7 @@ Lemma VLSM_projection_finite_trace_project_in :
     itemX ∈ trX -> itemY ∈ VLSM_projection_finite_trace_project Hsimul trX.
 Proof.
   exact (pre_VLSM_projection_finite_trace_project_elem_of _ _ label_project state_project).
-Defined.
+Qed.
 
 Lemma VLSM_projection_finite_trace_last :
   forall (sX : state X) (trX : list (transition_item X)),
@@ -629,7 +629,7 @@ Lemma VLSM_projection_finite_trace_last :
       finite_trace_last (state_project sX) (VLSM_projection_finite_trace_project Hsimul trX).
 Proof.
   exact (final_state_project _ _ _ _ Hsimul).
-Defined.
+Qed.
 
 Lemma VLSM_projection_finite_valid_trace :
   forall (sX : state X) (trX : list (transition_item X)),
@@ -637,7 +637,7 @@ Lemma VLSM_projection_finite_valid_trace :
       finite_valid_trace Y (state_project sX) (VLSM_projection_finite_trace_project Hsimul trX).
 Proof.
   exact (trace_project_preserves_valid_trace _ _ _ _ Hsimul).
-Defined.
+Qed.
 
 (**
   Any [VLSM_projection] determines a [VLSM_partial_projection], allowing us
@@ -673,7 +673,7 @@ Lemma VLSM_projection_valid_state :
     valid_state_prop X sX -> valid_state_prop Y (state_project sX).
 Proof.
   exact (VLSM_weak_projection_valid_state VLSM_projection_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_projection_input_valid_transition :
   forall lX lY,
@@ -683,7 +683,7 @@ Lemma VLSM_projection_input_valid_transition :
     input_valid_transition Y lY (state_project s, im) (state_project s', om).
 Proof.
   exact (VLSM_weak_projection_input_valid_transition VLSM_projection_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_projection_input_valid :
   forall (lX : label X) (lY : label Y),
@@ -692,7 +692,7 @@ Lemma VLSM_projection_input_valid :
     input_valid X lX (s, im) -> input_valid Y lY (state_project s, im).
 Proof.
   exact (VLSM_weak_projection_input_valid VLSM_projection_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_projection_finite_valid_trace_from_to :
   forall sX s'X trX,
@@ -701,14 +701,14 @@ Lemma VLSM_projection_finite_valid_trace_from_to :
       (VLSM_projection_finite_trace_project Hsimul trX).
 Proof.
   exact (VLSM_weak_projection_finite_valid_trace_from_to VLSM_projection_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_projection_in_futures :
   forall s1 s2 : state X,
     in_futures X s1 s2 -> in_futures Y (state_project s1) (state_project s2).
 Proof.
   exact (VLSM_weak_projection_in_futures VLSM_projection_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_projection_infinite_valid_trace_from :
   forall sX trX (Hinf : InfinitelyOften (VLSM_projection_in Hsimul) trX),
@@ -717,7 +717,7 @@ Lemma VLSM_projection_infinite_valid_trace_from :
       (VLSM_projection_infinite_trace_project Hsimul trX Hinf).
 Proof.
   exact (VLSM_weak_projection_infinite_valid_trace_from VLSM_projection_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_projection_infinite_finite_valid_trace_from :
   forall sX trX (Hfin : FinitelyManyBound (VLSM_projection_in Hsimul) trX),
@@ -726,7 +726,7 @@ Lemma VLSM_projection_infinite_finite_valid_trace_from :
       (VLSM_projection_infinite_finite_trace_project Hsimul trX Hfin).
 Proof.
   exact (VLSM_weak_projection_infinite_finite_valid_trace_from VLSM_projection_weaken).
-Defined.
+Qed.
 
 Lemma VLSM_projection_initial_state
   : forall sX, initial_state_prop X sX -> initial_state_prop Y (state_project sX).

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -155,7 +155,7 @@ Qed.
 Lemma app_cons {A} :
   forall (a : A) (l : list A),
     [a] ++ l = a :: l.
-Proof. done. Defined.
+Proof. done. Qed.
 
 Lemma append_nodup_left {A} :
   forall (l1 l2 : list A), List.NoDup (l1 ++ l2) -> List.NoDup l1.


### PR DESCRIPTION
I believe that the fact that these proofs were originally transparent was an entirely accidental side effect of using `Definition`. Since nothing depends on their being transparent and nothing breaks in neither repo, I think it's ok to make them opaque.

This PR touches only the proofs that were recently changed from `Definition` to `Lemma`.