### PR TITLE
Remove the last remnants of the _Ri/_RMi naming

### DIFF
--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -403,7 +403,7 @@ Section sec_ELMOComponent_lemmas.
 Context
   (i : index)
   (Ei : VLSM Message := ELMOComponent i)
-  (Ri : VLSM Message := pre_loaded_with_all_messages_vlsm Ei).
+  .
 
 Lemma ELMO_reachable_adr (s : State) :
   constrained_state_prop Ei s -> adr s = idx i.
@@ -414,7 +414,7 @@ Qed.
 Lemma ELMO_constrained_transition_output_not_initial :
   forall l (s : State) (om : option Message) (s' : State) (om' : option Message),
     input_constrained_transition Ei l (s, om) (s', om') ->
-    ~ initial_state_prop Ri s'.
+    ~ initial_state_prop Ei s'.
 Proof.
   intros l s om [ol a] om' [(_ & _ & Hv) Ht]; compute; intros [-> _].
   by inversion Hv; subst; inversion Ht.
@@ -491,7 +491,8 @@ Proof.
       intros tr' Htr'.
       induction Htr' using finite_valid_trace_from_to_rev_ind;
         [by contradict Hsuf; apply Irreflexive_state_suffix | clear IHHtr'].
-      pose proof (ELMO_input_constrained_transition_inj _ _ _ _ _ Ht _ _ _ _ Ht0) as (-> & -> & -> & ->).
+      destruct (ELMO_input_constrained_transition_inj _ _ _ _ _ Ht _ _ _ _ Ht0)
+        as (-> & -> & -> & ->).
       eapply transition_monotone_empty_trace in Htr'; [| typeclasses eauto].
       by subst.
     + destruct (IHHsf Hss0) as (tr & Htr & Htr_unique).
@@ -500,7 +501,8 @@ Proof.
       intros tr' Htr'.
       induction Htr' using finite_valid_trace_from_to_rev_ind;
         [by contradict Hsuf; apply Irreflexive_state_suffix | clear IHHtr'].
-      pose proof (ELMO_input_constrained_transition_inj _ _ _ _ _ Ht _ _ _ _ Ht0) as (-> & -> & -> & ->).
+      destruct (ELMO_input_constrained_transition_inj _ _ _ _ _ Ht _ _ _ _ Ht0)
+        as (-> & -> & -> & ->).
       by f_equal; apply Htr_unique.
 Qed.
 
@@ -642,7 +644,7 @@ Proof.
 Qed.
 
 Lemma local_equivocators_full_nondecreasing (s : State) l om s' om' :
-  transition Ri l (s, om) = (s', om') ->
+  transition Ei l (s, om) = (s', om') ->
   (forall a, local_equivocators_full s a ->
              local_equivocators_full s' a).
 Proof.
@@ -650,7 +652,7 @@ Proof.
 Qed.
 
 Lemma local_equivocators_full_increase_only_received_adr (s : State) m s' om' :
-  transition Ri Receive (s, Some m) = (s', om') ->
+  transition Ei Receive (s, Some m) = (s', om') ->
   forall a, local_equivocators_full s' a ->
             local_equivocators_full s a \/ a = adr (state m).
 Proof.
@@ -1226,8 +1228,8 @@ Lemma ELMO_latest_observation_Send_state :
     s = state m.
 Proof.
   intros s' Hs' s m ->.
-  edestruct (ELMOComponent_state_destructor_input_constrained_transition_item _ Hs') as [(_ & _ & Hv) Ht];
-    [by apply elem_of_list_singleton |]; cbn in *.
+  edestruct (ELMOComponent_state_destructor_input_constrained_transition_item _ Hs')
+    as [(_ & _ & Hv) Ht]; [by apply elem_of_list_singleton |]; cbn in *.
   by inversion Hv; subst; inversion Ht; subst; destruct s.
 Qed.
 
@@ -1367,7 +1369,8 @@ Record global_equivocators_simple (s : composite_state ELMOComponent) (a : Addre
 }.
 Set Warnings "cannot-define-projection".
 
-Definition ELMO_global_equivocation : BasicEquivocation (composite_state ELMOComponent) Address Ca threshold :=
+Definition ELMO_global_equivocation :
+  BasicEquivocation (composite_state ELMOComponent) Address Ca threshold :=
 {|
   is_equivocating := ELMO_global_equivocators;
   is_equivocating_dec := ELMO_global_equivocators_dec;
@@ -1728,7 +1731,8 @@ Qed.
 Lemma ELMO_state_to_minimal_equivocation_trace_valid
   (s : composite_state ELMOComponent)
   (Hs : valid_state_prop ELMOProtocol s)
-  (Hs_pre := VLSM_incl_valid_state (constrained_preloaded_incl (free_composite_vlsm _) ELMO_global_constraint) _ Hs
+  (Hs_pre := VLSM_incl_valid_state (constrained_preloaded_incl
+    (free_composite_vlsm _) ELMO_global_constraint) _ Hs
     : composite_constrained_state_prop ELMOComponent s)
   (is : composite_state ELMOComponent)
   (tr : list (composite_transition_item ELMOComponent)) :
@@ -2230,7 +2234,8 @@ Proof.
     apply Forall_app in Hall_messages_observed as [Hall_messages_observed Hlast_obs].
     rewrite Forall_singleton in Hlast_obs.
     specialize (IHHtr_m Hsimis_eqvs Hall_messages_observed Hall_reachable).
-    assert (Hsis0_pre : composite_constrained_state_prop ELMOComponent (state_update ELMOComponent s i_m s0)).
+    assert (Hsis0_pre : composite_constrained_state_prop ELMOComponent
+      (state_update ELMOComponent s i_m s0)).
     {
       apply valid_trace_get_last in Htr_m as <-.
       rewrite Forall_forall in Hall_reachable.

--- a/theories/VLSM/Core/ELMO/MO.v
+++ b/theories/VLSM/Core/ELMO/MO.v
@@ -415,7 +415,7 @@ Context
   (RMi : VLSM Message := pre_loaded_with_all_messages_vlsm Mi).
 
 (** The VLSM [Mi] embeds into [RMi]. *)
-Lemma VLSM_incl_Mi_RMi :
+Lemma VLSM_incl_MOComponent_preloaded :
   VLSM_incl_part Mi RMi.
 Proof.
   by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
@@ -584,7 +584,7 @@ Proof.
   intros s1 s2 iom oom lbl Hivt.
   eapply input_constrained_transition_size.
   by apply (@VLSM_incl_input_valid_transition _ Mi Mi RMi)
-  ; eauto using VLSM_incl_Mi_RMi.
+  ; eauto using VLSM_incl_MOComponent_preloaded.
 Qed.
 
 Lemma finite_valid_trace_from_to_size :
@@ -597,7 +597,7 @@ Proof.
   intros s1 s2 tr Hfvt.
   eapply finite_constrained_trace_from_to_size.
   by apply (@VLSM_incl_finite_valid_trace_from_to _ Mi Mi RMi)
-  ; eauto using VLSM_incl_Mi_RMi.
+  ; eauto using VLSM_incl_MOComponent_preloaded.
 Qed.
 
 Lemma input_valid_transition_deterministic_conv :
@@ -609,7 +609,7 @@ Proof.
   intros s1 s2 f iom1 iom2 oom1 oom2 lbl1 lbl2 Hivt1 Hivt2.
   by eapply input_constrained_transition_deterministic_conv
   ; apply (@VLSM_incl_input_valid_transition _ Mi Mi RMi)
-  ; eauto using VLSM_incl_Mi_RMi.
+  ; eauto using VLSM_incl_MOComponent_preloaded.
 Qed.
 
 Lemma finite_valid_trace_from_to_unique :
@@ -621,7 +621,7 @@ Proof.
   by intros s1 s2 l1 l2 Hfvt1 Hfvt2
   ; eapply finite_constrained_trace_from_to_unique
   ; apply VLSM_incl_finite_valid_trace_from_to
-  ; eauto using VLSM_incl_Mi_RMi.
+  ; eauto using VLSM_incl_MOComponent_preloaded.
 Qed.
 
 Lemma finite_valid_trace_init_to_unique :
@@ -633,7 +633,7 @@ Proof.
   by intros s f l1 l2 Hfvit1 Hfvit2
   ; eapply finite_constrained_trace_init_to_unique
   ; apply VLSM_incl_finite_valid_trace_init_to
-  ; eauto using VLSM_incl_Mi_RMi.
+  ; eauto using VLSM_incl_MOComponent_preloaded.
 Qed.
 
 (** *** Extracting a trace from a state *)

--- a/theories/VLSM/Core/ELMO/UMO.v
+++ b/theories/VLSM/Core/ELMO/UMO.v
@@ -323,11 +323,12 @@ Context
   (Ri : VLSM Message := pre_loaded_with_all_messages_vlsm Ui).
 
 (**
-  There is a VLSM inclusion from [Ui] to [Ri]. This is an extremely useful
-  fact - we will prove many lemmas just for [Ri] and then use this fact to
-  transport them to [Ui].
+  There is a VLSM inclusion from any [UMOComponent] to its preloaded version.
+  This is an extremely useful act - we will prove many lemmas just for the
+  preloaded component and then use this fact to transport them to the bare
+  one.
 *)
-Lemma VLSM_incl_Ui_Ri :
+Lemma VLSM_incl_UMOComponent_preloaded :
   VLSM_incl_part Ui Ri.
 Proof.
   by apply vlsm_incl_pre_loaded_with_all_messages_vlsm.
@@ -506,7 +507,7 @@ Proof.
   intros s1 s2 iom oom lbl Hivt.
   eapply input_constrained_transition_size.
   by apply (@VLSM_incl_input_valid_transition _ Ui Ui Ri)
-  ; eauto using VLSM_incl_Ui_Ri.
+  ; eauto using VLSM_incl_UMOComponent_preloaded.
 Qed.
 
 Lemma finite_valid_trace_from_to_size :
@@ -519,7 +520,7 @@ Proof.
   intros s1 s2 tr Hfvt.
   eapply finite_constrained_trace_from_to_size.
   by apply (@VLSM_incl_finite_valid_trace_from_to _ Ui Ui Ri)
-  ; eauto using VLSM_incl_Ui_Ri.
+  ; eauto using VLSM_incl_UMOComponent_preloaded.
 Qed.
 
 Lemma finite_valid_trace_from_to_inv :
@@ -529,7 +530,7 @@ Proof.
   intros s tr Hfvt.
   eapply finite_constrained_trace_from_to_inv.
   by apply (@VLSM_incl_finite_valid_trace_from_to _ Ui Ui Ri)
-  ; eauto using VLSM_incl_Ui_Ri.
+  ; eauto using VLSM_incl_UMOComponent_preloaded.
 Qed.
 
 (**
@@ -567,7 +568,7 @@ Proof.
   intros s1 s2 f iom1 iom2 oom1 oom2 lbl1 lbl2 Hivt1 Hivt2.
   by eapply input_constrained_transition_deterministic_conv
   ; apply (@VLSM_incl_input_valid_transition _ Ui Ui Ri)
-  ; eauto using VLSM_incl_Ui_Ri.
+  ; eauto using VLSM_incl_UMOComponent_preloaded.
 Qed.
 
 (** Every trace segment is fully determined by its initial and final state. *)
@@ -600,7 +601,7 @@ Proof.
   by intros s1 s2 l1 l2 Hfvt1 Hfvt2
   ; eapply finite_constrained_trace_from_to_unique
   ; apply VLSM_incl_finite_valid_trace_from_to
-  ; eauto using VLSM_incl_Ui_Ri.
+  ; eauto using VLSM_incl_UMOComponent_preloaded.
 Qed.
 
 (** Every trace is determined by its final state. *)
@@ -625,7 +626,7 @@ Proof.
   by intros s f l1 l2 Hfvit1 Hfvit2
   ; eapply finite_constrained_trace_init_to_unique
   ; apply VLSM_incl_finite_valid_trace_init_to
-  ; eauto using VLSM_incl_Ui_Ri.
+  ; eauto using VLSM_incl_UMOComponent_preloaded.
 Qed.
 
 (** If a valid trace leads to state s, the trace extracted from s also leads to s. *)
@@ -694,7 +695,7 @@ Proof.
   by intros is s tr Hfvti
   ; eapply finite_constrained_trace_init_to_state2trace_inv
   ; apply VLSM_incl_finite_valid_trace_init_to
-  ; eauto using VLSM_incl_Ui_Ri.
+  ; eauto using VLSM_incl_UMOComponent_preloaded.
 Qed.
 
 (** The trace extracted from a reachable state [s] leads to [s]. *)


### PR DESCRIPTION
The last lemmas to use this naming were ones that established an inclusion from the component to the preloaded component. I dropped them and used `vlsm_incl_pre_loaded_with_all_messages_vlsm` directly.

ELMO was using the preloaded component `Ri` in a few places where the non-preloaded one would suffice. I changed that. Also, I reindented some lines in ELMO that were too long after the recent changes.