### PR TITLE
Refactor preloaded vlsm

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -188,7 +188,7 @@ Lemma fixed_non_byzantine_projection_incl_preloaded :
 Proof.
   apply basic_VLSM_strong_incl.
   - by intros s Hincl; apply fixed_non_byzantine_projection_initial_state_preservation.
-  - by intros.
+  - by do 2 red; cbn; itauto.
   - by intros l **; cbn; eapply induced_sub_projection_valid_preservation.
   - intros l s om s' om'; cbn.
     (* an ugly trick to get the forward direction from an iff (<->) lemma *)
@@ -473,7 +473,7 @@ Lemma pre_loaded_fixed_non_byzantine_incl
 Proof.
   apply basic_VLSM_incl; cbn.
   - by intro; intros; apply fixed_non_byzantine_projection_initial_state_preservation.
-  - by intros l s m Hv _ Him; apply initial_message_is_valid.
+  - by intros l s m Hv _ Him; apply initial_message_is_valid; cbn; itauto.
   - intros l s om Hv.
     exists (lift_sub_label fixed_byzantine_IM (elements non_byzantine) l).
     exists (lift_sub_state fixed_byzantine_IM (elements non_byzantine) s).
@@ -701,11 +701,12 @@ Lemma preloaded_non_byzantine_vlsm_lift
       (lift_sub_label IM (elements selection_complement))
       (lift_sub_state IM (elements selection_complement)).
 Proof.
-  apply basic_VLSM_strong_embedding; [| | | done].
+  apply basic_VLSM_strong_embedding.
   - intros l s om [Hv _]; cbn.
     by apply lift_sub_valid.
   - by intro; intros; rapply lift_sub_transition.
   - by intro; intros; apply (lift_sub_state_initial IM).
+  - by do 2 red; cbn; itauto.
 Qed.
 
 Section sec_assuming_initial_messages_lift.
@@ -742,7 +743,7 @@ Proof.
     split.
     + by apply composite_state_sub_projection_lift_to.
     + by apply (lift_sub_state_initial IM).
-  - by intro; intros; apply initial_message_is_valid.
+  - by intro; intros; apply initial_message_is_valid; cbn; itauto.
   - intros l s om Hv HsY HomY.
     exists (lift_sub_label IM (elements selection_complement) l).
     exists (lift_sub_state IM (elements selection_complement) s).

--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -188,7 +188,7 @@ Lemma fixed_non_byzantine_projection_incl_preloaded :
 Proof.
   apply basic_VLSM_strong_incl.
   - by intros s Hincl; apply fixed_non_byzantine_projection_initial_state_preservation.
-  - by do 2 red; cbn; itauto.
+  - by right.
   - by intros l **; cbn; eapply induced_sub_projection_valid_preservation.
   - intros l s om s' om'; cbn.
     (* an ugly trick to get the forward direction from an iff (<->) lemma *)
@@ -473,7 +473,7 @@ Lemma pre_loaded_fixed_non_byzantine_incl
 Proof.
   apply basic_VLSM_incl; cbn.
   - by intro; intros; apply fixed_non_byzantine_projection_initial_state_preservation.
-  - by intros l s m Hv _ Him; apply initial_message_is_valid; cbn; itauto.
+  - by intros l s m Hv _ Him; apply initial_message_is_valid; cbn; right.
   - intros l s om Hv.
     exists (lift_sub_label fixed_byzantine_IM (elements non_byzantine) l).
     exists (lift_sub_state fixed_byzantine_IM (elements non_byzantine) s).
@@ -706,7 +706,7 @@ Proof.
     by apply lift_sub_valid.
   - by intro; intros; rapply lift_sub_transition.
   - by intro; intros; apply (lift_sub_state_initial IM).
-  - by do 2 red; cbn; itauto.
+  - by right.
 Qed.
 
 Section sec_assuming_initial_messages_lift.
@@ -743,7 +743,7 @@ Proof.
     split.
     + by apply composite_state_sub_projection_lift_to.
     + by apply (lift_sub_state_initial IM).
-  - by intro; intros; apply initial_message_is_valid; cbn; itauto.
+  - by intro; intros; apply initial_message_is_valid; cbn; right.
   - intros l s om Hv HsY HomY.
     exists (lift_sub_label IM (elements selection_complement) l).
     exists (lift_sub_state IM (elements selection_complement) s).

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -835,14 +835,8 @@ Lemma lift_to_preloaded_free_weak_embedding :
       (lift_to_composite_state cs i).
 Proof.
   constructor; intros.
-  apply (VLSM_eq_finite_valid_trace_from
-    (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True free_composite_vlsm)).
-  apply pre_lift_to_free_weak_embedding.
-  - by apply (VLSM_eq_valid_state
-      (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True free_composite_vlsm)).
-  - apply (VLSM_eq_finite_valid_trace_from
-      (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True (IM i))).
-    by destruct (IM i).
+  apply pre_lift_to_free_weak_embedding; [done |].
+  by destruct (IM i).
 Qed.
 
 End sec_VLSM_composition.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -244,7 +244,7 @@ Lemma composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages :
       (pre_loaded_vlsm (composite_vlsm constraint) P)
       (pre_loaded_with_all_messages_vlsm free_composite_vlsm).
 Proof.
-  by intros; apply basic_VLSM_strong_incl; cbv; [.. | itauto |].
+  by intros; apply basic_VLSM_strong_incl; cbv; [| itauto.. |].
 Qed.
 
 Lemma constraint_free_valid_state_message_preservation :
@@ -1756,7 +1756,7 @@ Proof.
     unfold same_IM_state_rew at 2.
     by destruct (decide (i = j)); subst; state_update_simpl.
   - by intros i; apply same_VLSM_initial_state_preservation.
-  - by apply initial_message_is_valid.
+  - by apply initial_message_is_valid; right.
 Qed.
 
 End sec_same_IM_embedding.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1750,7 +1750,7 @@ Proof.
     unfold same_IM_state_rew at 2.
     by destruct (decide (i = j)); subst; state_update_simpl.
   - by intros i; apply same_VLSM_initial_state_preservation.
-  - by apply initial_message_is_valid; right.
+  - by apply initial_message_is_valid; cbn; right.
 Qed.
 
 End sec_same_IM_embedding.

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -456,7 +456,7 @@ Lemma input_valid_transition_Receive_RMi :
 Proof.
   intros s m Hvsp Hvalid.
   red; cbn; split_and!; [done | | | done].
-  - by exists (MkState [] i); constructor.
+  - by exists (MkState [] i); constructor; cbn; [| itauto].
   - by constructor.
 Qed.
 
@@ -926,7 +926,7 @@ Proof.
   - by exists (``(vs0 MO)); constructor.
   - eapply VLSM_weak_embedding_valid_message.
     + by apply (lift_to_RMO (``(vs0 MO))); exists None; constructor.
-    + by inversion 1.
+    + by inversion 1; cbn; [| right].
     + by apply Hovmp.
 Qed.
 

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -1129,9 +1129,7 @@ Proof.
     + apply IHis'.
       * intros j Hj. destruct (decide (i = j)); subst; state_update_simpl; [done |].
         by apply Hall; rewrite elem_of_cons; intros [].
-      * apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True MO)).
-        apply pre_composite_free_update_state_with_initial; [| by compute].
-        by apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True MO)).
+      * by apply pre_composite_free_update_state_with_initial; [| by compute].
     + replace us with (state_update M us i (us i)) at 2 by (state_update_simpl; done).
       apply lift_to_RMO_finite_valid_trace_from_to; [done |].
       apply (valid_state_project_preloaded_to_preloaded_free _ _ us i) in Hvsp as Hvsp'.

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -456,7 +456,7 @@ Lemma input_valid_transition_Receive_RMi :
 Proof.
   intros s m Hvsp Hvalid.
   red; cbn; split_and!; [done | | | done].
-  - by exists (MkState [] i); constructor; cbn; [| itauto].
+  - by exists (MkState [] i); constructor; cbn; [| right].
   - by constructor.
 Qed.
 
@@ -1129,7 +1129,7 @@ Proof.
     + apply IHis'.
       * intros j Hj. destruct (decide (i = j)); subst; state_update_simpl; [done |].
         by apply Hall; rewrite elem_of_cons; intros [].
-      * by apply pre_composite_free_update_state_with_initial; [| by compute].
+      * by apply pre_composite_free_update_state_with_initial.
     + replace us with (state_update M us i (us i)) at 2 by (state_update_simpl; done).
       apply lift_to_RMO_finite_valid_trace_from_to; [done |].
       apply (valid_state_project_preloaded_to_preloaded_free _ _ us i) in Hvsp as Hvsp'.

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -1578,10 +1578,7 @@ Proof.
     + apply IHis'.
       * intros j Hj. destruct (decide (i = j)); subst; state_update_simpl; [done |].
         apply Hall. rewrite elem_of_cons. by intros [].
-      * apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True UMO)).
-        apply pre_composite_free_update_state_with_initial; [| by compute].
-        by apply (VLSM_eq_valid_state
-          (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True UMO)).
+      * by apply pre_composite_free_update_state_with_initial.
     + replace us with (state_update U us i (us i)) at 2 by (state_update_simpl; done).
       apply lift_to_RUMO_finite_valid_trace_from_to; [done |].
       apply (valid_state_project_preloaded_to_preloaded_free _ _ us i) in Hvsp as Hvsp'.
@@ -1652,9 +1649,7 @@ Lemma valid_state_prop_state_update_init :
       valid_state_prop RUMO (state_update U us i (MkState [] (idx i))).
 Proof.
   intros us i Hvsp.
-  apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True UMO)).
-  apply pre_composite_free_update_state_with_initial; [| by compute].
-  by apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True UMO)).
+  by apply pre_composite_free_update_state_with_initial.
 Qed.
 
 Lemma elem_of_UMO_sentMessages :

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -483,8 +483,7 @@ Proof.
     split.
     + intros Hholds s0 tr Htr.
       by eapply (oracle_initial_trace_update Horacle).
-    + apply pre_loaded_with_all_messages_valid_state_prop,
-        valid_state_has_trace in Hs as (start & tr & Htr).
+    + apply valid_state_has_trace in Hs as (start & tr & Htr).
       intro H; specialize (H start tr Htr).
       by eapply oracle_initial_trace_update.
   - red; unfold negate_oracle, selected_message_exists_in_no_preloaded_trace,
@@ -493,8 +492,7 @@ Proof.
     + intros Hclaim start tr Htr.
       contradict Hclaim.
       by eapply oracle_initial_trace_update.
-    + apply pre_loaded_with_all_messages_valid_state_prop,
-        valid_state_has_trace in Hs as (start & tr & Htr).
+    + apply valid_state_has_trace in Hs as (start & tr & Htr).
       intro H; specialize (H start tr Htr); contradict H.
       by eapply (oracle_initial_trace_update Horacle).
 Qed.
@@ -1052,7 +1050,12 @@ Lemma preloaded_has_been_sent_stepwise_props
       (X := pre_loaded_vlsm vlsm seed) :
   has_been_sent_stepwise_prop (vlsm := X) (has_been_sent vlsm).
 Proof.
-  by destruct (has_been_sent_stepwise_props vlsm).
+  destruct (has_been_sent_stepwise_props vlsm); cbn in *.
+  split; cbn; [done |].
+  intros.
+  eapply oracle_step_update0.
+  eapply VLSM_incl_input_valid_transition; [| done].
+  by apply basic_VLSM_strong_incl; do 2 red; cbn; itauto.
 Qed.
 
 #[export] Instance preloaded_HasBeenSentCapability
@@ -1089,7 +1092,12 @@ Lemma preloaded_has_been_received_stepwise_props
       (X := pre_loaded_vlsm vlsm seed) :
   has_been_received_stepwise_prop (vlsm := X) (has_been_received vlsm).
 Proof.
-  by destruct (has_been_received_stepwise_props vlsm).
+  destruct (has_been_received_stepwise_props vlsm); cbn in *.
+  split; cbn; [done |].
+  intros.
+  eapply oracle_step_update0.
+  eapply VLSM_incl_input_valid_transition; [| done].
+  by apply basic_VLSM_strong_incl; do 2 red; cbn; itauto.
 Qed.
 
 #[export] Instance preloaded_HasBeenReceivedCapability
@@ -1903,11 +1911,14 @@ Lemma preloaded_composite_has_been_received_stepwise_props
   (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
   : has_been_received_stepwise_prop (vlsm := X) composite_has_been_received.
 Proof.
-  unfold has_been_received_stepwise_props.
-  specialize (composite_stepwise_props (fun i => has_been_received_stepwise_props (IM i)))
+  unfold has_been_received_stepwise_prop.
+  destruct (composite_stepwise_props (fun i => has_been_received_stepwise_props (IM i)) constraint)
     as [Hinits Hstep].
   split; [done |].
-  by intros l; specialize (Hstep l); destruct l.
+  intros l **; specialize (Hstep l); destruct l; cbn in *.
+  apply Hstep with om.
+  eapply VLSM_incl_input_valid_transition; [| done].
+  by apply basic_VLSM_strong_incl; do 2 red; cbn; itauto.
 Qed.
 
 Definition preloaded_composite_HasBeenReceivedCapability

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1051,10 +1051,9 @@ Lemma preloaded_has_been_sent_stepwise_props
   has_been_sent_stepwise_prop (vlsm := X) (has_been_sent vlsm).
 Proof.
   destruct (has_been_sent_stepwise_props vlsm); cbn in *.
-  split; cbn; [done |].
-  intros.
-  eapply oracle_step_update0.
-  eapply VLSM_incl_input_valid_transition; [| done].
+  split; [done |].
+  cbn; intros.
+  eapply oracle_step_update0, VLSM_incl_input_valid_transition; [| done].
   by apply basic_VLSM_strong_incl; do 2 red; cbn; itauto.
 Qed.
 
@@ -1093,10 +1092,9 @@ Lemma preloaded_has_been_received_stepwise_props
   has_been_received_stepwise_prop (vlsm := X) (has_been_received vlsm).
 Proof.
   destruct (has_been_received_stepwise_props vlsm); cbn in *.
-  split; cbn; [done |].
-  intros.
-  eapply oracle_step_update0.
-  eapply VLSM_incl_input_valid_transition; [| done].
+  split; [done |].
+  cbn; intros.
+  eapply oracle_step_update0, VLSM_incl_input_valid_transition; [| done].
   by apply basic_VLSM_strong_incl; do 2 red; cbn; itauto.
 Qed.
 
@@ -1913,8 +1911,7 @@ Proof.
     as [Hinits Hstep].
   split; [done |].
   intros l **; specialize (Hstep l); destruct l; cbn in *.
-  apply Hstep with om.
-  eapply VLSM_incl_input_valid_transition; [| done].
+  eapply Hstep with om, VLSM_incl_input_valid_transition; [| done].
   by apply basic_VLSM_strong_incl; do 2 red; cbn; itauto.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1554,10 +1554,7 @@ Lemma preloaded_sent_can_emit
   (Hsent : has_been_sent X s m) :
   can_emit (pre_loaded_with_all_messages_vlsm X) m.
 Proof.
-  pose proof (Heq := pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True X).
-  rewrite (VLSM_eq_can_emit Heq); cbn.
-  eapply sent_can_emit; [| done].
-  by apply (VLSM_eq_valid_state Heq).
+  by eapply sent_can_emit.
 Qed.
 
 Lemma sent_valid

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -265,24 +265,9 @@ Lemma seeded_no_equivocation_incl_preloaded :
   VLSM_incl composite_no_equivocation_vlsm_with_pre_loaded
     (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)).
 Proof.
-  unfold composite_no_equivocation_vlsm_with_pre_loaded.
-  match goal with
-  |- VLSM_incl (pre_loaded_vlsm ?v _) _ =>
-    specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True v) as Hprev
-  end.
-  destruct Hprev as [_ Hprev].
-  match type of Hprev with
-  | VLSM_incl (mk_vlsm ?m) _ => apply VLSM_incl_trans with m
-  end.
-  - cbn; clear Hprev.
-    by apply (@pre_loaded_vlsm_incl message
-      (composite_vlsm IM no_equivocations_additional_constraint_with_pre_loaded)).
-  - match type of Hprev with
-    | VLSM_incl _ (mk_vlsm ?m) => apply VLSM_incl_trans with m
-    end
-    ; [done |].
-    unfold free_composite_vlsm; cbn.
-    by apply preloaded_constraint_subsumption_incl_free.
+  apply (VLSM_incl_trans _ (pre_loaded_with_all_messages_vlsm (composite_vlsm IM _))).
+  - by cbn; apply (@pre_loaded_vlsm_incl message (composite_vlsm IM _)).
+  - by apply preloaded_constraint_subsumption_incl_free.
 Qed.
 
 End sec_seeded_composite_vlsm_no_equivocation_definition.

--- a/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
@@ -117,14 +117,10 @@ Lemma equivocator_state_append_preloaded_weak_projection
       (pre_loaded_with_all_messages_vlsm (equivocator_vlsm X))
       (equivocator_state_append_label base_s) (equivocator_state_append base_s).
 Proof.
-  specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True (equivocator_vlsm X)) as Heq.
   constructor.
   intros sX trX HtrX.
-  apply (VLSM_eq_finite_valid_trace_from Heq) in HtrX.
-  apply (VLSM_eq_finite_valid_trace_from Heq).
   revert sX trX HtrX.
-  apply equivocator_state_append_preloaded_with_weak_projection.
-  by apply (VLSM_eq_valid_state Heq).
+  by apply equivocator_state_append_preloaded_with_weak_projection.
 Qed.
 
 Lemma equivocator_state_append_weak_projection
@@ -164,14 +160,10 @@ Lemma equivocator_state_append_sent_left
   : forall m, equivocator_has_been_sent X base_s m ->
     equivocator_has_been_sent X (equivocator_state_append base_s s) m.
 Proof.
-  specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True (equivocator_vlsm X)) as Heq.
-  apply (VLSM_eq_valid_state Heq) in Hbase_s.
-  apply (VLSM_eq_valid_state Heq) in Hs.
   apply (equivocator_state_append_in_futures _ _ Hbase_s) in Hs.
-  apply (VLSM_eq_in_futures Heq) in Hs.
   apply (in_futures_preserving_oracle_from_stepwise _ (equivocator_vlsm X) (field_selector output)
     (equivocator_has_been_sent X)); [| done].
-  apply equivocator_has_been_sent_stepwise_props.
+  by apply equivocator_has_been_sent_stepwise_props.
 Qed.
 
 Lemma equivocator_state_append_sent_right

--- a/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorReplay.v
@@ -117,10 +117,7 @@ Lemma equivocator_state_append_preloaded_weak_projection
       (pre_loaded_with_all_messages_vlsm (equivocator_vlsm X))
       (equivocator_state_append_label base_s) (equivocator_state_append base_s).
 Proof.
-  constructor.
-  intros sX trX HtrX.
-  revert sX trX HtrX.
-  by apply equivocator_state_append_preloaded_with_weak_projection.
+  by constructor; apply equivocator_state_append_preloaded_with_weak_projection.
 Qed.
 
 Lemma equivocator_state_append_weak_projection

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -1065,11 +1065,7 @@ Lemma preloaded_equivocator_state_project_valid_state
       valid_state_prop (pre_loaded_with_all_messages_vlsm X) si.
 Proof.
   intros i si Hpr.
-  apply (VLSM_eq_valid_state
-    (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True equivocator_vlsm)) in Hbs.
-  specialize (preloaded_with_equivocator_state_project_valid_state _ _ Hbs _ _ Hpr) as Hsi.
-  apply (VLSM_eq_valid_state (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True X)) in Hsi.
-  by destruct X.
+  by apply (preloaded_with_equivocator_state_project_valid_state _ _ Hbs _ _ Hpr).
 Qed.
 
 (**

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -956,22 +956,13 @@ Lemma preloaded_equivocator_vlsm_trace_project_valid
       finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm X) s ej tr
     end.
 Proof.
-  apply (VLSM_incl_finite_valid_trace_from_to (proj1
-    (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True equivocator_vlsm))) in Hbtr.
   specialize (preloaded_with_equivocator_vlsm_trace_project_valid _ _ _ _ Hbtr _ _ Hj)
     as [tr [di [Hbtr_pr Hdi]]].
   eexists _, _; split; [done |].
   destruct di as [sn | i].
-  - destruct Hdi as [Hsn Htr].
-    split; [done |].
-    apply (VLSM_incl_finite_valid_trace_from_to (proj2
-      (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True X))) in Htr.
-    by clear -Htr; destruct X.
+  - by destruct Hdi as [Hsn Htr].
   - destruct Hdi as [s [Hpr_bs_i Htr]].
-    eexists; split; [done |].
-    apply (VLSM_incl_finite_valid_trace_from_to (proj2
-      (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True X))) in Htr.
-    by clear -Htr; destruct X.
+    by eexists.
 Qed.
 
 (**

--- a/theories/VLSM/Core/Equivocators/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/FullReplayTraces.v
@@ -580,18 +580,14 @@ Lemma SeededXE_PreFreeE_weak_embedding
 Proof.
   constructor.
   intros sX trX HtrX.
-  specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True FreeE) as Heq.
-  apply (VLSM_eq_finite_valid_trace_from Heq).
   eapply (lift_equivocators_sub_weak_projection (free_constraint _) (fun _ => True)) in HtrX; cycle 1.
   - done.
   - by intros; apply initial_message_is_valid; right.
-  - apply (VLSM_eq_valid_state Heq) in Hfull_replay_state.
-    apply (VLSM_incl_valid_state (MX := pre_loaded_vlsm FreeE (fun _ => True))); [| done].
+  - apply (VLSM_incl_valid_state (MX := pre_loaded_vlsm FreeE (fun _ => True))); [| done].
     by apply preloaded_free_composite_vlsm_spec.
   - done.
   - apply (@VLSM_incl_finite_valid_trace_from _ _ (pre_loaded_vlsm
       (composite_vlsm equivocator_IM (free_constraint _)) (fun _ => True))); [| done].
-    eapply VLSM_incl_trans; [| by apply Heq].
     by apply composite_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
 Qed.
 
@@ -608,12 +604,9 @@ Proof.
   - intros.
     rewrite <- replayed_initial_state_from_lift; [| done].
     apply finite_valid_trace_last_pstate.
-    specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True FreeE) as Heq.
-    apply (VLSM_eq_finite_valid_trace_from Heq).
     eapply VLSM_incl_finite_valid_trace_from; [by apply preloaded_free_composite_vlsm_spec |].
     apply replayed_initial_state_from_valid; [done | | done].
-    eapply VLSM_incl_valid_state; [by apply preloaded_free_composite_vlsm_spec |].
-    by apply (VLSM_eq_valid_state Heq).
+    by eapply VLSM_incl_valid_state; [apply preloaded_free_composite_vlsm_spec |].
   - by intros; apply any_message_is_valid_in_preloaded.
 Qed.
 

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -383,9 +383,10 @@ Lemma projection_valid_implies_projection_valid_state_message_outputs
 Proof.
   apply projection_valid_implies_projection_valid_state in Hv as Hs.
   destruct Hs as [? Hs].
-  assert (valid_state_message_prop Xj (` (vs0 (IM j))) om)
-      by (apply valid_initial_state_message; [destruct (vs0 (IM j)) | destruct om]; done).
-  by eapply (valid_generated_state_message Xj); cycle 2.
+  eapply (valid_generated_state_message Xj s x Hs (` (vs0 (IM j)))); [| done..].
+  apply valid_initial_state_message.
+  - by destruct (vs0 (IM j)); cbn.
+  - by destruct om; cbn; [right |].
 Qed.
 
 Lemma projection_valid_implies_destination_projection_valid_state

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -489,11 +489,7 @@ Proof.
       apply (pre_loaded_vlsm_incl v seed (fun m => True))
     end.
     itauto.
-  - match goal with
-    |- context [pre_loaded_with_all_messages_vlsm ?v] =>
-      specialize (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True v) as Hincl
-    end.
-    by destruct Hincl.
+  - by apply VLSM_incl_refl.
 Qed.
 
 (**
@@ -1733,10 +1729,7 @@ Lemma lift_sub_preloaded_free_embedding
 Proof.
   constructor.
   intros sX trX HtrX.
-  by apply (VLSM_eq_finite_valid_trace
-    (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True Free)),
-    (VLSM_embedding_finite_valid_trace (lift_sub_free_preloaded_with_embedding _)),
-    (VLSM_eq_finite_valid_trace (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True SubFree)).
+  by apply (VLSM_embedding_finite_valid_trace (lift_sub_free_preloaded_with_embedding _)).
 Qed.
 
 (**

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -471,25 +471,11 @@ Context
 Lemma Xj_incl_Pre_Sub_Free
   : VLSM_incl Xj (pre_loaded_with_all_messages_vlsm Sub_Free).
 Proof.
-  subst Xj.
-  unfold composite_no_equivocation_vlsm_with_pre_loaded.
-  pose proof (Hincl := preloaded_constraint_subsumption_incl_free sub_IM
-    (no_equivocations_additional_constraint_with_pre_loaded sub_IM (free_constraint sub_IM) seed)).
-  match goal with
-  |- context [pre_loaded_vlsm ?v _] =>
-    apply VLSM_incl_trans with (pre_loaded_with_all_messages_vlsm v)
-  end; [| apply Hincl].
-  clear Hincl.
-  match goal with
-  |- context [pre_loaded_with_all_messages_vlsm ?v] =>
-    apply VLSM_incl_trans with (pre_loaded_vlsm v (fun m => True))
-  end.
-  - match goal with
-    |- context [pre_loaded_vlsm ?v _] =>
-      apply (pre_loaded_vlsm_incl v seed (fun m => True))
-    end.
-    itauto.
-  - by apply VLSM_incl_refl.
+  apply (VLSM_incl_trans _ (pre_loaded_with_all_messages_vlsm
+    (composite_vlsm sub_IM (no_equivocations_additional_constraint_with_pre_loaded sub_IM _ seed)))).
+  - by cbn; apply (pre_loaded_vlsm_incl (composite_vlsm sub_IM
+      (no_equivocations_additional_constraint_with_pre_loaded sub_IM (free_constraint sub_IM) seed))).
+  - by apply preloaded_constraint_subsumption_incl_free.
 Qed.
 
 (**

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -708,8 +708,8 @@ Qed.
 
 (**
   For VLSMs initialized with many initial messages such as
-  the [composite_vlsm_induced_projection] the question of
-  whether a [VLSM] [can_emit] a message <<m>> becomes more
+  the [composite_vlsm_induced_projection] or the [pre_loaded_with_all_messages_vlsm],
+  the question of whether a [VLSM] [can_emit] a message <<m>> becomes more
   useful than that whether <<m>> is a [valid_message].
 *)
 

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -197,6 +197,17 @@ Proof.
   - by apply pre_loaded_vlsm_incl; itauto.
 Qed.
 
+Lemma pre_loaded_vlsm_or :
+  forall (P Q : message -> Prop),
+    VLSM_eq
+      (pre_loaded_vlsm (pre_loaded_vlsm X P) Q)
+      (pre_loaded_vlsm X (fun x => P x \/ Q x)).
+Proof.
+  split; cbn.
+  - by apply pre_loaded_vlsm_or_l.
+  - by apply pre_loaded_vlsm_or_r.
+Qed.
+
 Lemma pre_loaded_vlsm_idem
   (P : message -> Prop)
   : VLSM_eq (pre_loaded_vlsm (pre_loaded_vlsm X P) P) (pre_loaded_vlsm X P).
@@ -206,12 +217,10 @@ Proof.
   - by apply pre_loaded_vlsm_idem_r.
 Qed.
 
-Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True
-  : VLSM_eq (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun _ => True)).
+Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True :
+  VLSM_eq (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun _ => True)).
 Proof.
-  split; cbn.
-  - by apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_l.
-  - by apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_r.
+  apply VLSM_eq_refl.
 Qed.
 
 Lemma pre_loaded_with_all_messages_eq_validating_pre_loaded_vlsm
@@ -231,20 +240,20 @@ Proof.
   - by intros l s om s' om' [_ Ht].
 Qed.
 
-Lemma vlsm_is_pre_loaded_with_False
-  : VLSM_eq X (pre_loaded_vlsm X (fun _ => False)).
+Lemma vlsm_is_pre_loaded_with_False :
+  VLSM_eq X (pre_loaded_vlsm X (fun _ => False)).
 Proof.
   by cbn; split; apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
-Lemma vlsm_is_pre_loaded_with_False_initial_message
-  : strong_embedding_initial_message_preservation X (pre_loaded_vlsm X (fun _ => False)).
+Lemma vlsm_is_pre_loaded_with_False_initial_message :
+  strong_embedding_initial_message_preservation X (pre_loaded_vlsm X (fun _ => False)).
 Proof.
   by intros m Hm; left.
 Qed.
 
-Lemma vlsm_is_pre_loaded_with_False_initial_message_rev
-  : strong_embedding_initial_message_preservation (pre_loaded_vlsm X (fun _ => False)) X.
+Lemma vlsm_is_pre_loaded_with_False_initial_message_rev :
+  strong_embedding_initial_message_preservation (pre_loaded_vlsm X (fun _ => False)) X.
 Proof.
   by intros m [Hm | Hfalse].
 Qed.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -252,16 +252,6 @@ Proof.
   by intros m [Hm | Hfalse].
 Qed.
 
-Lemma pre_loaded_with_all_messages_vlsm_idem :
-  VLSM_eq
-    (pre_loaded_with_all_messages_vlsm (pre_loaded_with_all_messages_vlsm X))
-    (pre_loaded_with_all_messages_vlsm X).
-Proof.
-  split; cbn.
-  - by apply pre_loaded_with_all_messages_vlsm_idem_l.
-  - by apply pre_loaded_with_all_messages_vlsm_idem_r.
-Qed.
-
 Lemma vlsm_is_pre_loaded_with_False_valid_state_message s om :
   valid_state_message_prop X s om <->
   valid_state_message_prop (pre_loaded_vlsm X (fun _ => False)) s om.

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -217,12 +217,6 @@ Proof.
   - by apply pre_loaded_vlsm_idem_r.
 Qed.
 
-Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True :
-  VLSM_eq (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun _ => True)).
-Proof.
-  apply VLSM_eq_refl.
-Qed.
-
 Lemma pre_loaded_with_all_messages_eq_validating_pre_loaded_vlsm
   (P : message -> Prop)
   (Hvalidating :

--- a/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEquality.v
@@ -197,17 +197,6 @@ Proof.
   - by apply pre_loaded_vlsm_incl; itauto.
 Qed.
 
-Lemma pre_loaded_vlsm_or :
-  forall (P Q : message -> Prop),
-    VLSM_eq
-      (pre_loaded_vlsm (pre_loaded_vlsm X P) Q)
-      (pre_loaded_vlsm X (fun x => P x \/ Q x)).
-Proof.
-  split; cbn.
-  - by apply pre_loaded_vlsm_or_l.
-  - by apply pre_loaded_vlsm_or_r.
-Qed.
-
 Lemma pre_loaded_vlsm_idem
   (P : message -> Prop)
   : VLSM_eq (pre_loaded_vlsm (pre_loaded_vlsm X P) P) (pre_loaded_vlsm X P).

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -417,24 +417,6 @@ Proof.
   by apply pre_loaded_vlsm_incl_relaxed; itauto.
 Qed.
 
-Lemma pre_loaded_vlsm_or_l :
-  forall (P Q : message -> Prop),
-    VLSM_incl
-      (pre_loaded_vlsm (pre_loaded_vlsm X P) Q)
-      (pre_loaded_vlsm X (fun x => P x \/ Q x)).
-Proof.
-  by intros; apply basic_VLSM_strong_incl; cbv; itauto.
-Qed.
-
-Lemma pre_loaded_vlsm_or_r :
-  forall (P Q : message -> Prop),
-    VLSM_incl
-      (pre_loaded_vlsm X (fun x => P x \/ Q x))
-      (pre_loaded_vlsm (pre_loaded_vlsm X P) Q).
-Proof.
-  by intros; apply basic_VLSM_strong_incl; cbv; itauto.
-Qed.
-
 Lemma pre_loaded_vlsm_idem_l :
   forall (P : message -> Prop),
     VLSM_incl (pre_loaded_vlsm (pre_loaded_vlsm X P) P) (pre_loaded_vlsm X P).

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -456,22 +456,6 @@ Proof.
   by intros; apply pre_loaded_vlsm_incl.
 Qed.
 
-Lemma pre_loaded_with_all_messages_vlsm_idem_l :
-  VLSM_incl
-    (pre_loaded_with_all_messages_vlsm (pre_loaded_with_all_messages_vlsm X))
-    (pre_loaded_with_all_messages_vlsm X).
-Proof.
-  by apply pre_loaded_vlsm_idem_l.
-Qed.
-
-Lemma pre_loaded_with_all_messages_vlsm_idem_r :
-  VLSM_incl
-    (pre_loaded_with_all_messages_vlsm X)
-    (pre_loaded_with_all_messages_vlsm (pre_loaded_with_all_messages_vlsm X)).
-Proof.
-  by apply pre_loaded_vlsm_idem_r.
-Qed.
-
 Lemma pre_loaded_with_all_messages_can_emit
   (m : message)
   (Hm : can_emit X m)

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -449,18 +449,6 @@ Proof.
   by intros; apply basic_VLSM_incl_preloaded_with; cbv; itauto.
 Qed.
 
-Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_l :
-  VLSM_incl (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun m => True)).
-Proof.
-  by apply VLSM_incl_refl.
-Qed.
-
-Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_r :
-  VLSM_incl (pre_loaded_vlsm X (fun m => True)) (pre_loaded_with_all_messages_vlsm X).
-Proof.
-  by apply VLSM_incl_refl.
-Qed.
-
 Lemma pre_loaded_vlsm_incl_pre_loaded_with_all_messages :
   forall (P : message -> Prop),
     VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_with_all_messages_vlsm X).

--- a/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMInclusion.v
@@ -384,13 +384,17 @@ Context
   (X : VLSM message)
   .
 
-Lemma vlsm_incl_pre_loaded_with_all_messages_vlsm
-  : VLSM_incl X (pre_loaded_with_all_messages_vlsm X).
+Lemma vlsm_incl_pre_loaded :
+  forall (P : message -> Prop),
+    VLSM_incl X (pre_loaded_vlsm X P).
 Proof.
-  apply VLSM_incl_finite_traces_characterization.
-  intros. split; [| by apply H].
-  apply preloaded_weaken_valid_trace_from.
-  by destruct X; apply H.
+  by intros; apply basic_VLSM_strong_incl; cbv; itauto.
+Qed.
+
+Lemma vlsm_incl_pre_loaded_with_all_messages_vlsm :
+  VLSM_incl X (pre_loaded_with_all_messages_vlsm X).
+Proof.
+  by apply vlsm_incl_pre_loaded.
 Qed.
 
 Lemma pre_loaded_vlsm_incl_relaxed
@@ -413,45 +417,55 @@ Proof.
   by apply pre_loaded_vlsm_incl_relaxed; itauto.
 Qed.
 
-Lemma pre_loaded_vlsm_idem_l
-  (P : message -> Prop)
-  : VLSM_incl (pre_loaded_vlsm (pre_loaded_vlsm X P) P) (pre_loaded_vlsm X P).
+Lemma pre_loaded_vlsm_or_l :
+  forall (P Q : message -> Prop),
+    VLSM_incl
+      (pre_loaded_vlsm (pre_loaded_vlsm X P) Q)
+      (pre_loaded_vlsm X (fun x => P x \/ Q x)).
 Proof.
-  by apply basic_VLSM_strong_incl; cbv; itauto.
+  by intros; apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
-Lemma pre_loaded_vlsm_idem_r
-  (P : message -> Prop)
-  : VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_vlsm (pre_loaded_vlsm X P) P).
+Lemma pre_loaded_vlsm_or_r :
+  forall (P Q : message -> Prop),
+    VLSM_incl
+      (pre_loaded_vlsm X (fun x => P x \/ Q x))
+      (pre_loaded_vlsm (pre_loaded_vlsm X P) Q).
 Proof.
-  by apply basic_VLSM_incl_preloaded_with; cbv; itauto.
+  by intros; apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
-Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_l
-  : VLSM_incl (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun m => True)).
+Lemma pre_loaded_vlsm_idem_l :
+  forall (P : message -> Prop),
+    VLSM_incl (pre_loaded_vlsm (pre_loaded_vlsm X P) P) (pre_loaded_vlsm X P).
 Proof.
-  by apply basic_VLSM_strong_incl; cbv; itauto.
+  by intros; apply basic_VLSM_strong_incl; cbv; itauto.
 Qed.
 
-Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_r
-  : VLSM_incl (pre_loaded_vlsm X (fun m => True)) (pre_loaded_with_all_messages_vlsm X).
+Lemma pre_loaded_vlsm_idem_r :
+  forall (P : message -> Prop),
+    VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_vlsm (pre_loaded_vlsm X P) P).
 Proof.
-  by apply basic_VLSM_strong_incl; cbv; itauto.
+  by intros; apply basic_VLSM_incl_preloaded_with; cbv; itauto.
 Qed.
 
-Lemma pre_loaded_vlsm_incl_pre_loaded_with_all_messages
-  (P : message -> Prop)
-  : VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_with_all_messages_vlsm X).
+Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_l :
+  VLSM_incl (pre_loaded_with_all_messages_vlsm X) (pre_loaded_vlsm X (fun m => True)).
 Proof.
-  by apply basic_VLSM_strong_incl; cbv; itauto.
+  by apply VLSM_incl_refl.
 Qed.
 
-Lemma vlsm_incl_pre_loaded
-  (P : message -> Prop)
-  : VLSM_incl X (pre_loaded_vlsm X P).
+Lemma pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True_r :
+  VLSM_incl (pre_loaded_vlsm X (fun m => True)) (pre_loaded_with_all_messages_vlsm X).
 Proof.
-  eapply VLSM_incl_trans; [| by apply pre_loaded_vlsm_incl].
-  by apply basic_VLSM_strong_incl; cbv; itauto.
+  by apply VLSM_incl_refl.
+Qed.
+
+Lemma pre_loaded_vlsm_incl_pre_loaded_with_all_messages :
+  forall (P : message -> Prop),
+    VLSM_incl (pre_loaded_vlsm X P) (pre_loaded_with_all_messages_vlsm X).
+Proof.
+  by intros; apply pre_loaded_vlsm_incl.
 Qed.
 
 Lemma pre_loaded_with_all_messages_vlsm_idem_l :
@@ -459,7 +473,7 @@ Lemma pre_loaded_with_all_messages_vlsm_idem_l :
     (pre_loaded_with_all_messages_vlsm (pre_loaded_with_all_messages_vlsm X))
     (pre_loaded_with_all_messages_vlsm X).
 Proof.
-  by apply basic_VLSM_strong_incl; cbv; itauto.
+  by apply pre_loaded_vlsm_idem_l.
 Qed.
 
 Lemma pre_loaded_with_all_messages_vlsm_idem_r :
@@ -467,7 +481,7 @@ Lemma pre_loaded_with_all_messages_vlsm_idem_r :
     (pre_loaded_with_all_messages_vlsm X)
     (pre_loaded_with_all_messages_vlsm (pre_loaded_with_all_messages_vlsm X)).
 Proof.
-  by apply basic_VLSM_incl_preloaded; cbv; itauto.
+  by apply pre_loaded_vlsm_idem_r.
 Qed.
 
 Lemma pre_loaded_with_all_messages_can_emit

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -854,13 +854,7 @@ Lemma pre_composite_vlsm_induced_projection_validator_iff
       pre_composite_vlsm_induced_projection_validator
       (pre_composite_vlsm_induced_validator IM constraint i).
 Proof.
-  eapply VLSM_eq_trans;
-    [by apply pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True |].
-  eapply VLSM_eq_trans;
-    [by apply preloaded_composite_vlsm_induced_projection_validator_iff |].
-  by apply VLSM_eq_sym,
-    (pre_loaded_with_all_messages_vlsm_is_pre_loaded_with_True
-      (composite_vlsm_induced_validator IM constraint i)).
+  by apply preloaded_composite_vlsm_induced_projection_validator_iff.
 Qed.
 
 Lemma component_projection :

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -228,7 +228,7 @@ Proof.
   repeat split; [| | done].
   - by eapply VLSM_projection_valid_state.
   - destruct om as [m |]; [| apply option_valid_message_None].
-    by apply option_initial_message_is_valid.
+    by apply option_initial_message_is_valid; cbn; right.
 Qed.
 
 Section sec_projection_induced_validator_as_projection.
@@ -312,7 +312,7 @@ Proof.
     by specialize (Htransition_Some _ _ eq_refl) as [-> ->].
   - by eapply Htransition_None.
   - by exists s.
-  - by destruct Hv as [_ [Hm _]]; apply initial_message_is_valid.
+  - by destruct Hv as [_ [Hm _]]; apply initial_message_is_valid; cbn; right.
 Qed.
 
 Section sec_projection_induced_friendliness.
@@ -520,7 +520,7 @@ Lemma induced_validator_incl_preloaded_with_all_messages
 Proof.
   apply basic_VLSM_incl.
   - by intros is (s & <- & Hs); apply (VLSM_projection_initial_state Hproj).
-  - by intros l s m Hv HsY HmX; apply initial_message_is_valid.
+  - by intros l s m Hv HsY HmX; apply initial_message_is_valid; cbn; right.
   - intros l s om (_ & _ & lX & sX & [Hlx Heq Hv]) _ _.
     cbn in Heq; subst; simpl.
     by eapply VLSM_projection_input_valid in Hproj as (_ & _ & ?).


### PR DESCRIPTION
Summary of changes:
- Redefine `pre_loaded_with_all_messages_vlsm` to be `pre_loaded_vlsm (fun _ => True)`.
- Move these definitions further towards the end of Composition.v
- Fix the proofs that were broken (often this means doing an additional `cbn; right`)
- Remove some lemmas about `pre_loaded_with_all_messages_vlsm` which are now subsumed by the analogous lemmas for `pre_loaded_vlsm`.
- Refactor some proofs to get rid of uses of these removed lemmas.

Thanks to this refactoring I was able to get rid of some of the ugliest proofs in the codebase (these using lots of Ltac `match`es). The cost is that a few proofs got a bit more complicated, but on net I think it's a huge simplification.

As a bonus, this refactoring allowed me to spot some places which were inadvertently using doubly-preloaded vlsms. These are the parity example and Paxos. I will fix these in the update dependency PR.