### PR TITLE
Small refactoring of preloaded VLSM

### DIFF
--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -664,13 +664,16 @@ Lemma valid_state_project_preloaded_to_preloaded_free
   valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i).
 Proof.
   intros [om Hproto].
-  apply preloaded_valid_state_prop_iff.
-  induction Hproto; [by apply preloaded_valid_initial_state, (Hs i) |].
-  destruct l as [j lj]; cbn in Ht.
-  destruct (transition lj _) as (si', _om') eqn: Hti.
-  inversion_clear Ht.
-  destruct (decide (i = j)); subst; state_update_simpl; [| done].
-  by apply preloaded_protocol_generated with lj (s j) om _om'; [| apply Hv |].
+  induction Hproto; [by apply initial_state_is_valid; cbn |].
+  destruct l as [j lj]; cbn in Ht, Hv.
+  destruct (transition lj (s j, om)) eqn: Heq.
+  inversion Ht; subst; clear Ht.
+  destruct (decide (j = i)); subst; state_update_simpl; [| done].
+  destruct IHHproto1 as [om'' Hovmp].
+  exists om'.
+  eapply input_valid_transition_outputs_valid_state_message.
+  repeat split; [by exists om'' | | done..].
+  by apply any_message_is_valid_in_preloaded.
 Qed.
 
 (**

--- a/theories/VLSM/Core/PreloadedVLSM.v
+++ b/theories/VLSM/Core/PreloadedVLSM.v
@@ -92,37 +92,6 @@ Proof.
   by apply pre_loaded_with_all_messages_message_valid_initial_state_message.
 Qed.
 
-Inductive preloaded_valid_state_prop : state X -> Prop :=
-| preloaded_valid_initial_state
-    (s : state X)
-    (Hs : initial_state_prop (VLSMMachine := pre_loaded_with_all_messages_vlsm) s) :
-       preloaded_valid_state_prop s
-| preloaded_protocol_generated
-    (l : label X)
-    (s : state X)
-    (Hps : preloaded_valid_state_prop s)
-    (om : option message)
-    (Hv : valid (VLSMMachine := pre_loaded_with_all_messages_vlsm) l (s, om))
-    s' om'
-    (Ht : transition (VLSMMachine := pre_loaded_with_all_messages_vlsm) l (s, om) = (s', om'))
-  : preloaded_valid_state_prop s'.
-
-Lemma preloaded_valid_state_prop_iff (s : state X) :
-  valid_state_prop pre_loaded_with_all_messages_vlsm s
-  <-> preloaded_valid_state_prop s.
-Proof.
-  split.
-  - intros [om Hvalid].
-    induction Hvalid.
-    + by apply preloaded_valid_initial_state.
-    + by apply preloaded_protocol_generated with l s om om'.
-  - induction 1.
-    + by exists None; apply valid_initial_state_message.
-    + exists om'. destruct IHpreloaded_valid_state_prop as [_om Hs].
-      specialize (any_message_is_valid_in_preloaded om) as [_s Hom].
-      by apply (valid_generated_state_message pre_loaded_with_all_messages_vlsm) with s _om _s om l.
-Qed.
-
 Lemma preloaded_weaken_valid_state_message_prop s om :
   valid_state_message_prop X s om ->
   valid_state_message_prop pre_loaded_with_all_messages_vlsm s om.


### PR DESCRIPTION
In `PreloadedVLSM.v` there was this thing called `preloaded_valid_state_prop` which was a direct inductive definition of what it means for a state to be valid in the preloaded vlsm, and a lemma proving this fact. This lemma was then used to prove `valid_state_project_preloaded_to_preloaded_free` in `Composition.v`. I proved the latter directly and deleted `preloaded_valid_state_prop` and its lemma.

The motivation for this PR is that `preloaded_valid_state_prop` seemed a bit superfluous to me, since we already have `constrained_state_prop_alt` which uses an inductive definition underneath. I also suspected that `preloaded_valid_state_prop` is almost-dead code.