### PR TITLE
Refactor some of the duplicated lemmas in Equivocation.v

### DIFF
--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -2065,20 +2065,6 @@ Proof.
   by apply constraint_free_incl.
 Qed.
 
-Lemma composite_no_initial_valid_messages_have_sender
-    (can_emit_signed : channel_authentication_prop)
-    (no_initial_messages_in_IM : no_initial_messages_in_IM_prop)
-    (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-    (X := composite_vlsm IM constraint)
-    : forall (m : message) (Hm : valid_message_prop X m), sender m <> None.
-Proof.
-  intros m Hm.
-  cut (exists v : validator, sender m = Some v /\
-    can_emit (pre_loaded_with_all_messages_vlsm (IM (A v))) m).
-  - by intros (v & -> & _); congruence.
-  - by eapply composite_no_initial_valid_messages_emitted_by_sender.
-Qed.
-
 Lemma free_composite_no_initial_valid_messages_have_sender
   (can_emit_signed : channel_authentication_prop)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop) :
@@ -2090,6 +2076,19 @@ Proof.
     can_emit (pre_loaded_with_all_messages_vlsm (IM (A v))) m).
   - by intros (v & -> & _); congruence.
   - by apply free_composite_no_initial_valid_messages_emitted_by_sender.
+Qed.
+
+Lemma composite_no_initial_valid_messages_have_sender
+    (can_emit_signed : channel_authentication_prop)
+    (no_initial_messages_in_IM : no_initial_messages_in_IM_prop)
+    (constraint : composite_label IM -> composite_state IM * option message -> Prop)
+    (X := composite_vlsm IM constraint)
+    : forall (m : message) (Hm : valid_message_prop X m), sender m <> None.
+Proof.
+  intros m Hm.
+  apply free_composite_no_initial_valid_messages_have_sender; [done.. |].
+  eapply VLSM_incl_valid_message with X; [| by do 2 red | done].
+  by apply constraint_free_incl.
 Qed.
 
 Lemma composite_emitted_by_validator_have_sender

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -2290,20 +2290,6 @@ Proof.
   by apply (sent_valid X s); [| exists i].
 Qed.
 
-Lemma preloaded_messages_sent_from_component_of_valid_state_are_valid
-  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (seed : message -> Prop)
-  (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
-  (s : composite_state IM)
-  (Hs : valid_state_prop X s)
-  (i : index)
-  (m : message)
-  (Hsent : has_been_sent (IM i) (s i) m) :
-  valid_message_prop X m.
-Proof.
-  by eapply sent_valid; [| exists i].
-Qed.
-
 Lemma preloaded_messages_sent_from_component_of_valid_state_are_valid_free
   (seed : message -> Prop)
   (X := pre_loaded_vlsm (free_composite_vlsm IM) seed)
@@ -2320,20 +2306,6 @@ Qed.
 Lemma messages_received_from_component_of_valid_state_are_valid
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
-  (s : composite_state IM)
-  (Hs : valid_state_prop X s)
-  (i : index)
-  (m : message)
-  (Hreceived : has_been_received (IM i) (s i) m)
-  : valid_message_prop X m.
-Proof.
-  by eapply received_valid; [| exists i].
-Qed.
-
-Lemma preloaded_messages_received_from_component_of_valid_state_are_valid
-  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (seed : message -> Prop)
-  (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
   (s : composite_state IM)
   (Hs : valid_state_prop X s)
   (i : index)
@@ -2411,26 +2383,6 @@ Proof.
     + by eapply messages_received_from_component_of_valid_state_are_valid.
     + by eapply messages_sent_from_component_of_valid_state_are_valid.
   - by eapply valid_state_project_preloaded.
-Qed.
-
-Lemma preloaded_composite_directly_observed_valid
-  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (seed : message -> Prop)
-  (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
-  (s : composite_state IM)
-  (Hs : valid_state_prop X s)
-  (m : message)
-  (Hobserved : composite_has_been_directly_observed s m)
-  : valid_message_prop X m.
-Proof.
-  destruct Hobserved as [i Hobserved].
-  apply (has_been_directly_observed_sent_received_iff (IM i)) in Hobserved.
-  - destruct Hobserved as [Hreceived | Hsent].
-    + by eapply preloaded_messages_received_from_component_of_valid_state_are_valid.
-    + by eapply preloaded_messages_sent_from_component_of_valid_state_are_valid.
-  - eapply valid_state_project_preloaded_to_preloaded.
-    eapply VLSM_incl_valid_state; [| done].
-    by rapply @pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
 Qed.
 
 Lemma preloaded_free_composite_directly_observed_valid

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1809,18 +1809,6 @@ Proof.
   - by typeclasses eauto.
 Qed.
 
-Lemma composite_has_been_sent_stepwise_props
-  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (X := composite_vlsm IM constraint)
-  : has_been_sent_stepwise_prop (vlsm := X) composite_has_been_sent.
-Proof.
-  unfold has_been_sent_stepwise_props.
-  pose proof (composite_stepwise_props (fun i => has_been_sent_stepwise_props (IM i)))
-    as [Hinits Hstep].
-  split; [done |].
-  by intros l; specialize (Hstep l); destruct l.
-Qed.
-
 Lemma free_composite_has_been_sent_stepwise_props
   (X := free_composite_vlsm IM)
   : has_been_sent_stepwise_prop (vlsm := X) composite_has_been_sent.
@@ -1871,18 +1859,6 @@ Proof.
   - by typeclasses eauto.
 Qed.
 
-Lemma composite_has_been_received_stepwise_props
-  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (X := composite_vlsm IM constraint)
-  : has_been_received_stepwise_prop (vlsm := X) composite_has_been_received.
-Proof.
-  unfold has_been_received_stepwise_props.
-  pose proof (composite_stepwise_props (fun i => has_been_received_stepwise_props (IM i)))
-    as [Hinits Hstep].
-  split; [done |].
-  by intros l; specialize (Hstep l); destruct l.
-Qed.
-
 Lemma free_composite_has_been_received_stepwise_props
   (X := free_composite_vlsm IM)
   : has_been_received_stepwise_prop (vlsm := X) composite_has_been_received.
@@ -1912,31 +1888,6 @@ Qed.
   (constraint : label X -> state X * option message -> Prop)
   : HasBeenDirectlyObservedCapability X :=
   HasBeenDirectlyObservedCapability_from_sent_received X.
-
-Lemma preloaded_composite_has_been_received_stepwise_props
-  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (seed : message -> Prop)
-  (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
-  : has_been_received_stepwise_prop (vlsm := X) composite_has_been_received.
-Proof.
-  unfold has_been_received_stepwise_prop.
-  destruct (composite_stepwise_props (fun i => has_been_received_stepwise_props (IM i)) constraint)
-    as [Hinits Hstep].
-  split; [done |].
-  intros l **; specialize (Hstep l); destruct l; cbn in *.
-  eapply Hstep with om, VLSM_incl_input_valid_transition; [| done].
-  by apply basic_VLSM_strong_incl; do 2 red; cbn; itauto.
-Qed.
-
-Definition preloaded_composite_HasBeenReceivedCapability
-  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (seed : message -> Prop)
-  (X := pre_loaded_vlsm (composite_vlsm IM constraint) seed)
-  : HasBeenReceivedCapability X :=
-  Build_HasBeenReceivedCapability X
-    composite_has_been_received
-    composite_has_been_received_dec
-    (preloaded_composite_has_been_received_stepwise_props constraint seed).
 
 End sec_composite_has_been_received.
 
@@ -1981,16 +1932,6 @@ Proof.
   split; [done |].
   by intros l; specialize (Hstep l); destruct l.
 Qed.
-
-Definition composite_HasBeenDirectlyObservedCapability_from_stepwise
-  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-  (X := composite_vlsm IM constraint)
-  : HasBeenDirectlyObservedCapability X.
-Proof.
-  exists composite_has_been_directly_observed.
-  - by apply composite_has_been_directly_observed_dec.
-  - by apply (composite_has_been_directly_observed_stepwise_props constraint).
-Defined.
 
 Context
       {validator : Type}

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -2844,22 +2844,6 @@ Context
   Hence, given any pre_loaded trace leading to <<s>>, all messages received
   within it must be valid, thus the trace itself is valid.
 *)
-Lemma all_pre_traces_to_valid_state_are_valid
-  (s is : state PreX) (tr : list (transition_item PreX))
-  (Hs : valid_state_prop X s)
-  (Htr : finite_valid_trace_init_to PreX is s tr)
-  : finite_valid_trace_init_to X is s tr.
-Proof.
-  apply pre_traces_with_valid_inputs_are_valid in Htr; [done |].
-  apply valid_trace_last_pstate in Htr as Hspre.
-  intros.
-  eapply received_valid; [done |].
-  specialize (proper_received _ s Hspre m) as Hproper.
-  apply proj2 in Hproper. apply Hproper.
-  apply has_been_received_consistency; [by typeclasses eauto | done |].
-  by exists is, tr, Htr.
-Qed.
-
 Lemma all_pre_traces_to_valid_state_are_valid_free
   (s is : state PreY) (tr : list (transition_item PreY))
   (Hs : valid_state_prop Y s)


### PR DESCRIPTION
Summary of changes:
- refactor the proof of `free_composite_stepwise_props` and derive `composite_stepwise_props` from it
- add instances of `HasBeenSentCapability`, `HasBeenReceivedCapability` and `HasBeenDirectlyObservedCapability` for `constrained_vlsm` (together with the lemmas they depend on: `constrained_has_been_sent_stepwise_props`, `constrained_has_been_received_stepwise_props`) and delete these instances for `composite_vlsm` (since they can now be derived from instances for `free_composite_vlsm` and `constained_vlsm`)
- delete lemmas which are no longer needed because of the above changes: `composite_has_been_sent_stepwise_props`, `composite_has_been_received_stepwise_props`, `preloaded_composite_has_been_received_stepwise_props`, `preloaded_composite_HasBeenReceivedCapability`, `composite_HasBeenDirectlyObservedCapability_from_stepwise`
- derive `composite_no_initial_valid_messages_emitted_by_sender` from the corresponding lemma for free composition
- derive `composite_no_initial_valid_messages_have_sender` from the corresponding lemma for free composition
- remove lemmas `preloaded_messages_sent_from_component_of_valid_state_are_valid`, `preloaded_messages_received_from_component_of_valid_state_are_valid` and `preloaded_composite_directly_observed_valid` (their free composition versions are retained)
- remove the lemma `all_pre_traces_to_valid_state_are_valid` (its free composition version is retained)