### PR TITLE
Replace "ram" with "constrained" in names

### DIFF
--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -495,10 +495,6 @@ Notation "s <++> obs" := (addObservations obs s) (left associativity, at level 5
 Notation "m <*> ob" := (addObservationToMessage ob m) (left associativity, at level 50).
 Notation "m <**> obs" := (addObservationsToMessage obs m) (left associativity, at level 50).
 
-(** [ram_state_prop] defines the "reachable by any means" or ram states of a VLSM. *)
-Definition ram_state_prop {message} (V : VLSM message) (s : VLSM.state V) : Prop :=
-  valid_state_prop (pre_loaded_with_all_messages_vlsm V) s.
-
 Section sec_BaseELMO_Observations.
 
 Context

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -1099,7 +1099,7 @@ Proof.
     + by split; [done |]; eexists; split_and!; [done.. |]; constructor.
 Qed.
 
-Lemma ELMOComponent_elem_of_ram_trace
+Lemma ELMOComponent_elem_of_constrained_trace
   [s tr] (Htr : finite_valid_trace_from Ri s tr) :
   forall item, item ∈ tr ->
     exists (s : State) (m : Message),
@@ -1112,7 +1112,7 @@ Proof.
     inversion Hvi; subst; inversion Hti; subst; eexists _, _; split.
 Qed.
 
-Lemma ELMOComponent_receivedMessages_of_ram_trace
+Lemma ELMOComponent_receivedMessages_of_constrained_trace
   [s s' tr] (Htr : finite_valid_trace_from_to Ri s s' tr) :
   forall item, item ∈ tr ->
   forall m, (field_selector input) m item -> m ∈ receivedMessages s'.
@@ -1125,7 +1125,7 @@ Proof.
   by destruct Hitem as [Hitem | ->]; [right; cbn; eapply IHHtr | left].
 Qed.
 
-Lemma ELMOComponent_sentMessages_of_ram_trace
+Lemma ELMOComponent_sentMessages_of_constrained_trace
   [s s' tr] (Htr : finite_valid_trace_from_to Ri s s' tr) :
   forall item, item ∈ tr ->
   forall m, (field_selector output) m item -> m ∈ sentMessages s'.
@@ -1138,7 +1138,7 @@ Proof.
   by destruct Hitem as [Hitem | ->]; [right; cbn; eapply IHHtr | left].
 Qed.
 
-Lemma ELMOComponent_sizeState_of_ram_trace_output
+Lemma ELMOComponent_sizeState_of_constrained_trace_output
   [s tr] (Htr : finite_valid_trace_from Ri s tr) :
   forall item, item ∈ tr ->
   forall m, (field_selector output) m item ->
@@ -1153,14 +1153,14 @@ Proof.
     by eapply Nat.lt_le_incl, ELMOComponent_valid_transition_size; cbn in Hv, Ht.
 Qed.
 
-Lemma ELMOComponent_messages_of_ram_trace
+Lemma ELMOComponent_messages_of_constrained_trace
   [s s' tr] (Htr : finite_valid_trace_from_to Ri s s' tr) :
   forall item, item ∈ tr ->
   forall m, item_sends_or_receives m item -> m ∈ messages s'.
 Proof.
   intros ? ? ? [|]; apply elem_of_messages.
-  - by right; eapply ELMOComponent_receivedMessages_of_ram_trace.
-  - by left; eapply ELMOComponent_sentMessages_of_ram_trace.
+  - by right; eapply ELMOComponent_receivedMessages_of_constrained_trace.
+  - by left; eapply ELMOComponent_sentMessages_of_constrained_trace.
 Qed.
 
 End sec_ELMOComponent_lemmas.
@@ -2505,7 +2505,7 @@ Lemma all_intermediary_transitions_are_receive
   : Forall (fun item : transition_item ELMOComponentType => l item = Receive) tr_m.
 Proof.
   apply Forall_forall; intros item Hitem.
-  eapply ELMOComponent_elem_of_ram_trace in Hitem as H_item;
+  eapply ELMOComponent_elem_of_constrained_trace in Hitem as H_item;
     [| by eapply valid_trace_forget_last].
   destruct H_item as (s_m0 & m0 & Hs_m0 & H_item).
   destruct item; apply ELMOComponent_input_valid_transition_iff in H_item
@@ -2513,7 +2513,7 @@ Proof.
   inversion H_item as [| ? ? ? [(_ & _ & Hvi) Hti]]; subst;
     inversion Hvi; subst; inversion Hti; subst; clear H_item Hvi Hti.
   contradict Hnot_local_equivocator; apply Hspecial.
-  eapply ELMOComponent_sentMessages_of_ram_trace in Hitem as Hm0; [| done..].
+  eapply ELMOComponent_sentMessages_of_constrained_trace in Hitem as Hm0; [| done..].
   eapply reachable_sent_messages_adr in Hm0 as Hm0_adr;
     [| by eapply finite_valid_trace_from_to_last_pstate].
   exists (MkMessage s_m0); [by congruence | ..].
@@ -2533,7 +2533,7 @@ Proof.
       [| by eapply valid_state_project_preloaded_to_preloaded_free].
     rewrite Hm0_adr in Hsnd_adr.
     eapply inj in Hsnd_adr; [| done]; subst j.
-    eapply ELMOComponent_sizeState_of_ram_trace_output in Hitem;
+    eapply ELMOComponent_sizeState_of_constrained_trace_output in Hitem;
       [| by eapply valid_trace_forget_last | done].
     assert (sizeState s_m0 < sizeState (sigma i_m)).
     {

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -1065,12 +1065,12 @@ Lemma receivable_messages_reachable (ms s : State) i' :
   ELMO_recv_valid s (MkMessage ms) ->
   constrained_state_prop_alt (ELMOComponent i') ms.
 Proof.
-  intros Heq Hram Hrv.
+  intros Heq Hcsp Hrv.
   change ms with (state (MkMessage ms)).
   apply reachable_received_messages_reachable
     with (s := s <+> MkObservation Receive (MkMessage ms))
   ; [| constructor | done].
-  apply ELMO_reachable_view in Hram as [].
+  apply ELMO_reachable_view in Hcsp as [].
   apply ELMO_reachable_view; cbn.
   by split; [apply reach_recv |].
 Qed.

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -134,7 +134,7 @@ Lemma full_node_VLSM_reachable
     forall (l : Label) (s : State) (m : Message),
       valid V l (s, Some m) -> full_node s m) :
   forall (s : State),
-    ram_state_prop V s ->
+    constrained_state_prop_alt V s ->
     UMO_reachable full_node s.
 Proof.
   intro s.
@@ -355,7 +355,7 @@ Defined.
     HasBeenDirectlyObservedCapability_from_sent_received (ELMOComponent i).
 
 Lemma ELMO_reachable_view (s : State) i :
-  ram_state_prop (ELMOComponent i) s
+  constrained_state_prop_alt (ELMOComponent i) s
     <->
   UMO_reachable ELMO_recv_valid s /\ adr s = idx i.
 Proof.
@@ -381,7 +381,7 @@ Proof.
 Qed.
 
 Lemma ELMO_full_node_reachable i s :
-  ram_state_prop (ELMOComponent i) s -> UMO_reachable full_node s.
+  constrained_state_prop_alt (ELMOComponent i) s -> UMO_reachable full_node s.
 Proof.
   intro Hs; apply ELMO_reachable_view in Hs as [? _].
   eapply UMO_reachable_impl; [| done].
@@ -389,7 +389,7 @@ Proof.
 Qed.
 
 Lemma ELMO_no_self_equiv_reachable i s :
-  ram_state_prop (ELMOComponent i) s -> UMO_reachable no_self_equiv s.
+  constrained_state_prop_alt (ELMOComponent i) s -> UMO_reachable no_self_equiv s.
 Proof.
   intro Hs; apply ELMO_reachable_view in Hs as [? _].
   eapply UMO_reachable_impl; [| done].
@@ -406,7 +406,7 @@ Context
   (Ri : VLSM Message := pre_loaded_with_all_messages_vlsm Ei).
 
 Lemma ELMO_reachable_adr (s : State) :
-  ram_state_prop Ei s -> adr s = idx i.
+  constrained_state_prop_alt Ei s -> adr s = idx i.
 Proof.
   by intros [_ Hadr]%ELMO_reachable_view.
 Qed.
@@ -467,7 +467,7 @@ Qed.
 
 (** There is a unique trace from any prefix of a reachable state to that state. *)
 Lemma ELMO_unique_trace_segments (s sf : State) :
-  ram_state_prop Ei sf -> (s = sf \/ state_suffix s sf) ->
+  constrained_state_prop_alt Ei sf -> (s = sf \/ state_suffix s sf) ->
   exists! (tr : list transition_item),
     finite_valid_trace_from_to Ri s sf tr.
 Proof.
@@ -509,7 +509,7 @@ Qed.
   trace reaching that state from the initial state.
 *)
 Lemma ELMO_unique_traces (sf : State) :
-  ram_state_prop Ei sf ->
+  constrained_state_prop_alt Ei sf ->
     exists! tr : list transition_item, exists si : State,
       finite_valid_trace_init_to Ri si sf tr.
 Proof.
@@ -614,7 +614,7 @@ Qed.
 
 (**
   This lemma is convenient to prove for [local_equivocators_simple],
-  and our assumption is slightly weaker than [ram_state_prop Ei].
+  and our assumption is slightly weaker than [constrained_state_prop_alt Ei].
 *)
 Lemma local_equivocators_simple_no_self (s : State) :
   UMO_reachable no_self_equiv s ->
@@ -794,7 +794,7 @@ Qed.
 
 Lemma ELMO_reachable_msg_valid_full :
   forall s : State,
-    ram_state_prop Ei s -> ELMO_msg_valid_full (MkMessage s).
+    constrained_state_prop_alt Ei s -> ELMO_msg_valid_full (MkMessage s).
 Proof.
   intros s [Hs Hi]%ELMO_reachable_view.
   induction Hs as [| | ? ? Hvalid]; [| specialize (IHHs Hi)..].
@@ -804,7 +804,7 @@ Proof.
 Qed.
 
 Lemma reachable_full_node_for_all_messages i' (s : State) :
-  ram_state_prop (ELMOComponent i') s ->
+  constrained_state_prop_alt (ELMOComponent i') s ->
   forall m, m ∈ messages s -> full_node s m.
 Proof.
   intros [Hs _]%ELMO_reachable_view.
@@ -819,9 +819,9 @@ Proof.
 Qed.
 
 Lemma reachable_sent_messages_reachable i' (s ms : State) :
-  ram_state_prop (ELMOComponent i') s ->
+  constrained_state_prop_alt (ELMOComponent i') s ->
   MkMessage ms ∈ sentMessages s ->
-  ram_state_prop (ELMOComponent i') ms.
+  constrained_state_prop_alt (ELMOComponent i') ms.
 Proof.
   intros [Hs Hadr]%ELMO_reachable_view Hms.
   apply ELMO_reachable_view.
@@ -831,7 +831,7 @@ Proof.
 Qed.
 
 Lemma reachable_sent_messages_adr (s : State) (m : Message) :
-  ram_state_prop Ei s ->
+  constrained_state_prop_alt Ei s ->
   m ∈ sentMessages s ->
   adr (state m) = idx i.
 Proof.
@@ -840,7 +840,7 @@ Proof.
 Qed.
 
 Lemma reachable_messages_are_msg_valid (s : State) (m : Message) :
-  ram_state_prop Ei s ->
+  constrained_state_prop_alt Ei s ->
   m ∈ messages s ->
   ELMO_msg_valid_full m.
 Proof.
@@ -933,7 +933,7 @@ Lemma equivocation_limit_recv_msg_prefix_ok (v : State) (m : Message) ob
   (v'' := v <+> MkObservation Receive m)
   :
   adr (state m) <> adr v ->
-  ram_state_prop Ei v ->
+  constrained_state_prop_alt Ei v ->
   m' ∉ receivedMessages v ->
   m ∉ receivedMessages v ->
   ELMO_recv_valid v m' ->
@@ -975,7 +975,7 @@ Hint Resolve
   : ELMO_hints.
 
 Lemma ELMO_recv_valid_prefix s (m : Message) (ob : Observation) :
-  ram_state_prop Ei s ->
+  constrained_state_prop_alt Ei s ->
   m <*> ob ∉ receivedMessages s ->
   m ∉ receivedMessages s ->
   adr s <> adr (state m) ->
@@ -990,12 +990,12 @@ Qed.
 Hint Resolve ELMO_recv_valid_prefix : ELMO_hints.
 
 Lemma reachable_received_messages_reachable (s : State) :
-  ram_state_prop Ei s ->
+  constrained_state_prop_alt Ei s ->
   forall m,
     m ∈ receivedMessages s ->
   forall i',
     adr (state m) = idx i' ->
-    ram_state_prop (ELMOComponent i') (state m).
+    constrained_state_prop_alt (ELMOComponent i') (state m).
 Proof.
   intros Hs m Hm.
   destruct (decide (adr (state m) = adr s)).
@@ -1027,7 +1027,7 @@ Proof.
   {
     by intro; apply (ELMO_recv_valid_prefix s (MkMessage ms) ob); [apply ELMO_reachable_view | ..].
   }
-  assert (Hms : ram_state_prop (ELMOComponent i') ms).
+  assert (Hms : constrained_state_prop_alt (ELMOComponent i') ms).
   {
     destruct (decide (MkMessage ms ∈ receivedMessages s)); [| by eauto].
     revert e; clear -Hs IHms Hadr Hadr_ms Hadr_neq.
@@ -1061,9 +1061,9 @@ Qed.
 
 Lemma receivable_messages_reachable (ms s : State) i' :
   adr ms = idx i' ->
-  ram_state_prop Ei s ->
+  constrained_state_prop_alt Ei s ->
   ELMO_recv_valid s (MkMessage ms) ->
-  ram_state_prop (ELMOComponent i') ms.
+  constrained_state_prop_alt (ELMOComponent i') ms.
 Proof.
   intros Heq Hram Hrv.
   change ms with (state (MkMessage ms)).
@@ -1187,7 +1187,7 @@ Definition ELMOComponent_state_destructor (s : State)
   end.
 
 Lemma ELMOComponent_state_destructor_initial :
-  forall (s' : VLSM.state Ei), ram_state_prop Ei s' ->
+  forall (s' : VLSM.state Ei), constrained_state_prop_alt Ei s' ->
     initial_state_prop Ei s' <-> ELMOComponent_state_destructor s' = [].
 Proof.
   intros s' Hs'; split; intro Hs''.
@@ -1197,7 +1197,7 @@ Proof.
 Qed.
 
 Lemma ELMOComponent_state_destructor_input_valid_transition :
-  forall (s' : VLSM.state Ei), ram_state_prop Ei s' ->
+  forall (s' : VLSM.state Ei), constrained_state_prop_alt Ei s' ->
   forall (s : VLSM.state Ei) (item : transition_item Ei),
     (item, s) ∈ ELMOComponent_state_destructor s' ->
     input_valid_transition_item Ri s item.
@@ -1222,7 +1222,7 @@ Proof.
 Qed.
 
 Lemma ELMO_latest_observation_Send_state :
-  forall s' : State, ram_state_prop Ei s' ->
+  forall s' : State, constrained_state_prop_alt Ei s' ->
   forall (s : State) (m : Message), s' = s <+> MkObservation Send m ->
     s = state m.
 Proof.
@@ -1406,10 +1406,10 @@ Definition FreeELMO : VLSM Message :=
 Definition ReachELMO : VLSM Message :=
   pre_loaded_with_all_messages_vlsm FreeELMO.
 
-Definition composite_ram_state_prop
+Definition composite_constrained_state_prop_alt
   {message : Type} `{EqDecision index}
   (IM : index -> VLSM message) (s : composite_state IM) : Prop :=
-    ram_state_prop (free_composite_vlsm IM) s.
+    constrained_state_prop_alt (free_composite_vlsm IM) s.
 
 Lemma ELMO_initial_state_equivocating_validators :
   forall s : composite_state ELMOComponent,
@@ -1500,13 +1500,13 @@ Proof.
 Qed.
 
 Definition ELMO_state_to_minimal_equivocation_trace
-  (s : composite_state ELMOComponent) (Hs : composite_ram_state_prop ELMOComponent s)
+  (s : composite_state ELMOComponent) (Hs : composite_constrained_state_prop_alt ELMOComponent s)
   : composite_state ELMOComponent * list (composite_transition_item ELMOComponent) :=
   state_to_minimal_equivocation_trace ELMOComponent
     (fun _ : index => ELMOComponent_state_destructor) (fun _ : index => sizeState) s Hs.
 
 Lemma ELMO_state_to_minimal_equivocation_trace_reachable
-  (s : composite_state ELMOComponent) (Hs : composite_ram_state_prop ELMOComponent s)
+  (s : composite_state ELMOComponent) (Hs : composite_constrained_state_prop_alt ELMOComponent s)
   (is : composite_state ELMOComponent) (tr : list (composite_transition_item ELMOComponent)) :
     ELMO_state_to_minimal_equivocation_trace s Hs = (is, tr) ->
       finite_valid_trace_init_to ReachELMO is s tr.
@@ -1561,7 +1561,7 @@ Proof.
 Qed.
 
 Lemma ELMO_state_to_minimal_equivocation_trace_equivocation_monotonic :
-  forall (s : composite_state ELMOComponent) (Hs : composite_ram_state_prop ELMOComponent s),
+  forall (s : composite_state ELMOComponent) (Hs : composite_constrained_state_prop_alt ELMOComponent s),
   forall (is : composite_state ELMOComponent) (tr : list (composite_transition_item ELMOComponent)),
   ELMO_state_to_minimal_equivocation_trace s Hs = (is, tr) ->
   forall (pre suf : list (composite_transition_item ELMOComponent))
@@ -1586,7 +1586,7 @@ Qed.
 
 Lemma ELMO_global_equivocators_iff_simple :
   forall (s : VLSM.state ELMOProtocol) (a : Address),
-    composite_ram_state_prop ELMOComponent s ->
+    composite_constrained_state_prop_alt ELMOComponent s ->
       ELMO_global_equivocators s a <-> global_equivocators_simple s a.
 Proof.
   intros s a Hs.
@@ -1665,7 +1665,7 @@ Qed.
 
 Lemma ELMO_global_equivocators_iff_msg_dep_equivocation :
   forall (s : VLSM.state ELMOProtocol) (a : Address),
-    composite_ram_state_prop ELMOComponent s ->
+    composite_constrained_state_prop_alt ELMOComponent s ->
   ELMO_global_equivocators s a
     <->
   msg_dep_is_globally_equivocating ELMOComponent
@@ -1683,7 +1683,7 @@ Qed.
 
 Lemma ELMO_global_equivocators_iff_simple_by_generic :
   forall (s : VLSM.state ELMOProtocol) (a : Address),
-    composite_ram_state_prop ELMOComponent s ->
+    composite_constrained_state_prop_alt ELMOComponent s ->
       ELMO_global_equivocators s a <-> global_equivocators_simple s a.
 Proof.
   intros s a Hs.
@@ -1705,7 +1705,7 @@ Qed.
 
 Lemma ELMO_state_to_minimal_equivocation_equivocating_validators
   (s : composite_state ELMOComponent)
-  (Hs_pre :  composite_ram_state_prop ELMOComponent s)
+  (Hs_pre :  composite_constrained_state_prop_alt ELMOComponent s)
   (is : composite_state ELMOComponent)
   (tr : list (composite_transition_item ELMOComponent))
   (Heqtr_min : ELMO_state_to_minimal_equivocation_trace s Hs_pre = (is, tr)) :
@@ -1731,7 +1731,7 @@ Lemma ELMO_state_to_minimal_equivocation_trace_valid
   (s : composite_state ELMOComponent)
   (Hs : valid_state_prop ELMOProtocol s)
   (Hs_pre := VLSM_incl_valid_state (constrained_preloaded_incl (free_composite_vlsm _) ELMO_global_constraint) _ Hs
-    : composite_ram_state_prop ELMOComponent s)
+    : composite_constrained_state_prop_alt ELMOComponent s)
   (is : composite_state ELMOComponent)
   (tr : list (composite_transition_item ELMOComponent)) :
     ELMO_state_to_minimal_equivocation_trace s Hs_pre = (is, tr) ->
@@ -1899,7 +1899,7 @@ Qed.
 
 Lemma global_equivocators_simple_step_update_receive_already_observed
   (i : index) (sigma : composite_state ELMOComponent) (s' : State) (m : Message) :
-    composite_ram_state_prop ELMOComponent sigma ->
+    composite_constrained_state_prop_alt ELMOComponent sigma ->
     ELMOComponentRAMTransition i Receive (sigma i) s' m ->
     composite_has_been_directly_observed ELMOComponent sigma m ->
       forall a : Address,
@@ -1919,7 +1919,7 @@ Qed.
 
 Lemma ELMO_equivocating_validators_step_update_Send
   (i : index) (sigma : composite_state ELMOComponent) (s' : State) (m : Message) :
-  composite_ram_state_prop ELMOComponent sigma ->
+  composite_constrained_state_prop_alt ELMOComponent sigma ->
   ELMOComponentRAMTransition i Send (sigma i) s' m ->
     ELMO_equivocating_validators (state_update ELMOComponent sigma i s')
       ⊆
@@ -1941,7 +1941,7 @@ Qed.
 
 Lemma ELMO_equivocating_validators_step_update_Receive
   (i : index) (sigma : composite_state ELMOComponent) (s' : State) (m : Message) :
-  composite_ram_state_prop ELMOComponent sigma ->
+  composite_constrained_state_prop_alt ELMOComponent sigma ->
   ELMOComponentRAMTransition i Receive (sigma i) s' m ->
     ELMO_equivocating_validators (state_update ELMOComponent sigma i s')
       ⊆
@@ -1965,7 +1965,7 @@ Qed.
 
 Lemma ELMO_equivocating_validators_step_update_Receive_already_Observed
   (i : index) (sigma : composite_state ELMOComponent) (s' : State) (m : Message) :
-  composite_ram_state_prop ELMOComponent sigma ->
+  composite_constrained_state_prop_alt ELMOComponent sigma ->
   composite_has_been_directly_observed ELMOComponent sigma m ->
   ELMOComponentRAMTransition i Receive (sigma i) s' m ->
     ELMO_equivocating_validators (state_update ELMOComponent sigma i s')
@@ -2143,7 +2143,7 @@ Proof.
     - by apply any_message_is_valid_in_preloaded.
   }
   apply (VLSM_incl_valid_state Hincl) in Hs as Hs_pre.
-  assert (Hs' : composite_ram_state_prop ELMOComponent s').
+  assert (Hs' : composite_constrained_state_prop_alt ELMOComponent s').
   {
     apply valid_state_prop_iff; right.
     by exists (existT i Receive), (s, Some m), None; repeat split;
@@ -2204,7 +2204,7 @@ Proof.
   {
     assert (Hall_reachable :
       Forall (fun item =>
-        composite_ram_state_prop ELMOComponent
+        composite_constrained_state_prop_alt ELMOComponent
           ((state_update ELMOComponent s i_m item))) (is_m :: map destination tr_m)).
     {
       apply (VLSM_incl_valid_state Hincl) in Hsimis as Hsimis_pre.
@@ -2232,7 +2232,7 @@ Proof.
     apply Forall_app in Hall_messages_observed as [Hall_messages_observed Hlast_obs].
     rewrite Forall_singleton in Hlast_obs.
     specialize (IHHtr_m Hsimis_eqvs Hall_messages_observed Hall_reachable).
-    assert (Hsis0_pre : composite_ram_state_prop ELMOComponent (state_update ELMOComponent s i_m s0)).
+    assert (Hsis0_pre : composite_constrained_state_prop_alt ELMOComponent (state_update ELMOComponent s i_m s0)).
     {
       apply valid_trace_get_last in Htr_m as <-.
       rewrite Forall_forall in Hall_reachable.
@@ -2495,7 +2495,7 @@ Lemma all_intermediary_transitions_are_receive
   (Hadr_neq : adr (state m) <> idx i)
   (Hnot_local_equivocator : ~ local_equivocators_full si (adr (state m)))
   (sigma : composite_state ELMOComponent)
-  (Hsigma : composite_ram_state_prop ELMOComponent sigma)
+  (Hsigma : composite_constrained_state_prop_alt ELMOComponent sigma)
   (Hcomponent : sigma i = si)
   (Hspecial : component_reflects_composite sigma i)
   (tr_m : list transition_item)
@@ -2808,7 +2808,7 @@ Qed.
 *)
 Lemma reflecting_composite_for_reachable_component
   (i : index) (si : VLSM.state (ELMOComponent i))
-  (Hreachable : ram_state_prop (ELMOComponent i) si) :
+  (Hreachable : constrained_state_prop_alt (ELMOComponent i) si) :
   exists s : VLSM.state ELMOProtocol,
     s i = si
     /\ valid_state_prop ELMOProtocol s

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -675,7 +675,7 @@ Proof.
   by eapply finite_valid_trace_init_to_unique_RMi.
 Qed.
 
-(** The trace extracted from a ram-state <<s>> leads to <<s>>. *)
+(** The trace extracted from a constrained state <<s>> leads to <<s>>. *)
 
 Lemma finite_valid_trace_init_to_state2trace_RMi' :
   forall (s : State),

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -140,7 +140,7 @@ Defined.
 
 (**
   A reachability predicate specialized for VLSMs refining UMO.
-  [UMO_reachable C s] is equivalent to [ram_state_prop V s] if
+  [UMO_reachable C s] is equivalent to [constrained_state_prop_alt V s] if
   the valid transitions of VLSM <<V>> follow [UMOComponent_transition]
   and the validity predicate is a refinement of [UMOComponent_valid]
   which does not further restrict the [Send] case.
@@ -221,7 +221,7 @@ Qed.
 
 (**
   This lemma shows that for a VLSM based on UMO
-  reachability in the VLSM according to [ram_state_prop]
+  reachability in the VLSM according to [constrained_state_prop_alt]
   is equivalent to [UMO_reachable] with a predicate
   based on the VLSM's [valid] predicate, plus
   a condition on the address.
@@ -241,10 +241,10 @@ Lemma UMO_based_valid_reachable
   (VM : VLSMMachine (Build_VLSMType Message State Label))
   (V := mk_vlsm VM)
   (Hinit_empty : forall si, initial_state_prop V si -> obs si = [])
-  (Hsend_spec : forall s om, ram_state_prop V s -> valid V Send (s, om) <-> om = None)
+  (Hsend_spec : forall s om, constrained_state_prop_alt V s -> valid V Send (s, om) <-> om = None)
   (Htransition : forall l s om, transition V l (s, om) = UMOComponent_transition l s om) :
   forall (s : State),
-    ram_state_prop V s
+    constrained_state_prop_alt V s
       <->
     UMO_reachable (fun s m => VM.(valid) Receive (s, Some m)) s
       /\ initial_state_prop V (MkState [] (adr s)).

--- a/theories/VLSM/Core/Equivocation/MinimalEquivocationTrace.v
+++ b/theories/VLSM/Core/Equivocation/MinimalEquivocationTrace.v
@@ -11,7 +11,7 @@ From VLSM.Core Require Import Equivocation MessageDependencies TraceableVLSM.
   relation (see [minimal_equivocation_choice_monotone]).
 
   We then show that the trace determined by [state_to_trace] using this choice
-  function yields a minimally equivocating ram-trace reaching that state
+  function yields a minimally equivocating constrained trace reaching that state
   (see [state_to_minimal_equivocation_trace_equivocation_monotonic]).
 *)
 
@@ -280,7 +280,7 @@ Proof.
 Qed.
 
 (**
-  Given a list of indices and a composite ram-state, select from the given
+  Given a list of indices and a composite constrained state, select from the given
   list of indices the ones whose corresponding component state is initial.
 *)
 Program Definition initial_indices
@@ -669,7 +669,7 @@ Context
   [composite_state_to_trace] with the [minimal_equivocation_choice] function.
 
   By [reachable_composite_state_to_trace], we know that the obtained trace is
-  a ram-trace.
+  a constrained trace.
 *)
 Definition state_to_minimal_equivocation_trace
   (s : composite_state IM) (Hs : valid_state_prop RFree s)

--- a/theories/VLSM/Core/MessageDependencies.v
+++ b/theories/VLSM/Core/MessageDependencies.v
@@ -173,7 +173,7 @@ Proof.
     + by eapply has_been_directly_observed_step_update; [done |]; right; eapply IHHs.
 Qed.
 
-Lemma ram_transition_preserves_message_dependencies_full_node_condition
+Lemma constrained_transition_preserves_message_dependencies_full_node_condition
   `(input_valid_transition (pre_loaded_with_all_messages_vlsm X) lX (s, im) (s', om)) :
   forall m, message_dependencies_full_node_condition X message_dependencies s m ->
     message_dependencies_full_node_condition X message_dependencies s' m.

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -7,12 +7,12 @@ From VLSM.Core Require Import VLSM PreloadedVLSM Composition VLSMEmbedding.
 (** * Traceable VLSMs
 
   This section introduces [TraceableVLSM]s, characterized by the fact that from
-  any ram-state we can derive the possible (valid) transitions leading
+  any constrained state we can derive the possible (valid) transitions leading
   to that state.
 
   We derive several properties of these machines and their composition,
-  including the possibility of extracting a ram-trace from a ram-state
-  (see [reachable_composite_state_to_trace]) as well as that of extracting
+  including the possibility of extracting a constrained trace from a constrained
+  state (see [reachable_composite_state_to_trace]) as well as that of extracting
   a trace with monotonic global equivocation
   (see [state_to_minimal_equivocation_trace_equivocation_monotonic]).
 *)
@@ -63,11 +63,12 @@ Qed.
 
 (**
   A class characterizing VLSMs with reversible transitions. A VLSM is traceable
-  when given a ram-state, one can compute a set of ram-transitions leading to it.
+  when given a constrained state, one can compute a set of constrained transitions
+  leading to it.
 
   We assume that such machines are [TransitionMonotoneVLSM]s and that the
-  set of ram-transitions associated to a ram-state is empty iff the state is
-  initial.
+  set of constrained transitions associated to a constrained state is empty
+  iff the state is initial.
 *)
 Class TraceableVLSM
   `(X : VLSM message)
@@ -116,7 +117,7 @@ Proof.
 Qed.
 
 (**
-  Given any ram-state we can extract a trace leading to it by recursively
+  Given any constrained state we can extract a trace leading to it by recursively
   following the transitions leading to it.
 *)
 Equations state_to_trace (s' : state X) (Hs' : valid_state_prop R s') :
@@ -138,7 +139,7 @@ Proof.
   by rewrite Hdestruct; left.
 Qed.
 
-(** Traces extracted using [state_to_trace] are ram-traces. *)
+(** Traces extracted using [state_to_trace] are constrained traces. *)
 Lemma reachable_state_to_trace :
   forall (s : state X) (Hs : valid_state_prop R s) is tr,
     state_to_trace s Hs = (is, tr) -> finite_valid_trace_init_to R is s tr.
@@ -341,9 +342,10 @@ Qed.
   to that state. Therefore, when trying to reconstruct a particular trace leading
   to the given state, we must choose one among the possible transitions.
 
-  Let us define the type of such a choice function, which takes a composite ram-state
-  and a list of indices as arguments and returns one of the indices and a position
-  in the list of possible transitions to the state for that particular index.
+  Let us define the type of such a choice function, which takes a composite
+  constrained state and a list of indices as arguments and returns one of the
+  indices and a position in the list of possible transitions to the state for
+  that particular index.
 *)
 
 Definition choice_function : Type :=
@@ -358,7 +360,7 @@ Definition choice_function : Type :=
   - if the component state corresponding to the returned index in not initial, then
     the returned position must identify a transition leading to the given state
 
-  - the choice does not depend on the particular proof for the composite ram-state
+  - the choice does not depend on the particular proof for the composite constrained state
 *)
 Record ChoosingWell
   (choose : choice_function)
@@ -405,8 +407,8 @@ Definition not_in_indices_initial_prop
   forall i, i ∉ indices -> initial_state_prop (IM i) (s' i).
 
 (**
-  The ram-transitions leading to a composite ram-state reflect the
-  [not_in_indices_initial_prop]erty, or, alternately, the
+  The constrained transitions leading to a composite constrained state reflect
+  the [not_in_indices_initial_prop]erty, or, alternately, the
   [composite_state_destructor] function reflects it.
 *)
 Lemma composite_tv_state_destructor_preserves_not_in_indices_initial  :
@@ -444,8 +446,8 @@ Qed.
 
 (**
   A [choice_function] is choosing well if it is [ChoosingWell] for any
-  instance of its arguments (a ram-state and a set of indices) satisfying the
-  [not_in_indices_initial_prop]erty.
+  instance of its arguments (a constrained state and a set of indices)
+  satisfying the [not_in_indices_initial_prop]erty.
 *)
 Definition choosing_well (choose : choice_function) : Prop :=
   forall (s' : composite_state IM) (Hs' : valid_state_prop RFree s') (indices : list index),
@@ -453,10 +455,10 @@ Definition choosing_well (choose : choice_function) : Prop :=
       ChoosingWell choose s' Hs' indices.
 
 (**
-  Given a composite ram-state, a [choice_function] and an initial set of indices,
-  we can extract a trace leading to that state by following backwards the
-  transitions yielded by the choice function until the states corresponding to
-  any of the given indices become initial states.
+  Given a composite constrained state, a [choice_function] and an initial
+  set of indices, we can extract a trace leading to that state by following
+  backwards the transitions yielded by the choice function until the states
+  corresponding to any of the given indices become initial states.
 *)
 Equations indexed_composite_state_to_trace
   (choose : choice_function)
@@ -494,7 +496,7 @@ Proof.
 Qed.
 
 (**
-  For any composite ram-state <<s>> and for any index <<i>> for which the
+  For any composite constrained state <<s>> and for any index <<i>> for which the
   component state <<s i>> has the [initial_state_prop]erty, the component state of
   index <<i>> of the origin state of the trace extracted from <<s>> is equal
   to <<s i>>.
@@ -577,7 +579,7 @@ Proof.
 Qed.
 
 (**
-  For any composite ram-state <<s>> and for any index <<i>> for which the
+  For any composite constrained state <<s>> and for any index <<i>> for which the
   component state <<s i>> satisfies [initial_state_prop], the component state of
   index <<i>> of any state of the trace extracted from <<s>> is equal to <<s i>>.
 *)
@@ -640,8 +642,9 @@ Proof.
 Qed.
 
 (**
-  For any given composite ram-state, [indexed_reachable_composite_state_to_trace]
-  yields a ram-trace leading to it.
+  For any given composite constrained state,
+  [indexed_reachable_composite_state_to_trace] yields a constrained trace
+  leading to it.
 *)
 Lemma indexed_reachable_composite_state_to_trace :
   forall (choose : choice_function), choosing_well choose ->
@@ -674,9 +677,9 @@ Proof.
 Qed.
 
 (**
-  Given a composite ram-state, and a [choice_function], we can extract a ram-trace
-  leading to that state by instantiating [indexed_composite_state_to_trace] with
-  the set of all indices.
+  Given a composite constrained state, and a [choice_function], we can extract a
+  constrained trace leading to that state by instantiating
+  [indexed_composite_state_to_trace] with the set of all indices.
 *)
 Definition composite_state_to_trace
   (choose : choice_function)


### PR DESCRIPTION
I noticed that both `ram_state_prop` and `constrained_state_prop` are used to refer to the notion of valid state in the preloaded vlsm, and since "constrained" is the more up to date term that we prefer, I did some refactoring to get rid of the old "ram" naming.