### PR TITLE
Refactor EquivocatorsCompositionProjections.v

### DIFF
--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -17,8 +17,7 @@ Context {message : Type}
   `{finite.Finite index}
   (IM : index -> VLSM message)
   `{forall i : index, HasBeenSentCapability (IM i)}
-  (equivocator_IM := equivocator_IM IM)
-  (FreeE := free_composite_vlsm equivocator_IM)
+  (FreeE := free_composite_vlsm (equivocator_IM IM))
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   (Free := free_composite_vlsm IM)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
@@ -35,7 +34,7 @@ Context {message : Type}
 *)
 Definition equivocators_transition_item_project
   (eqv_descriptors : equivocator_descriptors IM)
-  (item : composite_transition_item equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
   : option (option (composite_transition_item IM) * equivocator_descriptors IM)
   :=
   let sx := equivocators_state_project IM eqv_descriptors (destination item) in
@@ -44,7 +43,7 @@ Definition equivocators_transition_item_project
   match
     equivocator_vlsm_transition_item_project
       (IM eqv)
-      (composite_transition_item_projection equivocator_IM item)
+      (composite_transition_item_projection (equivocator_IM IM) item)
       deqv
       with
   | Some (Some item', deqv') =>
@@ -59,13 +58,13 @@ Definition equivocators_transition_item_project
 
 Lemma equivocators_transition_item_project_preserves_equivocating_indices
   (descriptors : equivocator_descriptors IM)
-  (item : composite_transition_item equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
   oitem idescriptors
   s
   (Hdescriptors : proper_equivocator_descriptors IM descriptors (destination item))
-  (Ht : composite_transition equivocator_IM (l item) (s, input item) =
+  (Ht : composite_transition (equivocator_IM IM) (l item) (s, input item) =
           (destination item, output item))
-  (Hv : composite_valid equivocator_IM (l item) (s, input item))
+  (Hv : composite_valid (equivocator_IM IM) (l item) (s, input item))
   (Hpr : equivocators_transition_item_project descriptors item = Some (oitem, idescriptors))
   :
     set_union
@@ -121,12 +120,12 @@ Qed.
 *)
 Lemma equivocators_transition_item_project_preserves_zero_descriptors
   (descriptors : equivocator_descriptors IM)
-  (item : composite_transition_item equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
   oitem idescriptors
   s
-  (Ht : composite_transition equivocator_IM (l item) (s, input item) =
+  (Ht : composite_transition (equivocator_IM IM) (l item) (s, input item) =
           (destination item, output item))
-  (Hv : composite_valid equivocator_IM (l item) (s, input item))
+  (Hv : composite_valid (equivocator_IM IM) (l item) (s, input item))
   (Hpr : equivocators_transition_item_project descriptors item = Some (oitem, idescriptors))
   : forall i, descriptors i = Existing 0 -> idescriptors i = Existing 0.
 Proof.
@@ -136,10 +135,10 @@ Proof.
   - subst i. rewrite Hi in Hpr.
     specialize
       (equivocators_vlsm_transition_item_project_zero_descriptor (IM (projT1 (l item)))
-        (composite_transition_item_projection equivocator_IM item)
+        (composite_transition_item_projection (equivocator_IM IM) item)
         (s (projT1 (l item))))
       as Hpr_item.
-    remember (composite_transition_item_projection equivocator_IM item) as pr_item.
+    remember (composite_transition_item_projection (equivocator_IM IM) item) as pr_item.
     spec Hpr_item.
     {
       clear -Ht Heqpr_item.
@@ -163,7 +162,7 @@ Proof.
     by destruct oitem'; inversion Hpr; state_update_simpl.
   - destruct
     (equivocator_vlsm_transition_item_project (IM (projT1 (l item)))
-      (composite_transition_item_projection equivocator_IM item)
+      (composite_transition_item_projection (equivocator_IM IM) item)
       (descriptors (projT1 (l item))))
     eqn: Hpr'; [| by congruence].
   by destruct p, o; inversion Hpr; state_update_simpl.
@@ -171,14 +170,14 @@ Qed.
 
 Lemma equivocators_transition_item_project_proper_descriptor
   (eqv_descriptors : equivocator_descriptors IM)
-  (item : composite_transition_item equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
   (i := projT1 (l item))
   (Hproper : proper_descriptor (IM i) (eqv_descriptors i) (destination item i))
   : is_Some (equivocators_transition_item_project eqv_descriptors item).
 Proof.
   specialize
     (equivocator_transition_item_project_proper (IM (projT1 (l item)))
-      (composite_transition_item_projection equivocator_IM item)
+      (composite_transition_item_projection (equivocator_IM IM) item)
       (eqv_descriptors (projT1 (l item))) Hproper)
     as [itemx Hpr_item].
   unfold equivocators_transition_item_project.
@@ -188,7 +187,7 @@ Qed.
 
 Lemma equivocators_transition_item_project_proper
   (eqv_descriptors : equivocator_descriptors IM)
-  (item : composite_transition_item equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
   (Hproper : proper_equivocator_descriptors IM eqv_descriptors (destination item))
   : is_Some (equivocators_transition_item_project eqv_descriptors item).
 Proof.
@@ -202,13 +201,13 @@ Qed.
 *)
 Lemma no_equivocating_equivocators_transition_item_project
   (eqv_descriptors : equivocator_descriptors IM)
-  (item : composite_transition_item equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
   (i := projT1 (l item))
   (Hzero : (eqv_descriptors i) = Existing 0)
   (Hdest_i : is_singleton_state (IM i) (destination item i))
-  (s : composite_state equivocator_IM)
-  (Hv : composite_valid equivocator_IM (l item) (s, input item))
-  (Ht : composite_transition equivocator_IM (l item) (s, input item) =
+  (s : composite_state (equivocator_IM IM))
+  (Hv : composite_valid (equivocator_IM IM) (l item) (s, input item))
+  (Ht : composite_transition (equivocator_IM IM) (l item) (s, input item) =
           (destination item, output item))
   : exists (Hex : existing_equivocator_label _ (projT2 (l item)))
     (lx : composite_label IM :=
@@ -221,7 +220,7 @@ Lemma no_equivocating_equivocators_transition_item_project
 Proof.
   specialize
     (no_equivocating_equivocator_transition_item_project (IM i)
-      (composite_transition_item_projection equivocator_IM item)
+      (composite_transition_item_projection (equivocator_IM IM) item)
       Hdest_i
       (s i))
     as Heqv_pr.
@@ -243,11 +242,11 @@ Proof.
 Qed.
 
 Lemma exists_equivocators_transition_item_project
-  (item : composite_transition_item equivocator_IM)
-  (s : composite_state equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
+  (s : composite_state (equivocator_IM IM))
   (Hs : proper_existing_equivocator_label _ (projT2 (l item)) (s (projT1 (l item))))
-  (Hv : composite_valid equivocator_IM (l item) (s, input item))
-  (Ht : composite_transition equivocator_IM (l item) (s, input item) =
+  (Hv : composite_valid (equivocator_IM IM) (l item) (s, input item))
+  (Ht : composite_transition (equivocator_IM IM) (l item) (s, input item) =
           (destination item, output item))
   : exists equivocators,
       not_equivocating_equivocator_descriptors IM equivocators (destination item)
@@ -264,7 +263,7 @@ Proof.
   specialize
     (exists_equivocator_transition_item_project
       (IM (projT1 (l item)))
-      (composite_transition_item_projection equivocator_IM item)
+      (composite_transition_item_projection (equivocator_IM IM) item)
       (s (projT1 (l item)))
       Hs)
     as Hproject.
@@ -279,7 +278,7 @@ Proof.
     - by cbn; rewrite equivocator_state_project_zero.
   }
   exists (equivocator_descriptors_update IM (zero_descriptor IM) (projT1 (l item))
-    (equivocator_label_descriptor (l (composite_transition_item_projection equivocator_IM item)))).
+    (equivocator_label_descriptor (l (composite_transition_item_projection (equivocator_IM IM) item)))).
   split.
   { intro i. unfold equivocator_descriptors_update. destruct (decide (i = projT1 (l item))).
     - by subst; state_update_simpl.
@@ -292,7 +291,7 @@ Qed.
 
 Lemma equivocators_transition_item_project_proper_descriptor_characterization
   (eqv_descriptors : equivocator_descriptors IM)
-  (item : composite_transition_item equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
   (i := projT1 (l item))
   (Hproper : proper_descriptor (IM i) (eqv_descriptors i) (destination item i))
   : exists oitem eqv_descriptors',
@@ -307,13 +306,13 @@ Lemma equivocators_transition_item_project_proper_descriptor_characterization
       | None => True
       end
     /\ forall
-      (s : composite_state equivocator_IM)
-      (Hv : composite_valid equivocator_IM (l item) (s, input item))
-      (Ht : composite_transition equivocator_IM (l item) (s, input item) =
+      (s : composite_state (equivocator_IM IM))
+      (Hv : composite_valid (equivocator_IM IM) (l item) (s, input item))
+      (Ht : composite_transition (equivocator_IM IM) (l item) (s, input item) =
               (destination item, output item)),
       proper_descriptor (IM i) (eqv_descriptors' i) (s i) /\
       eqv_descriptors' = equivocator_descriptors_update IM eqv_descriptors i (eqv_descriptors' i) /\
-      s = state_update equivocator_IM (destination item) i (s i) /\
+      s = state_update (equivocator_IM IM) (destination item) i (s i) /\
       previous_state_descriptor_prop (IM i) (eqv_descriptors i) (s i) (eqv_descriptors' i) /\
       match oitem with
       | Some itemx =>
@@ -328,7 +327,7 @@ Lemma equivocators_transition_item_project_proper_descriptor_characterization
 Proof.
   destruct
     (equivocator_transition_item_project_proper_characterization (IM i)
-      (composite_transition_item_projection equivocator_IM item)
+      (composite_transition_item_projection (equivocator_IM IM) item)
       (eqv_descriptors i) Hproper)
     as (oitemi & eqv_descriptorsi' & Hoitemi & Hitemx & Hchar).
   subst i.
@@ -377,7 +376,7 @@ Qed.
 
 Lemma equivocators_transition_item_project_proper_characterization
   (eqv_descriptors : equivocator_descriptors IM)
-  (item : composite_transition_item equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
   (Hproper : proper_equivocator_descriptors IM eqv_descriptors (destination item))
   : exists oitem eqv_descriptors',
     equivocators_transition_item_project eqv_descriptors item = Some (oitem, eqv_descriptors')
@@ -391,14 +390,14 @@ Lemma equivocators_transition_item_project_proper_characterization
       | None => True
       end
     /\ forall
-      (s : composite_state equivocator_IM)
-      (Hv : composite_valid equivocator_IM (l item) (s, input item))
-      (Ht : composite_transition equivocator_IM (l item) (s, input item) =
+      (s : composite_state (equivocator_IM IM))
+      (Hv : composite_valid (equivocator_IM IM) (l item) (s, input item))
+      (Ht : composite_transition (equivocator_IM IM) (l item) (s, input item) =
         (destination item, output item)),
       proper_equivocator_descriptors IM eqv_descriptors' s /\
       eqv_descriptors' = equivocator_descriptors_update IM eqv_descriptors
                           (projT1 (l item)) (eqv_descriptors' (projT1 (l item))) /\
-      s = state_update equivocator_IM (destination item) (projT1 (l item)) (s (projT1 (l item))) /\
+      s = state_update (equivocator_IM IM) (destination item) (projT1 (l item)) (s (projT1 (l item))) /\
       previous_state_descriptor_prop (IM (projT1 (l item))) (eqv_descriptors (projT1 (l item)))
         (s (projT1 (l item))) (eqv_descriptors' (projT1 (l item))) /\
       match oitem with
@@ -428,7 +427,7 @@ Qed.
 
 Lemma equivocators_transition_item_project_inv_characterization
   (eqv_descriptors eqv_descriptors' : equivocator_descriptors IM)
-  (item : composite_transition_item equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
   (itemx : composite_transition_item IM)
   (Hpr_item : equivocators_transition_item_project eqv_descriptors item =
               Some (Some itemx, eqv_descriptors'))
@@ -441,7 +440,7 @@ Proof.
   destruct
     (equivocator_vlsm_transition_item_project
       (IM (projT1 (l item)))
-      (composite_transition_item_projection equivocator_IM item)
+      (composite_transition_item_projection (equivocator_IM IM) item)
       (eqv_descriptors (projT1 (l item))))
     as [([itemi |], descriptori) |] eqn: Hpr_itemi
   ; [| by congruence..].
@@ -454,7 +453,7 @@ Proof.
 Qed.
 
 Definition equivocators_trace_project_folder
-  (item : composite_transition_item equivocator_IM)
+  (item : composite_transition_item (equivocator_IM IM))
   (result : option (list (composite_transition_item IM) * equivocator_descriptors IM))
   : option (list (composite_transition_item IM) * equivocator_descriptors IM)
   :=
@@ -469,14 +468,14 @@ Definition equivocators_trace_project_folder
   end.
 
 Lemma equivocators_trace_project_fold_None
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   : fold_right equivocators_trace_project_folder None tr = None.
 Proof.
   by induction tr; cbn; rewrite ?IHtr.
 Qed.
 
 Lemma equivocators_trace_project_folder_additive_iff
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (itrX : list (composite_transition_item IM))
   (ieqv_descriptors eqv_descriptors : equivocator_descriptors IM)
   (trX' : list (composite_transition_item IM))
@@ -520,7 +519,7 @@ Proof.
 Qed.
 
 Lemma equivocators_trace_project_folder_additive
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (itrX trX : list (composite_transition_item IM))
   (ieqv_descriptors eqv_descriptors : equivocator_descriptors IM)
   (Htr : fold_right equivocators_trace_project_folder (Some ([], ieqv_descriptors)) tr
@@ -540,7 +539,7 @@ Qed.
 *)
 Definition equivocators_trace_project
   (eqv_descriptors : equivocator_descriptors IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   : option (list (composite_transition_item IM) * equivocator_descriptors IM)
   :=
   fold_right
@@ -549,7 +548,7 @@ Definition equivocators_trace_project
     tr.
 
 Lemma equivocators_trace_project_app_iff
-  (pre suf : list (composite_transition_item equivocator_IM))
+  (pre suf : list (composite_transition_item (equivocator_IM IM)))
   (ieqv_descriptors eqv_descriptors : equivocator_descriptors IM)
   (trX : list (composite_transition_item IM))
   : equivocators_trace_project eqv_descriptors (pre ++ suf)
@@ -584,15 +583,15 @@ Qed.
   which projects to it.
 *)
 Lemma equivocators_trace_project_app_inv_item
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (ieqv_descriptors eqv_descriptors : equivocator_descriptors IM)
   (preX sufX : list (composite_transition_item IM))
   (itemX : composite_transition_item IM)
   : equivocators_trace_project eqv_descriptors tr
     = Some (preX ++ [itemX] ++ sufX, ieqv_descriptors) ->
   exists
-    (pre suf : list (composite_transition_item equivocator_IM))
-    (item : (composite_transition_item equivocator_IM))
+    (pre suf : list (composite_transition_item (equivocator_IM IM)))
+    (item : (composite_transition_item (equivocator_IM IM)))
     (item_descriptors pre_descriptors : equivocator_descriptors IM),
     equivocators_trace_project eqv_descriptors suf = Some (sufX, item_descriptors) /\
     equivocators_transition_item_project item_descriptors item = Some (Some itemX, pre_descriptors) /\
@@ -647,13 +646,13 @@ Qed.
 
 (** A corollary of the above, reflecting a split in the projection to the original trace. *)
 Lemma equivocators_trace_project_app_inv
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (ieqv_descriptors eqv_descriptors : equivocator_descriptors IM)
   (preX sufX : list (composite_transition_item IM))
   : equivocators_trace_project eqv_descriptors tr
     = Some (preX ++ sufX, ieqv_descriptors) ->
   exists
-    (pre suf : list (composite_transition_item equivocator_IM))
+    (pre suf : list (composite_transition_item (equivocator_IM IM)))
     (eqv_descriptors' : equivocator_descriptors IM),
     equivocators_trace_project eqv_descriptors suf = Some (sufX, eqv_descriptors') /\
     equivocators_trace_project eqv_descriptors' pre = Some (preX, ieqv_descriptors) /\
@@ -678,11 +677,11 @@ Qed.
 
 Lemma equivocators_trace_project_preserves_equivocating_indices
   (descriptors idescriptors : equivocator_descriptors IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (trX : list (composite_transition_item IM))
-  (is s : composite_state equivocator_IM)
+  (is s : composite_state (equivocator_IM IM))
   (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm
-          (free_composite_vlsm equivocator_IM)) is s tr)
+          (free_composite_vlsm (equivocator_IM IM))) is s tr)
   (Hdescriptors : proper_equivocator_descriptors IM descriptors s)
   (Hproject_tr : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   :
@@ -726,11 +725,11 @@ Qed.
 *)
 Lemma equivocators_trace_project_from_state_descriptors
   (descriptors idescriptors : equivocator_descriptors IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (trX : list (composite_transition_item IM))
-  (is s : composite_state equivocator_IM)
+  (is s : composite_state (equivocator_IM IM))
   (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm
-          (free_composite_vlsm equivocator_IM)) is s tr)
+          (free_composite_vlsm (equivocator_IM IM))) is s tr)
   (Hdescriptors : proper_equivocator_descriptors IM descriptors s)
   (Hproject_tr : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   : forall eqv, previous_state_descriptor_prop (IM eqv) (descriptors eqv) (is eqv) (idescriptors eqv).
@@ -782,11 +781,11 @@ Qed.
 
 Lemma equivocators_trace_project_preserves_equivocating_indices_final
   (descriptors idescriptors : equivocator_descriptors IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (trX : list (composite_transition_item IM))
-  (is s : composite_state equivocator_IM)
+  (is s : composite_state (equivocator_IM IM))
   (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm
-          (free_composite_vlsm equivocator_IM)) is s tr)
+          (free_composite_vlsm (equivocator_IM IM))) is s tr)
   (Hdescriptors : not_equivocating_equivocator_descriptors IM descriptors s)
   (Hproject_tr : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   :
@@ -822,14 +821,14 @@ Lemma equivocators_trace_project_finite_trace_projection_list_commute
   (i : index)
   (final_descriptors initial_descriptors : equivocator_descriptors IM)
   (eqv_initial : MachineDescriptor (IM i))
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (trX : list (composite_transition_item IM))
   (trXi : list (transition_item (IM i)))
   (eqv_final := final_descriptors i)
   (Hproject_tr : equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors))
   (Hproject_tri :
     equivocator_vlsm_trace_project (IM i)
-      (finite_trace_projection_list equivocator_IM i tr) eqv_final
+      (finite_trace_projection_list (equivocator_IM IM) i tr) eqv_final
     = Some (trXi, eqv_initial))
   : initial_descriptors i = eqv_initial /\
     finite_trace_projection_list IM i trX = trXi.
@@ -861,7 +860,7 @@ Proof.
       unfold equivocators_transition_item_project in Hpr_item_x.
       destruct (decide (i = projT1 (l x))).
       - subst i.
-        rewrite (composite_transition_item_projection_iff equivocator_IM x)
+        rewrite (composite_transition_item_projection_iff (equivocator_IM IM) x)
          in Hproject_xi.
         simpl in Hproject_xi.
         subst eqv_final.
@@ -884,7 +883,7 @@ Proof.
         apply equivocator_transition_item_project_inv_characterization in Heqpr_item_x.
         simpl in *.
         by destruct Heqpr_item_x as [Hl [-> [-> [<- _]]]].
-      - rewrite (composite_transition_item_projection_neq equivocator_IM i x)
+      - rewrite (composite_transition_item_projection_neq (equivocator_IM IM) i x)
          in Hproject_xi by congruence.
         simpl in Hproject_xi.
         subst eqv_final.
@@ -914,8 +913,8 @@ Qed.
   to full (valid) traces.
 *)
 Lemma equivocators_trace_project_preserves_zero_descriptors
-  (is : composite_state equivocator_IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (is : composite_state (equivocator_IM IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (Htr : finite_valid_trace_from PreFreeE is tr)
   (descriptors : equivocator_descriptors IM)
   (idescriptors : equivocator_descriptors IM)
@@ -942,8 +941,8 @@ Qed.
 
 Lemma preloaded_equivocators_valid_trace_from_project
   (final_descriptors : equivocator_descriptors IM)
-  (is : composite_state equivocator_IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (is : composite_state (equivocator_IM IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (final_state := finite_trace_last is tr)
   (Hproper : proper_equivocator_descriptors IM final_descriptors final_state)
   (Htr : finite_valid_trace_from PreFreeE is tr)
@@ -992,8 +991,8 @@ Proof.
 Qed.
 
 Lemma equivocators_trace_project_zero_descriptors
-  (is : composite_state equivocator_IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (is : composite_state (equivocator_IM IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (Htr : finite_valid_trace_from PreFreeE is tr)
   : exists (trX : list (composite_transition_item IM)),
     equivocators_trace_project (zero_descriptor IM) tr = Some (trX, (zero_descriptor IM)).
@@ -1013,8 +1012,8 @@ Qed.
 
 Lemma preloaded_equivocators_valid_trace_project_inv
   (final_descriptors : equivocator_descriptors IM)
-  (is : composite_state equivocator_IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (is : composite_state (equivocator_IM IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (final_state := finite_trace_last is tr)
   (Htr : finite_valid_trace PreFreeE is tr)
   (trX : list (composite_transition_item IM))
@@ -1098,8 +1097,8 @@ Qed.
   only the [proper_equivocator_descriptors] property.
 *)
 Lemma preloaded_equivocators_valid_trace_project_proper_initial
-  (is : composite_state equivocator_IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (is : composite_state (equivocator_IM IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (final_state := finite_trace_last is tr)
   (Htr : finite_valid_trace_from PreFreeE is tr)
   (final_descriptors : equivocator_descriptors IM)
@@ -1118,10 +1117,10 @@ Proof.
 Qed.
 
 Lemma equivocators_trace_project_output_reflecting_inv
-  (is : composite_state equivocator_IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (is : composite_state (equivocator_IM IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (Htr : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm
-           (free_composite_vlsm equivocator_IM)) is tr)
+           (free_composite_vlsm (equivocator_IM IM))) is tr)
   (m : message)
   (Hbbs : Exists (field_selector output m) tr)
   : exists
@@ -1133,17 +1132,17 @@ Lemma equivocators_trace_project_output_reflecting_inv
 Proof.
   apply Exists_exists in Hbbs.
   destruct Hbbs as [item [Hitem Hm]]. simpl in Hm.
-  apply (finite_trace_projection_list_in  equivocator_IM) in Hitem.
+  apply (finite_trace_projection_list_in (equivocator_IM IM)) in Hitem.
   destruct item. simpl in *. destruct l as (i, li). simpl in *.
   specialize
-    (preloaded_finite_valid_trace_projection equivocator_IM i _ _ Htr)
+    (preloaded_finite_valid_trace_projection (equivocator_IM IM) i _ _ Htr)
     as Htri.
   specialize
     (equivocator_vlsm_trace_project_output_reflecting_inv (IM i) _ _ Htri m) as Hex.
   spec Hex; [by apply Exists_exists; eexists _ |].
   destruct Hex as [eqv_final [eqv_init [Heqv_init [Heqv_final [trXi [Hprojecti Hex]]]]]].
   specialize (VLSM_projection_finite_trace_last
-    (preloaded_component_projection equivocator_IM i) _ _ Htr) as Hlst.
+    (preloaded_component_projection (equivocator_IM IM) i) _ _ Htr) as Hlst.
   simpl in Hlst, Heqv_final. rewrite <- Hlst in Heqv_final. clear Hlst.
   match type of Heqv_final with
   | existing_descriptor _ _ (?l i) => remember l as final
@@ -1180,10 +1179,10 @@ Proof.
 Qed.
 
 Lemma equivocators_trace_project_output_reflecting_iff
-  (is : composite_state equivocator_IM)
-  (tr : list (composite_transition_item equivocator_IM))
+  (is : composite_state (equivocator_IM IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (Htr : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm
-          (free_composite_vlsm equivocator_IM)) is tr)
+          (free_composite_vlsm (equivocator_IM IM))) is tr)
   (m : message)
   : Exists (field_selector output m) tr
   <-> exists
@@ -1216,7 +1215,7 @@ Qed.
 *)
 Lemma pre_equivocators_valid_trace_project
   (is final_state : state (equivocators_no_equivocations_vlsm IM))
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (Htr : finite_valid_trace_init_to PreFreeE is final_state tr)
   (final_descriptors : equivocator_descriptors IM)
   (Hproper : proper_equivocator_descriptors IM final_descriptors final_state)
@@ -1298,7 +1297,7 @@ Qed.
 
 Definition equivocators_partial_trace_project
   (final_descriptors : equivocator_descriptors IM)
-  (str : composite_state equivocator_IM * list (composite_transition_item equivocator_IM))
+  (str : composite_state (equivocator_IM IM) * list (composite_transition_item (equivocator_IM IM)))
   : option (composite_state IM * list (composite_transition_item IM))
   :=
   let (s, tr) := str in
@@ -1315,7 +1314,7 @@ Definition equivocators_partial_trace_project
 
 Lemma equivocators_partial_trace_project_characterization
   (final_descriptors : equivocator_descriptors IM)
-  (X := free_composite_vlsm equivocator_IM)
+  (X := free_composite_vlsm (equivocator_IM IM))
   (partial_trace_project := equivocators_partial_trace_project final_descriptors)
   sX trX sY trY
   : partial_trace_project (sX, trX) = Some (sY, trY) <->
@@ -1338,7 +1337,7 @@ Qed.
 
 Lemma destruct_equivocators_partial_trace_project
   {final_descriptors : equivocator_descriptors IM}
-  (X := free_composite_vlsm equivocator_IM)
+  (X := free_composite_vlsm (equivocator_IM IM))
   (partial_trace_project := equivocators_partial_trace_project final_descriptors)
   {sX trX sY trY}
   (Hpr_tr : partial_trace_project (sX, trX) = Some (sY, trY)) :
@@ -1353,7 +1352,7 @@ Qed.
 
 Lemma construct_equivocators_partial_trace_project
   {final_descriptors : equivocator_descriptors IM}
-  (X := free_composite_vlsm equivocator_IM)
+  (X := free_composite_vlsm (equivocator_IM IM))
   (partial_trace_project := equivocators_partial_trace_project final_descriptors)
   {sX trX sY trY}
   (Hed : not_equivocating_equivocator_descriptors IM final_descriptors (finite_trace_last sX trX) /\
@@ -1368,7 +1367,7 @@ Qed.
 
 Lemma equivocators_partial_trace_project_extends_left
   (final_descriptors : equivocator_descriptors IM)
-  (X := free_composite_vlsm equivocator_IM)
+  (X := free_composite_vlsm (equivocator_IM IM))
   (partial_trace_project := equivocators_partial_trace_project final_descriptors)
   : forall sX trX sY trY,
   partial_trace_project (sX, trX) = Some (sY, trY) ->
@@ -1409,12 +1408,12 @@ Qed.
 Definition equivocators_total_state_project := equivocators_state_project IM (zero_descriptor IM).
 
 Definition equivocators_total_label_project
-  (l : composite_label equivocator_IM) : option (composite_label IM) :=
+  (l : composite_label (equivocator_IM IM)) : option (composite_label IM) :=
   let (i, li) := l in
   option_map (existT i) (equivocator_label_zero_project _ li).
 
 Definition equivocators_total_trace_project
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   : list (composite_transition_item IM)
   :=
   from_option fst [] (equivocators_trace_project (zero_descriptor IM) tr).
@@ -1926,8 +1925,7 @@ Context {message : Type}
   `{finite.Finite index}
   (IM : index -> VLSM message)
   `{forall i : index, HasBeenSentCapability (IM i)}
-  (equivocator_IM := equivocator_IM IM)
-  (FreeE := free_composite_vlsm equivocator_IM)
+  (FreeE := free_composite_vlsm (equivocator_IM IM))
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   (Free := free_composite_vlsm IM)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
@@ -1959,22 +1957,22 @@ Proof.
       as [Hnot_equiv [initial_descriptors [Htr_project Hs_project]]].
     apply not_equivocating_equivocator_descriptors_proper in Hnot_equiv as Hproper.
 
-    specialize (sub_composition_all_embedding equivocator_IM
+    specialize (sub_composition_all_embedding (equivocator_IM IM)
       (equivocators_no_equivocations_constraint IM)) as Hproj.
     apply (VLSM_embedding_finite_valid_trace Hproj) in Htr.
     specialize
       (false_composite_no_equivocation_vlsm_with_pre_loaded
-        (SubProjectionTraces.sub_IM equivocator_IM (enum index))
+        (SubProjectionTraces.sub_IM (equivocator_IM IM) (enum index))
         (free_constraint _))
       as Heq.
     assert (Htr' :
       finite_valid_trace
         (composite_vlsm
-          (SubProjectionTraces.sub_IM equivocator_IM (enum index))
+          (SubProjectionTraces.sub_IM (equivocator_IM IM) (enum index))
           (no_equivocations_additional_constraint
-            (SubProjectionTraces.sub_IM equivocator_IM (enum index))
+            (SubProjectionTraces.sub_IM (equivocator_IM IM) (enum index))
             (free_constraint _)))
-        (composite_state_sub_projection equivocator_IM (finite.enum index) s)
+        (composite_state_sub_projection (equivocator_IM IM) (finite.enum index) s)
         (VLSM_embedding_finite_trace_project Hproj tr)).
     { revert Htr.
       apply VLSM_incl_finite_valid_trace.
@@ -2052,7 +2050,7 @@ Proof.
       (EquivocatorsComposition.equivocators_state_project
         (SubProjectionTraces.sub_IM IM (finite.enum index))
         (fun i : sub_index (finite.enum index) => initial_descriptors (` i))
-        (composite_state_sub_projection equivocator_IM (finite.enum index) s))
+        (composite_state_sub_projection (equivocator_IM IM) (finite.enum index) s))
       (finite_trace_sub_projection IM (finite.enum index) trX)).
     {
       revert HtrX.
@@ -2083,7 +2081,7 @@ Qed.
 Lemma equivocators_valid_trace_from_project
   (final_descriptors : equivocator_descriptors IM)
   (is final_state : state (equivocators_no_equivocations_vlsm IM))
-  (tr : list (composite_transition_item equivocator_IM))
+  (tr : list (composite_transition_item (equivocator_IM IM)))
   (Hproper : not_equivocating_equivocator_descriptors IM final_descriptors final_state)
   (Htr : finite_valid_trace_from_to (equivocators_no_equivocations_vlsm IM) is final_state tr)
   : exists

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -17,7 +17,6 @@ Context {message : Type}
   `{finite.Finite index}
   (IM : index -> VLSM message)
   `{forall i : index, HasBeenSentCapability (IM i)}
-  (equivocator_descriptors := equivocator_descriptors IM)
   (equivocator_IM := equivocator_IM IM)
   (FreeE := free_composite_vlsm equivocator_IM)
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
@@ -35,9 +34,9 @@ Context {message : Type}
   the plain composition of [IM].
 *)
 Definition equivocators_transition_item_project
-  (eqv_descriptors : equivocator_descriptors)
+  (eqv_descriptors : equivocator_descriptors IM)
   (item : composite_transition_item equivocator_IM)
-  : option (option (composite_transition_item IM) * equivocator_descriptors)
+  : option (option (composite_transition_item IM) * equivocator_descriptors IM)
   :=
   let sx := equivocators_state_project IM eqv_descriptors (destination item) in
   let eqv := projT1 (l item) in
@@ -59,7 +58,7 @@ Definition equivocators_transition_item_project
   end.
 
 Lemma equivocators_transition_item_project_preserves_equivocating_indices
-  (descriptors : equivocator_descriptors)
+  (descriptors : equivocator_descriptors IM)
   (item : composite_transition_item equivocator_IM)
   oitem idescriptors
   s
@@ -121,7 +120,7 @@ Qed.
   composition of equivocators.
 *)
 Lemma equivocators_transition_item_project_preserves_zero_descriptors
-  (descriptors : equivocator_descriptors)
+  (descriptors : equivocator_descriptors IM)
   (item : composite_transition_item equivocator_IM)
   oitem idescriptors
   s
@@ -171,7 +170,7 @@ Proof.
 Qed.
 
 Lemma equivocators_transition_item_project_proper_descriptor
-  (eqv_descriptors : equivocator_descriptors)
+  (eqv_descriptors : equivocator_descriptors IM)
   (item : composite_transition_item equivocator_IM)
   (i := projT1 (l item))
   (Hproper : proper_descriptor (IM i) (eqv_descriptors i) (destination item i))
@@ -188,7 +187,7 @@ Proof.
 Qed.
 
 Lemma equivocators_transition_item_project_proper
-  (eqv_descriptors : equivocator_descriptors)
+  (eqv_descriptors : equivocator_descriptors IM)
   (item : composite_transition_item equivocator_IM)
   (Hproper : proper_equivocator_descriptors IM eqv_descriptors (destination item))
   : is_Some (equivocators_transition_item_project eqv_descriptors item).
@@ -202,7 +201,7 @@ Qed.
   the composition of equivocators.
 *)
 Lemma no_equivocating_equivocators_transition_item_project
-  (eqv_descriptors : equivocator_descriptors)
+  (eqv_descriptors : equivocator_descriptors IM)
   (item : composite_transition_item equivocator_IM)
   (i := projT1 (l item))
   (Hzero : (eqv_descriptors i) = Existing 0)
@@ -252,7 +251,7 @@ Lemma exists_equivocators_transition_item_project
           (destination item, output item))
   : exists equivocators,
       not_equivocating_equivocator_descriptors IM equivocators (destination item)
-      /\ exists (equivocators' : equivocator_descriptors)
+      /\ exists (equivocators' : equivocator_descriptors IM)
         (lx : composite_label IM := existT (projT1 (l item))
           (existing_equivocator_label_extract _ _ (existing_equivocator_label_forget_proper _ Hs)))
         (sx : composite_state IM := equivocators_state_project IM equivocators (destination item))
@@ -292,7 +291,7 @@ Proof.
 Qed.
 
 Lemma equivocators_transition_item_project_proper_descriptor_characterization
-  (eqv_descriptors : equivocator_descriptors)
+  (eqv_descriptors : equivocator_descriptors IM)
   (item : composite_transition_item equivocator_IM)
   (i := projT1 (l item))
   (Hproper : proper_descriptor (IM i) (eqv_descriptors i) (destination item i))
@@ -377,7 +376,7 @@ Proof.
 Qed.
 
 Lemma equivocators_transition_item_project_proper_characterization
-  (eqv_descriptors : equivocator_descriptors)
+  (eqv_descriptors : equivocator_descriptors IM)
   (item : composite_transition_item equivocator_IM)
   (Hproper : proper_equivocator_descriptors IM eqv_descriptors (destination item))
   : exists oitem eqv_descriptors',
@@ -428,7 +427,7 @@ Proof.
 Qed.
 
 Lemma equivocators_transition_item_project_inv_characterization
-  (eqv_descriptors eqv_descriptors' : equivocator_descriptors)
+  (eqv_descriptors eqv_descriptors' : equivocator_descriptors IM)
   (item : composite_transition_item equivocator_IM)
   (itemx : composite_transition_item IM)
   (Hpr_item : equivocators_transition_item_project eqv_descriptors item =
@@ -456,8 +455,8 @@ Qed.
 
 Definition equivocators_trace_project_folder
   (item : composite_transition_item equivocator_IM)
-  (result : option (list (composite_transition_item IM) * equivocator_descriptors))
-  : option (list (composite_transition_item IM) * equivocator_descriptors)
+  (result : option (list (composite_transition_item IM) * equivocator_descriptors IM))
+  : option (list (composite_transition_item IM) * equivocator_descriptors IM)
   :=
   match result with
   | None => None
@@ -479,7 +478,7 @@ Qed.
 Lemma equivocators_trace_project_folder_additive_iff
   (tr : list (composite_transition_item equivocator_IM))
   (itrX : list (composite_transition_item IM))
-  (ieqv_descriptors eqv_descriptors : equivocator_descriptors)
+  (ieqv_descriptors eqv_descriptors : equivocator_descriptors IM)
   (trX' : list (composite_transition_item IM))
   : fold_right equivocators_trace_project_folder (Some (itrX, ieqv_descriptors)) tr
     = Some (trX', eqv_descriptors)
@@ -523,7 +522,7 @@ Qed.
 Lemma equivocators_trace_project_folder_additive
   (tr : list (composite_transition_item equivocator_IM))
   (itrX trX : list (composite_transition_item IM))
-  (ieqv_descriptors eqv_descriptors : equivocator_descriptors)
+  (ieqv_descriptors eqv_descriptors : equivocator_descriptors IM)
   (Htr : fold_right equivocators_trace_project_folder (Some ([], ieqv_descriptors)) tr
     = Some (trX, eqv_descriptors))
   : fold_right equivocators_trace_project_folder (Some (itrX, ieqv_descriptors)) tr
@@ -540,9 +539,9 @@ Qed.
   [transition_item]s it produces.
 *)
 Definition equivocators_trace_project
-  (eqv_descriptors : equivocator_descriptors)
+  (eqv_descriptors : equivocator_descriptors IM)
   (tr : list (composite_transition_item equivocator_IM))
-  : option (list (composite_transition_item IM) * equivocator_descriptors)
+  : option (list (composite_transition_item IM) * equivocator_descriptors IM)
   :=
   fold_right
     equivocators_trace_project_folder
@@ -551,13 +550,13 @@ Definition equivocators_trace_project
 
 Lemma equivocators_trace_project_app_iff
   (pre suf : list (composite_transition_item equivocator_IM))
-  (ieqv_descriptors eqv_descriptors : equivocator_descriptors)
+  (ieqv_descriptors eqv_descriptors : equivocator_descriptors IM)
   (trX : list (composite_transition_item IM))
   : equivocators_trace_project eqv_descriptors (pre ++ suf)
     = Some (trX, ieqv_descriptors)
   <-> exists
     (preX sufX : list (composite_transition_item IM))
-    (eqv_descriptors' : equivocator_descriptors),
+    (eqv_descriptors' : equivocator_descriptors IM),
     equivocators_trace_project eqv_descriptors suf = Some (sufX, eqv_descriptors') /\
     equivocators_trace_project eqv_descriptors' pre = Some (preX, ieqv_descriptors) /\
     trX = preX ++ sufX.
@@ -586,7 +585,7 @@ Qed.
 *)
 Lemma equivocators_trace_project_app_inv_item
   (tr : list (composite_transition_item equivocator_IM))
-  (ieqv_descriptors eqv_descriptors : equivocator_descriptors)
+  (ieqv_descriptors eqv_descriptors : equivocator_descriptors IM)
   (preX sufX : list (composite_transition_item IM))
   (itemX : composite_transition_item IM)
   : equivocators_trace_project eqv_descriptors tr
@@ -594,7 +593,7 @@ Lemma equivocators_trace_project_app_inv_item
   exists
     (pre suf : list (composite_transition_item equivocator_IM))
     (item : (composite_transition_item equivocator_IM))
-    (item_descriptors pre_descriptors : equivocator_descriptors),
+    (item_descriptors pre_descriptors : equivocator_descriptors IM),
     equivocators_trace_project eqv_descriptors suf = Some (sufX, item_descriptors) /\
     equivocators_transition_item_project item_descriptors item = Some (Some itemX, pre_descriptors) /\
     equivocators_trace_project pre_descriptors pre = Some (preX, ieqv_descriptors) /\
@@ -649,13 +648,13 @@ Qed.
 (** A corollary of the above, reflecting a split in the projection to the original trace. *)
 Lemma equivocators_trace_project_app_inv
   (tr : list (composite_transition_item equivocator_IM))
-  (ieqv_descriptors eqv_descriptors : equivocator_descriptors)
+  (ieqv_descriptors eqv_descriptors : equivocator_descriptors IM)
   (preX sufX : list (composite_transition_item IM))
   : equivocators_trace_project eqv_descriptors tr
     = Some (preX ++ sufX, ieqv_descriptors) ->
   exists
     (pre suf : list (composite_transition_item equivocator_IM))
-    (eqv_descriptors' : equivocator_descriptors),
+    (eqv_descriptors' : equivocator_descriptors IM),
     equivocators_trace_project eqv_descriptors suf = Some (sufX, eqv_descriptors') /\
     equivocators_trace_project eqv_descriptors' pre = Some (preX, ieqv_descriptors) /\
     tr = pre ++ suf.
@@ -678,7 +677,7 @@ Proof.
 Qed.
 
 Lemma equivocators_trace_project_preserves_equivocating_indices
-  (descriptors idescriptors : equivocator_descriptors)
+  (descriptors idescriptors : equivocator_descriptors IM)
   (tr : list (composite_transition_item equivocator_IM))
   (trX : list (composite_transition_item IM))
   (is s : composite_state equivocator_IM)
@@ -726,7 +725,7 @@ Qed.
   on a pre-loaded valid trace satisfy the [previous_state_descriptor_prop]erty.
 *)
 Lemma equivocators_trace_project_from_state_descriptors
-  (descriptors idescriptors : equivocator_descriptors)
+  (descriptors idescriptors : equivocator_descriptors IM)
   (tr : list (composite_transition_item equivocator_IM))
   (trX : list (composite_transition_item IM))
   (is s : composite_state equivocator_IM)
@@ -782,7 +781,7 @@ Proof.
 Qed.
 
 Lemma equivocators_trace_project_preserves_equivocating_indices_final
-  (descriptors idescriptors : equivocator_descriptors)
+  (descriptors idescriptors : equivocator_descriptors IM)
   (tr : list (composite_transition_item equivocator_IM))
   (trX : list (composite_transition_item IM))
   (is s : composite_state equivocator_IM)
@@ -821,7 +820,7 @@ Qed.
 *)
 Lemma equivocators_trace_project_finite_trace_projection_list_commute
   (i : index)
-  (final_descriptors initial_descriptors : equivocator_descriptors)
+  (final_descriptors initial_descriptors : equivocator_descriptors IM)
   (eqv_initial : MachineDescriptor (IM i))
   (tr : list (composite_transition_item equivocator_IM))
   (trX : list (composite_transition_item IM))
@@ -918,8 +917,8 @@ Lemma equivocators_trace_project_preserves_zero_descriptors
   (is : composite_state equivocator_IM)
   (tr : list (composite_transition_item equivocator_IM))
   (Htr : finite_valid_trace_from PreFreeE is tr)
-  (descriptors : equivocator_descriptors)
-  (idescriptors : equivocator_descriptors)
+  (descriptors : equivocator_descriptors IM)
+  (idescriptors : equivocator_descriptors IM)
   (trX : list (composite_transition_item IM))
   (HtrX : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   : forall i, descriptors i = Existing 0 -> idescriptors i = Existing 0.
@@ -942,7 +941,7 @@ Proof.
 Qed.
 
 Lemma preloaded_equivocators_valid_trace_from_project
-  (final_descriptors : equivocator_descriptors)
+  (final_descriptors : equivocator_descriptors IM)
   (is : composite_state equivocator_IM)
   (tr : list (composite_transition_item equivocator_IM))
   (final_state := finite_trace_last is tr)
@@ -950,7 +949,7 @@ Lemma preloaded_equivocators_valid_trace_from_project
   (Htr : finite_valid_trace_from PreFreeE is tr)
   : exists
     (trX : list (composite_transition_item IM))
-    (initial_descriptors : equivocator_descriptors),
+    (initial_descriptors : equivocator_descriptors IM),
     equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors)
     /\ proper_equivocator_descriptors IM initial_descriptors is
     /\ equivocators_state_project IM final_descriptors (finite_trace_last is tr)
@@ -1013,13 +1012,13 @@ Proof.
 Qed.
 
 Lemma preloaded_equivocators_valid_trace_project_inv
-  (final_descriptors : equivocator_descriptors)
+  (final_descriptors : equivocator_descriptors IM)
   (is : composite_state equivocator_IM)
   (tr : list (composite_transition_item equivocator_IM))
   (final_state := finite_trace_last is tr)
   (Htr : finite_valid_trace PreFreeE is tr)
   (trX : list (composite_transition_item IM))
-  (initial_descriptors : equivocator_descriptors)
+  (initial_descriptors : equivocator_descriptors IM)
   (Hproject : equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors))
   (Hproper : proper_equivocator_descriptors IM initial_descriptors is)
   : proper_equivocator_descriptors IM final_descriptors final_state.
@@ -1103,9 +1102,9 @@ Lemma preloaded_equivocators_valid_trace_project_proper_initial
   (tr : list (composite_transition_item equivocator_IM))
   (final_state := finite_trace_last is tr)
   (Htr : finite_valid_trace_from PreFreeE is tr)
-  (final_descriptors : equivocator_descriptors)
+  (final_descriptors : equivocator_descriptors IM)
   (trX : list (composite_transition_item IM))
-  (initial_descriptors : equivocator_descriptors)
+  (initial_descriptors : equivocator_descriptors IM)
   (Hproject : equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors))
   (Hproper : proper_equivocator_descriptors IM final_descriptors final_state)
   : proper_equivocator_descriptors IM initial_descriptors is.
@@ -1126,7 +1125,7 @@ Lemma equivocators_trace_project_output_reflecting_inv
   (m : message)
   (Hbbs : Exists (field_selector output m) tr)
   : exists
-    (final_descriptors initial_descriptors : equivocator_descriptors)
+    (final_descriptors initial_descriptors : equivocator_descriptors IM)
     (trX : list (composite_transition_item IM)),
     not_equivocating_equivocator_descriptors IM final_descriptors (finite_trace_last is tr) /\
     equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors) /\
@@ -1188,7 +1187,7 @@ Lemma equivocators_trace_project_output_reflecting_iff
   (m : message)
   : Exists (field_selector output m) tr
   <-> exists
-    (final_descriptors initial_descriptors : equivocator_descriptors)
+    (final_descriptors initial_descriptors : equivocator_descriptors IM)
     (trX : list (composite_transition_item IM)),
     not_equivocating_equivocator_descriptors IM final_descriptors (finite_trace_last is tr) /\
     equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors) /\
@@ -1219,10 +1218,10 @@ Lemma pre_equivocators_valid_trace_project
   (is final_state : state (equivocators_no_equivocations_vlsm IM))
   (tr : list (composite_transition_item equivocator_IM))
   (Htr : finite_valid_trace_init_to PreFreeE is final_state tr)
-  (final_descriptors : equivocator_descriptors)
+  (final_descriptors : equivocator_descriptors IM)
   (Hproper : proper_equivocator_descriptors IM final_descriptors final_state)
   : exists
-    (initial_descriptors : equivocator_descriptors),
+    (initial_descriptors : equivocator_descriptors IM),
     proper_equivocator_descriptors IM initial_descriptors is /\
     exists
     (isX := equivocators_state_project IM initial_descriptors is)
@@ -1298,7 +1297,7 @@ Proof.
 Qed.
 
 Definition equivocators_partial_trace_project
-  (final_descriptors : equivocator_descriptors)
+  (final_descriptors : equivocator_descriptors IM)
   (str : composite_state equivocator_IM * list (composite_transition_item equivocator_IM))
   : option (composite_state IM * list (composite_transition_item IM))
   :=
@@ -1315,7 +1314,7 @@ Definition equivocators_partial_trace_project
     else None.
 
 Lemma equivocators_partial_trace_project_characterization
-  (final_descriptors : equivocator_descriptors)
+  (final_descriptors : equivocator_descriptors IM)
   (X := free_composite_vlsm equivocator_IM)
   (partial_trace_project := equivocators_partial_trace_project final_descriptors)
   sX trX sY trY
@@ -1338,7 +1337,7 @@ Proof.
 Qed.
 
 Lemma destruct_equivocators_partial_trace_project
-  {final_descriptors : equivocator_descriptors}
+  {final_descriptors : equivocator_descriptors IM}
   (X := free_composite_vlsm equivocator_IM)
   (partial_trace_project := equivocators_partial_trace_project final_descriptors)
   {sX trX sY trY}
@@ -1353,7 +1352,7 @@ Proof.
 Qed.
 
 Lemma construct_equivocators_partial_trace_project
-  {final_descriptors : equivocator_descriptors}
+  {final_descriptors : equivocator_descriptors IM}
   (X := free_composite_vlsm equivocator_IM)
   (partial_trace_project := equivocators_partial_trace_project final_descriptors)
   {sX trX sY trY}
@@ -1368,7 +1367,7 @@ Proof.
 Qed.
 
 Lemma equivocators_partial_trace_project_extends_left
-  (final_descriptors : equivocator_descriptors)
+  (final_descriptors : equivocator_descriptors IM)
   (X := free_composite_vlsm equivocator_IM)
   (partial_trace_project := equivocators_partial_trace_project final_descriptors)
   : forall sX trX sY trY,
@@ -1508,7 +1507,7 @@ Proof.
 Qed.
 
 Lemma PreFreeE_PreFree_vlsm_partial_projection
-  (final_descriptors : equivocator_descriptors)
+  (final_descriptors : equivocator_descriptors IM)
   : VLSM_partial_projection PreFreeE PreFree (equivocators_partial_trace_project final_descriptors).
 Proof.
   split; [by split; apply equivocators_partial_trace_project_extends_left |].

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -19,7 +19,6 @@ Context {message : Type}
   `{forall i : index, HasBeenSentCapability (IM i)}
   (equivocator_descriptors := equivocator_descriptors IM)
   (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM)
-  (equivocators_state_project := equivocators_state_project IM)
   (equivocator_IM := equivocator_IM IM)
   (FreeE := free_composite_vlsm equivocator_IM)
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
@@ -41,7 +40,7 @@ Definition equivocators_transition_item_project
   (item : composite_transition_item equivocator_IM)
   : option (option (composite_transition_item IM) * equivocator_descriptors)
   :=
-  let sx := equivocators_state_project eqv_descriptors (destination item) in
+  let sx := equivocators_state_project IM eqv_descriptors (destination item) in
   let eqv := projT1 (l item) in
   let deqv := eqv_descriptors eqv in
   match
@@ -219,7 +218,7 @@ Lemma no_equivocating_equivocators_transition_item_project
   equivocators_transition_item_project eqv_descriptors item =
     Some (Some
       {| l := lx; input := input item; output := output item;
-        destination := equivocators_state_project eqv_descriptors (destination item) |},
+        destination := equivocators_state_project IM eqv_descriptors (destination item) |},
       eqv_descriptors).
 Proof.
   specialize
@@ -257,7 +256,7 @@ Lemma exists_equivocators_transition_item_project
       /\ exists (equivocators' : equivocator_descriptors)
         (lx : composite_label IM := existT (projT1 (l item))
           (existing_equivocator_label_extract _ _ (existing_equivocator_label_forget_proper _ Hs)))
-        (sx : composite_state IM := equivocators_state_project equivocators (destination item))
+        (sx : composite_state IM := equivocators_state_project IM equivocators (destination item))
       ,
         proper_equivocator_descriptors IM equivocators' s
         /\ equivocators_transition_item_project equivocators item = Some
@@ -305,7 +304,7 @@ Lemma equivocators_transition_item_project_proper_descriptor_characterization
         (exists (Hex : existing_equivocator_label _ (projT2 (l item))),
           existT i (existing_equivocator_label_extract _ _ Hex) = l itemx) /\
         input item = input itemx /\ output item = output itemx /\
-        (equivocators_state_project eqv_descriptors (destination item) = destination itemx)
+        (equivocators_state_project IM eqv_descriptors (destination item) = destination itemx)
         /\ eqv_descriptors' i = (equivocator_label_descriptor (projT2 (l item)))
       | None => True
       end
@@ -321,12 +320,12 @@ Lemma equivocators_transition_item_project_proper_descriptor_characterization
       match oitem with
       | Some itemx =>
         forall (sx : composite_state IM)
-          (Hsx : sx = equivocators_state_project eqv_descriptors' s),
+          (Hsx : sx = equivocators_state_project IM eqv_descriptors' s),
           composite_valid IM (l itemx) (sx, input itemx) /\
           composite_transition IM (l itemx) (sx, input itemx) = (destination itemx, output itemx)
       | None =>
-        equivocators_state_project eqv_descriptors (destination item) =
-        equivocators_state_project eqv_descriptors' s
+        equivocators_state_project IM eqv_descriptors (destination item) =
+        equivocators_state_project IM eqv_descriptors' s
       end.
 Proof.
   destruct
@@ -389,7 +388,7 @@ Lemma equivocators_transition_item_project_proper_characterization
         (exists (Hex : existing_equivocator_label _ (projT2 (l item))),
           existT (projT1 (l item)) (existing_equivocator_label_extract _ _ Hex) = l itemx) /\
          input item = input itemx /\ output item = output itemx /\
-        (equivocators_state_project eqv_descriptors (destination item) = destination itemx)
+        (equivocators_state_project IM eqv_descriptors (destination item) = destination itemx)
         /\ eqv_descriptors' (projT1 (l item)) = (equivocator_label_descriptor (projT2 (l item)))
       | None => True
       end
@@ -407,12 +406,12 @@ Lemma equivocators_transition_item_project_proper_characterization
       match oitem with
       | Some itemx =>
         forall (sx : composite_state IM)
-          (Hsx : sx = equivocators_state_project eqv_descriptors' s),
+          (Hsx : sx = equivocators_state_project IM eqv_descriptors' s),
           composite_valid IM (l itemx) (sx, input itemx) /\
           composite_transition IM (l itemx) (sx, input itemx) = (destination itemx, output itemx)
       | None =>
-        equivocators_state_project eqv_descriptors (destination item) =
-        equivocators_state_project eqv_descriptors' s
+        equivocators_state_project IM eqv_descriptors (destination item) =
+        equivocators_state_project IM eqv_descriptors' s
       end.
 Proof.
   destruct (equivocators_transition_item_project_proper_descriptor_characterization
@@ -438,7 +437,7 @@ Lemma equivocators_transition_item_project_inv_characterization
   : (exists (Hex : existing_equivocator_label _ (projT2 (l item))),
       existT (projT1 (l item)) (existing_equivocator_label_extract _ _ Hex) = l itemx) /\
     input item = input itemx /\ output item = output itemx /\
-    equivocators_state_project eqv_descriptors (destination item) = destination itemx.
+    equivocators_state_project IM eqv_descriptors (destination item) = destination itemx.
 Proof.
   unfold equivocators_transition_item_project in Hpr_item.
   destruct
@@ -955,8 +954,8 @@ Lemma preloaded_equivocators_valid_trace_from_project
     (initial_descriptors : equivocator_descriptors),
     equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors)
     /\ proper_equivocator_descriptors IM initial_descriptors is
-    /\ equivocators_state_project final_descriptors (finite_trace_last is tr)
-     = finite_trace_last (equivocators_state_project initial_descriptors is) trX.
+    /\ equivocators_state_project IM final_descriptors (finite_trace_last is tr)
+     = finite_trace_last (equivocators_state_project IM initial_descriptors is) trX.
 Proof.
   generalize dependent final_descriptors; generalize dependent is.
   induction tr using rev_ind; intros; [by exists [], final_descriptors |].
@@ -1227,8 +1226,8 @@ Lemma pre_equivocators_valid_trace_project
     (initial_descriptors : equivocator_descriptors),
     proper_equivocator_descriptors IM initial_descriptors is /\
     exists
-    (isX := equivocators_state_project initial_descriptors is)
-    (final_stateX := equivocators_state_project final_descriptors final_state)
+    (isX := equivocators_state_project IM initial_descriptors is)
+    (final_stateX := equivocators_state_project IM final_descriptors final_state)
     (trX : list (composite_transition_item IM)),
     equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors) /\
     finite_valid_trace_init_to PreFree isX final_stateX trX.
@@ -1242,7 +1241,7 @@ Proof.
     exists [].
     repeat (split; [done |]).
     cut (initial_state_prop (free_composite_vlsm IM)
-      (equivocators_state_project final_descriptors is)).
+      (equivocators_state_project IM final_descriptors is)).
     {
       intro Hinit; split; [| done].
       by constructor; apply initial_state_is_valid.
@@ -1279,7 +1278,7 @@ Proof.
         by rewrite Hpr_x.
       * apply
           (finite_valid_trace_from_to_app PreFree
-            (equivocators_state_project final_descriptors' (finite_trace_last is tr)))
+            (equivocators_state_project IM final_descriptors' (finite_trace_last is tr)))
         ; [done |].
         specialize (Hchar2 _ eq_refl).
         destruct item. destruct l0 as (ix, lix).
@@ -1312,7 +1311,7 @@ Definition equivocators_partial_trace_project
     match equivocators_trace_project final_descriptors tr with
     | None => None
     | Some (trX, initial_descriptors) =>
-        Some (equivocators_state_project initial_descriptors s, trX)
+        Some (equivocators_state_project IM initial_descriptors s, trX)
     end
     else None.
 
@@ -1325,7 +1324,7 @@ Lemma equivocators_partial_trace_project_characterization
     not_equivocating_equivocator_descriptors IM final_descriptors (finite_trace_last sX trX) /\
     exists initial_descriptors,
       equivocators_trace_project final_descriptors trX = Some (trY, initial_descriptors) /\
-      equivocators_state_project initial_descriptors sX = sY.
+      equivocators_state_project IM initial_descriptors sX = sY.
 Proof.
   unfold partial_trace_project, equivocators_partial_trace_project.
   split.
@@ -1348,7 +1347,7 @@ Lemma destruct_equivocators_partial_trace_project
     not_equivocating_equivocator_descriptors IM final_descriptors (finite_trace_last sX trX) /\
       exists initial_descriptors,
         equivocators_trace_project final_descriptors trX = Some (trY, initial_descriptors) /\
-        equivocators_state_project initial_descriptors sX = sY.
+        equivocators_state_project IM initial_descriptors sX = sY.
 Proof.
   exact (proj1 (equivocators_partial_trace_project_characterization
     final_descriptors sX trX sY trY) Hpr_tr).
@@ -1362,7 +1361,7 @@ Lemma construct_equivocators_partial_trace_project
   (Hed : not_equivocating_equivocator_descriptors IM final_descriptors (finite_trace_last sX trX) /\
     exists initial_descriptors,
       equivocators_trace_project final_descriptors trX = Some (trY, initial_descriptors) /\
-      equivocators_state_project initial_descriptors sX = sY) :
+      equivocators_state_project IM initial_descriptors sX = sY) :
     partial_trace_project (sX, trX) = Some (sY, trY).
 Proof.
   exact (proj2 (equivocators_partial_trace_project_characterization
@@ -1396,7 +1395,7 @@ Proof.
     (preloaded_equivocators_valid_trace_from_project
       _ _ _ Hinitial_descriptors Hpre)
     as [preX [pre_descriptors [Hpre_project [Hpre_desciptors Hs_project]]]].
-  exists (equivocators_state_project pre_descriptors s_pre), preX.
+  exists (equivocators_state_project IM pre_descriptors s_pre), preX.
   split; [| done].
   apply construct_equivocators_partial_trace_project.
   split; [by rewrite finite_trace_last_app |].
@@ -1409,7 +1408,7 @@ Qed.
   The projection of an composite equivocator state using [zero_descriptor]s
   which is guaranteed to always succeed.
 *)
-Definition equivocators_total_state_project := equivocators_state_project (zero_descriptor IM).
+Definition equivocators_total_state_project := equivocators_state_project IM (zero_descriptor IM).
 
 Definition equivocators_total_label_project
   (l : composite_label equivocator_IM) : option (composite_label IM) :=
@@ -1478,7 +1477,7 @@ Proof.
     by state_update_simpl; cbn.
   - destruct (equivocator_state_project _ _) as [s_i |]; [| done].
     destruct (transition _ _ _) as (si', _om').
-    inversion_clear Ht. state_update_simpl.
+    inversion_clear Ht.
     destruct ji as [| ji].
     + by rewrite decide_True.
     + by rewrite decide_False.
@@ -1930,7 +1929,6 @@ Context {message : Type}
   (IM : index -> VLSM message)
   `{forall i : index, HasBeenSentCapability (IM i)}
   (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM)
-  (equivocators_state_project := equivocators_state_project IM)
   (equivocator_IM := equivocator_IM IM)
   (FreeE := free_composite_vlsm equivocator_IM)
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
@@ -2095,10 +2093,10 @@ Lemma equivocators_valid_trace_from_project
     isX final_stateX
     (trX : list (composite_transition_item IM))
     (initial_descriptors : equivocator_descriptors IM),
-    isX = equivocators_state_project initial_descriptors is /\
+    isX = equivocators_state_project IM initial_descriptors is /\
     proper_equivocator_descriptors IM initial_descriptors is /\
     equivocators_trace_project IM final_descriptors tr = Some (trX, initial_descriptors) /\
-    equivocators_state_project final_descriptors final_state = final_stateX /\
+    equivocators_state_project IM final_descriptors final_state = final_stateX /\
     finite_valid_trace_from_to Free isX final_stateX trX.
 Proof.
   apply valid_trace_get_last in Htr as Hfinal_state. apply valid_trace_forget_last in Htr.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -1926,12 +1926,11 @@ Context {message : Type}
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   (Free := free_composite_vlsm IM)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
-  (sub_IM := sub_IM IM (finite.enum index))
   .
 
 Definition free_sub_free_equivocator_descriptors
   (descriptors : equivocator_descriptors IM)
-  : equivocator_descriptors sub_IM
+  : equivocator_descriptors (sub_IM IM (finite.enum index))
   := fun i => descriptors (proj1_sig i).
 
 Lemma equivocators_no_equivocations_vlsm_X_vlsm_partial_projection

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -1875,9 +1875,10 @@ Proof.
 Qed.
 
 Lemma SeededXE_SeededX_vlsm_partial_projection
-  (final_descriptors : equivocator_descriptors _)
+  (IM' := fun i : sub_index selection => IM (`i))
+  (final_descriptors : equivocator_descriptors IM')
   : VLSM_partial_projection SeededXE SeededX
-      (equivocators_partial_trace_project _ final_descriptors).
+      (equivocators_partial_trace_project IM' final_descriptors).
 Proof.
   split; [split |].
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -22,7 +22,6 @@ Context {message : Type}
   (equivocators_state_project := equivocators_state_project IM)
   (equivocator_IM := equivocator_IM IM)
   (equivocator_descriptors_update := equivocator_descriptors_update IM)
-  (proper_equivocator_descriptors := proper_equivocator_descriptors IM)
   (FreeE := free_composite_vlsm equivocator_IM)
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   (Free := free_composite_vlsm IM)
@@ -69,7 +68,7 @@ Lemma equivocators_transition_item_project_preserves_equivocating_indices
   (item : composite_transition_item equivocator_IM)
   oitem idescriptors
   s
-  (Hdescriptors : proper_equivocator_descriptors descriptors (destination item))
+  (Hdescriptors : proper_equivocator_descriptors IM descriptors (destination item))
   (Ht : composite_transition equivocator_IM (l item) (s, input item) =
           (destination item, output item))
   (Hv : composite_valid equivocator_IM (l item) (s, input item))
@@ -196,7 +195,7 @@ Qed.
 Lemma equivocators_transition_item_project_proper
   (eqv_descriptors : equivocator_descriptors)
   (item : composite_transition_item equivocator_IM)
-  (Hproper : proper_equivocator_descriptors eqv_descriptors (destination item))
+  (Hproper : proper_equivocator_descriptors IM eqv_descriptors (destination item))
   : is_Some (equivocators_transition_item_project eqv_descriptors item).
 Proof.
   apply equivocators_transition_item_project_proper_descriptor.
@@ -263,7 +262,7 @@ Lemma exists_equivocators_transition_item_project
           (existing_equivocator_label_extract _ _ (existing_equivocator_label_forget_proper _ Hs)))
         (sx : composite_state IM := equivocators_state_project equivocators (destination item))
       ,
-        proper_equivocator_descriptors equivocators' s
+        proper_equivocator_descriptors IM equivocators' s
         /\ equivocators_transition_item_project equivocators item = Some
           (Some ({| l := lx; input := input item; output := output item; destination := sx |}),
             equivocators').
@@ -387,7 +386,7 @@ Qed.
 Lemma equivocators_transition_item_project_proper_characterization
   (eqv_descriptors : equivocator_descriptors)
   (item : composite_transition_item equivocator_IM)
-  (Hproper : proper_equivocator_descriptors eqv_descriptors (destination item))
+  (Hproper : proper_equivocator_descriptors IM eqv_descriptors (destination item))
   : exists oitem eqv_descriptors',
     equivocators_transition_item_project eqv_descriptors item = Some (oitem, eqv_descriptors')
     /\ match oitem with
@@ -404,7 +403,7 @@ Lemma equivocators_transition_item_project_proper_characterization
       (Hv : composite_valid equivocator_IM (l item) (s, input item))
       (Ht : composite_transition equivocator_IM (l item) (s, input item) =
         (destination item, output item)),
-      proper_equivocator_descriptors eqv_descriptors' s /\
+      proper_equivocator_descriptors IM eqv_descriptors' s /\
       eqv_descriptors' = equivocator_descriptors_update eqv_descriptors
                           (projT1 (l item)) (eqv_descriptors' (projT1 (l item))) /\
       s = state_update equivocator_IM (destination item) (projT1 (l item)) (s (projT1 (l item))) /\
@@ -692,7 +691,7 @@ Lemma equivocators_trace_project_preserves_equivocating_indices
   (is s : composite_state equivocator_IM)
   (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm
           (free_composite_vlsm equivocator_IM)) is s tr)
-  (Hdescriptors : proper_equivocator_descriptors descriptors s)
+  (Hdescriptors : proper_equivocator_descriptors IM descriptors s)
   (Hproject_tr : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   :
     set_union
@@ -740,7 +739,7 @@ Lemma equivocators_trace_project_from_state_descriptors
   (is s : composite_state equivocator_IM)
   (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm
           (free_composite_vlsm equivocator_IM)) is s tr)
-  (Hdescriptors : proper_equivocator_descriptors descriptors s)
+  (Hdescriptors : proper_equivocator_descriptors IM descriptors s)
   (Hproject_tr : equivocators_trace_project descriptors tr = Some (trX, idescriptors))
   : forall eqv, previous_state_descriptor_prop (IM eqv) (descriptors eqv) (is eqv) (idescriptors eqv).
 Proof.
@@ -954,13 +953,13 @@ Lemma preloaded_equivocators_valid_trace_from_project
   (is : composite_state equivocator_IM)
   (tr : list (composite_transition_item equivocator_IM))
   (final_state := finite_trace_last is tr)
-  (Hproper : proper_equivocator_descriptors final_descriptors final_state)
+  (Hproper : proper_equivocator_descriptors IM final_descriptors final_state)
   (Htr : finite_valid_trace_from PreFreeE is tr)
   : exists
     (trX : list (composite_transition_item IM))
     (initial_descriptors : equivocator_descriptors),
     equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors)
-    /\ proper_equivocator_descriptors initial_descriptors is
+    /\ proper_equivocator_descriptors IM initial_descriptors is
     /\ equivocators_state_project final_descriptors (finite_trace_last is tr)
      = finite_trace_last (equivocators_state_project initial_descriptors is) trX.
 Proof.
@@ -1029,8 +1028,8 @@ Lemma preloaded_equivocators_valid_trace_project_inv
   (trX : list (composite_transition_item IM))
   (initial_descriptors : equivocator_descriptors)
   (Hproject : equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors))
-  (Hproper : proper_equivocator_descriptors initial_descriptors is)
-  : proper_equivocator_descriptors final_descriptors final_state.
+  (Hproper : proper_equivocator_descriptors IM initial_descriptors is)
+  : proper_equivocator_descriptors IM final_descriptors final_state.
 Proof.
   revert Hproject. revert trX Htr final_descriptors.
   induction tr using rev_ind; intros; [by inversion Hproject |].
@@ -1116,8 +1115,8 @@ Lemma preloaded_equivocators_valid_trace_project_proper_initial
   (trX : list (composite_transition_item IM))
   (initial_descriptors : equivocator_descriptors)
   (Hproject : equivocators_trace_project final_descriptors tr = Some (trX, initial_descriptors))
-  (Hproper : proper_equivocator_descriptors final_descriptors final_state)
-  : proper_equivocator_descriptors initial_descriptors is.
+  (Hproper : proper_equivocator_descriptors IM final_descriptors final_state)
+  : proper_equivocator_descriptors IM initial_descriptors is.
 Proof.
   destruct
     (preloaded_equivocators_valid_trace_from_project
@@ -1168,7 +1167,7 @@ Proof.
   exists final_descriptors.
   subst final.
   assert (Hfinal_descriptors_proper :
-    proper_equivocator_descriptors final_descriptors (finite_trace_last is tr)).
+    proper_equivocator_descriptors IM final_descriptors (finite_trace_last is tr)).
   { by apply not_equivocating_equivocator_descriptors_proper. }
   destruct (preloaded_equivocators_valid_trace_from_project  _ _ _ Hfinal_descriptors_proper Htr)
     as [trX [initial_descriptors [Hproject_tr _]]].
@@ -1229,10 +1228,10 @@ Lemma pre_equivocators_valid_trace_project
   (tr : list (composite_transition_item equivocator_IM))
   (Htr : finite_valid_trace_init_to PreFreeE is final_state tr)
   (final_descriptors : equivocator_descriptors)
-  (Hproper : proper_equivocator_descriptors final_descriptors final_state)
+  (Hproper : proper_equivocator_descriptors IM final_descriptors final_state)
   : exists
     (initial_descriptors : equivocator_descriptors),
-    proper_equivocator_descriptors initial_descriptors is /\
+    proper_equivocator_descriptors IM initial_descriptors is /\
     exists
     (isX := equivocators_state_project initial_descriptors is)
     (final_stateX := equivocators_state_project final_descriptors final_state)
@@ -1940,7 +1939,6 @@ Context {message : Type}
   (equivocators_state_project := equivocators_state_project IM)
   (equivocator_IM := equivocator_IM IM)
   (equivocator_descriptors_update := equivocator_descriptors_update IM)
-  (proper_equivocator_descriptors := proper_equivocator_descriptors IM)
   (FreeE := free_composite_vlsm equivocator_IM)
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   (Free := free_composite_vlsm IM)
@@ -2107,7 +2105,7 @@ Lemma equivocators_valid_trace_from_project
     (trX : list (composite_transition_item IM))
     (initial_descriptors : equivocator_descriptors IM),
     isX = equivocators_state_project initial_descriptors is /\
-    proper_equivocator_descriptors initial_descriptors is /\
+    proper_equivocator_descriptors IM initial_descriptors is /\
     equivocators_trace_project IM final_descriptors tr = Some (trX, initial_descriptors) /\
     equivocators_state_project final_descriptors final_state = final_stateX /\
     finite_valid_trace_from_to Free isX final_stateX trX.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -18,7 +18,6 @@ Context {message : Type}
   (IM : index -> VLSM message)
   `{forall i : index, HasBeenSentCapability (IM i)}
   (equivocator_descriptors := equivocator_descriptors IM)
-  (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM)
   (equivocator_IM := equivocator_IM IM)
   (FreeE := free_composite_vlsm equivocator_IM)
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
@@ -1217,7 +1216,7 @@ Qed.
   of the free composition of nodes.
 *)
 Lemma pre_equivocators_valid_trace_project
-  (is final_state : state equivocators_no_equivocations_vlsm)
+  (is final_state : state (equivocators_no_equivocations_vlsm IM))
   (tr : list (composite_transition_item equivocator_IM))
   (Htr : finite_valid_trace_init_to PreFreeE is final_state tr)
   (final_descriptors : equivocator_descriptors)
@@ -1928,7 +1927,6 @@ Context {message : Type}
   `{finite.Finite index}
   (IM : index -> VLSM message)
   `{forall i : index, HasBeenSentCapability (IM i)}
-  (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM)
   (equivocator_IM := equivocator_IM IM)
   (FreeE := free_composite_vlsm equivocator_IM)
   (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
@@ -1944,7 +1942,7 @@ Definition free_sub_free_equivocator_descriptors
 
 Lemma equivocators_no_equivocations_vlsm_X_vlsm_partial_projection
   (final_descriptors : equivocator_descriptors IM)
-  : VLSM_partial_projection equivocators_no_equivocations_vlsm Free
+  : VLSM_partial_projection (equivocators_no_equivocations_vlsm IM) Free
       (equivocators_partial_trace_project IM final_descriptors).
 Proof.
   split; [split |].
@@ -2085,10 +2083,10 @@ Qed.
 
 Lemma equivocators_valid_trace_from_project
   (final_descriptors : equivocator_descriptors IM)
-  (is final_state : state equivocators_no_equivocations_vlsm)
+  (is final_state : state (equivocators_no_equivocations_vlsm IM))
   (tr : list (composite_transition_item equivocator_IM))
   (Hproper : not_equivocating_equivocator_descriptors IM final_descriptors final_state)
-  (Htr : finite_valid_trace_from_to equivocators_no_equivocations_vlsm is final_state tr)
+  (Htr : finite_valid_trace_from_to (equivocators_no_equivocations_vlsm IM) is final_state tr)
   : exists
     isX final_stateX
     (trX : list (composite_transition_item IM))
@@ -2143,7 +2141,7 @@ Proof.
 Qed.
 
 Lemma equivocators_no_equivocations_vlsm_X_vlsm_projection
-  : VLSM_projection equivocators_no_equivocations_vlsm Free
+  : VLSM_projection (equivocators_no_equivocations_vlsm IM) Free
       (equivocators_total_label_project IM) (equivocators_total_state_project IM).
 Proof.
   constructor; [constructor |].

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -1712,8 +1712,7 @@ Section sec_seeded_equivocators_valid_trace_project.
 Context
   (seed : message -> Prop)
   (SeededXE := seeded_equivocators_no_equivocation_vlsm IM selection seed)
-  (sub_equivocator_IM := sub_IM (equivocator_IM IM) selection)
-  (SubFreeE := free_composite_vlsm sub_equivocator_IM)
+  (SubFreeE := free_composite_vlsm (sub_IM (equivocator_IM IM) selection))
   (SubPreFreeE := pre_loaded_with_all_messages_vlsm SubFreeE)
   (SubFree := free_composite_vlsm (sub_IM IM selection))
   (SeededX := pre_loaded_vlsm SubFree seed)
@@ -1736,8 +1735,8 @@ Proof.
 Qed.
 
 Lemma seeded_equivocators_valid_trace_project
-  (is : composite_state sub_equivocator_IM)
-  (tr : list (composite_transition_item sub_equivocator_IM))
+  (is : composite_state _)
+  (tr : list (composite_transition_item _))
   (Htr : finite_valid_trace SeededXE is tr)
   (final_state := finite_trace_last is tr)
   (final_descriptors : equivocator_descriptors _)
@@ -1850,7 +1849,7 @@ Proof.
     ; [by apply initial_message_is_valid, seeded_equivocators_initial_message; right |].
     assert (Hs_free : valid_state_prop SubPreFreeE (finite_trace_last is tr'))
       by (apply proj1, finite_valid_trace_from_to_last_pstate in Hpre_tr_to; done).
-    apply (composite_proper_sent sub_equivocator_IM _ Hs_free) in Hno_equiv.
+    apply (composite_proper_sent _ _ Hs_free) in Hno_equiv.
     specialize (Hno_equiv is tr' Hpre_tr_to).
     apply finite_valid_trace_init_to_forget_last in Hpre_tr_to as Hpre_tr.
     destruct (equivocators_trace_project_output_reflecting_inv _ _ _ (proj1 Hpre_tr) _ Hno_equiv)

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -1720,20 +1720,21 @@ Proof.
 Qed.
 
 Lemma seeded_equivocators_valid_trace_project
-  (is : composite_state _)
-  (tr : list (composite_transition_item _))
+  (is : composite_state (sub_IM (equivocator_IM IM) selection))
+  (tr : list (composite_transition_item (sub_IM (equivocator_IM IM) selection)))
   (Htr : finite_valid_trace SeededXE is tr)
   (final_state := finite_trace_last is tr)
-  (final_descriptors : equivocator_descriptors _)
-  (Hproper : proper_equivocator_descriptors _ final_descriptors final_state)
+  (IM' := fun i : sub_index selection => IM (`i))
+  (final_descriptors : equivocator_descriptors IM')
+  (Hproper : proper_equivocator_descriptors IM' final_descriptors final_state)
   : exists
-    (trX : list (composite_transition_item _))
-    (initial_descriptors : equivocator_descriptors _)
-    (isX := equivocators_state_project _ initial_descriptors is)
+    (trX : list (composite_transition_item IM'))
+    (initial_descriptors : equivocator_descriptors IM')
+    (isX := equivocators_state_project IM' initial_descriptors is)
     (final_stateX := finite_trace_last isX trX),
-    proper_equivocator_descriptors _ initial_descriptors is /\
-    equivocators_trace_project _ final_descriptors tr = Some (trX, initial_descriptors) /\
-    equivocators_state_project _ final_descriptors final_state = final_stateX /\
+    proper_equivocator_descriptors IM' initial_descriptors is /\
+    equivocators_trace_project IM' final_descriptors tr = Some (trX, initial_descriptors) /\
+    equivocators_state_project IM' final_descriptors final_state = final_stateX /\
     finite_valid_trace SeededX isX trX.
 Proof.
   assert (Htr_to : finite_valid_trace_init_to SeededXE is final_state tr).
@@ -1745,7 +1746,7 @@ Proof.
     revert Htr_to; apply VLSM_incl_finite_valid_trace_init_to.
     by apply seeded_no_equivocation_incl_preloaded.
   }
-  pose proof (pre_equivocators_valid_trace_project _ _ _ _
+  pose proof (pre_equivocators_valid_trace_project IM' _ _ _
     Hpre_tr_to final_descriptors Hproper) as Hex.
   destruct Hex as [initial_descriptors [Hproper_initial [trX [Hpr_trX Hpre_trX]]]].
   exists trX, initial_descriptors.
@@ -1816,7 +1817,7 @@ Proof.
       revert Htr_to; apply VLSM_incl_finite_valid_trace_init_to.
       by apply seeded_no_equivocation_incl_preloaded.
     }
-    pose proof (pre_equivocators_valid_trace_project _ _ _ _
+    pose proof (pre_equivocators_valid_trace_project IM' _ _ _
      Hpre_tr_to final_descriptors' Hproper') as Hpr_tr'.
     destruct Hpr_tr' as [_initial_descriptors [_ [_trX' [_Hpr_trX' Heq_final_stateX']]]].
     replace (equivocators_trace_project _ _ _) with (Some (trX', initial_descriptors))

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -1715,8 +1715,7 @@ Context
   (sub_equivocator_IM := sub_IM (equivocator_IM IM) selection)
   (SubFreeE := free_composite_vlsm sub_equivocator_IM)
   (SubPreFreeE := pre_loaded_with_all_messages_vlsm SubFreeE)
-  (sub_IM := sub_IM IM selection)
-  (SubFree := free_composite_vlsm sub_IM)
+  (SubFree := free_composite_vlsm (sub_IM IM selection))
   (SeededX := pre_loaded_vlsm SubFree seed)
   .
 
@@ -1741,16 +1740,16 @@ Lemma seeded_equivocators_valid_trace_project
   (tr : list (composite_transition_item sub_equivocator_IM))
   (Htr : finite_valid_trace SeededXE is tr)
   (final_state := finite_trace_last is tr)
-  (final_descriptors : (equivocator_descriptors sub_IM))
-  (Hproper : proper_equivocator_descriptors sub_IM final_descriptors final_state)
+  (final_descriptors : equivocator_descriptors _)
+  (Hproper : proper_equivocator_descriptors _ final_descriptors final_state)
   : exists
-    (trX : list (composite_transition_item sub_IM))
-    (initial_descriptors : equivocator_descriptors sub_IM)
-    (isX := equivocators_state_project sub_IM initial_descriptors is)
+    (trX : list (composite_transition_item _))
+    (initial_descriptors : equivocator_descriptors _)
+    (isX := equivocators_state_project _ initial_descriptors is)
     (final_stateX := finite_trace_last isX trX),
-    proper_equivocator_descriptors sub_IM initial_descriptors is /\
-    equivocators_trace_project sub_IM final_descriptors tr = Some (trX, initial_descriptors) /\
-    equivocators_state_project sub_IM final_descriptors final_state = final_stateX /\
+    proper_equivocator_descriptors _ initial_descriptors is /\
+    equivocators_trace_project _ final_descriptors tr = Some (trX, initial_descriptors) /\
+    equivocators_state_project _ final_descriptors final_state = final_stateX /\
     finite_valid_trace SeededX isX trX.
 Proof.
   assert (Htr_to : finite_valid_trace_init_to SeededXE is final_state tr).
@@ -1779,7 +1778,7 @@ Proof.
   subst len_tr.
   destruct_list_last tr tr' lst Htr_lst.
   - clear H. subst. subst final_state. simpl in *. inversion Hpr_trX. subst.
-    cut (initial_state_prop SubFree (equivocators_state_project sub_IM initial_descriptors is)).
+    cut (initial_state_prop SubFree (equivocators_state_project _ initial_descriptors is)).
     { intro. split; [| done]. constructor.
       apply valid_state_prop_iff. left.
       by exists (exist _ _ H).
@@ -1792,7 +1791,7 @@ Proof.
     apply finite_valid_trace_from_app_iff in Htr.
     destruct Htr as [Htr Hlst].
     specialize (H' tr' (conj Htr Hinit) eq_refl).
-    specialize (equivocators_transition_item_project_proper_characterization sub_IM
+    specialize (equivocators_transition_item_project_proper_characterization _
       final_descriptors lst) as Hproperx.
     unfold final_state in Hproper. rewrite Htr_lst in Hproper.
     rewrite finite_trace_last_is_last in Hproper.
@@ -1817,7 +1816,7 @@ Proof.
     split; [| done]. apply finite_valid_trace_from_app_iff.
     split; [done |].
     assert (Hlst_trX' : valid_state_prop SeededX (finite_trace_last
-      (equivocators_state_project sub_IM initial_descriptors is) trX')).
+      (equivocators_state_project _ initial_descriptors is) trX')).
     { by apply (finite_valid_trace_last_pstate SeededX) in HtrX'. }
     destruct oitem as [item |]; inversion _Hprojectx; subst lstX; clear _Hprojectx
     ; [| by constructor].
@@ -1833,7 +1832,7 @@ Proof.
       revert Htr_to; apply VLSM_incl_finite_valid_trace_init_to.
       by apply seeded_no_equivocation_incl_preloaded.
     }
-    pose proof (pre_equivocators_valid_trace_project sub_IM _ _ _
+    pose proof (pre_equivocators_valid_trace_project _ _ _ _
      Hpre_tr_to final_descriptors' Hproper') as Hpr_tr'.
     destruct Hpr_tr' as [_initial_descriptors [_ [_trX' [_Hpr_trX' Heq_final_stateX']]]].
     replace (equivocators_trace_project _ _ _) with (Some (trX', initial_descriptors))
@@ -1861,7 +1860,7 @@ Proof.
     spec H; [by rewrite app_length; cbn; lia |].
     specialize (H tr' (conj Htr Hinit) eq_refl).
     assert (Hfinal_descriptors_m_proper :
-      proper_equivocator_descriptors sub_IM final_descriptors_m (finite_trace_last is tr'))
+      proper_equivocator_descriptors _ final_descriptors_m (finite_trace_last is tr'))
       by (apply not_equivocating_equivocator_descriptors_proper; done).
     specialize (H final_descriptors_m Hfinal_descriptors_m_proper).
     pose proof (pre_equivocators_valid_trace_project _ _ _ _
@@ -1891,9 +1890,9 @@ Proof.
 Qed.
 
 Lemma SeededXE_SeededX_vlsm_partial_projection
-  (final_descriptors : equivocator_descriptors sub_IM)
+  (final_descriptors : equivocator_descriptors _)
   : VLSM_partial_projection SeededXE SeededX
-      (equivocators_partial_trace_project sub_IM final_descriptors).
+      (equivocators_partial_trace_project _ final_descriptors).
 Proof.
   split; [split |].
   - intros s tr sX trX Hpr_tr s_pre pre Hs_lst Hpre_tr.
@@ -1906,13 +1905,12 @@ Proof.
     clear Hpre_tr. revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
     by apply equivocators_partial_trace_project_extends_left.
   - intros s tr sX trX Hpr_tr Htr.
-    destruct (destruct_equivocators_partial_trace_project sub_IM  Hpr_tr)
+    destruct (destruct_equivocators_partial_trace_project _  Hpr_tr)
       as [Hnot_equiv [initial_descriptors [Htr_project Hs_project]]].
     apply not_equivocating_equivocator_descriptors_proper in Hnot_equiv as Hproper.
     destruct (seeded_equivocators_valid_trace_project _ _ Htr _ Hproper)
       as [_trX [_initial_descriptors [_ [_Htr_project [_ HtrX]]]]].
-    rewrite Htr_project in _Htr_project.
-    by inversion _Htr_project; subst.
+    by unfold sub_IM in *; congruence.
 Qed.
 
 End sec_seeded_equivocators_valid_trace_project.


### PR DESCRIPTION
At the beginning of the module EquivocatorsCompositionProjections there was a big `Context` with abbreviations whose only purpose was to avoid writing one argument.
```
  (equivocator_descriptors := equivocator_descriptors IM)
  (equivocators_no_equivocations_vlsm := equivocators_no_equivocations_vlsm IM)
  (equivocators_state_project := equivocators_state_project IM)
  (equivocator_IM := equivocator_IM IM)
  (equivocator_descriptors_update := equivocator_descriptors_update IM)
  (proper_equivocator_descriptors := proper_equivocator_descriptors IM)
```
A very unpleasant side effect of these abbreviations was that in proof mode, they were cluttering the proof context, which decreased readability and necessitated lots of scrolling just to see what the goal is.

In this PR I removed these abbreviations by just writing out the `IM` argument in full (or sometimes, just `_`). The result is that the proof contexts are much shorter now and less scrolling is needed - overall, stepping over the proofs is much nicer now.

Some proofs required tiny fixes because a `Hint Unfold`, which was no longer necessary, was also removed.