### PR TITLE
Define `adr2idx`

### DIFF
--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -686,12 +686,14 @@ Context
   `{!Inj (=) (=) idx}
   .
 
-Definition ELMO_A (a : Address) : index :=
-  hd inhabitant (filter (fun i => idx i = a) (enum index)).
+Definition adr2idx (a : Address) : option index :=
+  head (filter (fun i => idx i = a) (enum index)).
 
-Lemma ELMO_A_inv : forall i, ELMO_A (idx i) = i.
+Lemma adr2idx_idx :
+  forall (i : index),
+    adr2idx (idx i) = Some i.
 Proof.
-  intro i; unfold ELMO_A; cbn.
+  intro i; unfold adr2idx; cbn.
   replace (filter _ _) with [i]; [done |].
   generalize (enum index), (NoDup_enum index) as Hnodup, (elem_of_enum i) as Hi.
   induction l; intros; [by inversion Hi |].
@@ -706,6 +708,30 @@ Proof.
   - by rewrite decide_True, Hnil.
   - rewrite decide_False, IHl; [done.. |].
     by intro Hcontra; eapply inj in Hcontra; [| done]; subst.
+Qed.
+
+Lemma idx_adr2idx :
+  forall (i : index) (adr : Address),
+    adr2idx adr = Some i -> idx i = adr.
+Proof.
+  unfold adr2idx.
+  intros i adr Heq.
+  apply (@elem_of_list_filter _ (fun i => idx i = adr) _ (enum index) i).
+  destruct (filter _ _); inversion Heq; subst.
+  by left.
+Qed.
+
+Definition ELMO_A (a : Address) : index :=
+match adr2idx a with
+| None => inhabitant
+| Some i => i
+end.
+
+Lemma ELMO_A_inv :
+  forall (i : index), ELMO_A (idx i) = i.
+Proof.
+  intros i; unfold ELMO_A.
+  by rewrite adr2idx_idx.
 Qed.
 
 End sec_BaseELMO_Observations.

--- a/theories/VLSM/Core/ELMO/BaseELMO.v
+++ b/theories/VLSM/Core/ELMO/BaseELMO.v
@@ -722,10 +722,10 @@ Proof.
 Qed.
 
 Definition ELMO_A (a : Address) : index :=
-match adr2idx a with
-| None => inhabitant
-| Some i => i
-end.
+  match adr2idx a with
+  | None => inhabitant
+  | Some i => i
+  end.
 
 Lemma ELMO_A_inv :
   forall (i : index), ELMO_A (idx i) = i.


### PR DESCRIPTION
BaseELMO already had a function `ELMO_A : Address -> index` which could be used to find an index of the component with the given address. The problem with it was that it was defined with a default value instead of returning an option, and this needed to be changed to prove an additional lemma which was needed for SUMO.