### PR TITLE
Refactor many things related to `Context`s

### DIFF
--- a/theories/VLSM/Core/ByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces.v
@@ -163,10 +163,10 @@ Qed.
 Section sec_pre_loaded_with_all_messages_byzantine_alt.
 
 Context
-    (PreLoaded := pre_loaded_with_all_messages_vlsm M)
-    (Alt1 := binary_free_composition_fst M emit_any_message_vlsm)
-    (Alt := binary_free_composition M emit_any_message_vlsm)
-    .
+  (PreLoaded := pre_loaded_with_all_messages_vlsm M)
+  (Alt1 := binary_free_composition_fst M emit_any_message_vlsm)
+  (Alt := binary_free_composition M emit_any_message_vlsm)
+  .
 
 (**
   Let <<PreLoaded>> denote the [pre_loaded_with_all_messages_vlsm] of <<M>>, <<Alt>> denote

--- a/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/VLSM/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -94,10 +94,8 @@ Context
   (non_byzantine : Ci := difference (list_to_set (enum index)) byzantine)
   (Hlimit : (sum_weights byzantine_vs <= threshold)%R)
   (PreNonByzantine := pre_loaded_fixed_non_byzantine_vlsm IM byzantine A sender)
-  (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) validator Cv threshold
+  (HBE : BasicEquivocation (composite_state IM) validator Cv threshold
     := equivocation_dec_tracewise IM threshold A sender)
-  (tracewise_not_heavy := not_heavy (1 := Htracewise_BasicEquivocation))
-  (tracewise_equivocating_validators := equivocating_validators (1 := Htracewise_BasicEquivocation))
   .
 
 (**
@@ -107,12 +105,12 @@ Context
 Lemma limited_PreNonByzantine_valid_state_lift_not_heavy s
   (Hs : valid_state_prop PreNonByzantine s)
   (sX := lift_sub_state IM (elements non_byzantine) s)
-  : tracewise_not_heavy sX.
+  : not_heavy (1 := HBE) sX.
 Proof.
-  cut (tracewise_equivocating_validators sX ⊆ byzantine_vs).
+  cut (equivocating_validators (1 := HBE) sX ⊆ byzantine_vs).
   {
     intro Hincl.
-    unfold tracewise_not_heavy, not_heavy.
+    unfold not_heavy.
     transitivity (sum_weights byzantine_vs); [| done].
     apply sum_weights_subseteq_list.
     - by apply NoDup_elements.
@@ -166,7 +164,7 @@ Proof.
       by apply elem_of_list_to_set, elem_of_enum.
 Qed.
 
-Existing Instance Htracewise_BasicEquivocation.
+Existing Instance HBE.
 
 (**
   When replacing the byzantine components of a composite [valid_state] with
@@ -298,8 +296,6 @@ Context
     IM threshold full_message_dependencies sender)
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   (Hchannel : channel_authentication_prop IM A sender)
-  (Hsender_safety : sender_safety_alt_prop IM A sender :=
-    channel_authentication_sender_safety _ _ _ Hchannel)
   (Hvalidator :
     forall i : index,
       msg_dep_limited_equivocation_message_validator_prop (Cv := Cv)

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1143,7 +1143,8 @@ End sec_composite_plan_properties.
 
 Section sec_empty_composition_properties.
 
-Context {message : Type}
+Context
+  {message : Type}
   `{finite.Finite index}
   (IM : index -> VLSM message)
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)

--- a/theories/VLSM/Core/ConstrainedVLSM.v
+++ b/theories/VLSM/Core/ConstrainedVLSM.v
@@ -15,7 +15,8 @@ Section sec_constrained_vlsm.
 Context
   {message : Type}
   (X : VLSM message)
-  (constraint : label X -> state X * option message -> Prop).
+  (constraint : label X -> state X * option message -> Prop)
+  .
 
 Definition constrained_vlsm_type : VLSMType message :=
   vtype X.
@@ -62,7 +63,8 @@ Section sec_constrained_vlsm_lemmas.
 Context
   {message : Type}
   (X : VLSM message)
-  (constraint : label X -> state X * option message -> Prop).
+  (constraint : label X -> state X * option message -> Prop)
+  .
 
 Lemma option_initial_message_prop_constrained_vlsm :
   forall om : option message,
@@ -328,7 +330,8 @@ Section sec_constraint_subsumption.
 
 Context
   `(X : VLSM message)
-  (constraint : label X -> state X * option message -> Prop).
+  (constraint : label X -> state X * option message -> Prop)
+  .
 
 Lemma constrained_pre_loaded_vlsm_incl_pre_loaded_with_all_messages :
   forall (P : message -> Prop),

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -23,9 +23,7 @@ Context
   {Address : Type}
   (State := @State Address)
   (Observation := @Observation Address)
-  (Message := @Message Address).
-
-Context
+  (Message := @Message Address)
   {measurable_Address : Measurable Address}
   `{FinSet Address Ca}
   (threshold : R)
@@ -1301,7 +1299,9 @@ End sec_MessageDependencies_ELMOComponent.
 
 Section sec_ELMOProtocol.
 
-Context `{Inhabited index}.
+Context
+  `{Inhabited index}
+  .
 
 (** ** Protocol
 

--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1428,7 +1428,8 @@ Global Hint Mode ComputableReceivedMessages - ! : typeclass_instances.
 Section sec_computable_sent_received_observed.
 
 Context
-  `(vlsm : VLSM message).
+  `(vlsm : VLSM message)
+  .
 
 Lemma computable_messages_oracle_initial_state_empty
   `(Hrm : computable_messages_oracle vlsm oracle_set message_selector)
@@ -1934,15 +1935,15 @@ Proof.
 Qed.
 
 Context
-      {validator : Type}
-      `{finite.Finite validator}
-      {measurable_V : Measurable validator}
-      (threshold : R)
-      `{FinSet validator Cv}
-      `{!ReachableThreshold validator Cv threshold}
-      (A : validator -> index)
-      (sender : message -> option validator)
-      .
+  {validator : Type}
+  `{finite.Finite validator}
+  {measurable_V : Measurable validator}
+  (threshold : R)
+  `{FinSet validator Cv}
+  `{!ReachableThreshold validator Cv threshold}
+  (A : validator -> index)
+  (sender : message -> option validator)
+  .
 
 Definition node_signed_message (node_idx : index) (m : message) : Prop :=
   option_map A (sender m) = Some node_idx.
@@ -2678,7 +2679,8 @@ Proof.
 Qed.
 
 Context
-  (Hno_resend : cannot_resend_message_stepwise_prop).
+  (Hno_resend : cannot_resend_message_stepwise_prop)
+  .
 
 Lemma input_valid_transition_received_not_resent l s m s' om'
   (Ht : input_valid_transition (pre_loaded_with_all_messages_vlsm X) l (s, Some m) (s', om'))
@@ -2804,15 +2806,13 @@ Context
   (X : VLSM message)
   (Hbs1 : HasBeenSentCapability X)
   (Hbs2 : HasBeenSentCapability X)
-  (has_been_sent1 := @has_been_sent _ X Hbs1)
-  (has_been_sent2 := @has_been_sent _ X Hbs2)
   .
 
 Lemma has_been_sent_irrelevance
   (s : state (pre_loaded_with_all_messages_vlsm X))
   (m : message)
   (Hs : valid_state_prop (pre_loaded_with_all_messages_vlsm X) s)
-  : has_been_sent1 s m -> has_been_sent2 s m.
+  : @has_been_sent _ X Hbs1 s m -> @has_been_sent _ X Hbs2 s m.
 Proof.
   intro H.
   apply proper_sent in H; [| done].
@@ -2868,7 +2868,7 @@ Context
   {message : Type}
   (X : VLSM message)
   `{HasBeenReceivedCapability message X}
-.
+  .
 
 Lemma has_been_received_in_state s1 m :
   valid_state_prop X s1 ->

--- a/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/FixedSetEquivocation.v
@@ -28,10 +28,6 @@ Context
   `{forall i : index, HasBeenSentCapability (IM i)}
   `{forall i : index, HasBeenReceivedCapability (IM i)}
   (equivocating : Ci)
-  (Free := free_composite_vlsm IM)
-  (index_equivocating_prop : index -> Prop := sub_index_prop (elements equivocating))
-  (equivocating_index : Type := sub_index (elements equivocating))
-  (equivocating_IM := sub_IM IM (elements equivocating))
   .
 
 (**
@@ -39,7 +35,7 @@ Context
   nodes which are allowed to equivocate.
 *)
 Definition free_equivocating_vlsm_composition : VLSM message :=
-  free_composite_vlsm equivocating_IM.
+  free_composite_vlsm (sub_IM IM (elements equivocating)).
 
 (**
   [pre_loaded_free_equivocating_vlsm_composition] preloads the free composition
@@ -83,7 +79,7 @@ Definition fixed_equivocation_vlsm_composition : VLSM message
   := composite_vlsm IM fixed_equivocation_constraint.
 
 Lemma fixed_equivocation_vlsm_composition_incl_free
-  : VLSM_incl fixed_equivocation_vlsm_composition Free.
+  : VLSM_incl fixed_equivocation_vlsm_composition (free_composite_vlsm IM).
 Proof.
   by apply VLSM_incl_constrained_vlsm.
 Qed.

--- a/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/LimitedMessageEquivocation.v
@@ -133,11 +133,11 @@ Context
   (A : validator -> index)
   (sender : message -> option validator)
   `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM A sender)}
-  (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) validator Cv threshold
+  (HBE : BasicEquivocation (composite_state IM) validator Cv threshold
     := equivocation_dec_tracewise IM threshold A sender)
   .
 
-Existing Instance Htracewise_BasicEquivocation.
+Existing Instance HBE.
 
 Lemma tracewise_basic_equivocation_state_validators_comprehensive_prop :
   basic_equivocation_state_validators_comprehensive_prop IM.
@@ -201,19 +201,17 @@ Context
   (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
   (PreFree := pre_loaded_with_all_messages_vlsm Free)
   (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition (Cv := Cv) IM threshold A sender)
-  (Htracewise_BasicEquivocation : BasicEquivocation (composite_state IM) validator Cv threshold
-    := equivocation_dec_tracewise IM threshold A sender)
-  (tracewise_not_heavy := not_heavy (1 := Htracewise_BasicEquivocation))
-  (tracewise_equivocating_validators := equivocating_validators (1 := Htracewise_BasicEquivocation))
+  (HBE : BasicEquivocation (composite_state IM) validator Cv threshold :=
+    equivocation_dec_tracewise IM threshold A sender)
   .
 
 Lemma StrongFixed_valid_state_not_heavy s
   (Hs : valid_state_prop StrongFixed s)
-  : tracewise_not_heavy s.
+  : not_heavy (1 := HBE) s.
 Proof.
-  cut (tracewise_equivocating_validators s ⊆ eqv_validators).
+  cut (equivocating_validators (1 := HBE) s ⊆ eqv_validators).
   {
-    intro Hincl; unfold tracewise_not_heavy, not_heavy.
+    intro Hincl; unfold not_heavy.
     by etransitivity; [apply sum_weights_subseteq |].
   }
   apply valid_state_has_trace in Hs as [is [tr Htr]].
@@ -302,7 +300,8 @@ Context
   `{FinSet message Cm}
   (message_dependencies : message -> Cm)
   `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM A sender)}
-  (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition (Cv := Cv) IM threshold A sender)
+  (Limited : VLSM message :=
+    tracewise_limited_equivocation_vlsm_composition (Cv := Cv) IM threshold A sender)
   .
 
 (**

--- a/theories/VLSM/Core/Equivocation/NoEquivocation.v
+++ b/theories/VLSM/Core/Equivocation/NoEquivocation.v
@@ -54,7 +54,7 @@ End sec_no_equivocations.
 Section sec_no_equivocation_invariants.
 
 Context
-  message
+  (message : Type)
   (X : VLSM message)
   `{HasBeenSentCapability message X}
   `{HasBeenDirectlyObservedCapability message X}

--- a/theories/VLSM/Core/EquivocationProjections.v
+++ b/theories/VLSM/Core/EquivocationProjections.v
@@ -19,7 +19,8 @@ Context
   {X Y : VLSM message}
   {label_project : label X -> option (label Y)}
   {state_project : state X -> state Y}
-  (Hsimul : VLSM_projection (pre_loaded_with_all_messages_vlsm X) (pre_loaded_with_all_messages_vlsm Y) label_project state_project)
+  (Hsimul : VLSM_projection (pre_loaded_with_all_messages_vlsm X) (pre_loaded_with_all_messages_vlsm Y)
+    label_project state_project)
   .
 
 Section sec_selectors.
@@ -116,7 +117,8 @@ Context
   {X Y : VLSM message}
   {label_project : label X -> label Y}
   {state_project : state X -> state Y}
-  (Hsimul : VLSM_weak_embedding (pre_loaded_with_all_messages_vlsm X) (pre_loaded_with_all_messages_vlsm Y) label_project state_project)
+  (Hsimul : VLSM_weak_embedding (pre_loaded_with_all_messages_vlsm X)
+    (pre_loaded_with_all_messages_vlsm Y) label_project state_project)
   .
 
 Section sec_selectors.

--- a/theories/VLSM/Core/Equivocators/Equivocators.v
+++ b/theories/VLSM/Core/Equivocators/Equivocators.v
@@ -713,7 +713,6 @@ Section sec_equivocator_vlsm_valid_state_projections.
 Context
   {message : Type}
   (X : VLSM message)
-  (equivocator_vlsm := equivocator_vlsm X)
   .
 
 (**
@@ -778,7 +777,7 @@ Definition equivocator_state_descriptor_project
 *)
 Definition proper_descriptor
   (d : MachineDescriptor)
-  (s : state equivocator_vlsm)
+  (s : state (equivocator_vlsm X))
   :=
   match d with
   | NewMachine sn => initial_state_prop X sn
@@ -793,7 +792,7 @@ Definition proper_equivocator_label
 (** Existing-only descriptor. *)
 Definition existing_descriptor
   (d : MachineDescriptor)
-  (s : state equivocator_vlsm)
+  (s : state (equivocator_vlsm X))
   :=
   match d with
   | Existing i => is_Some (equivocator_state_project s i)
@@ -837,7 +836,7 @@ Qed.
 
 Lemma existing_descriptor_proper
   (d : MachineDescriptor)
-  (s : state equivocator_vlsm)
+  (s : state (equivocator_vlsm X))
   (Hned : existing_descriptor d s)
   : proper_descriptor d s.
 Proof. by destruct d. Qed.
@@ -855,10 +854,10 @@ Proof. by destruct d. Qed.
 *)
 Lemma equivocator_transition_no_equivocation_zero_descriptor
   (iom oom : option message)
-  (l : label equivocator_vlsm)
-  (s s' : state equivocator_vlsm)
-  (Hv : valid equivocator_vlsm l (s, iom))
-  (Ht : transition equivocator_vlsm l (s, iom) = (s', oom))
+  (l : label (equivocator_vlsm X))
+  (s s' : state (equivocator_vlsm X))
+  (Hv : valid (equivocator_vlsm X) l (s, iom))
+  (Ht : transition (equivocator_vlsm X) l (s, iom) = (s', oom))
   (Hs' : is_singleton_state X s')
   : exists li, l = ContinueWith 0 li.
 Proof.
@@ -878,8 +877,8 @@ Qed.
 *)
 Lemma equivocator_transition_reflects_singleton_state
   (iom oom : option message)
-  (l : label equivocator_vlsm)
-  (s s' : state equivocator_vlsm)
+  (l : label (equivocator_vlsm X))
+  (s s' : state (equivocator_vlsm X))
   (Ht : equivocator_transition X l (s, iom) = (s', oom))
   : is_singleton_state X s' -> is_singleton_state X s.
 Proof.
@@ -894,8 +893,8 @@ Qed.
 
 Lemma equivocator_transition_cannot_decrease_state_size
   (iom oom : option message)
-  (l : label equivocator_vlsm)
-  (s s' : state equivocator_vlsm)
+  (l : label (equivocator_vlsm X))
+  (s s' : state (equivocator_vlsm X))
   (Ht : equivocator_transition X l (s, iom) = (s', oom))
   : equivocator_state_n s <= equivocator_state_n s'.
 Proof.
@@ -913,8 +912,8 @@ Qed.
 
 Lemma equivocator_transition_preserves_equivocating_state
   (iom oom : option message)
-  (l : label equivocator_vlsm)
-  (s s' : state equivocator_vlsm)
+  (l : label (equivocator_vlsm X))
+  (s s' : state (equivocator_vlsm X))
   (Ht : equivocator_transition X l (s, iom) = (s', oom))
   : is_equivocating_state X s -> is_equivocating_state X s'.
 Proof.
@@ -924,8 +923,8 @@ Qed.
 
 Lemma zero_descriptor_transition_reflects_equivocating_state
   (iom oom : option message)
-  (l : label equivocator_vlsm)
-  (s s' : state equivocator_vlsm)
+  (l : label (equivocator_vlsm X))
+  (s s' : state (equivocator_vlsm X))
   (Ht : equivocator_transition X l (s, iom) = (s', oom))
   li
   (Hzero : l = ContinueWith 0 li)
@@ -947,9 +946,9 @@ Qed.
 *)
 Lemma preloaded_equivocator_state_projection_preserves_validity
   (seed : message -> Prop)
-  (bs : state equivocator_vlsm)
+  (bs : state (equivocator_vlsm X))
   (om : option message)
-  (Hbs : valid_state_message_prop (pre_loaded_vlsm equivocator_vlsm seed) bs om)
+  (Hbs : valid_state_message_prop (pre_loaded_vlsm (equivocator_vlsm X) seed) bs om)
   : option_valid_message_prop (pre_loaded_vlsm X seed) om /\
     forall i si,
       equivocator_state_project bs i = Some si ->
@@ -969,7 +968,7 @@ Proof.
 
     (*
       destruction tactic for a valid equivocator transition
-      transition equivocator_vlsm l (s, om) = (s', om')
+      transition (equivocator_vlsm X) l (s, om) = (s', om')
     *)
     destruct l as [sn | i l | i l]
     ; [inversion_clear Ht; split; [by apply option_valid_message_None |]
@@ -1002,8 +1001,8 @@ Qed.
 
 Lemma preloaded_with_equivocator_state_project_valid_state
   (seed : message -> Prop)
-  (bs : state equivocator_vlsm)
-  (Hbs : valid_state_prop (pre_loaded_vlsm equivocator_vlsm seed) bs)
+  (bs : state (equivocator_vlsm X))
+  (Hbs : valid_state_prop (pre_loaded_vlsm (equivocator_vlsm X) seed) bs)
   : forall i si,
     equivocator_state_project bs i = Some si ->
     valid_state_prop (pre_loaded_vlsm X seed) si.
@@ -1015,7 +1014,7 @@ Qed.
 Lemma preloaded_with_equivocator_state_project_valid_message
   (seed : message -> Prop)
   (om : option message)
-  (Hom : option_valid_message_prop (pre_loaded_vlsm equivocator_vlsm seed) om)
+  (Hom : option_valid_message_prop (pre_loaded_vlsm (equivocator_vlsm X) seed) om)
   :
   option_valid_message_prop (pre_loaded_vlsm X seed) om.
 Proof.
@@ -1024,13 +1023,13 @@ Proof.
 Qed.
 
 Lemma equivocator_state_project_valid_state
-  (bs : state equivocator_vlsm)
-  (Hbs : valid_state_prop equivocator_vlsm bs)
+  (bs : state (equivocator_vlsm X))
+  (Hbs : valid_state_prop (equivocator_vlsm X) bs)
   : forall i si,
     equivocator_state_project bs i = Some si -> valid_state_prop X si.
 Proof.
   intros i si Hpr.
-  apply (VLSM_eq_valid_state (vlsm_is_pre_loaded_with_False equivocator_vlsm)) in Hbs.
+  apply (VLSM_eq_valid_state (vlsm_is_pre_loaded_with_False (equivocator_vlsm X))) in Hbs.
   specialize (preloaded_with_equivocator_state_project_valid_state _ _ Hbs _ _ Hpr) as Hsi.
   apply (VLSM_eq_valid_state (vlsm_is_pre_loaded_with_False X)) in Hsi.
   by destruct X.
@@ -1038,13 +1037,13 @@ Qed.
 
 Lemma equivocator_state_project_valid_message
   (om : option message)
-  (Hom : option_valid_message_prop equivocator_vlsm om)
+  (Hom : option_valid_message_prop (equivocator_vlsm X) om)
   :
   option_valid_message_prop X om.
 Proof.
   destruct om as [m |]; [| by apply option_valid_message_None].
-  specialize (vlsm_is_pre_loaded_with_False_initial_message equivocator_vlsm) as Hinit.
-  apply (VLSM_incl_valid_message (proj1 (vlsm_is_pre_loaded_with_False equivocator_vlsm)))
+  specialize (vlsm_is_pre_loaded_with_False_initial_message (equivocator_vlsm X)) as Hinit.
+  apply (VLSM_incl_valid_message (proj1 (vlsm_is_pre_loaded_with_False (equivocator_vlsm X))))
     in Hom; [| done].
   apply preloaded_with_equivocator_state_project_valid_message in Hom.
   specialize (vlsm_is_pre_loaded_with_False_initial_message_rev X) as Hinit_rev.
@@ -1058,8 +1057,8 @@ Qed.
   corresponding to the original machine.
 *)
 Lemma preloaded_equivocator_state_project_valid_state
-  (bs : state equivocator_vlsm)
-  (Hbs : valid_state_prop (pre_loaded_with_all_messages_vlsm equivocator_vlsm) bs)
+  (bs : state (equivocator_vlsm X))
+  (Hbs : valid_state_prop (pre_loaded_with_all_messages_vlsm (equivocator_vlsm X)) bs)
   : forall i si,
     equivocator_state_project bs i = Some si ->
       valid_state_prop (pre_loaded_with_all_messages_vlsm X) si.
@@ -1082,7 +1081,7 @@ Qed.
 
 Lemma new_machine_label_equivocator_transition_size
   {sn s oin s' oout}
-  (Ht : transition equivocator_vlsm (Spawn sn) (s, oin) = (s', oout))
+  (Ht : transition (equivocator_vlsm X) (Spawn sn) (s, oin) = (s', oout))
   : equivocator_state_n s' = S (equivocator_state_n s).
 Proof.
   inversion_clear Ht.
@@ -1091,7 +1090,7 @@ Qed.
 
 Lemma existing_true_label_equivocator_transition_size
   {ieqvi li s oin s' oout}
-  (Ht : transition equivocator_vlsm (ForkWith ieqvi li) (s, oin) = (s', oout))
+  (Ht : transition (equivocator_vlsm X) (ForkWith ieqvi li) (s, oin) = (s', oout))
   si
   (Hv : equivocator_state_project s ieqvi = Some si)
   : equivocator_state_n s' = S (equivocator_state_n s).
@@ -1105,7 +1104,7 @@ Qed.
 
 Lemma existing_false_label_equivocator_transition_size
   {ieqvi li s oin s' oout}
-  (Ht : transition equivocator_vlsm (ContinueWith ieqvi li) (s, oin) = (s', oout))
+  (Ht : transition (equivocator_vlsm X) (ContinueWith ieqvi li) (s, oin) = (s', oout))
   si
   (Hv : equivocator_state_project s ieqvi = Some si)
   : equivocator_state_n s' = equivocator_state_n s.
@@ -1119,7 +1118,7 @@ Qed.
 
 Lemma new_machine_label_equivocator_state_project_last
   {sn s oin s' oout}
-  (Ht : transition equivocator_vlsm (Spawn sn) (s, oin) = (s', oout))
+  (Ht : transition (equivocator_vlsm X) (Spawn sn) (s, oin) = (s', oout))
   : equivocator_state_descriptor_project s' (Existing (equivocator_state_n s)) =
     equivocator_state_descriptor_project s (NewMachine sn).
 Proof.
@@ -1130,7 +1129,7 @@ Qed.
 
 Lemma new_machine_label_equivocator_state_project_not_last
   {sn s oin s' oout}
-  (Ht : transition equivocator_vlsm (Spawn sn) (s, oin) = (s', oout))
+  (Ht : transition (equivocator_vlsm X) (Spawn sn) (s, oin) = (s', oout))
   ni
   (Hni : ni < equivocator_state_n s)
   : equivocator_state_descriptor_project s' (Existing ni) =
@@ -1142,7 +1141,7 @@ Qed.
 
 Lemma existing_true_label_equivocator_state_project_not_last
   {ieqvi li s oin s' oout}
-  (Ht : transition equivocator_vlsm (ForkWith ieqvi li) (s, oin) = (s', oout))
+  (Ht : transition (equivocator_vlsm X) (ForkWith ieqvi li) (s, oin) = (s', oout))
   si
   (Hsi : equivocator_state_project s ieqvi = Some si)
   ni
@@ -1160,7 +1159,7 @@ Qed.
 
 Lemma existing_true_label_equivocator_state_project_last
   {ieqvi li s oin s' oout}
-  (Ht : transition equivocator_vlsm (ForkWith ieqvi li) (s, oin) = (s', oout))
+  (Ht : transition (equivocator_vlsm X) (ForkWith ieqvi li) (s, oin) = (s', oout))
   si
   (Hsi : equivocator_state_project s ieqvi = Some si)
   si' _oout
@@ -1177,7 +1176,7 @@ Qed.
 
 Lemma existing_false_label_equivocator_state_project_not_same
   {ieqvi li s oin s' oout}
-  (Ht : transition equivocator_vlsm (ContinueWith ieqvi li) (s, oin) = (s', oout))
+  (Ht : transition (equivocator_vlsm X) (ContinueWith ieqvi li) (s, oin) = (s', oout))
   si
   (Hsi : equivocator_state_project s ieqvi = Some si)
   ni
@@ -1196,7 +1195,7 @@ Qed.
 
 Lemma existing_false_label_equivocator_state_project_same
   {ieqvi li s oin s' oout}
-  (Ht : transition equivocator_vlsm (ContinueWith ieqvi li) (s, oin) = (s', oout))
+  (Ht : transition (equivocator_vlsm X) (ContinueWith ieqvi li) (s, oin) = (s', oout))
   si
   (Hsi : equivocator_state_project s ieqvi = Some si)
   si' _oout

--- a/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsComposition.v
@@ -34,7 +34,8 @@ From VLSM.Core Require Import Equivocators.MessageProperties.
 
 Section sec_fully_equivocating_composition.
 
-Context {message : Type}
+Context
+  {message : Type}
   `{finite.Finite index}
   (IM : index -> VLSM message)
   `{forall i : index, HasBeenSentCapability (IM i)}
@@ -517,14 +518,14 @@ End sec_fully_equivocating_composition.
 
 Section sec_equivocators_sub_projections.
 
-Context {message : Type}
+Context
+  {message : Type}
   `{EqDecision index}
   (IM : index -> VLSM message)
   `{forall i, HasBeenSentCapability (IM i)}
   (equivocating : list index)
   (sub_equivocator_IM := sub_IM (equivocator_IM IM) equivocating)
-  (sub_IM := sub_IM IM equivocating)
-  (sub_IM_equivocator := equivocator_IM sub_IM)
+  (sub_IM_equivocator := equivocator_IM (sub_IM IM equivocating))
   .
 
 Definition seeded_equivocators_no_equivocation_vlsm

--- a/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -1905,7 +1905,8 @@ End sec_equivocators_composition_sub_projections.
 
 Section sec_equivocators_composition_vlsm_projection.
 
-Context {message : Type}
+Context
+  {message : Type}
   `{finite.Finite index}
   (IM : index -> VLSM message)
   `{forall i : index, HasBeenSentCapability (IM i)}

--- a/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/VLSM/Core/Equivocators/EquivocatorsProjections.v
@@ -21,8 +21,6 @@ Section sec_equivocator_vlsm_projections.
 Context
   {message : Type}
   (X : VLSM message)
-  (equivocator_vlsm := equivocator_vlsm X)
-  (MachineDescriptor := MachineDescriptor X)
   .
 
 (**
@@ -33,9 +31,9 @@ Context
   referring to a position in the state prior to the transition.
 *)
 Definition equivocator_vlsm_transition_item_project
-  (item : transition_item equivocator_vlsm)
-  (descriptor : MachineDescriptor)
-  : option (option (transition_item X) * MachineDescriptor)
+  (item : transition_item (equivocator_vlsm X))
+  (descriptor : MachineDescriptor X)
+  : option (option (transition_item X) * MachineDescriptor X)
   :=
   match descriptor with
   | NewMachine _ => Some (None, descriptor)
@@ -67,10 +65,10 @@ Definition equivocator_vlsm_transition_item_project
   equivocator [transition item] to component 0.
 *)
 Lemma equivocators_vlsm_transition_item_project_zero_descriptor
-  (item : transition_item equivocator_vlsm)
+  (item : transition_item (equivocator_vlsm X))
   s
-  (Ht : transition equivocator_vlsm (l item) (s, input item) = (destination item, output item))
-  (Hv : valid equivocator_vlsm (l item) (s, input item))
+  (Ht : transition (equivocator_vlsm X) (l item) (s, input item) = (destination item, output item))
+  (Hv : valid (equivocator_vlsm X) (l item) (s, input item))
   : exists oitem, equivocator_vlsm_transition_item_project item (Existing 0) =
       Some (oitem, Existing 0).
 Proof.
@@ -90,12 +88,12 @@ Qed.
 
 (** An injectivity result for [equivocator_vlsm_transition_item_project]. *)
 Lemma equivocator_vlsm_transition_item_project_some_inj
-  {item : transition_item equivocator_vlsm}
+  {item : transition_item (equivocator_vlsm X)}
   {itemX itemX' : transition_item X}
   {i i' : nat}
   (idescriptor := Existing i)
   (idescriptor' := Existing i')
-  {odescriptor odescriptor' : MachineDescriptor}
+  {odescriptor odescriptor' : MachineDescriptor X}
   (HitemX : equivocator_vlsm_transition_item_project item idescriptor =
     Some (Some itemX, odescriptor))
   (HitemX' : equivocator_vlsm_transition_item_project item idescriptor' =
@@ -124,8 +122,8 @@ Qed.
   descriptor.
 *)
 Lemma equivocator_transition_item_project_inv_none
-  (item : transition_item equivocator_vlsm)
-  (descriptor : MachineDescriptor)
+  (item : transition_item (equivocator_vlsm X))
+  (descriptor : MachineDescriptor X)
   (Hitem : equivocator_vlsm_transition_item_project item descriptor = None)
   : exists (i : nat),
     descriptor = Existing i /\
@@ -139,8 +137,8 @@ Proof.
 Qed.
 
 Lemma equivocator_transition_item_project_proper
-  (item : transition_item equivocator_vlsm)
-  (descriptor : MachineDescriptor)
+  (item : transition_item (equivocator_vlsm X))
+  (descriptor : MachineDescriptor X)
   (Hproper : proper_descriptor X descriptor (destination item))
   : is_Some (equivocator_vlsm_transition_item_project item descriptor).
 Proof.
@@ -157,9 +155,9 @@ Qed.
   then that item has the same [input] and [output] as the argument item.
 *)
 Lemma equivocator_transition_item_project_inv_messages
-  (item : transition_item equivocator_vlsm)
+  (item : transition_item (equivocator_vlsm X))
   (itemX : transition_item X)
-  (idescriptor odescriptor : MachineDescriptor)
+  (idescriptor odescriptor : MachineDescriptor X)
   (Hitem : equivocator_vlsm_transition_item_project item idescriptor = Some (Some itemX, odescriptor))
   : exists
     (i : nat),
@@ -182,11 +180,11 @@ Qed.
   [transition_item] for the original machine.
 *)
 Lemma no_equivocating_equivocator_transition_item_project
-  (item : transition_item equivocator_vlsm)
+  (item : transition_item (equivocator_vlsm X))
   (Hno_equiv_item : is_singleton_state X (destination item))
-  (s : state equivocator_vlsm)
-  (Hv : valid equivocator_vlsm (l item) (s, input item))
-  (Ht : transition equivocator_vlsm (l item) (s, input item) = (destination item, output item))
+  (s : state (equivocator_vlsm X))
+  (Hv : valid (equivocator_vlsm X) (l item) (s, input item))
+  (Ht : transition (equivocator_vlsm X) (l item) (s, input item) = (destination item, output item))
   : exists (Hex : existing_equivocator_label _ (l item)),
     equivocator_vlsm_transition_item_project item (Existing 0) =
       Some (Some
@@ -210,11 +208,11 @@ Qed.
   item corresponding to the input transition.
 *)
 Lemma exists_equivocator_transition_item_project
-  (item : transition_item equivocator_vlsm)
-  (s : state equivocator_vlsm)
+  (item : transition_item (equivocator_vlsm X))
+  (s : state (equivocator_vlsm X))
   (Hs : proper_existing_equivocator_label X (l item) s)
-  (Hv : valid equivocator_vlsm (l item) (s, input item))
-  (Ht : transition equivocator_vlsm (l item) (s, input item) = (destination item, output item))
+  (Hv : valid (equivocator_vlsm X) (l item) (s, input item))
+  (Ht : transition (equivocator_vlsm X) (l item) (s, input item) = (destination item, output item))
   : proper_equivocator_label X (l item) s /\
     exists dest_eqv,
       existing_descriptor X dest_eqv (destination item) /\
@@ -267,9 +265,9 @@ Qed.
   (see [full_node_limited_equivocation_constraint_known_equivocators]).
 *)
 Definition previous_state_descriptor_prop
-  (original_descriptor : MachineDescriptor)
-  (s : state equivocator_vlsm)
-  (s_descriptor : MachineDescriptor)
+  (original_descriptor : MachineDescriptor X)
+  (s : state (equivocator_vlsm X))
+  (s_descriptor : MachineDescriptor X)
   : Prop :=
     match original_descriptor with
     | NewMachine sd => s_descriptor = original_descriptor
@@ -281,8 +279,8 @@ Definition previous_state_descriptor_prop
     end.
 
 Lemma equivocator_transition_item_project_proper_characterization
-  (item : transition_item equivocator_vlsm)
-  (descriptor : MachineDescriptor)
+  (item : transition_item (equivocator_vlsm X))
+  (descriptor : MachineDescriptor X)
   (Hproper : proper_descriptor X descriptor (destination item))
   : exists oitem descriptor',
     equivocator_vlsm_transition_item_project item descriptor = Some (oitem, descriptor')
@@ -296,9 +294,9 @@ Lemma equivocator_transition_item_project_proper_characterization
       | None => True
       end
     /\ forall
-      (s : state equivocator_vlsm)
-      (Hv : valid equivocator_vlsm (l item) (s, input item))
-      (Ht : transition equivocator_vlsm (l item) (s, input item) = (destination item, output item)),
+      (s : state (equivocator_vlsm X))
+      (Hv : valid (equivocator_vlsm X) (l item) (s, input item))
+      (Ht : transition (equivocator_vlsm X) (l item) (s, input item) = (destination item, output item)),
       proper_descriptor X descriptor' s /\
       previous_state_descriptor_prop descriptor s descriptor' /\
       match oitem with
@@ -417,14 +415,14 @@ Proof.
 Qed.
 
 Lemma equivocator_transition_item_project_preserves_equivocating_indices
-  (item : transition_item equivocator_vlsm)
-  (descriptor : MachineDescriptor)
+  (item : transition_item (equivocator_vlsm X))
+  (descriptor : MachineDescriptor X)
   (Hproper : proper_descriptor X descriptor (destination item))
   oitem idescriptor
   (Hproject : equivocator_vlsm_transition_item_project item descriptor = Some (oitem, idescriptor))
-  (s : state equivocator_vlsm)
-  (Hv : valid equivocator_vlsm (l item) (s, input item))
-  (Ht : transition equivocator_vlsm (l item) (s, input item) = (destination item, output item))
+  (s : state (equivocator_vlsm X))
+  (Hv : valid (equivocator_vlsm X) (l item) (s, input item))
+  (Ht : transition (equivocator_vlsm X) (l item) (s, input item) = (destination item, output item))
   : is_equivocating_state X s \/ is_newmachine_descriptor X idescriptor ->
     is_equivocating_state X (destination item) \/ is_newmachine_descriptor X descriptor.
 Proof.
@@ -460,9 +458,9 @@ Proof.
 Qed.
 
 Lemma equivocator_transition_item_project_inv_characterization
-  (item : transition_item equivocator_vlsm)
+  (item : transition_item (equivocator_vlsm X))
   (itemx : transition_item X)
-  (descriptor descriptor' : MachineDescriptor)
+  (descriptor descriptor' : MachineDescriptor X)
   (Hitem : equivocator_vlsm_transition_item_project item descriptor = Some (Some itemx, descriptor'))
   : (exists (Hex : existing_equivocator_label _ (l item)), l itemx =
       existing_equivocator_label_extract _ (l item) Hex) /\
@@ -487,9 +485,9 @@ Qed.
   [transition_item]s it produces.
 *)
 Definition equivocator_vlsm_trace_project
-  (tr : list (transition_item equivocator_vlsm))
-  (descriptor : MachineDescriptor)
-  : option (list (transition_item X) * MachineDescriptor)
+  (tr : list (transition_item (equivocator_vlsm X)))
+  (descriptor : MachineDescriptor X)
+  : option (list (transition_item X) * MachineDescriptor X)
   :=
   fold_right
     (fun item result =>
@@ -510,7 +508,7 @@ Definition equivocator_vlsm_trace_project
   descriptor.
 *)
 Lemma equivocator_vlsm_trace_project_on_new_machine
-  (tr : list (transition_item equivocator_vlsm))
+  (tr : list (transition_item (equivocator_vlsm X)))
   (s : state X)
   : equivocator_vlsm_trace_project tr (NewMachine s) = Some ([], NewMachine s).
 Proof.
@@ -522,13 +520,13 @@ Qed.
   (single element in left operand case).
 *)
 Lemma equivocator_vlsm_trace_project_cons
-  (bprefix : transition_item equivocator_vlsm)
-  (bsuffix : list (transition_item equivocator_vlsm))
-  (dstart dlast : MachineDescriptor)
+  (bprefix : transition_item (equivocator_vlsm X))
+  (bsuffix : list (transition_item (equivocator_vlsm X)))
+  (dstart dlast : MachineDescriptor X)
   (tr : list (transition_item X))
   (Hproject : equivocator_vlsm_trace_project ([bprefix] ++ bsuffix) dlast = Some (tr, dstart))
   : exists
-    (dmiddle : MachineDescriptor)
+    (dmiddle : MachineDescriptor X)
     (prefix suffix : list (transition_item X))
     (Hprefix : equivocator_vlsm_trace_project [bprefix] dmiddle = Some (prefix, dstart))
     (Hsuffix : equivocator_vlsm_trace_project bsuffix dlast = Some (suffix, dmiddle)),
@@ -548,12 +546,12 @@ Qed.
 
 (** [equivocator_vlsm_trace_project] acts like a morphism w.r.t. concatenation. *)
 Lemma equivocator_vlsm_trace_project_app
-  (bprefix bsuffix : list (transition_item equivocator_vlsm))
-  (dlast dstart : MachineDescriptor)
+  (bprefix bsuffix : list (transition_item (equivocator_vlsm X)))
+  (dlast dstart : MachineDescriptor X)
   (tr : list (transition_item X))
   (Hproject : equivocator_vlsm_trace_project (bprefix ++ bsuffix) dlast = Some (tr, dstart))
   : exists
-    (dmiddle : MachineDescriptor)
+    (dmiddle : MachineDescriptor X)
     (prefix suffix : list (transition_item X))
     (Hprefix : equivocator_vlsm_trace_project bprefix dmiddle = Some (prefix, dstart))
     (Hsuffix : equivocator_vlsm_trace_project bsuffix dlast = Some (suffix, dmiddle)),
@@ -584,8 +582,8 @@ Qed.
   (converse).
 *)
 Lemma equivocator_vlsm_trace_project_app_inv
-  (bprefix bsuffix : list (transition_item equivocator_vlsm))
-  (dlast dstart dmiddle : MachineDescriptor)
+  (bprefix bsuffix : list (transition_item (equivocator_vlsm X)))
+  (dlast dstart dmiddle : MachineDescriptor X)
   (prefix suffix : list (transition_item X))
   (Hprefix : equivocator_vlsm_trace_project bprefix dmiddle = Some (prefix, dstart))
   (Hsuffix : equivocator_vlsm_trace_project bsuffix dlast = Some (suffix, dmiddle))
@@ -606,13 +604,13 @@ Qed.
 
 (** Next we prove some inversion properties for [equivocator_vlsm_transition_item_project]. *)
 Lemma equivocator_valid_transition_project_inv2
-  (l : label equivocator_vlsm)
-  (s' s : state equivocator_vlsm)
+  (l : label (equivocator_vlsm X))
+  (s' s : state (equivocator_vlsm X))
   (iom oom : option message)
-  (Hv : valid equivocator_vlsm l (s', iom))
-  (Ht : transition equivocator_vlsm l (s', iom) = (s, oom))
+  (Hv : valid (equivocator_vlsm X) l (s', iom))
+  (Ht : transition (equivocator_vlsm X) l (s', iom) = (s, oom))
   (item := {| l := l; input := iom; destination := s; output := oom |})
-  (di di' : MachineDescriptor)
+  (di di' : MachineDescriptor X)
   (item' : transition_item X)
   (Hitem : equivocator_vlsm_transition_item_project item di = Some (Some item', di'))
   : exists (i : nat), di = Existing i /\
@@ -648,13 +646,13 @@ Proof.
 Qed.
 
 Lemma equivocator_valid_transition_project_inv3
-  (l : label equivocator_vlsm)
-  (s s' : state equivocator_vlsm)
+  (l : label (equivocator_vlsm X))
+  (s s' : state (equivocator_vlsm X))
   (iom oom : option message)
-  (Hv : valid equivocator_vlsm l (s', iom))
-  (Ht : transition equivocator_vlsm l (s', iom) = (s, oom))
+  (Hv : valid (equivocator_vlsm X) l (s', iom))
+  (Ht : transition (equivocator_vlsm X) l (s', iom) = (s, oom))
   (item := {| l := l; input := iom; destination := s; output := oom |})
-  (di di' : MachineDescriptor)
+  (di di' : MachineDescriptor X)
   (Hitem : equivocator_vlsm_transition_item_project item di = Some (None, di'))
   : match di with
     | NewMachine sn => di' = di
@@ -712,11 +710,11 @@ Proof.
 Qed.
 
 Lemma equivocator_valid_transition_project_inv4
-  (l : label equivocator_vlsm)
-  (s s' : state equivocator_vlsm)
+  (l : label (equivocator_vlsm X))
+  (s s' : state (equivocator_vlsm X))
   (iom oom : option message)
-  (Hv : valid equivocator_vlsm l (s', iom))
-  (Ht : transition equivocator_vlsm l (s', iom) = (s, oom))
+  (Hv : valid (equivocator_vlsm X) l (s', iom))
+  (Ht : transition (equivocator_vlsm X) l (s', iom) = (s, oom))
   (i' : nat)
   si'
   (Hi' : equivocator_state_project s' i' = Some si')
@@ -754,10 +752,10 @@ Proof.
 Qed.
 
 Lemma equivocator_valid_transition_project_inv5_new_machine
-  (l : label equivocator_vlsm)
-  (s s' : state equivocator_vlsm)
+  (l : label (equivocator_vlsm X))
+  (s s' : state (equivocator_vlsm X))
   (iom oom : option message)
-  (Ht : transition equivocator_vlsm l (s', iom) = (s, oom))
+  (Ht : transition (equivocator_vlsm X) l (s', iom) = (s, oom))
   (item := {| l := l; input := iom; destination := s; output := oom |})
   (sn : state X)
   (Hnew : l = Spawn sn)
@@ -774,11 +772,11 @@ Proof.
 Qed.
 
 Lemma equivocator_valid_transition_project_inv5
-  (l : label equivocator_vlsm)
-  (s s' : state equivocator_vlsm)
+  (l : label (equivocator_vlsm X))
+  (s s' : state (equivocator_vlsm X))
   (iom oom : option message)
-  (Hv : valid equivocator_vlsm l (s', iom))
-  (Ht : transition equivocator_vlsm l (s', iom) = (s, oom))
+  (Hv : valid (equivocator_vlsm X) l (s', iom))
+  (Ht : transition (equivocator_vlsm X) l (s', iom) = (s, oom))
   (item := {| l := l; input := iom; destination := s; output := oom |})
   (_i : nat)
   (Hsndl : equivocator_label_descriptor l = Existing _i)
@@ -821,15 +819,15 @@ Qed.
 *)
 Lemma preloaded_with_equivocator_vlsm_trace_project_valid
   (seed : message -> Prop)
-  (bs be : state equivocator_vlsm)
-  (btr : list (transition_item equivocator_vlsm))
-  (Hbtr : finite_valid_trace_from_to (pre_loaded_vlsm equivocator_vlsm seed) bs be btr)
+  (bs be : state (equivocator_vlsm X))
+  (btr : list (transition_item (equivocator_vlsm X)))
+  (Hbtr : finite_valid_trace_from_to (pre_loaded_vlsm (equivocator_vlsm X) seed) bs be btr)
   (j : nat)
   ej
   (Hj : equivocator_state_project be j = Some ej)
   : exists
     (tr : list (transition_item X))
-    (di : MachineDescriptor),
+    (di : MachineDescriptor X),
     equivocator_vlsm_trace_project btr (Existing j) = Some (tr, di) /\
     match di with
     | NewMachine sn =>
@@ -894,15 +892,15 @@ Proof.
 Qed.
 
 Lemma equivocator_vlsm_trace_project_valid
-  (bs be : state equivocator_vlsm)
-  (btr : list (transition_item equivocator_vlsm))
-  (Hbtr : finite_valid_trace_from_to equivocator_vlsm bs be btr)
+  (bs be : state (equivocator_vlsm X))
+  (btr : list (transition_item (equivocator_vlsm X)))
+  (Hbtr : finite_valid_trace_from_to (equivocator_vlsm X) bs be btr)
   (j : nat)
   ej
   (Hj : equivocator_state_project be j = Some ej)
   : exists
     (tr : list (transition_item X))
-    (di : MachineDescriptor),
+    (di : MachineDescriptor X),
     equivocator_vlsm_trace_project btr (Existing j) = Some (tr, di) /\
     match di with
     | NewMachine sn =>
@@ -914,7 +912,7 @@ Lemma equivocator_vlsm_trace_project_valid
     end.
 Proof.
   apply (VLSM_incl_finite_valid_trace_from_to
-    (proj1 (vlsm_is_pre_loaded_with_False equivocator_vlsm))) in Hbtr.
+    (proj1 (vlsm_is_pre_loaded_with_False (equivocator_vlsm X)))) in Hbtr.
   specialize (preloaded_with_equivocator_vlsm_trace_project_valid _ _ _ _ Hbtr _ _ Hj)
     as [tr [di [Hbtr_pr Hdi]]].
   eexists _, _; split; [done |].
@@ -937,15 +935,15 @@ Qed.
   trace segment in the [pre_loaded_with_all_messages_vlsm] corresponding to the original vlsm.
 *)
 Lemma preloaded_equivocator_vlsm_trace_project_valid
-  (bs be : state equivocator_vlsm)
-  (btr : list (transition_item equivocator_vlsm))
-  (Hbtr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm equivocator_vlsm) bs be btr)
+  (bs be : state (equivocator_vlsm X))
+  (btr : list (transition_item (equivocator_vlsm X)))
+  (Hbtr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm (equivocator_vlsm X)) bs be btr)
   (j : nat)
   ej
   (Hj : equivocator_state_project be j = Some ej)
   : exists
     (tr : list (transition_item X))
-    (di : MachineDescriptor),
+    (di : MachineDescriptor X),
     equivocator_vlsm_trace_project btr (Existing j) = Some (tr, di) /\
     match di with
     | NewMachine sn =>
@@ -974,7 +972,7 @@ Lemma equivocator_vlsm_trace_project_inv
   (Hntr : tr <> [])
   (j : nat)
   (HtrX : is_Some (equivocator_vlsm_trace_project tr (Existing j)))
-  (is : state equivocator_vlsm)
+  (is : state (equivocator_vlsm X))
   : exists sj, equivocator_state_project (finite_trace_last is tr) j = Some sj.
 Proof.
   apply exists_last in Hntr.
@@ -1005,9 +1003,9 @@ Qed.
   first state of the trace does not fail and yields the same index.
 *)
 Lemma preloaded_equivocator_vlsm_trace_project_valid_inv
-  (bs : state equivocator_vlsm)
-  (btr : list (transition_item equivocator_vlsm))
-  (Hbtr : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm equivocator_vlsm) bs btr)
+  (bs : state (equivocator_vlsm X))
+  (btr : list (transition_item (equivocator_vlsm X)))
+  (Hbtr : finite_valid_trace_from (pre_loaded_with_all_messages_vlsm (equivocator_vlsm X)) bs btr)
   (i : nat)
   si
   (Hi : equivocator_state_project bs i = Some si)
@@ -1039,12 +1037,12 @@ Qed.
 
 (** An inversion lemma about projections of a valid trace. *)
 Lemma preloaded_equivocator_vlsm_valid_trace_project_inv2
-  (is fs : state (pre_loaded_with_all_messages_vlsm equivocator_vlsm))
+  (is fs : state (pre_loaded_with_all_messages_vlsm (equivocator_vlsm X)))
   (tr : list transition_item)
   (Hntr : tr <> [])
-  (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm equivocator_vlsm) is fs tr)
+  (Htr : finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm (equivocator_vlsm X)) is fs tr)
   (j : nat)
-  (di : MachineDescriptor)
+  (di : MachineDescriptor X)
   (trX : list (transition_item X))
   (HtrX : equivocator_vlsm_trace_project tr (Existing j) = Some (trX, di))
   : exists fsj, equivocator_state_project fs j = Some fsj /\
@@ -1055,7 +1053,7 @@ Lemma preloaded_equivocator_vlsm_valid_trace_project_inv2
     | Existing i =>
       exists isi, equivocator_state_project is i = Some isi /\
       finite_valid_trace_from_to (pre_loaded_with_all_messages_vlsm X) isi fsj trX /\
-      (initial_state_prop (pre_loaded_with_all_messages_vlsm equivocator_vlsm) is ->
+      (initial_state_prop (pre_loaded_with_all_messages_vlsm (equivocator_vlsm X)) is ->
         initial_state_prop (pre_loaded_with_all_messages_vlsm X) isi)
     end.
 Proof.
@@ -1083,7 +1081,7 @@ Definition equivocator_label_zero_project (l : equivocator_label X) : option (la
   end.
 
 Lemma equivocator_zero_projection
-  : VLSM_projection equivocator_vlsm X
+  : VLSM_projection (equivocator_vlsm X) X
     equivocator_label_zero_project equivocator_state_zero.
 Proof.
   apply basic_VLSM_strong_projection; intro; intros.
@@ -1106,7 +1104,7 @@ Qed.
 
 Lemma preloaded_equivocator_zero_projection :
   VLSM_projection
-    (pre_loaded_with_all_messages_vlsm equivocator_vlsm) (pre_loaded_with_all_messages_vlsm X)
+    (pre_loaded_with_all_messages_vlsm (equivocator_vlsm X)) (pre_loaded_with_all_messages_vlsm X)
     equivocator_label_zero_project equivocator_state_zero.
 Proof.
   apply basic_VLSM_projection_preloaded; intro; intros.

--- a/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
+++ b/theories/VLSM/Core/Equivocators/FixedEquivocationSimulation.v
@@ -28,7 +28,8 @@ From VLSM.Core Require Import Equivocators.SimulatingFree.
 
 Section sec_fixed_equivocating.
 
-Context {message : Type}
+Context
+  {message : Type}
   {index : Type}
   `{FinSet index Ci}
   `{finite.Finite index}
@@ -383,7 +384,8 @@ End sec_fixed_equivocating.
 
 Section sec_no_equivocation.
 
-Context {message : Type}
+Context
+  {message : Type}
   `{finite.Finite index}
   (IM : index -> VLSM message)
   (Free := free_composite_vlsm IM)

--- a/theories/VLSM/Core/Equivocators/SimulatingFree.v
+++ b/theories/VLSM/Core/Equivocators/SimulatingFree.v
@@ -234,7 +234,8 @@ End sec_generalized_constraints.
 
 Section sec_seeded_all_equivocating.
 
-Context {message : Type}
+Context
+  {message : Type}
   `{finite.Finite index}
   (IM : index -> VLSM message)
   `{forall i : index, HasBeenSentCapability (IM i)}
@@ -370,7 +371,8 @@ End sec_seeded_all_equivocating.
 
 Section sec_all_equivocating.
 
-Context {message : Type}
+Context
+  {message : Type}
   {index : Type}
   `{finite.Finite index}
   (IM : index -> VLSM message)

--- a/theories/VLSM/Core/PreloadedVLSM.v
+++ b/theories/VLSM/Core/PreloadedVLSM.v
@@ -583,7 +583,9 @@ Section sec_constrained_defs_alt.
   where all messages are valid (initial).
 *)
 
-Context `(X : VLSM message).
+Context
+  `(X : VLSM message)
+  .
 
 Definition finite_constrained_trace_init_to_alt :=
   finite_valid_trace_init_to (pre_loaded_with_all_messages_vlsm X).

--- a/theories/VLSM/Core/ProjectionTraces.v
+++ b/theories/VLSM/Core/ProjectionTraces.v
@@ -523,12 +523,13 @@ End sec_fixed_projection.
 
 Section sec_projection_friendliness_sufficient_condition.
 
-Context {message : Type}
-        `{EqDecision index}
-        (IM : index -> VLSM message)
-        (constraint : composite_label IM -> composite_state IM * option message -> Prop)
-        (X := composite_vlsm IM constraint)
-.
+Context
+  {message : Type}
+  `{EqDecision index}
+  (IM : index -> VLSM message)
+  (constraint : composite_label IM -> composite_state IM * option message -> Prop)
+  (X := composite_vlsm IM constraint)
+  .
 
 (** ** A sufficient condition for the [projection_friendly_prop]erty *)
 

--- a/theories/VLSM/Core/ReachableThreshold.v
+++ b/theories/VLSM/Core/ReachableThreshold.v
@@ -23,7 +23,8 @@ Section sec_reachable_threshold_props.
 
 Context
   (threshold : R)
-  `{Hrt : ReachableThreshold V Cv threshold}.
+  `{Hrt : ReachableThreshold V Cv threshold}
+  .
 
 (**
   Given a list with no duplicates and whose added weight does not pass the

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -2717,7 +2717,9 @@ Section sec_constrained_defs.
 
 (** ** Constrained traces, states and messages *)
 
-Context `(X : VLSM message).
+Context
+  `(X : VLSM message)
+  .
 
 Inductive constrained_transitions_from_to :
   state X -> state X -> list (transition_item X) -> Prop :=
@@ -2750,7 +2752,9 @@ Section sec_finite_valid_trace_init_to_alt.
   when checking whether a concrete trace is valid.
 *)
 
-Context `(X : VLSM message).
+Context
+  `(X : VLSM message)
+  .
 
 Inductive message_valid_transitions_from_to :
   state X -> state X -> list (transition_item X) -> Prop :=

--- a/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMEmbedding.v
@@ -628,9 +628,6 @@ Context
   (X Y : VLSM message)
   (label_project : label X -> label Y)
   (state_project : state X -> state Y)
-  .
-
-Context
   (Hvalid : weak_embedding_valid_preservation X Y label_project state_project)
   (Htransition : weak_embedding_transition_preservation X Y label_project state_project)
   .

--- a/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/VLSM/Core/VLSMProjections/VLSMTotalProjection.v
@@ -217,7 +217,6 @@ Context
   (TY : VLSMType message)
   (label_project : label X -> option (label TY))
   (state_project : state X -> state TY)
-  (trace_project := pre_VLSM_projection_finite_trace_project _ _ label_project state_project)
   .
 
 (**
@@ -895,9 +894,6 @@ Context
   (X Y : VLSM message)
   (label_project : label X -> option (label Y))
   (state_project : state X -> state Y)
-  .
-
-Context
   (Hvalid : weak_projection_valid_preservation X Y label_project state_project)
   (Htransition_Some : weak_projection_transition_preservation_Some X Y label_project state_project)
   (Htransition_None : weak_projection_transition_consistency_None _ _ label_project state_project)

--- a/theories/VLSM/Core/Validator.v
+++ b/theories/VLSM/Core/Validator.v
@@ -298,8 +298,6 @@ Qed.
 
 Context
   (Htransition_None : weak_projection_transition_consistency_None _ _ label_project state_project)
-  (Htype : VLSM_projection_type X TY label_project state_project :=
-    basic_VLSM_projection_type X TY label_project state_project Htransition_None)
   .
 
 Lemma projection_induced_validator_is_projection
@@ -316,10 +314,6 @@ Proof.
 Qed.
 
 Section sec_projection_induced_friendliness.
-
-Context
-  (Hproj := projection_induced_validator_is_projection)
-  .
 
 Lemma induced_validator_transition_item_lift
   (item : transition_item TY)
@@ -349,7 +343,7 @@ Qed.
 *)
 Lemma basic_projection_induces_friendliness
   : VLSM_embedding pre_projection_induced_validator X label_lift state_lift ->
-    projection_friendly_prop Hproj.
+    projection_friendly_prop projection_induced_validator_is_projection.
 Proof.
   intros Hfull_proj isY trY HtrY.
   exists (state_lift isY), (VLSM_embedding_finite_trace_project Hfull_proj trY).
@@ -373,7 +367,6 @@ Context
   (TY : VLSMType message)
   (label_project : label TX -> option (label TY))
   (state_project : state TX -> state TY)
-  (trace_project := pre_VLSM_projection_finite_trace_project _ _ label_project state_project)
   (label_lift : label TY -> label TX)
   (state_lift : state TY -> state TX)
   (Hlabel_lift : induced_validator_label_lift_prop label_project label_lift)
@@ -477,18 +470,12 @@ Context
   (Htransition_None : weak_projection_transition_consistency_None _ _ label_project state_project)
   (label_lift : label Y -> label X)
   (state_lift : state Y -> state X)
-  (Xi := pre_projection_induced_validator X Y
-          label_project state_project label_lift state_lift)
+  (Xi := pre_projection_induced_validator X Y label_project state_project label_lift state_lift)
   (Hlabel_lift : induced_validator_label_lift_prop label_project label_lift)
   (Hstate_lift : induced_validator_state_lift_prop state_project state_lift)
   (Hinitial_lift : strong_projection_initial_state_preservation Y X state_lift)
   (Htransition_consistency :
     induced_validator_transition_consistency_Some _ _ label_project state_project)
-  (Htransition_Some
-    : weak_projection_transition_consistency_Some
-        _ _ label_project state_project label_lift state_lift
-    := basic_weak_projection_transition_consistency_Some
-        _ _ _ _ _ _ Hlabel_lift Hstate_lift Htransition_consistency)
   (Hproji :=
     projection_induced_validator_is_projection
       _ _ _ _ _ _ Hlabel_lift Hstate_lift Htransition_consistency Htransition_None)

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -26,7 +26,12 @@ Section sec_min_predecessors.
   occurring in that list.
 *)
 
-Context {A} (precedes : relation A) `{!RelDecision precedes} (l : list A).
+Context
+  {A : Type}
+  (precedes : relation A)
+  `{!RelDecision precedes}
+  (l : list A)
+  .
 
 Definition count_predecessors
   (a : A)
@@ -252,7 +257,12 @@ Section sec_topologically_sorted.
 
 (** ** Definition and properties of topologically sorted lists *)
 
-Context {A} (precedes : relation A) `{!RelDecision precedes} (l : list A).
+Context
+  {A : Type}
+  (precedes : relation A)
+  `{!RelDecision precedes}
+  (l : list A)
+  .
 
 (**
   We say that a list <<l>> is [topologically_sorted] w.r.t a <<precedes>>
@@ -430,7 +440,11 @@ Section sec_top_sort.
 
 (** ** The topological sorting algorithm *)
 
-Context {A} `{EqDecision A} (precedes : relation A) `{!RelDecision precedes}.
+Context
+  `{EqDecision A}
+  (precedes : relation A)
+  `{!RelDecision precedes}
+  .
 
 (**
   Iteratively extracts <<n>> elements with minimal number of predecessors


### PR DESCRIPTION
This PR follows #255, #268, #269, #270.

Summary of changes:
- Standardize indentation of `Context`s across the entire codebase.
- Remove abbreviations that were not used (I think this might be pretty important, because we gain clarity regarding what assumptions are needed for which theorems).
- Inline abbreviations in case where they were just cluttering the proof context in interactive mode.