### PR TITLE
Cleanup some definitions in `Composition.v`

### DIFF
--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -664,13 +664,16 @@ Lemma valid_state_project_preloaded_to_preloaded_free
   valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i).
 Proof.
   intros [om Hproto].
-  apply preloaded_valid_state_prop_iff.
-  induction Hproto; [by apply preloaded_valid_initial_state, (Hs i) |].
-  destruct l as [j lj]; cbn in Ht.
-  destruct (transition lj _) as (si', _om') eqn: Hti.
-  inversion_clear Ht.
-  destruct (decide (i = j)); subst; state_update_simpl; [| done].
-  by apply preloaded_protocol_generated with lj (s j) om _om'; [| apply Hv |].
+  induction Hproto; [by apply initial_state_is_valid; cbn |].
+  destruct l as [j lj]; cbn in Ht, Hv.
+  destruct (transition lj (s j, om)) eqn: Heq.
+  inversion Ht; subst; clear Ht.
+  destruct (decide (j = i)); subst; state_update_simpl; [| done].
+  destruct IHHproto1 as [om'' Hovmp].
+  exists om'.
+  eapply input_valid_transition_outputs_valid_state_message.
+  repeat split; [by exists om'' | | done..].
+  by apply any_message_is_valid_in_preloaded.
 Qed.
 
 (**

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1360,11 +1360,6 @@ Qed.
 Definition CompositeValidTransitionNext s1 s2 : Prop :=
   ValidTransitionNext Free s1 s2.
 
-Lemma composite_valid_transition_next :
-  forall l s1 iom s2 oom,
-    CompositeValidTransition l s1 iom s2 oom -> CompositeValidTransitionNext s1 s2.
-Proof. by econstructor. Qed.
-
 Definition composite_valid_transition_future : relation (composite_state IM) :=
   tc CompositeValidTransitionNext.
 

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1351,10 +1351,7 @@ Definition composite_valid_transition_item
 Lemma composite_valid_transition_reachable_iff l s1 iom s2 oom :
   CompositeValidTransition l s1 iom s2 oom <-> ValidTransition RFree l s1 iom s2 oom.
 Proof.
-  split; [by intros []; constructor |].
-  intros []; constructor.
-  - by apply vt_valid.
-  - by apply vt_transition.
+  by split; intros []; constructor.
 Qed.
 
 Definition CompositeValidTransitionNext s1 s2 : Prop :=

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1341,11 +1341,8 @@ Context
   (RFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
-Record CompositeValidTransition l s1 iom s2 oom : Prop :=
-{
-  cvt_valid : composite_valid IM l (s1, iom);
-  cvt_transition : composite_transition IM l (s1, iom) = (s2, oom);
-}.
+Definition CompositeValidTransition l s1 iom s2 oom : Prop :=
+  ValidTransition Free l s1 iom s2 oom.
 
 Definition composite_valid_transition_item
   (s : composite_state IM) (item : composite_transition_item IM) : Prop :=
@@ -1360,15 +1357,13 @@ Proof.
   - by apply vt_transition.
 Qed.
 
-Inductive CompositeValidTransitionNext (s1 s2 : composite_state IM) : Prop :=
-| composite_transition_next : forall l iom oom,
-    CompositeValidTransition l s1 iom s2 oom ->
-    CompositeValidTransitionNext s1 s2.
+Definition CompositeValidTransitionNext s1 s2 : Prop :=
+  ValidTransitionNext Free s1 s2.
 
 Lemma composite_valid_transition_next :
   forall l s1 iom s2 oom,
     CompositeValidTransition l s1 iom s2 oom -> CompositeValidTransitionNext s1 s2.
-Proof. by intros * [Hv Ht]; econstructor. Qed.
+Proof. by econstructor. Qed.
 
 Definition composite_valid_transition_future : relation (composite_state IM) :=
   tc CompositeValidTransitionNext.

--- a/theories/VLSM/Core/HistoryVLSM.v
+++ b/theories/VLSM/Core/HistoryVLSM.v
@@ -84,7 +84,7 @@ Lemma not_CompositeValidTransitionNext_initial :
   forall s1, ~ CompositeValidTransitionNext IM s1 s2.
 Proof.
   intros s2 Hs2 s1 [* Hs1].
-  apply composite_valid_transition_projection, proj1, valid_transition_next in Hs1; cbn in Hs1.
+  apply composite_valid_transition_projection, proj1, transition_next in Hs1; cbn in Hs1.
   by contradict Hs1; apply not_ValidTransitionNext_initial, Hs2.
 Qed.
 
@@ -115,7 +115,7 @@ Lemma CompositeValidTransition_reflects_rechability :
 Proof.
   intros * Hnext Hs2; revert l s1 iom oom Hnext.
   induction Hs2 using valid_state_prop_ind; intros * Hnext.
-  - apply composite_valid_transition_next in Hnext.
+  - apply transition_next in Hnext.
     by contradict Hnext; apply not_CompositeValidTransitionNext_initial.
   - destruct l as [i li], l0 as [j lj].
     destruct (decide (i = j)).

--- a/theories/VLSM/Core/PreloadedVLSM.v
+++ b/theories/VLSM/Core/PreloadedVLSM.v
@@ -92,37 +92,6 @@ Proof.
   by apply pre_loaded_with_all_messages_message_valid_initial_state_message.
 Qed.
 
-Inductive preloaded_valid_state_prop : state X -> Prop :=
-| preloaded_valid_initial_state
-    (s : state X)
-    (Hs : initial_state_prop (VLSMMachine := pre_loaded_with_all_messages_vlsm) s) :
-       preloaded_valid_state_prop s
-| preloaded_protocol_generated
-    (l : label X)
-    (s : state X)
-    (Hps : preloaded_valid_state_prop s)
-    (om : option message)
-    (Hv : valid (VLSMMachine := pre_loaded_with_all_messages_vlsm) l (s, om))
-    s' om'
-    (Ht : transition (VLSMMachine := pre_loaded_with_all_messages_vlsm) l (s, om) = (s', om'))
-  : preloaded_valid_state_prop s'.
-
-Lemma preloaded_valid_state_prop_iff (s : state X) :
-  valid_state_prop pre_loaded_with_all_messages_vlsm s
-  <-> preloaded_valid_state_prop s.
-Proof.
-  split.
-  - intros [om Hvalid].
-    induction Hvalid.
-    + by apply preloaded_valid_initial_state.
-    + by apply preloaded_protocol_generated with l s om om'.
-  - induction 1.
-    + by exists None; apply valid_initial_state_message.
-    + exists om'. destruct IHpreloaded_valid_state_prop as [_om Hs].
-      specialize (any_message_is_valid_in_preloaded om) as [_s Hom].
-      by apply (valid_generated_state_message pre_loaded_with_all_messages_vlsm) with s _om _s om l.
-Qed.
-
 Lemma preloaded_weaken_valid_state_message_prop s om :
   valid_state_message_prop X s om ->
   valid_state_message_prop pre_loaded_with_all_messages_vlsm s om.

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -45,7 +45,7 @@ Proof.
   destruct Hfutures as [tr Htr].
   induction Htr; [done |].
   by apply input_valid_transition_forget_input,
-    valid_transition_next, transition_monotonicity in Ht; lia.
+    transition_next, transition_monotonicity in Ht; lia.
 Qed.
 
 Lemma transition_monotone_empty_trace
@@ -58,7 +58,7 @@ Proof.
   assert (state_size s <= state_size s')
     by (apply transition_monotone_in_futures; [| eexists]; done).
   by apply input_valid_transition_forget_input,
-    valid_transition_next, transition_monotonicity in Ht; lia.
+    transition_next, transition_monotonicity in Ht; lia.
 Qed.
 
 (**

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -2700,11 +2700,6 @@ Context
   `(X : VLSM message)
   .
 
-Lemma valid_transition_next :
-  forall l s1 iom s2 oom,
-    ValidTransition X l s1 iom s2 oom -> ValidTransitionNext X s1 s2.
-Proof. by intros * [Hv Ht]; econstructor. Qed.
-
 Lemma input_valid_transition_forget_input :
   forall l s1 iom s2 oom,
     input_valid_transition X l (s1, iom) (s2, oom) ->


### PR DESCRIPTION
I noticed that some notions for composite vlsms, like `CompositeValidTransition` and `CompositeValidTransitionNext`, were defined as records/inductives but could have easily been defined as just `ValidTransition`/`ValidTransitionNext` for the free composition. I changed that and deleted some superfluous lemmas, and simplified the proof of another one.