### PR TITLE
consistently use parity_label definition in parity example

### DIFF
--- a/theories/VLSM/Core/Examples/Parity.v
+++ b/theories/VLSM/Core/Examples/Parity.v
@@ -168,7 +168,7 @@ Definition parity_label : label ParityVLSM := ().
 (** *** Example of an arbitrary transition *)
 
 Lemma parity_example_transition_1 `(X : VLSM message) :
-  transition ParityVLSM () ((5, 4), Some 10) = ((5, -6), Some 20).
+  transition ParityVLSM parity_label ((5, 4), Some 10) = ((5, -6), Some 20).
 Proof. done. Qed.
 
 (** *** Example of a valid trace *)
@@ -196,7 +196,7 @@ Proof. by apply initial_message_is_valid. Qed.
 Example parity_can_emit_4 : can_emit ParityVLSM 4.
 Proof.
   unfold can_emit.
-  exists ((2, 2), Some 2), (), (2, 0).
+  exists ((2, 2), Some 2), parity_label, (2, 0).
   repeat split; [| | done | done].
   - by apply initial_state_is_valid.
   - by apply parity_valid_message_prop_2.
@@ -398,7 +398,7 @@ Proof.
   intros m [n ->] Hmgt0.
   pose (s := (n, n)).
   unfold constrained_message_prop, can_emit; cbn.
-  exists (s, Some n), (), (n, 0).
+  exists (s, Some n), parity_label, (n, 0).
   repeat split.
   - by apply initial_state_is_valid; constructor; cbn; lia.
   - by apply any_message_is_valid_in_preloaded.
@@ -439,7 +439,7 @@ Proof.
   - by apply initial_state_is_valid; split; lia.
   - pose (s := (st.1, st.1)).
     unfold constrained_state_prop.
-    apply input_valid_transition_destination with (l := ()) (s := s)
+    apply input_valid_transition_destination with (l := parity_label) (s := s)
       (om := Some (st.1 - st.2)) (om' := Some (2 * (st.1 - st.2))).
     repeat split.
     + by apply initial_state_is_valid; constructor; cbn; lia.
@@ -497,7 +497,7 @@ Proof.
     pose (msgin := 2 ^ (x + 1)).
     pose (x' := (msgin, msgin)).
     apply emitted_messages_are_valid.
-    exists (x', Some (2 ^ (x + 1))), (), (x'.1, msgin - msgin); subst x' msgin; cbn.
+    exists (x', Some (2 ^ (x + 1))), parity_label, (x'.1, msgin - msgin); subst x' msgin; cbn.
     repeat split; [| by apply Hindh | by cbn | by lia |].
     + by apply initial_state_is_valid; constructor; cbn; lia.
     + by unfold transition; cbn; rewrite <- Z.pow_succ_r, Z.add_succ_l; [| lia].
@@ -553,7 +553,7 @@ Proof.
   destruct x; [.. | by lia].
   - by apply initial_state_is_valid; constructor; lia.
   - apply input_valid_transition_destination
-      with (l := ()) (s := (s.1, s.2 + 2)) (om := Some 2) (om' := Some 4).
+      with (l := parity_label) (s := (s.1, s.2 + 2)) (om := Some 2) (om' := Some 4).
     repeat split; cbn; [| | by lia | by lia |].
     + by eapply Hind with (y := Z.pos p - 1); cbn; lia.
     + by apply initial_message_is_valid.

--- a/theories/VLSM/Core/Examples/Parity.v
+++ b/theories/VLSM/Core/Examples/Parity.v
@@ -1,8 +1,6 @@
 From stdpp Require Import prelude finite.
 From VLSM.Core Require Import VLSM PreloadedVLSM VLSMProjections.
 
-#[local] Open Scope Z_scope.
-
 (** * Parity VLSM
 
   This module demonstrates some basic notions of the VLSM framework. The idea
@@ -12,6 +10,8 @@ From VLSM.Core Require Import VLSM PreloadedVLSM VLSMProjections.
   difference ([parity_valid_states_same_parity]). The definitions and lemmas tap into
   concepts such as valid and constrained traces, transitions, states, and messages.
 *)
+
+#[local] Open Scope Z_scope.
 
 (** ** General arithmetic results
 
@@ -62,9 +62,9 @@ Proof.
     by rewrite <- Zeven_unary_minus.
 Qed.
 
-(** ** General VLSM results and automation *)
+(** ** General automation *)
 
-(** *** Custom tactic used to simplify proofs on valid VLSM transitions *)
+(** Custom tactic used to simplify proofs on valid VLSM transitions *)
 
 Ltac app_valid_tran :=
   repeat split; cbn; try done;
@@ -74,16 +74,6 @@ Ltac app_valid_tran :=
   | |- valid_state_prop _ _ => by apply initial_state_is_valid
   | |- valid_state_prop _ _ => eapply input_valid_transition_destination
   end.
-
-(** *** Last transition of a valid VLSM trace is valid *)
-
-Lemma input_valid_transition_last `(X : VLSM message) :
-  forall (s f : state X) (tr tr' : list (transition_item X)) (li : transition_item X),
-    finite_valid_trace_from_to X s f tr' -> tr' = tr ++ [li] ->
-      input_valid_transition_item X (finite_trace_last s tr) li.
-Proof.
-  by intros * Htr; eapply input_valid_transition_to, valid_trace_forget_last.
-Qed.
 
 (** ** Definition of Parity VLSM
 
@@ -358,7 +348,7 @@ Lemma parity_example_valid_transition :
   input_valid_transition ParityVLSM parity_label
    ((8, 2), Some 2) ((8, 0), Some 4).
 Proof.
-  apply (input_valid_transition_last ParityVLSM
+  apply (finite_valid_trace_from_to_last_transition ParityVLSM
     parity_trace1_first_state parity_trace1_last_state
     parity_trace1_init parity_trace1 parity_trace1_last_item); [| done].
   by apply parity_valid_trace1.
@@ -373,7 +363,8 @@ Example parity_example_constrained_transition :
   input_valid_transition (pre_loaded_with_all_messages_vlsm ParityVLSM) parity_label
    ((5, 1), Some 1) ((5, 0), Some 2).
 Proof.
-  apply (input_valid_transition_last (pre_loaded_with_all_messages_vlsm ParityVLSM)
+  apply (finite_valid_trace_from_to_last_transition
+    (pre_loaded_with_all_messages_vlsm ParityVLSM)
     parity_trace2_init_first_state parity_trace2_last_state parity_trace2_init
     parity_trace2 parity_trace2_last_item); [| done].
   by apply parity_constrained_trace2.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -2617,6 +2617,15 @@ Proof.
     by eexists _, l0; apply Ht.
 Qed.
 
+(** The last transition of a valid VLSM trace is valid *)
+Lemma finite_valid_trace_from_to_last_transition `(X : VLSM message) :
+  forall (s f : state X) (tr tr' : list (transition_item X)) (li : transition_item X),
+    finite_valid_trace_from_to X s f tr' -> tr' = tr ++ [li] ->
+      input_valid_transition_item X (finite_trace_last s tr) li.
+Proof.
+  by intros * Htr; eapply input_valid_transition_to, valid_trace_forget_last.
+Qed.
+
 (** *** Properties of provably-equal VLSMs
 
   If we know that two VLSMs are provably equal, we could try rewriting by them.


### PR DESCRIPTION
Let's avoid confusing people with the `()` notation. This is on top of #261.