### PR TITLE
Remove the lemma `related_components` and some lemmas it depends on

### DIFF
--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1247,19 +1247,9 @@ Lemma irrelevant_components_one
   let res := snd (composite_apply_plan IM s [ai]) in
   (res i) = (s i).
 Proof.
-  unfold composite_apply_plan, apply_plan, _apply_plan.
-  simpl.
-  destruct ai.
-  match goal with
-  |- context [let (_, _) := let (_, _) := ?t in _ in _] =>
-    destruct t eqn: eq_trans
-  end.
-  simpl in *.
-  simpl in eq_trans.
-  destruct label_a; simpl in *.
-  match type of eq_trans with
-  | (let (si', om') := ?t in _) = _ => destruct t end.
-  inversion eq_trans.
+  unfold composite_apply_plan, apply_plan, _apply_plan; cbn.
+  repeat case_match; cbn.
+  inversion H; inversion H1; subst.
   by state_update_simpl.
 Qed.
 

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1156,26 +1156,6 @@ Context
 (* A transition on component <<i>> is [input_valid] from <<s'>> if it is
    [input_valid] from <<s>> and their <<i>>'th components are equal. *)
 
-Lemma relevant_component_transition
-  (Free' := composite_vlsm _ (free_constraint IM))
-  (s s' : state Free')
-  (l : label Free')
-  (input : option message)
-  (i := projT1 l)
-  (Heq : (s i) = (s' i))
-  (Hprs : valid_state_prop Free' s')
-  (Hiv : input_valid Free' l (s, input)) :
-  input_valid Free' l (s', input).
-Proof.
-  split_and!; [done | by apply Hiv |].
-  cbn in Hiv |- *.
-  destruct l.
-  simpl in i.
-  unfold i in Heq.
-  rewrite <- Heq.
-  by itauto.
-Qed.
-
 Lemma relevant_component_transition_free
   (s s' : state Free)
   (l : label Free)
@@ -1197,24 +1177,6 @@ Qed.
 
 (* The effect of the transition is also the same. *)
 
-Lemma relevant_component_transition2
-  (Free' := composite_vlsm _ (free_constraint IM))
-  (s s' : state Free')
-  (l : label Free')
-  (input : option message)
-  (i := projT1 l)
-  (Heq : (s i) = (s' i))
-  (Hprs : valid_state_prop Free' s') :
-  let (dest, output) := transition Free' l (s, input) in
-  let (dest', output') := transition Free' l (s', input) in
-  output = output' /\ (dest i) = (dest' i).
-Proof.
-  destruct l as [x l]; simpl in i |- *.
-  unfold i in Heq; rewrite Heq.
-  destruct (transition (IM x) l (s' x, input)).
-  by state_update_simpl.
-Qed.
-
 Lemma relevant_component_transition2_free
   (s s' : state Free)
   (l : label Free)
@@ -1230,47 +1192,6 @@ Proof.
   unfold i in Heq; rewrite Heq.
   destruct (transition (IM x) l (s' x, input)).
   by state_update_simpl.
-Qed.
-
-Lemma relevant_components_one
-  (s s' : state (composite_vlsm _ (free_constraint IM)))
-  (Hprs' : valid_state_prop (composite_vlsm _ (free_constraint IM)) s')
-  (ai : vplan_item (composite_vlsm _ (free_constraint IM)))
-  (i := projT1 (label_a ai))
-  (Heq : (s i) = (s' i))
-  (Hpr : finite_valid_plan_from (composite_vlsm _ (free_constraint IM)) s [ai]) :
-  let res' := snd (apply_plan (composite_vlsm _ (free_constraint IM)) s' [ai]) in
-  let res := snd (apply_plan (composite_vlsm _ (free_constraint IM)) s [ai]) in
-  finite_valid_plan_from (composite_vlsm _ (free_constraint IM)) s' [ai] /\
-  (res' i) = res i.
-Proof.
-  simpl.
-  unfold finite_valid_plan_from, apply_plan, _apply_plan in *.
-  destruct ai; simpl in *.
-  match goal with
-  |- context [let (_, _) := let (_, _) := ?t in _ in _] =>
-    destruct t eqn: eq_trans'
-  end.
-  match goal with
-  |- context [let (_, _) := let (_, _) := ?t in _ in _] =>
-    destruct t eqn: eq_trans
-  end.
-  inversion Hpr; subst.
-  split.
-  - assert (Ht' : input_valid_transition (composite_vlsm _ (free_constraint IM)) label_a (s', input_a) (c, o)).
-    {
-      unfold input_valid_transition in *.
-      destruct Ht as [Hpr_valid Htrans].
-      by apply relevant_component_transition with (s' := s') in Hpr_valid; itauto.
-    }
-    apply finite_valid_trace_from_extend; [| done].
-    apply finite_valid_trace_from_empty.
-    by apply input_valid_transition_destination in Ht'.
-  - specialize (relevant_component_transition2 s s' label_a input_a Heq Hprs') as Hrel.
-    cbn in *.
-    repeat case_match.
-    unfold i; cbn in *.
-    by itauto congruence.
 Qed.
 
 Lemma relevant_components_one_free
@@ -1386,88 +1307,6 @@ Proof.
 Qed.
 
 (* Same as relevant_components_one but for multiple transitions. *)
-
-Lemma relevant_components
-  (s s' : state (composite_vlsm _ (free_constraint IM)))
-  (Hprs' : valid_state_prop (composite_vlsm _ (free_constraint IM)) s')
-  (a : plan (composite_vlsm _ (free_constraint IM)))
-  (a_indices := List.map (@projT1 _ _) (List.map (@label_a _ _) a))
-  (li : list index)
-  (Heq : forall (i : index), i ∈ li -> (s' i) = (s i))
-  (Hincl : a_indices ⊆ li)
-  (Hpr : finite_valid_plan_from (composite_vlsm _ (free_constraint IM)) s a) :
-  let res' := snd (apply_plan (composite_vlsm _ (free_constraint IM)) s' a) in
-  let res := snd (apply_plan (composite_vlsm _ (free_constraint IM)) s a) in
-  finite_valid_plan_from (composite_vlsm _ (free_constraint IM)) s' a /\
-  (forall (i : index), i ∈ li -> (res' i) = res i).
-Proof.
-  induction a using rev_ind.
-  - by split; [apply finite_valid_plan_empty |].
-  - simpl in *.
-    apply finite_valid_plan_from_app_iff in Hpr.
-    destruct Hpr as [Hrem Hsingle].
-
-    spec IHa. {
-      remember (List.map (@projT1 _ (fun n : index => label (IM n))) (List.map label_a a)) as small.
-      transitivity a_indices; [| done].
-      unfold a_indices.
-      intros e H; simpl.
-      rewrite 2 map_app, elem_of_app.
-      by itauto.
-    }
-
-    spec IHa; [done |].
-
-    destruct IHa as [IHapr IHaind].
-
-    specialize (relevant_components_one
-      (snd (apply_plan (composite_vlsm _ (free_constraint IM)) s a))
-      (snd (apply_plan (composite_vlsm _ (free_constraint IM)) s' a))) as Hrel.
-
-    spec Hrel; [by apply apply_plan_last_valid; itauto |].
-
-    specialize (Hrel x); simpl in *.
-
-    spec Hrel. {
-      specialize (IHaind (projT1 (label_a x))).
-      symmetry.
-      apply IHaind.
-      specialize (Hincl (projT1 (label_a x))).
-      apply Hincl.
-      unfold a_indices.
-      by rewrite 2 map_app, elem_of_app; right; left.
-    }
-    specialize (Hrel Hsingle).
-    destruct Hrel as [Hrelpr Hrelind].
-    split.
-    + by apply finite_valid_plan_from_app_iff; split.
-    + intros i Hi.
-      specialize (IHaind i Hi).
-      specialize (Heq i Hi).
-      rewrite !apply_plan_app.
-      simpl in *.
-      destruct (apply_plan (composite_vlsm IM (free_constraint IM)) s' a) as [tra' sa'] eqn: eq_as'.
-      destruct (apply_plan (composite_vlsm IM (free_constraint IM)) s a) as [tra sa] eqn: eq_as.
-      simpl in *.
-      destruct (apply_plan (composite_vlsm IM (free_constraint IM)) sa [x]) as [trx sx] eqn: eq_xsa.
-      destruct (apply_plan (composite_vlsm IM (free_constraint IM)) sa' [x]) as [trx' sx'] eqn: eq_xsa'.
-      simpl in *.
-      destruct (decide (i = (projT1 (label_a x)))).
-      * by rewrite e.
-      * specialize (irrelevant_components_one sa) as Hdiff.
-        specialize (Hdiff x i n).
-
-        specialize (irrelevant_components_one sa') as Hdiff0.
-        specialize (Hdiff0 x i n).
-        simpl in *.
-        apply (f_equal snd) in eq_xsa.
-        apply (f_equal snd) in eq_xsa'.
-
-        replace sx' with (snd (composite_apply_plan IM sa' [x])).
-        replace sx with (snd (composite_apply_plan IM sa [x])).
-        setoid_rewrite Hdiff.
-        by setoid_rewrite Hdiff0.
-Qed.
 
 Lemma relevant_components_free
   (s s' : state Free)

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -292,17 +292,12 @@ Lemma false_composite_no_equivocation_vlsm_with_pre_loaded
 Proof.
   unfold SeededNoeqvFalse.
   unfold composite_no_equivocation_vlsm_with_pre_loaded.
-  match goal with
-  |- VLSM_eq (pre_loaded_vlsm ?m _) _ => specialize (vlsm_is_pre_loaded_with_False m) as Heq
-  end.
-  apply VLSM_eq_sym in Heq.
-  match type of Heq with
-  | VLSM_eq _ ?v => apply VLSM_eq_trans with v
-  end
-  ; [done |].
-  specialize (constraint_subsumption_incl IM) as Hincl.
-  unfold no_equivocations_additional_constraint_with_pre_loaded.
-  by split; apply Hincl; intros l [s [m |]] Hpv; apply Hpv.
+  apply VLSM_eq_trans with
+    (composite_vlsm IM (no_equivocations_additional_constraint_with_pre_loaded (fun _ =>  False))).
+  - by apply VLSM_eq_sym, vlsm_is_pre_loaded_with_False.
+  - specialize (constraint_subsumption_incl IM) as Hincl.
+    unfold no_equivocations_additional_constraint_with_pre_loaded.
+    by split; apply Hincl; intros l [s [m |]] Hpv; apply Hpv.
 Qed.
 
 End sec_seeded_composite_vlsm_no_equivocation.

--- a/theories/VLSM/Core/Equivocators/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocation.v
@@ -1231,13 +1231,7 @@ Proof.
         (proj1 (valid_trace_forget_last Htr)))
       as Heq_lst.
     simpl in Heq_lst.
-    match goal with
-    |- proper_equivocator_descriptors _ _ ?l =>
-      match type of Heq_lst with
-      | _ = ?l' =>
-        replace l with l'
-      end
-    end.
+    rewrite Heq_lst.
     intros e.
     destruct e.
     apply not_equivocating_equivocator_descriptors_proper in Hfinal_descriptors_m.

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -440,10 +440,7 @@ Proof.
   cbn; unfold composite_state_sub_projection at 1; cbn.
   destruct (transition (IM i) li (s i, om)) as (si', omi') eqn: Hti.
   inversion Ht. subst omi' s'. clear Ht.
-  match goal with
-  |- (let (_, _) := ?t in _) = _ =>
-    replace t with (si', om')
-  end.
+  setoid_rewrite Hti.
   f_equal.
   extensionality sub_j.
   destruct_dec_sig sub_j j Hj Heqj.

--- a/theories/VLSM/Lib/StreamFilters.v
+++ b/theories/VLSM/Lib/StreamFilters.v
@@ -747,14 +747,9 @@ Proof.
   revert s Hinf.
   assert (Hfirst : forall s Hinf k,
     (stream_filter_fst_pos (is_Some ∘ (Some ∘ f)) s (fHere _ _ Hinf) k).1 = k).
-  { intros.
-    match goal with
-    |- fst (stream_filter_fst_pos ?P s ?Hex k) = k =>
-      specialize (stream_filter_fst_pos_characterization P s Hex k)
-        as [_k [Heq1 [_ H_k]]]
-    end.
-    rewrite Heq1.
-    simpl.
+  {
+    intros.
+    edestruct stream_filter_fst_pos_characterization as (_k & -> & _ & H_k); cbn.
     destruct _k; [lia |].
     by exfalso; apply (H_k 0); [lia | eexists].
   }

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -190,8 +190,7 @@ Proof.
   - left.
     specialize (Forall_forall P l0); intros [Hall _].
     specialize (Hall HPl0 x Hin).
-    match goal with |- ?X = 0  => cut (X <= 0) end.
-    lia.
+    match goal with |- ?X = 0  => cut (X <= 0) end; [by lia |].
     rewrite <- Hlen; clear Hlen.
     apply filter_length_fn.
     revert HPl0.


### PR DESCRIPTION
The removed lemmas were duplicated when introducing new definition of `free_composite_vlsm`.

This PR requires a fix in casper-cbc-proofs, which I already have.