### PR TITLE
add Coq 8.17 to CI

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:8.16-ocaml-4.14-flambda'
+          - 'coqorg/coq:8.17-ocaml-4.14-flambda'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/meta.yml
+++ b/meta.yml
@@ -65,6 +65,7 @@ dependencies:
 
 tested_coq_opam_versions:
 - version: '8.16-ocaml-4.14-flambda'
+- version: '8.17-ocaml-4.14-flambda'
 
 namespace: VLSM
 


### PR DESCRIPTION
I think it's a good idea as a general policy to support the latest two Coq versions with the project, as [Std++ does](https://gitlab.mpi-sws.org/iris/stdpp/#prerequisites). To this end, I add 8.17 to CI that must pass for a PR to be merged. Coq's compatibility policy ensures that this is always possible.

This means that we'd do a small "sliding window" of supported Coq versions going forward. For example, some time after Coq 8.18.0 is out, we switch to testing Coq 8.17 and 8.18.