### PR TITLE
Decouple `annotated_vlsm` from its constraint

### DIFF
--- a/theories/VLSM/Core/AnnotatedVLSM.v
+++ b/theories/VLSM/Core/AnnotatedVLSM.v
@@ -2,6 +2,7 @@ From VLSM.Lib Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import ListExtras.
 From VLSM.Core Require Import VLSM PreloadedVLSM VLSMProjections Validator Composition.
+From VLSM.Core Require Import ConstrainedVLSM.
 
 (** * State-annotated VLSMs
 
@@ -49,8 +50,6 @@ Proof.
 Qed.
 
 Context
-  (annotated_constraint :
-    label annotated_type -> annotated_state * option message -> Prop)
   (annotated_transition_state :
     label annotated_type -> annotated_state * option message -> annotation)
   .
@@ -59,8 +58,7 @@ Definition annotated_valid
   (l : label annotated_type)
   (som : annotated_state * option message)
   : Prop :=
-  valid X l (original_state som.1, som.2) /\
-  annotated_constraint l som.
+  valid X l (original_state som.1, som.2).
 
 Definition annotated_transition
   (l : label annotated_type)
@@ -189,8 +187,8 @@ Context
     label (annotated_type X annotation) ->
       annotated_state X annotation * option message -> annotation)
   (AnnotatedX : VLSM message :=
-    annotated_vlsm X annotation initial_annotation_prop annotated_constraint
-      annotated_transition_state)
+    constrained_vlsm (annotated_vlsm X annotation initial_annotation_prop annotated_transition_state)
+      annotated_constraint)
   .
 
 Definition forget_annotations_projection
@@ -224,8 +222,9 @@ Context
     label (annotated_type Free annotation) ->
       annotated_state Free annotation * option message -> annotation)
   (AnnotatedFree : VLSM message :=
-    annotated_vlsm Free annotation initial_annotation_prop annotated_constraint
-      annotated_transition_state)
+    constrained_vlsm
+      (annotated_vlsm Free annotation initial_annotation_prop annotated_transition_state)
+      annotated_constraint)
   (i : index)
   .
 

--- a/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -62,8 +62,10 @@ Next Obligation.
 Proof. done. Defined.
 
 Definition coeqv_limited_equivocation_vlsm : VLSM message :=
-  annotated_vlsm (free_composite_vlsm IM) Cv (fun s => s = ∅)
-    coeqv_limited_equivocation_constraint coeqv_composite_transition_message_equivocators.
+  constrained_vlsm
+    (annotated_vlsm (free_composite_vlsm IM) Cv (fun s => s = ∅)
+      coeqv_composite_transition_message_equivocators)
+    coeqv_limited_equivocation_constraint.
 
 Definition coeqv_annotate_trace_with_equivocators :=
   annotate_trace (free_composite_vlsm IM) Cv (fun s => s = ∅)
@@ -249,9 +251,9 @@ Proof.
 Qed.
 
 Lemma annotated_free_input_valid_projection
-  iprop `{Inhabited (sig iprop)} constr trans
+  iprop `{Inhabited (sig iprop)} trans constr
   i li s om
-  : input_valid (annotated_vlsm (free_composite_vlsm IM) Cv iprop constr trans)
+  : input_valid (constrained_vlsm (annotated_vlsm (free_composite_vlsm IM) Cv iprop trans) constr)
       (existT i li) (s, om) ->
     input_valid (pre_loaded_with_all_messages_vlsm (IM i)) li (original_state s i, om).
 Proof.


### PR DESCRIPTION
Currently `annotated_vlsm` modifies the validity constraint of the underlying VLSM. The goal of this PR is to change it, so that the new `annotated_vlsm` deals only with the annotation, whereas the constraining is done by `constrained_vlsm`.