### PR TITLE
Improve parity example coqdoc comments

### DIFF
--- a/theories/VLSM/Core/Examples/Parity.v
+++ b/theories/VLSM/Core/Examples/Parity.v
@@ -25,12 +25,13 @@ Proof. by intros n; split; intros [p Hp]; exists (-p); lia. Qed.
 
 (** Even right-hand side and difference implies even left-hand side 
     This lemma will be useful when proving the final result of this section, because of the way 
-    we defined the transitions in the Parity VLSM *)
+    we defined the transitions in the Parity VLSM
+*)
 Lemma Zeven_sub_preserve_parity :
   forall (n m : Z), Z.Even n -> Z.Even (m - n) -> Z.Even m.
 Proof. by intros m n [m'] [n']; exists (m' + n'); lia. Qed.
 
-(** Parity is preserved by taking sum *)
+(** Parity is preserved by addition *)
 Lemma Zeven_equiv_plus :
   forall (n m : Z), (Z.Even n <-> Z.Even m) -> Z.Even (m + n).
 Proof.
@@ -45,7 +46,7 @@ Proof.
     by rewrite Zeven_equiv, <- Hparity, <- Zeven_equiv.
 Qed.
 
-(** Parity is preserved by taking difference *)
+(** Parity is preserved by subtraction *)
 Lemma Zeven_equiv_minus :
   forall (n m : Z), (Z.Even n <-> Z.Even m) -> Z.Even (m - n).
 Proof.
@@ -57,7 +58,6 @@ Proof.
   by apply Zeven_unary_minus.
 Qed.
 
-(** Even sum term implies parity of the sum depends on the parity of the other sum term *)
 Lemma Zeven_plus_equiv :
   forall (n m : Z), Z.Even n -> (Z.Even m <-> Z.Even (m + n)).
 Proof.
@@ -184,7 +184,8 @@ Proof. done. Qed.
     Regarding the transition which leads to the final state, it technically could be
     included, but we choose to model this way, in order to be consistent
     with the subsequent example, where adding the last transition makes a qualitative
-    difference to the trace *)
+    difference to the trace
+*)
 Definition parity_trace1_init : list (transition_item ParityVLSM) :=
   [ Build_transition_item parity_label (Some 4) (8, 4) (Some 8)
   ; Build_transition_item parity_label (Some 2) (8, 2) (Some 4) ].
@@ -393,7 +394,7 @@ Proof.
   by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
-(** *** Constrained messages are strictly positive even integers *)
+(** *** Constrained messages are positive even integers *)
 
 Lemma parity_constrained_messages_left :
   forall (m : ParityMessage), constrained_message_prop_alt ParityVLSM m ->

--- a/theories/VLSM/Core/Examples/Parity.v
+++ b/theories/VLSM/Core/Examples/Parity.v
@@ -26,7 +26,6 @@ Proof. by intros n; split; intros [p Hp]; exists (-p); lia. Qed.
 (** Even right-hand side and difference implies even left-hand side 
     This lemma will be useful when proving the final result of this section, because of the way 
     we defined the transitions in the Parity VLSM *)
-(** Maybe also renamed to be more suggestive in the sense that is about a difference? *)
 Lemma Zeven_sub_preserve_parity :
   forall (n m : Z), Z.Even n -> Z.Even (m - n) -> Z.Even m.
 Proof. by intros m n [m'] [n']; exists (m' + n'); lia. Qed.

--- a/theories/VLSM/Core/Examples/Parity.v
+++ b/theories/VLSM/Core/Examples/Parity.v
@@ -27,7 +27,7 @@ Proof. by intros n; split; intros [p Hp]; exists (-p); lia. Qed.
     This lemma will be useful when proving the final result of this section, because of the way 
     we defined the transitions in the Parity VLSM *)
 (** Maybe also renamed to be more suggestive in the sense that is about a difference? *)
-Lemma Zeven_preserve_parity :
+Lemma Zeven_sub_preserve_parity :
   forall (n m : Z), Z.Even n -> Z.Even (m - n) -> Z.Even m.
 Proof. by intros m n [m'] [n']; exists (m' + n'); lia. Qed.
 
@@ -64,7 +64,7 @@ Lemma Zeven_plus_equiv :
 Proof.
   split; intros.
   - by apply Zeven_equiv, Zeven_plus_Zeven; rewrite Zeven_equiv.
-  - apply Zeven_preserve_parity with (m + n); [done |].
+  - apply Zeven_sub_preserve_parity with (m + n); [done |].
     replace (m - (m + n)) with (-n) by lia.
     by rewrite <- Zeven_unary_minus.
 Qed.
@@ -541,12 +541,12 @@ Proof.
     split_and!; [| by lia ..].
     transitivity (Z.Even s.2); [| done].
     split.
-    + apply Zeven_preserve_parity.
+    + apply Zeven_sub_preserve_parity.
       destruct p'; [lia | | lia].
       exists (2 ^ (Z.pos p - 1)); rewrite <- Z.pow_succ_r; [| lia].
       by f_equal; lia.
     + intro Heis.
-      apply Zeven_preserve_parity with (n := s.2); [done |].
+      apply Zeven_sub_preserve_parity with (n := s.2); [done |].
       exists (- 2 ^ (p' - 1)).
       by rewrite Z.mul_opp_r, <- Z.pow_succ_r, Z.sub_1_r, Z.succ_pred; lia.
 Qed.

--- a/theories/VLSM/Core/Examples/Parity.v
+++ b/theories/VLSM/Core/Examples/Parity.v
@@ -23,7 +23,7 @@ Lemma Zeven_unary_minus :
   forall n : Z, Z.Even n <-> Z.Even (-n).
 Proof. by intros n; split; intros [p Hp]; exists (-p); lia. Qed.
 
-(** Even subtrahend and difference implies even minuend 
+(** Even right-hand side and difference implies even left-hand side 
     This lemma will be useful when proving the final result of this section, because of the way 
     we defined the transitions in the Parity VLSM *)
 (** Maybe also renamed to be more suggestive in the sense that is about a difference? *)
@@ -180,9 +180,12 @@ Proof. done. Qed.
 
 (** *** Example of a valid trace *)
 
-(** The initial state cannot be included to this definition, because, since there is no transition reaching this state, it cannot be expressed in the below manner
-    Regarding the transition which leads to the final state, it technically could be included, but we choose to model this way, in order to be consistent
-    with the subsequent example, where adding the last transition makes a qualitative difference to the trace *)
+(** The initial state cannot be included to this definition, because, since there is no
+    transition reaching this state, it cannot be expressed in the below manner
+    Regarding the transition which leads to the final state, it technically could be
+    included, but we choose to model this way, in order to be consistent
+    with the subsequent example, where adding the last transition makes a qualitative
+    difference to the trace *)
 Definition parity_trace1_init : list (transition_item ParityVLSM) :=
   [ Build_transition_item parity_label (Some 4) (8, 4) (Some 8)
   ; Build_transition_item parity_label (Some 2) (8, 2) (Some 4) ].
@@ -536,7 +539,7 @@ Proof.
     destruct Hv as [Hv1 Hv2], IHvalid_state_prop as (Heven & Hgt1 & Hgt2); cbn.
     apply parity_valid_messages_powers_of_2_right in Hm as [p' (Hpgt0 & [= ->])]; [| auto] .
     split_and!; [| by lia ..].
-    etransitivity; [| done].
+    transitivity (Z.Even s.2); [| done].
     split.
     + apply Zeven_preserve_parity.
       destruct p'; [lia | | lia].

--- a/theories/VLSM/Core/Examples/Parity.v
+++ b/theories/VLSM/Core/Examples/Parity.v
@@ -18,20 +18,26 @@ From VLSM.Core Require Import VLSM PreloadedVLSM VLSMProjections.
   These lemmas will be helpful in subsequent proofs.
 *)
 
+(** Parity is preserved by taking opposite *)
 Lemma Zeven_unary_minus :
   forall n : Z, Z.Even n <-> Z.Even (-n).
 Proof. by intros n; split; intros [p Hp]; exists (-p); lia. Qed.
 
+(** Even subtrahend and difference implies even minuend 
+    This lemma will be useful when proving the final result of this section, because of the way 
+    we defined the transitions in the Parity VLSM *)
+(** Maybe also renamed to be more suggestive in the sense that is about a difference? *)
 Lemma Zeven_preserve_parity :
   forall (n m : Z), Z.Even n -> Z.Even (m - n) -> Z.Even m.
 Proof. by intros m n [m'] [n']; exists (m' + n'); lia. Qed.
 
+(** Parity is preserved by taking sum *)
 Lemma Zeven_equiv_plus :
   forall (n m : Z), (Z.Even n <-> Z.Even m) -> Z.Even (m + n).
 Proof.
   intros n m Hparity.
   destruct (Zeven_odd_dec m).
-  - apply Zeven_equiv, Zeven_plus_Zeven; [done |].
+  - apply Zeven_equiv, Zeven_plus_Zeven; [done |]. 
     by rewrite Zeven_equiv, Hparity, <- Zeven_equiv.
   - apply Zeven_equiv, Zodd_plus_Zodd; [done |].
     destruct (Zeven_odd_dec n); [| done].
@@ -40,6 +46,7 @@ Proof.
     by rewrite Zeven_equiv, <- Hparity, <- Zeven_equiv.
 Qed.
 
+(** Parity is preserved by taking difference *)
 Lemma Zeven_equiv_minus :
   forall (n m : Z), (Z.Even n <-> Z.Even m) -> Z.Even (m - n).
 Proof.
@@ -51,12 +58,12 @@ Proof.
   by apply Zeven_unary_minus.
 Qed.
 
+(** Even sum term implies parity of the sum depends on the parity of the other sum term *)
 Lemma Zeven_plus_equiv :
   forall (n m : Z), Z.Even n -> (Z.Even m <-> Z.Even (m + n)).
 Proof.
   split; intros.
-  - apply Zeven_preserve_parity with m; [done |].
-    by replace (m + n - m) with n by lia.
+  - by apply Zeven_equiv, Zeven_plus_Zeven; rewrite Zeven_equiv.
   - apply Zeven_preserve_parity with (m + n); [done |].
     replace (m - (m + n)) with (-n) by lia.
     by rewrite <- Zeven_unary_minus.
@@ -101,7 +108,7 @@ Definition ParityType : VLSMType ParityMessage :=
 
 (**
   The specifications for the initial state, transition
-  and validity constraint are as follows:
+  and guard predicate are as follows:
 *)
 
 Definition ParityComponent_initial_state_prop (st : ParityState) : Prop :=
@@ -173,6 +180,9 @@ Proof. done. Qed.
 
 (** *** Example of a valid trace *)
 
+(** The initial state cannot be included to this definition, because, since there is no transition reaching this state, it cannot be expressed in the below manner
+    Regarding the transition which leads to the final state, it technically could be included, but we choose to model this way, in order to be consistent
+    with the subsequent example, where adding the last transition makes a qualitative difference to the trace *)
 Definition parity_trace1_init : list (transition_item ParityVLSM) :=
   [ Build_transition_item parity_label (Some 4) (8, 4) (Some 8)
   ; Build_transition_item parity_label (Some 2) (8, 2) (Some 4) ].
@@ -246,6 +256,7 @@ Qed.
 
 (** *** Example of a constrained trace *)
 
+(** Previously defined trace is obviously constrained, since it's valid *)
 Lemma parity_constrained_trace1 :
   finite_constrained_trace_init_to ParityVLSM
    parity_trace1_first_state parity_trace1_last_state parity_trace1.
@@ -380,7 +391,7 @@ Proof.
   by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
 Qed.
 
-(** *** Constrained messages are even integers *)
+(** *** Constrained messages are strictly positive even integers *)
 
 Lemma parity_constrained_messages_left :
   forall (m : ParityMessage), constrained_message_prop_alt ParityVLSM m ->
@@ -397,12 +408,11 @@ Lemma parity_constrained_messages_right :
 Proof.
   intros m [n ->] Hmgt0.
   pose (s := (n, n)).
-  unfold constrained_message_prop, can_emit; cbn.
   exists (s, Some n), parity_label, (n, 0).
   repeat split.
   - by apply initial_state_is_valid; constructor; cbn; lia.
   - by apply any_message_is_valid_in_preloaded.
-  - by cbn; lia.
+  - by cbn.
   - by lia.
   - by cbn; do 2 f_equal; lia.
 Qed.
@@ -438,7 +448,6 @@ Proof.
   destruct (decide (st.1 = st.2)).
   - by apply initial_state_is_valid; split; lia.
   - pose (s := (st.1, st.1)).
-    unfold constrained_state_prop.
     apply input_valid_transition_destination with (l := parity_label) (s := s)
       (om := Some (st.1 - st.2)) (om' := Some (2 * (st.1 - st.2))).
     repeat split.
@@ -458,7 +467,7 @@ Proof.
   - by intros [? ?]; apply parity_constrained_states_left.
 Qed.
 
-(** *** Powers of 2 are valid messages *)
+(** *** Powers of 2 greater or equal than 2 are valid messages *)
 
 Lemma parity_valid_messages_powers_of_2_right :
   forall (m : option ParityMessage),
@@ -527,11 +536,11 @@ Proof.
     destruct Hv as [Hv1 Hv2], IHvalid_state_prop as (Heven & Hgt1 & Hgt2); cbn.
     apply parity_valid_messages_powers_of_2_right in Hm as [p' (Hpgt0 & [= ->])]; [| auto] .
     split_and!; [| by lia ..].
-    transitivity (Z.Even s.2); [| done].
+    etransitivity; [| done].
     split.
     + apply Zeven_preserve_parity.
       destruct p'; [lia | | lia].
-      exists (2 ^ (Z.pos p - 1)); cbn; rewrite <- Z.pow_succ_r; [| lia].
+      exists (2 ^ (Z.pos p - 1)); rewrite <- Z.pow_succ_r; [| lia].
       by f_equal; lia.
     + intro Heis.
       apply Zeven_preserve_parity with (n := s.2); [done |].


### PR DESCRIPTION
In addition to adding more coqdoc comments (which I hope to be useful, maybe some of them are to obvious, I'm not sure), I made a few minor changes in some proofs, where I thought I found a shorter proof (for a utility lemma, using a stdpp lemma in the proof made it a bit shorter), or there was a redundant step (eg. a `cbn` which did nothing). Please let me know if that's ok.