### PR TITLE
Use lemma `constrained_preloaded_incl` in a few places instead of reproving it inline

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -562,19 +562,12 @@ Proof.
   cbn; destruct (sender m) as [v |] eqn: Hsender; [| done]; cbn.
   case_decide as HAv; [| done].
   unfold sub_IM; cbn.
-  eapply VLSM_incl_valid_state in Hs; [| by apply VLSM_incl_constrained_vlsm].
-  apply (VLSM_incl_valid_state (vlsm_incl_pre_loaded_with_all_messages_vlsm
-    (free_composite_vlsm IM))) in Hs.
-  assert (Hpre_si : forall i, valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i)).
-  {
-    intro i.
-    revert Hs.
-    by apply valid_state_project_preloaded_to_preloaded_free.
-  }
   apply elem_of_elements, elem_of_difference in HAv as [_ HAv].
   destruct Hstrong_v as [(i & Hi & Hsent) | Hemitted].
   - apply valid_state_has_trace in Hs as (is & tr & Htr).
-    by eapply has_been_sent_iff_by_sender; [| | | exists i].
+    eapply has_been_sent_iff_by_sender; [done | | done | by exists i].
+    eapply VLSM_incl_finite_valid_trace_init_to in Htr; [done |].
+    by apply constrained_preloaded_incl.
   - by contradict HAv; apply elem_of_elements; eapply sub_can_emit_sender.
 Qed.
 

--- a/theories/VLSM/Core/ConstrainedVLSM.v
+++ b/theories/VLSM/Core/ConstrainedVLSM.v
@@ -339,12 +339,6 @@ Proof.
   by intros; apply basic_VLSM_strong_incl; cbv; [| itauto.. |].
 Qed.
 
-(*
-  TODO(traiansf): There are many places where, because the lemma below
-  was missing, it was either reproved locally, or multiple VLSM_incl_
-  lemmas were used to achieve a similar result. It would be nice to
-  find those usages and use this lemma instad.
-*)
 Lemma constrained_preloaded_incl :
   VLSM_incl (constrained_vlsm X constraint) (pre_loaded_with_all_messages_vlsm X).
 Proof.
@@ -511,7 +505,8 @@ Proof.
   intros l som Hv.
   apply Hpre_subsumption.
   destruct som.
-  by apply (VLSM_incl_input_valid (vlsm_incl_pre_loaded_with_all_messages_vlsm X1)).
+  eapply VLSM_incl_input_valid; [| done].
+  by apply (vlsm_incl_pre_loaded_with_all_messages_vlsm X1).
 Qed.
 
 Lemma strong_constraint_subsumption_strongest

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -489,8 +489,8 @@ Proof.
     + intros m Hobs; exfalso.
       eapply (@has_been_directly_observed_no_inits _ Free); [done |].
       by apply composite_has_been_directly_observed_free_iff.
-  - apply (VLSM_incl_input_valid_transition
-      (constrained_preloaded_incl (free_composite_vlsm IM) _)) in Ht as Hpre_t.
+  - eapply (VLSM_incl_input_valid_transition) in Ht as Hpre_t;
+      [| by apply constrained_preloaded_incl].
     assert (Hfuture_s : in_futures PreFree s base_s).
     {
       destruct Hfuture as [tr' Htr'].
@@ -566,8 +566,7 @@ Lemma fixed_directly_observed_has_strong_fixed_equivocation f
   (Hobs : composite_has_been_directly_observed IM f m)
   : strong_fixed_equivocation IM equivocators f m.
 Proof.
-  apply (VLSM_incl_valid_state (constrained_preloaded_incl
-    (free_composite_vlsm IM) _)) in Hf as Hfuture.
+  eapply VLSM_incl_valid_state in Hf as Hfuture; [| by apply constrained_preloaded_incl].
   apply in_futures_refl in Hfuture.
   apply valid_state_has_trace in Hf as [is [tr Htr]].
   eapply fixed_finite_valid_trace_sub_projection_helper in Htr as Htr_pr; [| done].
@@ -616,8 +615,7 @@ Proof.
   apply input_valid_transition_origin in Ht as Hs.
   apply fixed_output_has_strong_fixed_equivocation_helper with s sf l iom.
   - intros m Hobs. apply in_futures_preserves_strong_fixed_equivocation with s.
-    + apply (VLSM_incl_input_valid_transition
-        (constrained_preloaded_incl (free_composite_vlsm IM) _)) in Ht.
+    + eapply VLSM_incl_input_valid_transition in Ht; [| by apply constrained_preloaded_incl].
       by eapply (input_valid_transition_in_futures PreFree).
     + by apply fixed_directly_observed_has_strong_fixed_equivocation.
   - apply input_valid_transition_in_futures in Ht.

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -88,14 +88,6 @@ Proof.
   by apply VLSM_incl_constrained_vlsm.
 Qed.
 
-Lemma fixed_equivocation_vlsm_composition_incl_preloaded_free
-  : VLSM_incl fixed_equivocation_vlsm_composition (pre_loaded_with_all_messages_vlsm Free).
-Proof.
-  apply VLSM_incl_trans with Free.
-  - by apply fixed_equivocation_vlsm_composition_incl_free.
-  - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
-Qed.
-
 (** ** A (seemingly) stronger definition for fixed-set equivocation
 
   A seemingly stronger fixed equivocation constraint requires that a received
@@ -302,12 +294,6 @@ Context
 
 Definition Fixed_incl_Free : VLSM_incl Fixed Free := VLSM_incl_constrained_vlsm _ _.
 
-Lemma Fixed_incl_Preloaded : VLSM_incl Fixed (pre_loaded_with_all_messages_vlsm Free).
-Proof.
-  eapply VLSM_incl_trans; [by apply Fixed_incl_Free |].
-  by apply (vlsm_incl_pre_loaded_with_all_messages_vlsm Free).
-Qed.
-
 Lemma preloaded_Fixed_incl_Preloaded :
   VLSM_incl (pre_loaded_with_all_messages_vlsm Fixed) (pre_loaded_with_all_messages_vlsm Free).
 Proof.
@@ -317,12 +303,6 @@ Qed.
 Lemma StrongFixed_incl_Free : VLSM_incl StrongFixed Free.
 Proof.
   exact (VLSM_incl_constrained_vlsm _ _).
-Qed.
-
-Lemma StrongFixed_incl_Preloaded : VLSM_incl StrongFixed (pre_loaded_with_all_messages_vlsm Free).
-Proof.
-  eapply VLSM_incl_trans; [by apply StrongFixed_incl_Free |].
-  by apply (vlsm_incl_pre_loaded_with_all_messages_vlsm Free).
 Qed.
 
 Lemma in_futures_preserves_sent_by_non_equivocating s base_s
@@ -468,7 +448,8 @@ Proof.
       (preloaded_component_projection IM (projT1 l))) in Hfuture.
     apply in_futures_preserving_oracle_from_stepwise with (field_selector output) (sf (projT1 l))
     ; [by apply has_been_sent_stepwise_props | done |].
-    apply (VLSM_incl_input_valid_transition Fixed_incl_Preloaded) in Ht.
+    apply (VLSM_incl_input_valid_transition
+      (constrained_preloaded_incl (free_composite_vlsm IM) _)) in Ht.
     specialize (VLSM_projection_input_valid_transition
       (preloaded_component_projection IM (projT1 l)) l (projT2 l)) as Hproject.
     spec Hproject.
@@ -508,7 +489,8 @@ Proof.
     + intros m Hobs; exfalso.
       eapply (@has_been_directly_observed_no_inits _ Free); [done |].
       by apply composite_has_been_directly_observed_free_iff.
-  - apply (VLSM_incl_input_valid_transition Fixed_incl_Preloaded) in Ht as Hpre_t.
+  - apply (VLSM_incl_input_valid_transition
+      (constrained_preloaded_incl (free_composite_vlsm IM) _)) in Ht as Hpre_t.
     assert (Hfuture_s : in_futures PreFree s base_s).
     {
       destruct Hfuture as [tr' Htr'].
@@ -569,7 +551,8 @@ Proof.
     apply proj2 in Htr.
     by specialize (composite_initial_state_sub_projection IM (elements equivocators) is Htr).
   - apply in_futures_refl. apply valid_trace_last_pstate in Htr.
-    by apply (VLSM_incl_valid_state Fixed_incl_Preloaded).
+    apply VLSM_incl_valid_state; [| done].
+    by apply constrained_preloaded_incl.
 Qed.
 
 (**
@@ -583,7 +566,8 @@ Lemma fixed_directly_observed_has_strong_fixed_equivocation f
   (Hobs : composite_has_been_directly_observed IM f m)
   : strong_fixed_equivocation IM equivocators f m.
 Proof.
-  apply (VLSM_incl_valid_state Fixed_incl_Preloaded) in Hf as Hfuture.
+  apply (VLSM_incl_valid_state (constrained_preloaded_incl
+    (free_composite_vlsm IM) _)) in Hf as Hfuture.
   apply in_futures_refl in Hfuture.
   apply valid_state_has_trace in Hf as [is [tr Htr]].
   eapply fixed_finite_valid_trace_sub_projection_helper in Htr as Htr_pr; [| done].
@@ -632,13 +616,15 @@ Proof.
   apply input_valid_transition_origin in Ht as Hs.
   apply fixed_output_has_strong_fixed_equivocation_helper with s sf l iom.
   - intros m Hobs. apply in_futures_preserves_strong_fixed_equivocation with s.
-    + apply (VLSM_incl_input_valid_transition Fixed_incl_Preloaded) in Ht.
+    + apply (VLSM_incl_input_valid_transition
+        (constrained_preloaded_incl (free_composite_vlsm IM) _)) in Ht.
       by eapply (input_valid_transition_in_futures PreFree).
     + by apply fixed_directly_observed_has_strong_fixed_equivocation.
   - apply input_valid_transition_in_futures in Ht.
     by apply fixed_valid_state_sub_projection.
   - apply in_futures_refl. apply input_valid_transition_destination in Ht.
-    by apply (VLSM_incl_valid_state Fixed_incl_Preloaded).
+    apply VLSM_incl_valid_state; [| done].
+    by apply constrained_preloaded_incl.
   - done.
 Qed.
 

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -216,14 +216,9 @@ Proof.
     intro Hincl; unfold tracewise_not_heavy, not_heavy.
     by etransitivity; [apply sum_weights_subseteq |].
   }
-  assert (StrongFixedinclPreFree : VLSM_incl StrongFixed PreFree).
-  {
-    apply VLSM_incl_trans with Free.
-    - by apply VLSM_incl_constrained_vlsm.
-    - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
-  }
   apply valid_state_has_trace in Hs as [is [tr Htr]].
-  apply (VLSM_incl_finite_valid_trace_init_to StrongFixedinclPreFree) in Htr as Hpre_tr.
+  eapply VLSM_incl_finite_valid_trace_init_to in Htr as Hpre_tr;
+    [| by apply constrained_preloaded_incl].
   intros v Hv.
   apply equivocating_validators_is_equivocating_tracewise_iff in Hv as Hvs'.
   specialize (Hvs' _ _ Hpre_tr).
@@ -233,17 +228,18 @@ Proof.
   change (pre ++ item :: suf) with (pre ++ [item] ++ suf) in Htr.
   apply (finite_valid_trace_from_to_app_split StrongFixed) in Htr.
   destruct Htr as [Hpre Hitem].
-  apply (VLSM_incl_finite_valid_trace_from_to StrongFixedinclPreFree) in Hpre as Hpre_pre.
+  eapply VLSM_incl_finite_valid_trace_from_to in Hpre as Hpre_pre;
+    [| by apply constrained_preloaded_incl].
   apply valid_trace_last_pstate in Hpre_pre as Hs_pre.
   apply (finite_valid_trace_from_to_app_split StrongFixed), proj1 in Hitem.
   inversion Hitem; subst; clear Htl Hitem. simpl in Hm0. subst.
   destruct Ht as [(_ & _ & _ & Hc) _].
   destruct Hc as [(i & Hi & Hsenti) | Hemit].
-  + assert (Hsent : composite_has_been_sent IM (finite_trace_last is pre) m0)
+  - assert (Hsent : composite_has_been_sent IM (finite_trace_last is pre) m0)
       by (exists i; done).
     apply (composite_proper_sent IM) in Hsent; [| done].
     by specialize (Hsent _ _ (conj Hpre_pre Hinit)).
-  + apply (SubProjectionTraces.sub_can_emit_sender IM (elements equivocators)
+  - apply (SubProjectionTraces.sub_can_emit_sender IM (elements equivocators)
       A sender Hsender_safety _ _ v), elem_of_elements in Hemit; [| done].
     by revert Hemit; apply elem_of_set_map_inj.
 Qed.

--- a/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
@@ -243,9 +243,7 @@ Lemma equivocators_no_equivocations_vlsm_incl_PreFree :
     equivocators_no_equivocations_vlsm
     (pre_loaded_with_all_messages_vlsm equivocators_free_vlsm).
 Proof.
-  apply VLSM_incl_trans with equivocators_free_vlsm.
-  apply equivocators_no_equivocations_vlsm_incl_equivocators_free.
-  by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  by apply constrained_preloaded_incl.
 Qed.
 
 Lemma preloaded_equivocators_no_equivocations_vlsm_incl_PreFree :

--- a/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
@@ -238,14 +238,6 @@ Proof.
   - by destruct 1.
 Qed.
 
-Lemma equivocators_no_equivocations_vlsm_incl_PreFree :
-  VLSM_incl
-    equivocators_no_equivocations_vlsm
-    (pre_loaded_with_all_messages_vlsm equivocators_free_vlsm).
-Proof.
-  by apply constrained_preloaded_incl.
-Qed.
-
 Lemma preloaded_equivocators_no_equivocations_vlsm_incl_PreFree :
   VLSM_incl
     (pre_loaded_with_all_messages_vlsm equivocators_no_equivocations_vlsm)

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -1930,8 +1930,8 @@ Proof.
     assert
       (HPreFree_pre_tr : finite_valid_trace_from PreFreeE s_pre (pre ++ tr)).
     {
-      revert Hpre_tr; apply VLSM_incl_finite_valid_trace_from.
-      by apply equivocators_no_equivocations_vlsm_incl_PreFree.
+      apply VLSM_incl_finite_valid_trace_from; [| done].
+      by apply constrained_preloaded_incl.
     }
     clear Hpre_tr.  revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
     by apply equivocators_partial_trace_project_extends_left.
@@ -2085,8 +2085,8 @@ Proof.
   rewrite decide_True in Hsim by done.
   assert (HPreFree_tr : finite_valid_trace_from PreFreeE is tr).
   {
-    revert Htr; apply VLSM_incl_finite_valid_trace_from.
-    by apply equivocators_no_equivocations_vlsm_incl_PreFree.
+    apply VLSM_incl_finite_valid_trace_from; [| done].
+    by apply constrained_preloaded_incl.
   }
   apply not_equivocating_equivocator_descriptors_proper in Hproper.
   destruct
@@ -2127,12 +2127,12 @@ Proof.
   constructor; [constructor |].
   - intros * Htr. apply PreFreeE_Free_vlsm_projection_type.
     apply VLSM_incl_finite_valid_trace_from; [| done].
-    by apply equivocators_no_equivocations_vlsm_incl_PreFree.
+    by apply constrained_preloaded_incl.
   - intros * Htr.
     assert (Hpre_tr : finite_valid_trace PreFreeE sX trX).
     {
       apply VLSM_incl_finite_valid_trace; [| done].
-      by apply equivocators_no_equivocations_vlsm_incl_PreFree.
+      by apply constrained_preloaded_incl.
     }
     specialize
      (VLSM_partial_projection_finite_valid_trace

--- a/theories/VLSM/Core/Equivocators/FixedEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocation.v
@@ -158,9 +158,7 @@ Lemma equivocators_fixed_equivocations_vlsm_incl_PreFree :
   VLSM_incl equivocators_fixed_equivocations_vlsm
     (pre_loaded_with_all_messages_vlsm (free_composite_vlsm equivocator_IM)).
 Proof.
-  apply VLSM_incl_trans with (free_composite_vlsm equivocator_IM).
-  - by apply equivocators_fixed_equivocations_vlsm_incl_free.
-  - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  by apply constrained_preloaded_incl.
 Qed.
 
 (** Inclusion of preloaded machine into the preloaded free composition. *)
@@ -652,10 +650,9 @@ Proof.
   rewrite Hfinal_state.
 
   assert (Htr_Pre : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) is tr).
-  { revert Htr. apply VLSM_incl_finite_valid_trace.
-    apply VLSM_incl_trans with FreeE;
-    [| by apply vlsm_incl_pre_loaded_with_all_messages_vlsm].
-    apply equivocators_fixed_equivocations_vlsm_incl_free.
+  {
+    apply VLSM_incl_finite_valid_trace; [| done].
+    by apply constrained_preloaded_incl.
   }
 
   assert (HtrX_Pre : finite_valid_trace (pre_loaded_with_all_messages_vlsm Free)
@@ -788,10 +785,9 @@ Proof.
     by apply finite_valid_trace_last_pstate, HtrXPre.
   }
   assert (Htr_free : finite_valid_trace  (pre_loaded_with_all_messages_vlsm FreeE) is tr).
-  { revert Htr.  apply VLSM_incl_finite_valid_trace.
-    apply VLSM_incl_trans with FreeE
-    ; [by apply equivocators_fixed_equivocations_vlsm_incl_free |].
-    by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+  {
+    apply VLSM_incl_finite_valid_trace; [| done].
+    by apply constrained_preloaded_incl.
   }
   subst tr.
   destruct Htr as [Htr His].
@@ -805,10 +801,8 @@ Proof.
   assert (Hsuf_free : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE)
     (finite_trace_last is pre) ([item] ++ suf)).
   {
-    revert Hsuf; apply VLSM_incl_finite_valid_trace_from.
-    apply VLSM_incl_trans with FreeE
-    ; [by apply equivocators_fixed_equivocations_vlsm_incl_free |].
-    by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+    apply VLSM_incl_finite_valid_trace_from; [| done].
+    by apply constrained_preloaded_incl.
   }
   assert (Hs_free : valid_state_prop  (pre_loaded_with_all_messages_vlsm FreeE) s).
   { apply finite_valid_trace_last_pstate in Hsuf_free. subst s.
@@ -941,10 +935,8 @@ Proof.
   assert (Hsufpre :
     finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE) (destination item) suf).
   {
-    revert Hsuf. apply VLSM_incl_finite_valid_trace_from.
-    apply VLSM_incl_trans with FreeE.
-    - by apply equivocators_fixed_equivocations_vlsm_incl_free.
-    - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+    eapply VLSM_incl_finite_valid_trace_from; [| done].
+    by apply constrained_preloaded_incl.
   }
   specialize
     (equivocators_trace_project_preserves_proper_fixed_equivocator_descriptors _ _ Hsufpre
@@ -1134,10 +1126,8 @@ Proof.
   destruct Hs as [is [tr Htr]].
   assert (Htr'pre : finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm FreeE) is s tr).
   {
-    revert Htr; apply VLSM_incl_finite_valid_trace_init_to.
-    apply VLSM_incl_trans with FreeE.
-    - by apply VLSM_incl_constrained_vlsm.
-    - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
+    apply VLSM_incl_finite_valid_trace_init_to; [| done].
+    by apply constrained_preloaded_incl.
   }
   assert (Hplst : valid_state_prop (pre_loaded_with_all_messages_vlsm FreeE) s)
     by (apply valid_trace_last_pstate in Htr'pre; done).

--- a/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
@@ -68,8 +68,7 @@ Proof.
   pose proof (HinclE :=
     equivocators_fixed_equivocations_vlsm_incl_PreFree IM (elements equivocating)).
   apply sent_by_non_equivocating_are_sent in Hm.
-  pose proof (Hincl := StrongFixed_incl_Preloaded IM equivocating).
-  apply (VLSM_incl_valid_state Hincl) in Hs.
+  apply (VLSM_incl_valid_state (constrained_preloaded_incl (free_composite_vlsm IM) _)) in Hs.
   eapply sent_valid; [done |].
   revert Hm; apply (VLSM_incl_valid_state HinclE) in Heqv_state_s.
   by specialize

--- a/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
@@ -68,7 +68,7 @@ Proof.
   pose proof (HinclE :=
     equivocators_fixed_equivocations_vlsm_incl_PreFree IM (elements equivocating)).
   apply sent_by_non_equivocating_are_sent in Hm.
-  apply (VLSM_incl_valid_state (constrained_preloaded_incl (free_composite_vlsm IM) _)) in Hs.
+  eapply VLSM_incl_valid_state in Hs; [| by apply constrained_preloaded_incl].
   eapply sent_valid; [done |].
   revert Hm; apply (VLSM_incl_valid_state HinclE) in Heqv_state_s.
   by specialize

--- a/theories/VLSM/Core/Equivocators/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/LimitedStateEquivocation.v
@@ -93,13 +93,6 @@ Proof.
   by apply VLSM_incl_constrained_vlsm.
 Qed.
 
-(** Inclusion in the preloaded free composition. *)
-Lemma equivocators_limited_equivocations_vlsm_incl_preloaded_free
-  : VLSM_incl equivocators_limited_equivocations_vlsm PreFreeE.
-Proof.
-  by apply constrained_preloaded_incl.
-Qed.
-
 (** Inclusion of preloaded machine in the preloaded free composition. *)
 Lemma preloaded_equivocators_limited_equivocations_vlsm_incl_free
   : VLSM_incl (pre_loaded_with_all_messages_vlsm equivocators_limited_equivocations_vlsm) PreFreeE.
@@ -351,8 +344,8 @@ Proof.
     assert (HPreFree_pre_tr :
       finite_valid_trace_from (pre_loaded_with_all_messages_vlsm FreeE) s_pre (pre ++ tr)).
     {
-      revert Hpre_tr; apply VLSM_incl_finite_valid_trace_from.
-      by apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
+      apply VLSM_incl_finite_valid_trace_from; [| done].
+      by apply constrained_preloaded_incl.
     }
     clear Hpre_tr.  revert s tr sX trX Hpr_tr s_pre pre Hs_lst HPreFree_pre_tr.
     by apply equivocators_partial_trace_project_extends_left.
@@ -378,12 +371,12 @@ Proof.
   constructor; [constructor |]; intros ? *.
   - intros HtrX. apply PreFreeE_Free_vlsm_projection_type.
     revert HtrX. apply VLSM_incl_finite_valid_trace_from.
-    by apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
+    by apply constrained_preloaded_incl.
   - intro HtrX.
     assert (Hpre_tr : finite_valid_trace (pre_loaded_with_all_messages_vlsm FreeE) sX trX).
     {
-      revert HtrX; apply VLSM_incl_finite_valid_trace.
-      by apply equivocators_limited_equivocations_vlsm_incl_preloaded_free.
+      apply VLSM_incl_finite_valid_trace; [| done].
+      by apply constrained_preloaded_incl.
     }
     specialize (VLSM_partial_projection_finite_valid_trace
       (limited_equivocators_vlsm_partial_projection (zero_descriptor IM))

--- a/theories/VLSM/Core/Equivocators/LimitedStateEquivocation.v
+++ b/theories/VLSM/Core/Equivocators/LimitedStateEquivocation.v
@@ -97,10 +97,7 @@ Qed.
 Lemma equivocators_limited_equivocations_vlsm_incl_preloaded_free
   : VLSM_incl equivocators_limited_equivocations_vlsm PreFreeE.
 Proof.
-  specialize equivocators_limited_equivocations_vlsm_incl_free as Hincl1.
-  specialize (vlsm_incl_pre_loaded_with_all_messages_vlsm FreeE)
-    as Hincl2.
-  by eapply VLSM_incl_trans.
+  by apply constrained_preloaded_incl.
 Qed.
 
 (** Inclusion of preloaded machine in the preloaded free composition. *)

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -316,10 +316,8 @@ Proof.
   exists _li, (sX i).
   repeat split; [| by apply any_message_is_valid_in_preloaded | by apply Hv].
   apply (VLSM_projection_valid_state (preloaded_component_projection IM i)).
-  apply (VLSM_incl_valid_state (vlsm_incl_pre_loaded_with_all_messages_vlsm
-    (free_composite_vlsm IM))).
   apply VLSM_incl_valid_state; [| done].
-  by apply VLSM_incl_constrained_vlsm.
+  by apply constrained_preloaded_incl.
 Qed.
 
 Lemma induced_sub_projection_transition_is_composite l s om

--- a/theories/VLSM/Core/SubProjectionTraces.v
+++ b/theories/VLSM/Core/SubProjectionTraces.v
@@ -404,12 +404,6 @@ Definition finite_trace_sub_projection_app
     pre_VLSM_projection_finite_trace_project_app (composite_type IM) _
       composite_label_sub_projection_option composite_state_sub_projection tr1 tr2.
 
-Lemma X_incl_Pre : VLSM_incl X Pre.
-Proof.
-  apply VLSM_incl_trans with (free_composite_vlsm IM).
-  - by apply VLSM_incl_constrained_vlsm.
-  - by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
-Qed.
 
 Lemma finite_trace_sub_projection_last_state
   (start : composite_state IM)
@@ -627,13 +621,15 @@ Lemma valid_state_sub_projection
 Proof.
   apply valid_state_has_trace in Hps.
   destruct Hps as [is [tr Htr]].
-  specialize (Hs _ _ (VLSM_incl_finite_valid_trace_init_to X_incl_Pre _ _ _ Htr)).
+  specialize (Hs _ _ (VLSM_incl_finite_valid_trace_init_to
+    (constrained_preloaded_incl (free_composite_vlsm IM) constraint) _ _ _ Htr)).
   apply valid_trace_get_last in Htr as Hlst.
   apply valid_trace_forget_last in Htr.
   specialize (finite_trace_sub_projection_last_state _ _ (proj1 Htr)) as Hlst'.
   apply (finite_valid_trace_sub_projection _ _ Hs) in Htr as Hptr.
-  - destruct Hptr as [Hptr _]. apply finite_valid_trace_last_pstate in Hptr.
-    by cbn in *; rewrite Hlst' in Hptr; subst.
+  destruct Hptr as [Hptr _].
+  apply finite_valid_trace_last_pstate in Hptr.
+  by cbn in *; rewrite Hlst' in Hptr; subst.
 Qed.
 
 Lemma finite_valid_trace_from_sub_projection
@@ -659,7 +655,7 @@ Proof.
     by rewrite Hpre_lst in Htr.
   - specialize (Hmsg is (pre ++ tr)).
     apply Hmsg.
-    apply (VLSM_incl_finite_valid_trace_init_to X_incl_Pre).
+    apply VLSM_incl_finite_valid_trace_init_to; [by apply constrained_preloaded_incl |].
     apply valid_trace_add_last; [done |].
     rewrite finite_trace_last_app.
     by unfold lst; subst.

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -969,9 +969,7 @@ Lemma pre_loaded_with_all_messages_self_validator_vlsm_eq
 Proof.
   split.
   - by apply pre_loaded_with_all_messages_self_validator_vlsm_incl.
-  - pose (vlsm_incl_pre_loaded_with_all_messages_vlsm X) as Hincl.
-    destruct X as (T, M).
-    by apply Hincl.
+  - by apply (vlsm_incl_pre_loaded_with_all_messages_vlsm X).
 Qed.
 
 End sec_self_validator_vlsm.


### PR DESCRIPTION
There was a TODO mark in ConstrainedVLSM.v which suggested that the lemma `constrained_preloaded_incl` was being reproved inline in many places. I tried to hunt down these and use the lemma instead.