### PR TITLE
Flatten some deeply nested proofs

### DIFF
--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -1006,11 +1006,10 @@ Proof.
       apply reachable_sent_messages_reachable.
       assert (i = i') as ->; [| done].
       by (apply ELMO_reachable_view in Hs as []; apply (inj idx); congruence).
-    - apply self_messages_sent; [| done |].
-      + apply ELMO_reachable_view in Hs as [Hs ?].
-        revert Hs; apply UMO_reachable_impl.
-        by intros ? ? [].
-      + by apply elem_of_messages; auto.
+    - apply self_messages_sent; [| done | by apply elem_of_messages; auto].
+      apply ELMO_reachable_view in Hs as [Hs ?].
+      revert Hs; apply UMO_reachable_impl.
+      by intros ? ? [].
   }
   revert m Hm n.
   apply ELMO_reachable_view in Hs as [Hs Hadr].
@@ -1020,44 +1019,44 @@ Proof.
   destruct (decide (m ∈ receivedMessages s)); [by eauto |].
   clear IHHs; revert s Hs Hadr Hvalid n.
   destruct m as [ms]; cbn.
-  induction ms using addObservation_ind.
-  - by intros; apply initial_state_is_valid; constructor.
-  - set (m' := ms <+> ob); cbn.
-    intros s Hs Hadr Hrecv_m' Hfresh' Hadr_neq i' Hadr_ms.
-    assert (Hrecv_if_fresh : MkMessage ms ∉ receivedMessages s -> ELMO_recv_valid s (MkMessage ms)).
-    {
-      by intro; apply (ELMO_recv_valid_prefix s (MkMessage ms) ob); [apply ELMO_reachable_view | ..].
-    }
-    assert (Hms : ram_state_prop (ELMOComponent i') ms).
-    {
-      destruct (decide (MkMessage ms ∈ receivedMessages s)); [| by eauto].
-      revert e; clear -Hs IHms Hadr Hadr_ms Hadr_neq.
-      induction Hs; [by inversion 1 | by eapply IHHs |].
-      destruct (decide (MkMessage ms ∈ receivedMessages s)).
-      - by intros; eapply IHHs.
-      - intros [[Hms _] |]%elem_of_receivedMessages_addObservation; cbn in *; subst; eauto.
-    }
-    apply ELMO_reachable_view; split; [| done].
-    apply ELMO_reachable_view in Hms as [Hms _].
-    destruct ob as [[] [os]].
-    + apply reach_recv; [| done].
-      destruct Hrecv_m' as [Hfull_s_m' Hself Hmvf_m' Hlimit].
-      inversion Hmvf_m' as [| | ? ? Hfull_m_os Hself_os Hvalid Heqmo]; [done |].
-      assert (m = MkMessage ms)
-        by (destruct m; f_equal; apply eq_State; done).
-      subst m; clear mo Heqmo; cbn in *.
-      constructor; [done | done | |].
-      * apply reachable_messages_are_msg_valid with (s := s).
-        -- by apply ELMO_reachable_view.
-        -- by revert Hfull_s_m'; apply elem_of_submseteq, elem_of_list_here.
-      * apply equivocation_limit_recv_ok_msg_ok in Hlimit; try done.
-        -- by revert Hs; apply UMO_reachable_impl; intros ? ? [].
-        -- apply reach_recv; [done |].
-           by revert Hms; apply UMO_reachable_impl; intros ? ? [].
-    + destruct Hrecv_m' as [_ _ Hmvf _]; inversion Hmvf; [done |].
-      unfold m'.
-      replace os with ms by (apply eq_State; done).
-      by apply reach_send.
+  induction ms using addObservation_ind;
+    [by intros; apply initial_state_is_valid; constructor |].
+  set (m' := ms <+> ob); cbn.
+  intros s Hs Hadr Hrecv_m' Hfresh' Hadr_neq i' Hadr_ms.
+  assert (Hrecv_if_fresh : MkMessage ms ∉ receivedMessages s -> ELMO_recv_valid s (MkMessage ms)).
+  {
+    by intro; apply (ELMO_recv_valid_prefix s (MkMessage ms) ob); [apply ELMO_reachable_view | ..].
+  }
+  assert (Hms : ram_state_prop (ELMOComponent i') ms).
+  {
+    destruct (decide (MkMessage ms ∈ receivedMessages s)); [| by eauto].
+    revert e; clear -Hs IHms Hadr Hadr_ms Hadr_neq.
+    induction Hs; [by inversion 1 | by eapply IHHs |].
+    destruct (decide (MkMessage ms ∈ receivedMessages s)).
+    - by intros; eapply IHHs.
+    - intros [[Hms _] |]%elem_of_receivedMessages_addObservation; cbn in *; subst; eauto.
+  }
+  apply ELMO_reachable_view; split; [| done].
+  apply ELMO_reachable_view in Hms as [Hms _].
+  destruct ob as [[] [os]].
+  - apply reach_recv; [| done].
+    destruct Hrecv_m' as [Hfull_s_m' Hself Hmvf_m' Hlimit].
+    inversion Hmvf_m' as [| | ? ? Hfull_m_os Hself_os Hvalid Heqmo]; [done |].
+    assert (m = MkMessage ms)
+      by (destruct m; f_equal; apply eq_State; done).
+    subst m; clear mo Heqmo; cbn in *.
+    constructor; [done | done | |].
+    + apply reachable_messages_are_msg_valid with (s := s).
+      * by apply ELMO_reachable_view.
+      * by revert Hfull_s_m'; apply elem_of_submseteq, elem_of_list_here.
+    + apply equivocation_limit_recv_ok_msg_ok in Hlimit; try done.
+      * by revert Hs; apply UMO_reachable_impl; intros ? ? [].
+      * apply reach_recv; [done |].
+        by revert Hms; apply UMO_reachable_impl; intros ? ? [].
+  - destruct Hrecv_m' as [_ _ Hmvf _]; inversion Hmvf; [done |].
+    unfold m'.
+    replace os with ms by (apply eq_State; done).
+    by apply reach_send.
 Qed.
 
 Lemma receivable_messages_reachable (ms s : State) i' :

--- a/theories/VLSM/Core/Equivocators/FullReplayTraces.v
+++ b/theories/VLSM/Core/Equivocators/FullReplayTraces.v
@@ -169,33 +169,32 @@ Proof.
     rewrite decide_True; [done |].
     by apply elem_of_enum.
   }
-  induction l using rev_ind; intros.
-  - case_decide; [| done].
-    by rewrite decide_False; [| inversion 1].
-  - spec IHl; [by apply list_subseteq_inv_app in Hincl; apply Hincl |].
-    spec IHl; [by apply NoDup_app in Hnodup; apply Hnodup |].
-    subst tr_full_replay_is.
-    rewrite map_app, (composite_apply_plan_app (equivocator_IM IM)); simpl in *
-    ; destruct (composite_apply_plan _ _ _) as (aitems, afinal); simpl in *.
-    specialize (IHl i); destruct_dec_sig x ix Hix Heqx; subst x; simpl in *.
-    case_decide as _Hix; cycle 1;
-      destruct (decide (ix = i)); subst; equivocator_state_update_simpl; [done | done | |].
-    + rewrite decide_False in IHl.
-      * rewrite IHl, decide_True.
-        -- rewrite (sub_IM_state_pi is _Hix Hix); symmetry.
-           by apply equivocator_state_append_singleton_is_extend, (His (dexist i Hix)).
-        -- rewrite elem_of_app, elem_of_list_singleton; right.
-           by apply dsig_eq.
-      * intro Heqv.
-        apply NoDup_app in Hnodup as (_ & Hnodup & _).
-        eapply Hnodup; [done |].
-        rewrite elem_of_list_singleton.
+  induction l using rev_ind; intros;
+    [by case_decide; [rewrite decide_False by apply not_elem_of_nil |] |].
+  spec IHl; [by apply list_subseteq_inv_app in Hincl; apply Hincl |].
+  spec IHl; [by apply NoDup_app in Hnodup; apply Hnodup |].
+  subst tr_full_replay_is.
+  rewrite map_app, (composite_apply_plan_app (equivocator_IM IM)); simpl in *
+  ; destruct (composite_apply_plan _ _ _) as (aitems, afinal); simpl in *.
+  specialize (IHl i); destruct_dec_sig x ix Hix Heqx; subst x; simpl in *.
+  case_decide as _Hix; cycle 1;
+    destruct (decide (ix = i)); subst; equivocator_state_update_simpl; [done | done | |].
+  - rewrite decide_False in IHl.
+    + rewrite IHl, decide_True.
+      * rewrite (sub_IM_state_pi is _Hix Hix); symmetry.
+        by apply equivocator_state_append_singleton_is_extend, (His (dexist i Hix)).
+      * rewrite elem_of_app, elem_of_list_singleton; right.
         by apply dsig_eq.
-    + case_decide.
-      * rewrite decide_True; rewrite ?elem_of_app; itauto.
-      * rewrite decide_False; [done |].
-        intros [Hin | Hx]%elem_of_app; [done |].
-        by rewrite elem_of_list_singleton, dsig_eq in Hx.
+    + intro Heqv.
+      apply NoDup_app in Hnodup as (_ & Hnodup & _).
+      eapply Hnodup; [done |].
+      rewrite elem_of_list_singleton.
+      by apply dsig_eq.
+  - case_decide.
+    + rewrite decide_True; rewrite ?elem_of_app; itauto.
+    + rewrite decide_False; [done |].
+      intros [Hin | Hx]%elem_of_app; [done |].
+      by rewrite elem_of_list_singleton, dsig_eq in Hx.
 Qed.
 
 (**

--- a/theories/VLSM/Core/ReachableThreshold.v
+++ b/theories/VLSM/Core/ReachableThreshold.v
@@ -99,13 +99,11 @@ Proof.
       apply sum_weights_list_permutation_proper.
       rewrite elements_disj_union.
       * apply Permutation_app_tail.
-        etransitivity.
-        -- symmetry.
-           by apply (elements_list_to_set (H6 := H6)), set_remove_nodup.
-        -- apply elements_proper.
-           intro x.
-           rewrite elem_of_difference, !elem_of_list_to_set.
-           by rewrite set_remove_iff, elem_of_singleton.
+        etransitivity; [by symmetry; apply (elements_list_to_set (H6 := H6)), set_remove_nodup |].
+        apply elements_proper.
+        intro x.
+        rewrite elem_of_difference, !elem_of_list_to_set.
+        by rewrite set_remove_iff, elem_of_singleton.
       * intros x; rewrite elem_of_difference, elem_of_list_to_set, elem_of_singleton.
         by intros [] ?; eapply Hdisj; [apply elem_of_elements, Hincl |].
 Qed.


### PR DESCRIPTION
There were some proofs that were deeply nested (i.e. using the `--` and `++` bullets). I flattened some of them, most often by fusing the first easy case at the `-` level with the preceding tactic. Note that some deeply nested proofs remain, as they cannot be flattened in this way and would probably require splitting into lemmas. I was also able to remove around 40 lines of unused proofs.

The diff is not very readable because of all the reindentation...