### PR TITLE
compatibility with Coq 8.18, fix deprecations

### DIFF
--- a/theories/VLSM/Core/Equivocation.v
+++ b/theories/VLSM/Core/Equivocation.v
@@ -1917,8 +1917,9 @@ Lemma composite_has_been_directly_observed_stepwise_props
   (X := composite_vlsm IM constraint)
   : oracle_stepwise_props (vlsm := X) item_sends_or_receives composite_has_been_directly_observed.
 Proof.
-  pose proof (composite_stepwise_props
-                (fun i => (has_been_directly_observed_stepwise_props (IM i))))
+  pose proof 
+    (composite_stepwise_props
+       (fun i => (has_been_directly_observed_stepwise_props (IM i))) constraint)
        as [Hinits Hstep].
   split; [done |].
   by intros l; specialize (Hstep l); destruct l.

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -106,7 +106,7 @@ Proof.
     specialize (IHl H); clear H.
     destruct IHl as [prefix [suffix [last [Hf [-> Hnone_after]]]]].
     exists prefix, (suffix ++ [x]), last.
-    simpl. rewrite app_assoc_reverse. simpl.
+    simpl. rewrite <- app_assoc. simpl.
     rewrite Exists_app. rewrite Exists_cons. rewrite Exists_nil.
     by itauto.
 Qed.


### PR DESCRIPTION
We have Std++ working for 8.18 now, so this is the first step to adding support for 8.18.