### PR TITLE
Change CamelCase to snake_case for definitions related to valid transitions

### DIFF
--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -664,13 +664,16 @@ Lemma valid_state_project_preloaded_to_preloaded_free
   valid_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i).
 Proof.
   intros [om Hproto].
-  apply preloaded_valid_state_prop_iff.
-  induction Hproto; [by apply preloaded_valid_initial_state, (Hs i) |].
-  destruct l as [j lj]; cbn in Ht.
-  destruct (transition lj _) as (si', _om') eqn: Hti.
-  inversion_clear Ht.
-  destruct (decide (i = j)); subst; state_update_simpl; [| done].
-  by apply preloaded_protocol_generated with lj (s j) om _om'; [| apply Hv |].
+  induction Hproto; [by apply initial_state_is_valid; cbn |].
+  destruct l as [j lj]; cbn in Ht, Hv.
+  destruct (transition lj (s j, om)) eqn: Heq.
+  inversion Ht; subst; clear Ht.
+  destruct (decide (j = i)); subst; state_update_simpl; [| done].
+  destruct IHHproto1 as [om'' Hovmp].
+  exists om'.
+  eapply input_valid_transition_outputs_valid_state_message.
+  repeat split; [by exists om'' | | done..].
+  by apply any_message_is_valid_in_preloaded.
 Qed.
 
 (**

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1360,11 +1360,6 @@ Qed.
 Definition CompositeValidTransitionNext s1 s2 : Prop :=
   ValidTransitionNext Free s1 s2.
 
-Lemma composite_valid_transition_next :
-  forall l s1 iom s2 oom,
-    CompositeValidTransition l s1 iom s2 oom -> CompositeValidTransitionNext s1 s2.
-Proof. by econstructor. Qed.
-
 Definition composite_valid_transition_future : relation (composite_state IM) :=
   tc CompositeValidTransitionNext.
 

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1341,35 +1341,35 @@ Context
   (RFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
-Definition CompositeValidTransition l s1 iom s2 oom : Prop :=
-  ValidTransition Free l s1 iom s2 oom.
+Definition composite_valid_transition l s1 iom s2 oom : Prop :=
+  valid_transition Free l s1 iom s2 oom.
 
 Definition composite_valid_transition_item
   (s : composite_state IM) (item : composite_transition_item IM) : Prop :=
-  CompositeValidTransition (l item) s (input item) (destination item) (output item).
+  composite_valid_transition (l item) s (input item) (destination item) (output item).
 
 Lemma composite_valid_transition_reachable_iff l s1 iom s2 oom :
-  CompositeValidTransition l s1 iom s2 oom <-> ValidTransition RFree l s1 iom s2 oom.
+  composite_valid_transition l s1 iom s2 oom <-> valid_transition RFree l s1 iom s2 oom.
 Proof.
   by split; intros []; constructor.
 Qed.
 
-Definition CompositeValidTransitionNext s1 s2 : Prop :=
-  ValidTransitionNext Free s1 s2.
+Definition composite_valid_transition_next s1 s2 : Prop :=
+  valid_transition_next Free s1 s2.
 
 Definition composite_valid_transition_future : relation (composite_state IM) :=
-  tc CompositeValidTransitionNext.
+  tc composite_valid_transition_next.
 
-Lemma CompositeValidTransitionNext_reachable_iff s1 s2 :
-  CompositeValidTransitionNext s1 s2 <-> ValidTransitionNext RFree s1 s2.
+Lemma composite_valid_transition_next_reachable_iff s1 s2 :
+  composite_valid_transition_next s1 s2 <-> valid_transition_next RFree s1 s2.
 Proof.
   by split; intros []; econstructor; apply composite_valid_transition_reachable_iff.
 Qed.
 
 Lemma composite_valid_transition_projection :
   forall l s1 iom s2 oom,
-    CompositeValidTransition l s1 iom s2 oom ->
-    ValidTransition (IM (projT1 l)) (projT2 l) (s1 (projT1 l)) iom (s2 (projT1 l)) oom /\
+    composite_valid_transition l s1 iom s2 oom ->
+    valid_transition (IM (projT1 l)) (projT2 l) (s1 (projT1 l)) iom (s2 (projT1 l)) oom /\
     s2 = state_update IM s1 (projT1 l) (s2 (projT1 l)).
 Proof.
   intros [i li] * [Hv Ht]; cbn in Ht; destruct (transition _ _ _) eqn: Hti.
@@ -1378,25 +1378,25 @@ Qed.
 
 Lemma composite_valid_transition_projection_inv :
   forall i li si1 iom si2 oom,
-    ValidTransition (IM i) li si1 iom si2 oom ->
+    valid_transition (IM i) li si1 iom si2 oom ->
     forall s1, s1 i = si1 -> forall s2, s2 = state_update IM s1 i si2 ->
-    CompositeValidTransition (existT i li) s1 iom s2 oom.
+    composite_valid_transition (existT i li) s1 iom s2 oom.
 Proof.
   intros * [Hv Ht] s1 <- s2 ->; split; [done |].
   by cbn; replace (transition _ _ _) with (si2, oom).
 Qed.
 
-Inductive CompositeValidTransitionsFromTo
+Inductive composite_valid_transitions_from_to
   : composite_state IM -> composite_state IM -> list (composite_transition_item IM) -> Prop :=
-| cvtft_empty : forall s, CompositeValidTransitionsFromTo s s []
+| cvtft_empty : forall s, composite_valid_transitions_from_to s s []
 | cvtft_cons : forall s s' tr item,
-    CompositeValidTransitionsFromTo s s' tr ->
+    composite_valid_transitions_from_to s s' tr ->
     composite_valid_transition_item s' item ->
-    CompositeValidTransitionsFromTo s (destination item) (tr ++ [item]).
+    composite_valid_transitions_from_to s (destination item) (tr ++ [item]).
 
-Lemma CompositeValidTransitionsFromTo_trace : forall s s' tr,
+Lemma composite_valid_transitions_from_to_trace : forall s s' tr,
   finite_valid_trace_from_to RFree s s' tr ->
-  CompositeValidTransitionsFromTo s s' tr.
+  composite_valid_transitions_from_to s s' tr.
 Proof.
   induction 1 using finite_valid_trace_from_to_rev_ind; [by constructor |].
   remember {| destination := sf |} as item.

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1351,10 +1351,7 @@ Definition composite_valid_transition_item
 Lemma composite_valid_transition_reachable_iff l s1 iom s2 oom :
   CompositeValidTransition l s1 iom s2 oom <-> ValidTransition RFree l s1 iom s2 oom.
 Proof.
-  split; [by intros []; constructor |].
-  intros []; constructor.
-  - by apply vt_valid.
-  - by apply vt_transition.
+  by split; intros []; constructor.
 Qed.
 
 Definition CompositeValidTransitionNext s1 s2 : Prop :=

--- a/theories/VLSM/Core/Composition.v
+++ b/theories/VLSM/Core/Composition.v
@@ -1341,11 +1341,8 @@ Context
   (RFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
-Record CompositeValidTransition l s1 iom s2 oom : Prop :=
-{
-  cvt_valid : composite_valid IM l (s1, iom);
-  cvt_transition : composite_transition IM l (s1, iom) = (s2, oom);
-}.
+Definition CompositeValidTransition l s1 iom s2 oom : Prop :=
+  ValidTransition Free l s1 iom s2 oom.
 
 Definition composite_valid_transition_item
   (s : composite_state IM) (item : composite_transition_item IM) : Prop :=
@@ -1360,15 +1357,13 @@ Proof.
   - by apply vt_transition.
 Qed.
 
-Inductive CompositeValidTransitionNext (s1 s2 : composite_state IM) : Prop :=
-| composite_transition_next : forall l iom oom,
-    CompositeValidTransition l s1 iom s2 oom ->
-    CompositeValidTransitionNext s1 s2.
+Definition CompositeValidTransitionNext s1 s2 : Prop :=
+  ValidTransitionNext Free s1 s2.
 
 Lemma composite_valid_transition_next :
   forall l s1 iom s2 oom,
     CompositeValidTransition l s1 iom s2 oom -> CompositeValidTransitionNext s1 s2.
-Proof. by intros * [Hv Ht]; econstructor. Qed.
+Proof. by econstructor. Qed.
 
 Definition composite_valid_transition_future : relation (composite_state IM) :=
   tc CompositeValidTransitionNext.

--- a/theories/VLSM/Core/ELMO/ELMO.v
+++ b/theories/VLSM/Core/ELMO/ELMO.v
@@ -1786,14 +1786,14 @@ Qed.
   Due to the validity predicate, a transition must have either a non-empty
   input or a non-empty output, the distinction being made by the label.
 *)
-Inductive ELMOProtocolValidTransition
+Inductive ELMOProtocol_valid_transition
   : index -> Label -> VLSM.state ELMOProtocol -> VLSM.state ELMOProtocol -> Message -> Prop :=
 | ep_valid_receive : forall (i : index) (s1 s2 : VLSM.state ELMOProtocol) (m : Message),
-    ValidTransition ELMOProtocol (existT i Receive) s1 (Some m) s2 None ->
-    ELMOProtocolValidTransition i Receive s1 s2 m
+    valid_transition ELMOProtocol (existT i Receive) s1 (Some m) s2 None ->
+    ELMOProtocol_valid_transition i Receive s1 s2 m
 | ep_valid_send : forall (i : index) (s1 s2 : VLSM.state ELMOProtocol) (m : Message),
-    ValidTransition ELMOProtocol (existT i Send) s1 None s2 (Some m) ->
-    ELMOProtocolValidTransition i Send s1 s2 m.
+    valid_transition ELMOProtocol (existT i Send) s1 None s2 (Some m) ->
+    ELMOProtocol_valid_transition i Send s1 s2 m.
 
 Lemma local_equivocators_full_step_update
   (i : index) (l : Label) (s1 s2 : State) (m : Message) :
@@ -2112,7 +2112,7 @@ Lemma ELMO_valid_states_only_receive_valid_messages :
   forall s : VLSM.state ELMOProtocol,
     valid_state_prop ELMOProtocol s ->
   forall (i : index) (l : Label) (s' : VLSM.state ELMOProtocol) (m : Message),
-    ELMOProtocolValidTransition i l s s' m ->
+    ELMOProtocol_valid_transition i l s s' m ->
     valid_message_prop ELMOProtocol m.
 Proof.
   intros s Hs i l s' m Hvalid.
@@ -2821,7 +2821,7 @@ Lemma reflecting_composite_for_reachable_component
       si = s_prev <+> MkObservation l m ->
       let s' := state_update ELMO_component s i s_prev in
       valid_state_prop ELMOProtocol s' /\
-      ELMOProtocolValidTransition i l s' s m.
+      ELMOProtocol_valid_transition i l s' s m.
 Proof.
   induction Hreachable using valid_state_prop_ind;
     [| destruct IHHreachable as (sigma & <- & Hsigma & Hreflects & Hsend & Hall), l; cycle 1].
@@ -2893,7 +2893,7 @@ Proof.
       intros (gamma & Hfutures & Heq_i & [Hsigma'_messages Hsigma'_eqvs] & Hgamma_send).
       pose (sigma' := state_update ELMO_component gamma i s'); subst s'.
       exists sigma'; split; [by subst sigma'; state_update_simpl |].
-      assert (Hvtsigma : ValidTransition ELMOProtocol (existT i Receive) gamma (Some m) sigma' None).
+      assert (Hvtsigma : valid_transition ELMOProtocol (existT i Receive) gamma (Some m) sigma' None).
       {
         repeat split; cbn; [by rewrite Heq_i | | by rewrite Heq_i].
         unfold local_equivocation_limit_ok, not_heavy in Hlocal_ok.

--- a/theories/VLSM/Core/HistoryVLSM.v
+++ b/theories/VLSM/Core/HistoryVLSM.v
@@ -84,7 +84,7 @@ Lemma not_CompositeValidTransitionNext_initial :
   forall s1, ~ CompositeValidTransitionNext IM s1 s2.
 Proof.
   intros s2 Hs2 s1 [* Hs1].
-  apply composite_valid_transition_projection, proj1, valid_transition_next in Hs1; cbn in Hs1.
+  apply composite_valid_transition_projection, proj1, transition_next in Hs1; cbn in Hs1.
   by contradict Hs1; apply not_ValidTransitionNext_initial, Hs2.
 Qed.
 
@@ -115,7 +115,7 @@ Lemma CompositeValidTransition_reflects_rechability :
 Proof.
   intros * Hnext Hs2; revert l s1 iom oom Hnext.
   induction Hs2 using valid_state_prop_ind; intros * Hnext.
-  - apply composite_valid_transition_next in Hnext.
+  - apply transition_next in Hnext.
     by contradict Hnext; apply not_CompositeValidTransitionNext_initial.
   - destruct l as [i li], l0 as [j lj].
     destruct (decide (i = j)).

--- a/theories/VLSM/Core/PreloadedVLSM.v
+++ b/theories/VLSM/Core/PreloadedVLSM.v
@@ -169,15 +169,15 @@ Context
   (R := pre_loaded_with_all_messages_vlsm X)
   .
 
-Lemma ValidTransition_preloaded_iff :
+Lemma valid_transition_preloaded_iff :
   forall l s1 iom s2 oom,
-    ValidTransition X l s1 iom s2 oom <-> ValidTransition R l s1 iom s2 oom.
+    valid_transition X l s1 iom s2 oom <-> valid_transition R l s1 iom s2 oom.
 Proof. by firstorder. Qed.
 
-Lemma ValidTransitionNext_preloaded_iff :
-  forall s1 s2, ValidTransitionNext X s1 s2 <-> ValidTransitionNext R s1 s2.
+Lemma valid_transition_next_preloaded_iff :
+  forall s1 s2, valid_transition_next X s1 s2 <-> valid_transition_next R s1 s2.
 Proof.
-  by intros; split; intros []; econstructor; apply ValidTransition_preloaded_iff.
+  by intros; split; intros []; econstructor; apply valid_transition_preloaded_iff.
 Qed.
 
 End sec_pre_loaded_valid_transition.

--- a/theories/VLSM/Core/PreloadedVLSM.v
+++ b/theories/VLSM/Core/PreloadedVLSM.v
@@ -92,37 +92,6 @@ Proof.
   by apply pre_loaded_with_all_messages_message_valid_initial_state_message.
 Qed.
 
-Inductive preloaded_valid_state_prop : state X -> Prop :=
-| preloaded_valid_initial_state
-    (s : state X)
-    (Hs : initial_state_prop (VLSMMachine := pre_loaded_with_all_messages_vlsm) s) :
-       preloaded_valid_state_prop s
-| preloaded_protocol_generated
-    (l : label X)
-    (s : state X)
-    (Hps : preloaded_valid_state_prop s)
-    (om : option message)
-    (Hv : valid (VLSMMachine := pre_loaded_with_all_messages_vlsm) l (s, om))
-    s' om'
-    (Ht : transition (VLSMMachine := pre_loaded_with_all_messages_vlsm) l (s, om) = (s', om'))
-  : preloaded_valid_state_prop s'.
-
-Lemma preloaded_valid_state_prop_iff (s : state X) :
-  valid_state_prop pre_loaded_with_all_messages_vlsm s
-  <-> preloaded_valid_state_prop s.
-Proof.
-  split.
-  - intros [om Hvalid].
-    induction Hvalid.
-    + by apply preloaded_valid_initial_state.
-    + by apply preloaded_protocol_generated with l s om om'.
-  - induction 1.
-    + by exists None; apply valid_initial_state_message.
-    + exists om'. destruct IHpreloaded_valid_state_prop as [_om Hs].
-      specialize (any_message_is_valid_in_preloaded om) as [_s Hom].
-      by apply (valid_generated_state_message pre_loaded_with_all_messages_vlsm) with s _om _s om l.
-Qed.
-
 Lemma preloaded_weaken_valid_state_message_prop s om :
   valid_state_message_prop X s om ->
   valid_state_message_prop pre_loaded_with_all_messages_vlsm s om.

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -23,7 +23,7 @@ From VLSM.Core Require Import VLSM PreloadedVLSM Composition VLSMEmbedding.
 Class TransitionMonotoneVLSM `(X : VLSM message) (state_size : state X -> nat) : Prop :=
 {
   transition_monotonicity :
-    forall s1 s2 : state X, ValidTransitionNext X s1 s2 -> state_size s1 < state_size s2
+    forall s1 s2 : state X, valid_transition_next X s1 s2 -> state_size s1 < state_size s2
 }.
 
 #[global] Hint Mode TransitionMonotoneVLSM - ! - : typeclass_instances.
@@ -34,7 +34,7 @@ Class TransitionMonotoneVLSM `(X : VLSM message) (state_size : state X -> nat) :
   : TransitionMonotoneVLSM (pre_loaded_with_all_messages_vlsm X) state_size.
 Proof.
   constructor; intros s1 s2 Ht.
-  by apply transition_monotonicity, ValidTransitionNext_preloaded_iff.
+  by apply transition_monotonicity, valid_transition_next_preloaded_iff.
 Qed.
 
 Lemma transition_monotone_in_futures
@@ -112,7 +112,7 @@ Proof.
   apply transition_monotonicity.
   erewrite <- tv_state_destructor_destination by done.
   econstructor.
-  by eapply ValidTransition_preloaded_iff, input_valid_transition_forget_input,
+  by eapply valid_transition_preloaded_iff, input_valid_transition_forget_input,
     tv_state_destructor_transition.
 Qed.
 

--- a/theories/VLSM/Core/TraceableVLSM.v
+++ b/theories/VLSM/Core/TraceableVLSM.v
@@ -45,7 +45,7 @@ Proof.
   destruct Hfutures as [tr Htr].
   induction Htr; [done |].
   by apply input_valid_transition_forget_input,
-    valid_transition_next, transition_monotonicity in Ht; lia.
+    transition_next, transition_monotonicity in Ht; lia.
 Qed.
 
 Lemma transition_monotone_empty_trace
@@ -58,7 +58,7 @@ Proof.
   assert (state_size s <= state_size s')
     by (apply transition_monotone_in_futures; [| eexists]; done).
   by apply input_valid_transition_forget_input,
-    valid_transition_next, transition_monotonicity in Ht; lia.
+    transition_next, transition_monotonicity in Ht; lia.
 Qed.
 
 (**

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -2700,11 +2700,6 @@ Context
   `(X : VLSM message)
   .
 
-Lemma valid_transition_next :
-  forall l s1 iom s2 oom,
-    ValidTransition X l s1 iom s2 oom -> ValidTransitionNext X s1 s2.
-Proof. by intros * [Hv Ht]; econstructor. Qed.
-
 Lemma input_valid_transition_forget_input :
   forall l s1 iom s2 oom,
     input_valid_transition X l (s1, iom) (s2, oom) ->

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -2683,16 +2683,16 @@ Proof. by subst. Qed.
 
 End sec_same_VLSM.
 
-Record ValidTransition `(X : VLSM message) l s1 iom s2 oom : Prop :=
+Record valid_transition `(X : VLSM message) l s1 iom s2 oom : Prop :=
 {
   vt_valid : valid X l (s1, iom);
   vt_transition : transition X l (s1, iom) = (s2, oom);
 }.
 
-Inductive ValidTransitionNext `(X : VLSM message) (s1 s2 : state X) : Prop :=
+Inductive valid_transition_next `(X : VLSM message) (s1 s2 : state X) : Prop :=
 | transition_next :
-    forall l iom oom (Ht : ValidTransition X l s1 iom s2 oom),
-      ValidTransitionNext X s1 s2.
+    forall l iom oom (Ht : valid_transition X l s1 iom s2 oom),
+      valid_transition_next X s1 s2.
 
 Section sec_valid_transition_props.
 
@@ -2703,7 +2703,7 @@ Context
 Lemma input_valid_transition_forget_input :
   forall l s1 iom s2 oom,
     input_valid_transition X l (s1, iom) (s2, oom) ->
-    ValidTransition X l s1 iom s2 oom.
+    valid_transition X l s1 iom s2 oom.
 Proof. by firstorder. Qed.
 
 End sec_valid_transition_props.


### PR DESCRIPTION
Since we use `snake_case` for things like `input_valid_transition` and `finite_valid_trace_from_to`, it only makes sense to follow this convention for other related definitions, irregardless of whether they are `Record`s, `Inductive`s, etc.

Full list of renamings:
```bash
sed -i 's/ELMOProtocolValidTransition/ELMOProtocol_valid_transition/g' $(find -name "*.v")

sed -i 's/CompositeValidTransitionNext/composite_valid_transition_next/g' $(find -name "*.v")
sed -i 's/CompositeValidTransitionsFromTo/composite_valid_transitions_from_to/g' $(find -name "*.v")
sed -i 's/CompositeValidTransition/composite_valid_transition/g' $(find -name "*.v")

sed -i 's/ValidTransitionNext/valid_transition_next/g' $(find -name "*.v")
sed -i 's/ValidTransition/valid_transition/g' $(find -name "*.v")
```