### PR TITLE
allow coq-stdpp.1.9.0

### DIFF
--- a/coq-vlsm.opam
+++ b/coq-vlsm.opam
@@ -17,9 +17,9 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "3.5"}
   "coq" {>= "8.16"}
-  "coq-stdpp" {= "1.8.0"}
-  "coq-itauto" 
-  "coq-equations" 
+  "coq-stdpp" {>= "1.8.0"}
+  "coq-itauto"
+  "coq-equations"
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -52,9 +52,9 @@ supported_coq_versions:
 dependencies:
 - opam:
     name: coq-stdpp
-    version: '{= "1.8.0"}'
+    version: '{>= "1.8.0"}'
   description: |-
-    [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.8.0
+    [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.8.0 or later
 - opam:
     name: coq-itauto
   description: |-


### PR DESCRIPTION
This is needed to use stdpp 1.9.0 downstream.