### PR TITLE
Some additional comments for Lib modules

### DIFF
--- a/theories/VLSM/Lib/Ctauto.v
+++ b/theories/VLSM/Lib/Ctauto.v
@@ -1,6 +1,10 @@
 From Cdcl Require Export Itauto.
 
-(** * Classical Itauto tactic *)
+(** * Classical Itauto tactic
+
+  This module contains a version of the itauto tactic that uses classical logic
+  freely. See the comments in VLSM.Lib.Itauto for more details.
+*)
 
 Ltac gen_conflicts tac :=
   intros; unfold not in *; unfold iff in *;

--- a/theories/VLSM/Lib/FinSetExtras.v
+++ b/theories/VLSM/Lib/FinSetExtras.v
@@ -11,6 +11,10 @@ Context
 
 Section sec_general.
 
+(**
+  If <<X>> is a subset of <<Y>>, then the elements of <<X>> are a sublist
+  of the elements of <<Y>>.
+*)
 Lemma elements_subseteq (X Y : C) :
   X ⊆ Y -> elements X ⊆ elements Y.
 Proof. by set_solver. Qed.

--- a/theories/VLSM/Lib/Itauto.v
+++ b/theories/VLSM/Lib/Itauto.v
@@ -1,6 +1,22 @@
 From Cdcl Require Export Itauto.
 
-(** * Constructive Itauto tactic *)
+(** * Constructive Itauto tactic
+
+  This module contains a workaround that prevents the itauto tactic from using
+  classical logic.
+
+  The problem is that itauto uses classical logic by default if the current
+  module requires (even if only transitively) any module that uses classical
+  logic. For example, most modules about real numbers from the standard library
+  cause itauto to use excluded middle basically each time it's called.
+
+  The solution is to redefine the itauto tactic to avoid doing this.
+
+  Every time we want to use itauto, we should import it from the current module
+  instead of directly from the Cdcl library.
+
+  TODO: this workaround should be removed after the problem is fixed upstream.
+*)
 
 Ltac gen_conflicts tac :=
   intros; unfold not in *; unfold iff in *;

--- a/theories/VLSM/Lib/Itauto.v
+++ b/theories/VLSM/Lib/Itauto.v
@@ -15,7 +15,9 @@ From Cdcl Require Export Itauto.
   Every time we want to use itauto, we should import it from the current module
   instead of directly from the Cdcl library.
 
-  TODO: this workaround should be removed after the problem is fixed upstream.
+  TODO: This problem was fixed upstream for the Itauto version for Coq 8.18, so
+  this workaround should be removed after the minimum Coq version we support is
+  8.18.
 *)
 
 Ltac gen_conflicts tac :=

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -6,8 +6,8 @@ From VLSM.Lib Require Import Preamble.
 (** * Utility lemmas about lists *)
 
 (**
-  A list is either null or it can be decomposed into an initial prefix
-  and a last element.
+  A list is either empty or it can be decomposed into an initial prefix
+  and the last element.
 *)
 Lemma has_last_or_null {S} (l : list S)
   : {l' : list S & {a : S | l = l' ++ (a :: nil)}} + {l = nil} .
@@ -18,8 +18,8 @@ Proof.
 Qed.
 
 (**
-  Destructs a list in <<l>> in either null or a prefix <<l'>> and
-  a last element <<a>> with an equation <<Heq>> stating that <<l = l' ++ [a]>>.
+  Decompose a list in into a prefix <<l'>> and the last element <<a>>
+  with an equation <<Heq>> stating that <<l = l' ++ [a]>>.
 *)
 Ltac destruct_list_last l l' a Heq :=
  destruct (has_last_or_null l) as [[l' [a Heq]] | Heq]; rewrite Heq in *; swap 1 2.
@@ -30,6 +30,7 @@ Proof.
   by destruct l.
 Qed.
 
+(** Return the last element of the list if it's present and [None] otherwise. *)
 Definition last_error {S} (l : list S) : option S :=
   match l with
   | [] => None
@@ -207,6 +208,10 @@ Proof.
     by rewrite !unroll_last.
 Qed.
 
+(**
+  Compute the suffix of the list <<l>> that starts at position <<n>>,
+  i.e. throw away the first <<n>> elements from <<l>>.
+*)
 Fixpoint list_suffix
   {A : Type}
   (l : list A)
@@ -229,6 +234,10 @@ Proof.
   by revert l; induction n; intros [| a l]; [.. | apply IHn].
 Qed.
 
+(**
+  Compute the prefix of the list <<l>> whose length is <<n>>.
+  If the list is shorter than <<n>>, return the whole list.
+*)
 Fixpoint list_prefix
   {A : Type}
   (l : list A)
@@ -331,6 +340,11 @@ Lemma prefix_of_list_prefix
   : list_prefix l n `prefix_of` l.
 Proof. by eexists; symmetry; apply list_prefix_suffix. Qed.
 
+(**
+  Compute the sublist of list <<l>> which starts at index <<n1>>
+  and ends before index <<n2>>.
+  For example, <<list_segment [0; 1; 2; 3; 4; 5] 2 4 = [2; 3]>>.
+*)
 Definition list_segment
   {A : Type}
   (l : list A)
@@ -354,6 +368,10 @@ Proof.
   by apply list_prefix_prefix.
 Qed.
 
+(**
+  Annotate each element of a list with the proof that it satisfies the
+  given decidable predicate.
+*)
 Fixpoint list_annotate
   {A : Type} {P : A -> Prop} {Pdec : forall a, Decision (P a)}
   {l : list A} : Forall P l -> list (dsig P) :=
@@ -452,11 +470,15 @@ Qed.
 
 End sec_list_annotate_props.
 
+(**
+  Compute the index of the <<n>>-th element of the list that satisfies the
+  predicate <<P>>.
+*)
 Fixpoint nth_error_filter_index
   {A} P `{forall (x : A), Decision (P x)}
   (l : list A)
   (n : nat)
-  :=
+  : option nat :=
   match l with
   | [] => None
   | a :: l =>
@@ -517,8 +539,9 @@ Proof.
 Qed.
 
 (**
-  Produces the sublist of elements of a list filtered by a decidable predicate
-  each of them paired with the proof that it satisfies the predicate.
+  Compute the sublist of a list that contains only elements that satisfy the
+  given decidable predicate. Each element of the resulting list is paired with
+  the proof that it satisfies the predicate.
 *)
 Fixpoint filter_annotate
   {A : Type} (P : A -> Prop) {Pdec : forall a : A, Decision (P a)}
@@ -773,6 +796,10 @@ Proof.
   - by intros (n & _ & Hn); eexists.
 Qed.
 
+(**
+  Map a function <<f : A -> option B>> over a list <<l>> while throwing away
+  the [None]s and unwrapping the [Some]s.
+*)
 Definition map_option
   {A B : Type}
   (f : A -> option B)
@@ -967,6 +994,10 @@ Proof.
     by apply (Hnth (S n)).
 Qed.
 
+(**
+  Compute the list of all decompositions of the given list <<l>> into
+  triples <<(l1, x, l2)>> such that <<l = l1 ++ x :: l2>>.
+*)
 Fixpoint one_element_decompositions
   {A : Type}
   (l : list A)
@@ -1008,6 +1039,10 @@ Proof.
       by rewrite IHl.
 Qed.
 
+(**
+  Compute the list of all decompositions of the given list <<l>> into
+  tuples <<(l1, x, l2, y, l3)>> such that <<l = l1 ++ x :: l2 ++ y :: l3>>.
+*)
 Definition two_element_decompositions
   {A : Type}
   (l : list A)
@@ -1093,7 +1128,7 @@ Example mode1 : mode [1; 1; 2; 3; 3] = [1; 1; 3; 3].
 Proof. by itauto. Qed.
 
 (**
-  Computes the list suff which satisfies <<pref ++ suff = l>> or
+  Computes the list <<suff>> which satisfies <<pref ++ suff = l>> or
   reports that no such list exists.
 *)
 Fixpoint complete_prefix
@@ -1212,7 +1247,7 @@ Proof.
   by apply rev_involutive.
 Qed.
 
-(** Elements belonging to first type in a list of a sum type. *)
+(** Keep elements which are [inl] but throw away those that are [inr]. *)
 Definition list_sum_project_left
   {A B : Type}
   (x : list (A + B))
@@ -1220,7 +1255,7 @@ Definition list_sum_project_left
   :=
   map_option sum_project_left x.
 
-(** Elements belonging to second type in a list of a sum type. *)
+(** Keep elements which are [inr] but throw away those that are [inl]. *)
 Definition list_sum_project_right
   {A B : Type}
   (x : list (A + B))
@@ -1314,8 +1349,10 @@ Section sec_suffix_quantifiers.
 
 (** ** Quantifiers for all suffixes
 
-  In this section we define list quantifiers similar to [Streams.ForAll] and
-  [Streams.Exists] and prove several properties about them.
+  In this section we define inductive quantifiers for lists that are concerned
+  with predicates over the sublists of the list instead of the elements. They
+  are analogous to [Streams.ForAll] and [Streams.Exists]. We prove several
+  properties about them.
 
   Among the definitions, the more useful are [ForAllSuffix2] and [ExistsSuffix2]
   as they allow us to quantify over relations between consecutive elements.

--- a/theories/VLSM/Lib/ListSetExtras.v
+++ b/theories/VLSM/Lib/ListSetExtras.v
@@ -8,7 +8,7 @@ Definition set_eq {A} (s1 s2 : set A) : Prop :=
   s1 ⊆ s2 /\ s2 ⊆ s1.
 
 (**
-  By declaring [set_eq] and [Equivalence] relation, we enable rewriting with
+  By declaring [set_eq] an [Equivalence] relation, we enable rewriting with
   it using the rewrite tactic. See the Coq reference manual for details:
   https://coq.inria.fr/refman/addendum/generalized-rewriting.html
   (section "Declaring rewrite relations", subsection "First class setoids and morphisms").
@@ -478,10 +478,9 @@ Proof.
 Qed.
 
 (**
-  For each element X of l1, exactly one occurrence of X is removed
-  from l2. If no such occurrence exists, nothing happens. 
+  For each element <<X>> of <<l1>>, exactly one occurrence of <<X>> is removed
+  from <<l2>>. If no such occurrence exists, nothing happens.
 *)
-
 Definition set_remove_list `{EqDecision A} (l1 l2 : list A) : list A :=
   fold_right set_remove l2 l1.
 

--- a/theories/VLSM/Lib/Measurable.v
+++ b/theories/VLSM/Lib/Measurable.v
@@ -4,7 +4,13 @@ From VLSM.Lib Require Import Preamble ListExtras StdppListSet.
 
 (** * Measure-related definitions and lemmas *)
 
+(** The type of positive real numbers. *)
 Definition pos_R := {r : R | (r > 0)%R}.
+
+Definition weight_proj1_sig (w : pos_R) : R := proj1_sig w.
+
+(** We can treat a positive real number as if it were an ordinary real number. *)
+Coercion weight_proj1_sig : pos_R >-> R.
 
 Class Measurable (V : Type) : Type := weight : V -> pos_R.
 
@@ -50,10 +56,6 @@ Proof.
   rewrite sum_weights_list_rew.
   by apply sum_weights_positive_list.
 Qed.
-
-Definition weight_proj1_sig (w : pos_R) : R := proj1_sig w.
-
-Coercion weight_proj1_sig : pos_R >-> R.
 
 Lemma sum_weights_in_list
   : forall (v : V) (vs : list V),

--- a/theories/VLSM/Lib/NatExtras.v
+++ b/theories/VLSM/Lib/NatExtras.v
@@ -9,6 +9,7 @@ Proof. by intros x y z; apply Z.mul_assoc. Qed.
 
 (** * Natural number utility definitions and lemmas *)
 
+(** Compute the list of all naturals less than <<n>>. *)
 Fixpoint up_to_n_listing (n : nat) : list nat :=
   match n with
   | 0 => []
@@ -174,6 +175,11 @@ Context
   `(multipliers : index -> Z)
   .
 
+(**
+  Despite being functions, <<multipliers>> are supposed to represent a list
+  <<[m_1, ..., m_n]>> and <<powers>> are supposed to represent a list
+  <<[p_1, ..., p_n]>>. The function computes <<m_1^p_1 * ... * m_n^p_n>>.
+*)
 Definition prod_powers_aux (powers : index -> nat) (l : list index) : Z :=
   foldr Z.mul 1%Z (zip_with Z.pow (map multipliers l) (map (Z.of_nat ∘ powers) l)).
 
@@ -331,11 +337,16 @@ End sec_prod_powers.
 
 #[export] Instance prime_decision : forall n, Decision (prime n) := prime_dec.
 
+(** The type of prime numbers. *)
 Definition primes : Type := dsig prime.
 
 #[export] Program Instance primes_inhabited : Inhabited primes :=
   populate (dexist 2%Z prime_2).
 
+(**
+  Compute the product of powers of primes represented by <<powers>>.
+  Since there are only finitely many of them, the result is well-defined.
+*)
 Definition prod_primes_powers (powers : fsfun primes 0) : Z :=
   fsfun_prod (fun p : primes => ` p) powers.
 

--- a/theories/VLSM/Lib/NeList.v
+++ b/theories/VLSM/Lib/NeList.v
@@ -1,7 +1,15 @@
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import ListExtras StdppExtras.
 
-(** A straight-forward inductive definition of non-empty lists. *)
+(** * Non-empty lists *)
+
+(** ** Positive definition *)
+
+(**
+  A straight-forward inductive definition of non-empty lists akin to the usual
+  list: a non-empty list is either a singleton or a cons that has a head and a
+  tail.
+*)
 Inductive ne_list (A : Type) : Type :=
 | nel_singl : A -> ne_list A
 | nel_cons : A -> ne_list A -> ne_list A.
@@ -78,6 +86,8 @@ Definition list_to_option_ne_list {A} (l : list A) : option (ne_list A) :=
 Lemma list_to_option_ne_list_unroll {A} (a : A) l :
   list_to_option_ne_list (a :: l) = Some (ne_list_option_cons a (list_to_option_ne_list l)).
 Proof. done. Qed.
+
+(** ** List-based definition *)
 
 (** A definition of non-empty lists based on lists. *)
 Record NeList (A : Type) : Type :=
@@ -199,9 +209,11 @@ Proof.
   by apply Hle; [apply ne_list_min_length |].
 Qed.
 
+(** ** Negative definition *)
+
 (**
-  An alternative inductive definition of non-empty lists using a single
-  constructor.
+  An alternative inductive definition of non-empty lists as a record which
+  has a head and an optional tail.
 *)
 Inductive NonEmptyList (A : Type) : Type := NEL_cons
 {

--- a/theories/VLSM/Lib/SortedLists.v
+++ b/theories/VLSM/Lib/SortedLists.v
@@ -5,6 +5,7 @@ From VLSM.Lib Require Import Preamble ListExtras ListSetExtras.
 
 (** * Sorted list utility functions and lemmas *)
 
+(** Insert an element into a sorted list. *)
 Fixpoint add_in_sorted_list_fn
   {A} (compare : A -> A -> comparison) (x : A) (l : list A) : list A :=
   match l with

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -161,7 +161,6 @@ Qed.
   Returns all elements <<X>> of <<l>> such that <<X>> does not compare less
   than any other element w.r.t to the precedes relation.
 *)
-
 Definition maximal_elements_list
   {A} (precedes : relation A) `{!RelDecision precedes} (l : list A)
   : list A :=

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -133,6 +133,10 @@ Proof.
     by apply Further.
 Qed.
 
+(**
+  Retrieve an existential quantifier that works on elements from [Exists],
+  which works on substreams.
+*)
 Definition Exists1 [A : Type] (P : A -> Prop) := Exists (fun s => P (hd s)).
 
 Lemma Exists1_exists [A : Type] (P : A -> Prop) s
@@ -148,6 +152,10 @@ Proof.
     + by apply Further, IHn.
 Qed.
 
+(**
+  Retrieve a universal quantifier that works on elements from [ForAll],
+  which works on substreams.
+*)
 Definition ForAll1 [A : Type] (P : A -> Prop) := ForAll (fun s => P (hd s)).
 
 Lemma ForAll1_subsumption [A : Type] (P Q : A -> Prop)
@@ -199,6 +207,7 @@ Proof.
   by case s.
 Qed.
 
+(** Appends a stream to a list, yielding a stream. *)
 Definition stream_app
   {A : Type}
   (prefix : list A)
@@ -589,6 +598,11 @@ Proof.
   by apply stream_prefix_nth.
 Qed.
 
+(**
+  Compute the sublist of stream <<l>> which starts at index <<n1>>
+  and ends before index <<n2>>.
+*)
+
 Definition stream_segment_alt
   {A : Type}
   (l : Stream A)
@@ -717,9 +731,11 @@ Proof.
   by intros n1 n2; etransitivity; [| by apply (Hs (S n1) (S n2))]; lia.
 Qed.
 
+(** The stream of all natural numbers greater than or equal to <<n>>. *)
 CoFixpoint nat_sequence_from (n : nat) : Stream nat
   := Cons n (nat_sequence_from (S n)).
 
+(** The stream of all natural numbers. *)
 Definition nat_sequence : Stream nat := nat_sequence_from 0.
 
 Lemma nat_sequence_from_nth : forall m n, Str_nth n (nat_sequence_from m) = n + m.
@@ -835,10 +851,12 @@ Proof.
   by firstorder.
 Qed.
 
+(** Prepend a non-empty list to a stream. *)
 Definition stream_prepend {A} (nel : ne_list A) (s : Stream A) : Stream A :=
   (cofix prepend (l : ne_list A) :=
     Cons (ne_list_hd l) (from_option prepend s (ne_list_tl l))) nel.
 
+(** Concatenate a stream of non-empty lists. *)
 CoFixpoint stream_concat {A} (s : Stream (ne_list A)) : Stream A :=
   stream_prepend (hd s) (stream_concat (tl s)).
 

--- a/theories/VLSM/Lib/TopSort.v
+++ b/theories/VLSM/Lib/TopSort.v
@@ -12,7 +12,7 @@ From VLSM.Lib Require Import Preamble ListExtras ListSetExtras StdppListSet Stdp
   among the current elements, then recurses on the remaining elements.
 
   To begin with, we assume an unconstrained <<precedes>> function to say
-  whether an element precedes another.  The proofs will show that if
+  whether an element precedes another. The proofs will show that if
   <<precedes>> determines a strict order on the set of elements in the list,
   then the [top_sort] algorithm produces a linear extension of that ordering
   (Lemmas [top_sort_precedes] and [top_sort_precedes_before]).


### PR DESCRIPTION
Sometime in summer @palmskog suggested that maybe we should have higher comment coverage. I did some work on it and then forgot about it. Since we will have a release soon, it's a good time to revive this work.

In this PR, I added comments to some definitions (i.e. non-opaque things) in `VLSM.Lib`. I also wrote some sections headers, changed some existing comments and did a few more documentation-related things.