### PR TITLE
add fin_set_subseteq_dec instance to FinSetExtras

### DIFF
--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -145,6 +145,14 @@ Proof.
     by rewrite size_singleton in Hun_size; lia.
 Qed.
 
+#[export] Instance fin_set_subseteq_dec : RelDecision (⊆@{C}).
+Proof.
+  intros X Y.
+  eapply @Decision_iff with (P := set_Forall (fun a => a ∈ Y) X).
+  - by set_solver.
+  - by typeclasses eauto.
+Qed.
+
 End sec_general.
 
 Section sec_filter.


### PR DESCRIPTION
This is what I believe is the proper place for a utility lemma we needed downstream. I think this instance should be harmless for those that import `FinSetExtras`, but otherwise an option is to hide it in a submodule that has to be imported like `Module Instances`.