### PR TITLE
Remove `list_prefix` and `list_suffix`

### DIFF
--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -326,24 +326,24 @@ Qed.
 Lemma finite_trace_last_prefix
   (s : state T) (tr : list transition_item) (n : nat) (s' : state T) :
     finite_trace_nth s tr n = Some s' ->
-    finite_trace_last s (list_prefix tr n) = s'.
+    finite_trace_last s (firstn n tr) = s'.
 Proof.
   unfold finite_trace_nth, finite_trace_last.
-  rewrite list_prefix_map.
+  rewrite <- firstn_map.
   generalize (List.map destination tr); intro l; clear tr.
   destruct n; cbn.
   - by intros [= <-]; destruct l.
-  - by intros H; symmetry; apply list_prefix_nth_last.
+  - by intros H; symmetry; apply firstn_nth_last.
 Qed.
 
 Lemma finite_trace_last_suffix
   (s : state T) (tr : list transition_item) (n : nat) :
-    n < length tr -> finite_trace_last s (list_suffix tr n) = finite_trace_last s tr.
+    n < length tr -> finite_trace_last s (skipn n tr) = finite_trace_last s tr.
 Proof.
   intros H.
   unfold finite_trace_last.
-  rewrite list_suffix_map.
-  apply list_suffix_last.
+  rewrite <- skipn_map.
+  apply skipn_last.
   by rewrite map_length.
 Qed.
 
@@ -1273,9 +1273,9 @@ Lemma finite_valid_trace_from_prefix
   (ls : list transition_item)
   (Htr : finite_valid_trace_from s ls)
   (n : nat) :
-    finite_valid_trace_from s (list_prefix ls n).
+    finite_valid_trace_from s (firstn n ls).
 Proof.
-  specialize (list_prefix_suffix ls n); intro Hdecompose.
+  specialize (firstn_suffix ls n); intro Hdecompose.
   rewrite <- Hdecompose in Htr.
   by apply finite_valid_trace_from_app_iff in Htr as [Hpr _].
 Qed.
@@ -1287,18 +1287,18 @@ Lemma finite_valid_trace_from_suffix
   (n : nat)
   (nth : state X)
   (Hnth : finite_trace_nth s ls n = Some nth) :
-    finite_valid_trace_from nth (list_suffix ls n).
+    finite_valid_trace_from nth (skipn n ls).
 Proof.
-  rewrite <- (list_prefix_suffix ls n) in Htr.
+  rewrite <- (firstn_suffix ls n) in Htr.
   apply finite_valid_trace_from_app_iff in Htr.
   destruct Htr as [_ Htr].
-  replace (finite_trace_last s (list_prefix ls n)) with nth in Htr; [done |].
+  replace (finite_trace_last s (firstn n ls)) with nth in Htr; [done |].
   destruct n.
   - rewrite finite_trace_nth_first in Hnth.
     by destruct ls; cbn; congruence.
   - unfold finite_trace_last.
-    rewrite list_prefix_map.
-    by apply list_prefix_nth_last.
+    rewrite <- firstn_map.
+    by apply firstn_nth_last.
 Qed.
 
 Lemma finite_valid_trace_from_segment
@@ -1316,7 +1316,7 @@ Proof.
   - destruct n1; [done |].
     unfold finite_trace_nth in Hnth |- *.
     simpl in Hnth |- *.
-    by rewrite list_prefix_map, list_prefix_nth.
+    by rewrite <- firstn_map, firstn_nth.
 Qed.
 
 Lemma can_produce_from_valid_trace
@@ -2202,7 +2202,7 @@ Definition trace_prefix
 
 Definition trace_prefix_fn (tr : Trace) (n : nat) : Trace X :=
   match tr with
-  | Finite s ls => Finite s (list_prefix ls n)
+  | Finite s ls => Finite s (firstn n ls)
   | Infinite s st => Finite s (stream_prefix st n)
   end.
 
@@ -2310,9 +2310,9 @@ Proof.
       ; clear Heqpref_tr
       ; simpl
       ; intro Heqprefix.
-      * specialize (list_prefix_suffix l' n); intro Hl'.
+      * specialize (firstn_suffix l' n); intro Hl'.
         rewrite <- Hl'. rewrite Heqprefix.
-        exists (list_suffix l' n).
+        exists (skipn n l').
         by rewrite <- app_assoc.
       * specialize (stream_prefix_suffix l' n); intro Hl'.
         rewrite <- Hl'. rewrite Heqprefix.
@@ -2372,12 +2372,12 @@ Proof.
       rewrite finite_trace_last_suffix.
       * by apply finite_trace_last_prefix.
       * apply finite_trace_nth_length in Hs2.
-        by rewrite list_prefix_length; lia.
+        by rewrite firstn_length; lia.
     + unfold stream_segment.
       rewrite unlock_finite_trace_last.
-      rewrite list_suffix_map, stream_prefix_map.
+      rewrite <- skipn_map, stream_prefix_map.
       simpl in Hs2.
-      rewrite list_suffix_last.
+      rewrite skipn_last.
       * symmetry. rewrite stream_prefix_nth_last.
         unfold Str_nth in Hs2. simpl in Hs2.
         by inversion Hs2; subst.

--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -1275,7 +1275,7 @@ Lemma finite_valid_trace_from_prefix
   (n : nat) :
     finite_valid_trace_from s (firstn n ls).
 Proof.
-  specialize (firstn_suffix ls n); intro Hdecompose.
+  specialize (take_drop n ls); intro Hdecompose.
   rewrite <- Hdecompose in Htr.
   by apply finite_valid_trace_from_app_iff in Htr as [Hpr _].
 Qed.
@@ -1289,7 +1289,7 @@ Lemma finite_valid_trace_from_suffix
   (Hnth : finite_trace_nth s ls n = Some nth) :
     finite_valid_trace_from nth (skipn n ls).
 Proof.
-  rewrite <- (firstn_suffix ls n) in Htr.
+  rewrite <- (take_drop n ls) in Htr.
   apply finite_valid_trace_from_app_iff in Htr.
   destruct Htr as [_ Htr].
   replace (finite_trace_last s (firstn n ls)) with nth in Htr; [done |].
@@ -2310,7 +2310,7 @@ Proof.
       ; clear Heqpref_tr
       ; simpl
       ; intro Heqprefix.
-      * specialize (firstn_suffix l' n); intro Hl'.
+      * specialize (take_drop n l'); intro Hl'.
         rewrite <- Hl'. rewrite Heqprefix.
         exists (skipn n l').
         by rewrite <- app_assoc.

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -208,16 +208,6 @@ Proof.
     by rewrite !unroll_last.
 Qed.
 
-Lemma firstn_length
-  {A : Type}
-  (l : list A)
-  (n : nat)
-  (Hlen : n <= length l)
-  : length (firstn n l) = n.
-Proof.
-  by rewrite firstn_length; lia.
-Qed.
-
 Lemma firstn_prefix
   {A : Type}
   (l : list A)
@@ -552,12 +542,12 @@ Lemma firstn_nth_last
   : nth = List.last (firstn (S n) l) _last.
 Proof.
   specialize (nth_error_length l n nth Hnth); intro Hlen.
-  specialize (firstn_length l (S n) Hlen); intro Hpref_len.
+  specialize (firstn_length (S n) l); intro Hpref_len.
   symmetry in Hpref_len.
   specialize (firstn_nth l (S n) n); intro Hpref.
   rewrite <- Hpref in Hnth; [| by constructor].
-  specialize (nth_error_last (firstn (S n) l) n Hpref_len _last); intro Hlast.
-  by rewrite Hlast in Hnth; inversion Hnth.
+  erewrite nth_error_last in Hnth by lia.
+  by inversion Hnth.
 Qed.
 
 Lemma skipn_S_tail :
@@ -661,8 +651,7 @@ Proof.
   repeat rewrite app_assoc in Hl1.
   apply app_inv_tail in Hl1.
   specialize (take_drop n1 (firstn n2 l)); intro Hl2.
-  specialize (firstn_prefix l n1 n2 H12); intro Hl3.
-  rewrite Hl3 in Hl2.
+  rewrite (firstn_prefix l n1 n2 H12) in Hl2.
   rewrite <- Hl2 in Hl1.
   rewrite <- app_assoc in Hl1.
   by apply app_inv_head in Hl1.
@@ -687,8 +676,7 @@ Proof.
   specialize (skipn_length n (firstn (S n) l)).
   rewrite firstn_length by done.
   intro Hlength.
-  assert (Hs : S n - n = 1) by lia.
-  rewrite Hs in Hlength.
+  replace (S n `min` length l - n) with 1 in Hlength by lia.
   remember (skipn n (firstn (S n) l)) as x.
   clear -Hlength Hlast1.
   destruct x; inversion Hlength.

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -207,46 +207,13 @@ Proof.
     by rewrite !unroll_last.
 Qed.
 
-Fixpoint list_suffix
-  {A : Type}
-  (l : list A)
-  (n : nat)
-  {struct n}
-  : list A
-  := match n, l with
-    | 0, _ => l
-    | _, [] => []
-    | S n, a :: l => list_suffix l n
-    end.
-
-Lemma list_suffix_map
-  {A B : Type}
-  (f : A -> B)
-  (l : list A)
-  (n : nat)
-  : List.map f (list_suffix l n) = list_suffix (List.map f l) n.
-Proof.
-  by revert l; induction n; intros [| a l]; [.. | apply IHn].
-Qed.
-
-Fixpoint list_prefix
-  {A : Type}
-  (l : list A)
-  (n : nat)
-  : list A
-  := match n, l with
-    | 0, _ => []
-    | _, [] => []
-    | S n, a :: l => a :: list_prefix l n
-    end.
-
-Lemma list_prefix_split
+Lemma firstn_split
   {A : Type}
   (l left right : list A)
   (left_len : nat)
   (Hlen : left_len = length left)
   (Hsplit : l = left ++ right) :
-  list_prefix l left_len = left.
+  firstn left_len l = left.
 Proof.
   generalize dependent l.
   generalize dependent left.
@@ -257,7 +224,6 @@ Proof.
     symmetry in Hlen.
     rewrite length_zero_iff_nil in Hlen.
     rewrite Hlen.
-    unfold list_prefix.
     by destruct l.
   - intros.
     destruct left; [done |].
@@ -273,85 +239,63 @@ Proof.
     by rewrite IHleft_len.
 Qed.
 
-Lemma list_prefix_map
-  {A B : Type}
-  (f : A -> B)
-  (l : list A)
-  (n : nat)
-  : List.map f (list_prefix l n) = list_prefix (List.map f l) n.
-Proof.
-  by revert l; induction n; intros [| a l]; cbn; [.. | rewrite IHn].
-Qed.
-
-Lemma list_prefix_length
+Lemma firstn_length
   {A : Type}
   (l : list A)
   (n : nat)
   (Hlen : n <= length l)
-  : length (list_prefix l n) = n.
+  : length (firstn n l) = n.
 Proof.
-  by revert l Hlen; induction n; intros [| a l] Hlen; cbn in *;
-    [| | inversion Hlen | rewrite IHn; lia].
+  by rewrite firstn_length; lia.
 Qed.
 
-Lemma list_suffix_length
-  {A : Type}
-  (l : list A)
-  (n : nat)
-  : length (list_suffix l n) = length l - n.
-Proof.
-  by revert l; induction n; intros [| a l]; [.. | apply IHn].
-Qed.
-
-Lemma list_prefix_prefix
+Lemma firstn_prefix
   {A : Type}
   (l : list A)
   (n1 n2 : nat)
   (Hn : n1 <= n2)
-  : list_prefix (list_prefix l n2) n1 = list_prefix l n1.
+  : firstn n1 (firstn n2 l) = firstn n1 l.
 Proof.
-  generalize dependent n1. generalize dependent n2.
-  induction l; intros [| n2] [| n1] Hn; [done .. | by inversion Hn | done |].
-  by simpl; f_equal; apply IHl; lia.
+  by rewrite take_take, min_l.
 Qed.
 
-Lemma list_prefix_suffix
+Lemma firstn_suffix
   {A : Type}
   (l : list A)
   (n : nat)
-  : list_prefix l n ++ list_suffix l n = l.
+  : firstn n l ++ skipn n l = l.
 Proof.
-  by revert n; induction l; intros [| n]; cbn; [.. | rewrite IHl].
+  by rewrite take_drop.
 Qed.
 
-Lemma prefix_of_list_prefix
+Lemma prefix_of_firstn
   {A : Type}
   (l : list A)
   (n : nat)
-  : list_prefix l n `prefix_of` l.
-Proof. by eexists; symmetry; apply list_prefix_suffix. Qed.
+  : firstn n l `prefix_of` l.
+Proof. by eexists; symmetry; apply firstn_suffix. Qed.
 
 Definition list_segment
   {A : Type}
   (l : list A)
   (n1 n2 : nat)
-  := list_suffix (list_prefix l n2) n1.
+  := skipn n1 (firstn n2 l).
 
-Lemma list_prefix_segment_suffix
+Lemma firstn_segment_suffix
   {A : Type}
   (l : list A)
   (n1 n2 : nat)
   (Hn : n1 <= n2)
-  : list_prefix l n1 ++ list_segment l n1 n2 ++ list_suffix l n2 = l.
+  : firstn n1 l ++ list_segment l n1 n2 ++ skipn n2 l = l.
 Proof.
-  rewrite <- (list_prefix_suffix l n2) at 4.
+  rewrite <- (firstn_suffix l n2) at 4.
   rewrite app_assoc.
   f_equal.
   unfold list_segment.
-  rewrite <- (list_prefix_suffix (list_prefix l n2) n1) at 2.
+  rewrite <- (firstn_suffix (firstn n2 l) n1) at 2.
   f_equal.
   symmetry.
-  by apply list_prefix_prefix.
+  by apply firstn_prefix.
 Qed.
 
 Fixpoint list_annotate
@@ -596,13 +540,13 @@ Proof.
   by unfold list_filter_map; rewrite filter_annotate_app, map_app.
 Qed.
 
-Lemma list_prefix_nth
+Lemma firstn_nth
   {A : Type}
   (s : list A)
   (n : nat)
   (i : nat)
   (Hi : i < n)
-  : nth_error (list_prefix s n) i = nth_error s i.
+  : nth_error (firstn n s) i = nth_error s i.
 Proof.
   revert s n Hi.
   induction i; intros [| a s] [| n] Hi; try done.
@@ -624,31 +568,31 @@ Proof.
     [| specialize (IHn l b H0)]; lia.
 Qed.
 
-Lemma list_prefix_nth_last
+Lemma firstn_nth_last
   {A : Type}
   (l : list A)
   (n : nat)
   (nth : A)
   (Hnth : nth_error l n = Some nth)
   (_last : A)
-  : nth = List.last (list_prefix l (S n)) _last.
+  : nth = List.last (firstn (S n) l) _last.
 Proof.
   specialize (nth_error_length l n nth Hnth); intro Hlen.
-  specialize (list_prefix_length l (S n) Hlen); intro Hpref_len.
+  specialize (firstn_length l (S n) Hlen); intro Hpref_len.
   symmetry in Hpref_len.
-  specialize (list_prefix_nth l (S n) n); intro Hpref.
+  specialize (firstn_nth l (S n) n); intro Hpref.
   rewrite <- Hpref in Hnth; [| by constructor].
-  specialize (nth_error_last (list_prefix l (S n)) n Hpref_len _last); intro Hlast.
+  specialize (nth_error_last (firstn (S n) l) n Hpref_len _last); intro Hlast.
   by rewrite Hlast in Hnth; inversion Hnth.
 Qed.
 
-Lemma list_suffix_nth
+Lemma skipn_nth
   {A : Type}
   (s : list A)
   (n : nat)
   (i : nat)
   (Hi : n <= i)
-  : nth_error (list_suffix s n) (i - n) = nth_error s i.
+  : nth_error (skipn n s) (i - n) = nth_error s i.
 Proof.
   revert s n Hi.
   induction i; intros [| a s] [| n] Hi; cbn; try done.
@@ -657,13 +601,13 @@ Proof.
   - by apply IHi; lia.
 Qed.
 
-Lemma list_suffix_last
+Lemma skipn_last
   {A : Type}
   (l : list A)
   (i : nat)
   (Hlt : i < length l)
   (_default : A)
-  : List.last (list_suffix l i) _default  = List.last l _default.
+  : List.last (skipn i l) _default  = List.last l _default.
 Proof.
   revert l Hlt; induction i; intros [| a l] Hlt; [done.. |].
   simpl in Hlt.
@@ -676,13 +620,13 @@ Proof.
   - by rewrite unroll_last, unroll_last.
 Qed.
 
-Lemma list_suffix_last_default
+Lemma skipn_last_default
   {A : Type}
   (l : list A)
   (i : nat)
   (Hlast : i = length l)
   (_default : A)
-  : List.last (list_suffix l i) _default  = _default.
+  : List.last (skipn i l) _default  = _default.
 Proof.
   revert l Hlast; induction i; intros [| a l] Hlast; [done.. |].
   by apply IHi; inversion Hlast.
@@ -699,8 +643,8 @@ Lemma list_segment_nth
   : nth_error (list_segment l n1 n2) (i - n1) = nth_error l i.
 Proof.
   unfold list_segment.
-  rewrite list_suffix_nth; [| done].
-  by apply list_prefix_nth.
+  rewrite skipn_nth; [| done].
+  by apply firstn_nth.
 Qed.
 
 Lemma list_segment_app
@@ -712,13 +656,13 @@ Lemma list_segment_app
   : list_segment l n1 n2 ++ list_segment l n2 n3 = list_segment l n1 n3.
 Proof.
   assert (Hle : n1 <= n3) by lia.
-  specialize (list_prefix_segment_suffix l n1 n3 Hle); intro Hl1.
-  specialize (list_prefix_segment_suffix l n2 n3 H23); intro Hl2.
+  specialize (firstn_segment_suffix l n1 n3 Hle); intro Hl1.
+  specialize (firstn_segment_suffix l n2 n3 H23); intro Hl2.
   rewrite <- Hl2 in Hl1 at 4. clear Hl2.
   repeat rewrite app_assoc in Hl1.
   apply app_inv_tail in Hl1.
-  specialize (list_prefix_suffix (list_prefix l n2) n1); intro Hl2.
-  specialize (list_prefix_prefix l n1 n2 H12); intro Hl3.
+  specialize (firstn_suffix (firstn n2 l) n1); intro Hl2.
+  specialize (firstn_prefix l n1 n2 H12); intro Hl3.
   rewrite Hl3 in Hl2.
   rewrite <- Hl2 in Hl1.
   rewrite <- app_assoc in Hl1.
@@ -736,17 +680,17 @@ Proof.
   unfold list_segment.
   assert (Hle : S n <= length l)
     by (apply nth_error_length in Hnth; done).
-  assert (Hlt : n < length (list_prefix l (S n)))
-    by (rewrite list_prefix_length; try constructor; done).
-  specialize (list_suffix_last (list_prefix l (S n)) n Hlt a); intro Hlast1.
-  specialize (list_prefix_nth_last l n a Hnth a); intro Hlast2.
+  assert (Hlt : n < length (firstn (S n) l))
+    by (rewrite firstn_length; lia).
+  specialize (skipn_last (firstn (S n) l) n Hlt a); intro Hlast1.
+  specialize (firstn_nth_last l n a Hnth a); intro Hlast2.
   rewrite <- Hlast2 in Hlast1.
-  specialize (list_suffix_length (list_prefix l (S n)) n).
-  rewrite list_prefix_length; [| done].
+  specialize (skipn_length n (firstn (S n) l)).
+  rewrite firstn_length by done.
   intro Hlength.
   assert (Hs : S n - n = 1) by lia.
   rewrite Hs in Hlength.
-  remember (list_suffix (list_prefix l (S n)) n) as x.
+  remember (skipn n (firstn (S n) l)) as x.
   clear -Hlength Hlast1.
   destruct x; inversion Hlength.
   destruct x; inversion H0.
@@ -1340,7 +1284,7 @@ Proof. by inversion 1. Qed.
 Lemma fsFurther : forall a l, ForAllSuffix (a :: l) -> ForAllSuffix l.
 Proof. by inversion 1. Qed.
 
-Lemma ForAll_list_suffix : forall m x, ForAllSuffix x -> ForAllSuffix (list_suffix x m).
+Lemma ForAll_skipn : forall m x, ForAllSuffix x -> ForAllSuffix (skipn m x).
 Proof.
   induction m; simpl; intros [] **; [done.. |].
   by apply fsFurther in H; apply IHm.

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -244,15 +244,16 @@ Proof.
   by etransitivity; [| apply lookup_lt_is_Some].
 Qed.
 
-Lemma list_suffix_lookup
+Lemma skipn_lookup
   {A : Type}
   (s : list A)
   (n : nat)
   (i : nat)
   (Hi : n <= i)
-  : list_suffix s n !! (i - n) = s !! i.
+  : skipn n s !! (i - n) = s !! i.
 Proof.
-  by revert s n Hi; induction i; intros [| a s] [| n] Hi; cbn; try done; [| apply IHi]; lia.
+  rewrite lookup_drop.
+  by replace (n + (i - n)) with i by lia.
 Qed.
 
 Lemma list_difference_singleton_not_in `{EqDecision A} :

--- a/theories/VLSM/Lib/StdppExtras.v
+++ b/theories/VLSM/Lib/StdppExtras.v
@@ -17,37 +17,6 @@ Proof.
     + by right; eapply IHl.
 Qed.
 
-Lemma map_skipn [A B : Type] (f : A -> B) (l : list A) (n : nat) :
-  map f (skipn n l) = skipn n (map f l).
-Proof.
-  revert n; induction l; intros n.
-  - by rewrite !skipn_nil.
-  - by destruct n; cbn; auto.
-Qed.
-
-Lemma map_firstn [A B : Type] (f : A -> B) (l : list A) (n : nat) :
-  map f (firstn n l) = firstn n (map f l).
-Proof.
-  generalize dependent n.
-  induction l; intros n.
-  - by cbn; rewrite !firstn_nil.
-  - by destruct n; cbn; rewrite ?IHl.
-Qed.
-
-Lemma skipn_S_tail {A : Type} (l : list A) (n : nat) :
-  skipn (S n) l = (skipn n (tail l)).
-Proof.
-  by destruct l; cbn; rewrite ?drop_nil.
-Qed.
-
-Lemma skipn_tail_comm {A : Type} (l : list A) (n : nat) :
-  skipn n (tail l) = tail (skipn n l).
-Proof.
-  revert l; induction n; intros l.
-  - by rewrite !drop_0.
-  - by rewrite !skipn_S_tail, IHn.
-Qed.
-
 Lemma map_tail [A B : Type] (f : A -> B) (l : list A) :
   map f (tail l) = tail (map f l).
 Proof.
@@ -241,18 +210,6 @@ Lemma list_lookup_lt [A] (is : list A) :
 Proof.
   intros; apply lookup_lt_is_Some.
   by etransitivity; [| apply lookup_lt_is_Some].
-Qed.
-
-Lemma skipn_lookup
-  {A : Type}
-  (s : list A)
-  (n : nat)
-  (i : nat)
-  (Hi : n <= i)
-  : skipn n s !! (i - n) = s !! i.
-Proof.
-  rewrite lookup_drop.
-  by replace (n + (i - n)) with i by lia.
 Qed.
 
 Lemma list_difference_singleton_not_in `{EqDecision A} :

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -643,7 +643,7 @@ Lemma stream_prefix_segment
   : stream_prefix l n1 ++ stream_segment l n1 n2 = stream_prefix l n2.
 Proof.
   unfold stream_segment.
-  rewrite <- (firstn_suffix (stream_prefix l n2) n1) at 2.
+  rewrite <- (take_drop n1 (stream_prefix l n2)) at 2.
   by rewrite stream_prefix_prefix.
 Qed.
 
@@ -674,7 +674,7 @@ Proof.
   specialize (stream_prefix_segment_suffix l n2 n3 H23); intro Hl2.
   rewrite <- Hl2 in Hl1 at 4. clear Hl2.
   apply stream_app_inj_l in Hl1.
-  - specialize (firstn_suffix (stream_prefix l n2) n1); intro Hl2.
+  - specialize (take_drop n1 (stream_prefix l n2)); intro Hl2.
     specialize (stream_prefix_prefix l n1 n2 H12); intro Hl3.
     rewrite Hl3 in Hl2.
     rewrite <- Hl2, <- app_assoc in Hl1.

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -353,7 +353,7 @@ Lemma stream_prefix_app_l
   (s : Stream A)
   (n : nat)
   (Hle : n <= length l)
-  : stream_prefix (stream_app l s) n = list_prefix l n.
+  : stream_prefix (stream_app l s) n = firstn n l.
 Proof.
   revert n Hle; induction l; intros [| n] Hle; [by inversion Hle.. |].
   by cbn in *; rewrite IHl; [| lia].
@@ -549,10 +549,10 @@ Lemma stream_prefix_prefix
   (l : Stream A)
   (n1 n2 : nat)
   (Hn : n1 <= n2)
-  : list_prefix (stream_prefix l n2) n1 = stream_prefix l n1.
+  : firstn n1 (stream_prefix l n2) = stream_prefix l n1.
 Proof.
   revert l n2 Hn.
-  induction n1; intros [a l]; intros [| n2] Hn; cbn; [by inversion Hn.. |].
+  induction n1; intros [a l]; intros [| n2] Hn; simpl; [by inversion Hn.. |].
   by rewrite IHn1; [| lia].
 Qed.
 
@@ -564,7 +564,7 @@ Lemma stream_prefix_of
   : stream_prefix l n1 `prefix_of` stream_prefix l n2.
 Proof.
   rewrite <- (stream_prefix_prefix l n1 n2 Hn).
-  by apply prefix_of_list_prefix.
+  by apply prefix_of_firstn.
 Qed.
 
 Definition stream_segment
@@ -572,7 +572,7 @@ Definition stream_segment
   (l : Stream A)
   (n1 n2 : nat)
   : list A
-  := list_suffix (stream_prefix l n2) n1.
+  := skipn n1 (stream_prefix l n2).
 
 Lemma stream_segment_nth
   {A : Type}
@@ -585,7 +585,7 @@ Lemma stream_segment_nth
   : nth_error (stream_segment l n1 n2) (i - n1) = Some (Str_nth i l).
 Proof.
   unfold stream_segment.
-  rewrite list_suffix_nth; [| done].
+  rewrite skipn_nth; [| done].
   by apply stream_prefix_nth.
 Qed.
 
@@ -606,14 +606,14 @@ Proof.
   intro k.
   unfold stream_segment_alt. unfold stream_segment.
   destruct (decide (n2 - n1 <= k)).
-  - specialize (nth_error_None (list_suffix (stream_prefix l n2) n1) k); intros [_ H].
+  - specialize (nth_error_None (skipn n1 (stream_prefix l n2)) k); intros [_ H].
     specialize (nth_error_None (stream_prefix (stream_suffix l n1) (n2 - n1)) k); intros [_ H_alt].
     rewrite H, H_alt; [done | |].
     + by rewrite stream_prefix_length.
-    + by rewrite list_suffix_length, stream_prefix_length.
+    + by rewrite skipn_length, stream_prefix_length.
   - rewrite stream_prefix_nth, stream_suffix_nth by lia.
     assert (Hle : n1 <= n1 + k) by lia.
-    specialize (list_suffix_nth (stream_prefix l n2) n1 (n1 + k) Hle)
+    specialize (skipn_nth (stream_prefix l n2) n1 (n1 + k) Hle)
     ; intro Heq.
     clear Hle.
     assert (Hs : n1 + k - n1 = k) by lia.
@@ -629,7 +629,7 @@ Lemma stream_prefix_segment
   : stream_prefix l n1 ++ stream_segment l n1 n2 = stream_prefix l n2.
 Proof.
   unfold stream_segment.
-  rewrite <- (list_prefix_suffix (stream_prefix l n2) n1) at 2.
+  rewrite <- (firstn_suffix (stream_prefix l n2) n1) at 2.
   by rewrite stream_prefix_prefix.
 Qed.
 
@@ -660,14 +660,14 @@ Proof.
   specialize (stream_prefix_segment_suffix l n2 n3 H23); intro Hl2.
   rewrite <- Hl2 in Hl1 at 4. clear Hl2.
   apply stream_app_inj_l in Hl1.
-  - specialize (list_prefix_suffix (stream_prefix l n2) n1); intro Hl2.
+  - specialize (firstn_suffix (stream_prefix l n2) n1); intro Hl2.
     specialize (stream_prefix_prefix l n1 n2 H12); intro Hl3.
     rewrite Hl3 in Hl2.
     rewrite <- Hl2, <- app_assoc in Hl1.
     by apply app_inv_head in Hl1.
   - repeat rewrite app_length.
     unfold stream_segment.
-    by rewrite !list_suffix_length, !stream_prefix_length; lia.
+    by rewrite !skipn_length, !stream_prefix_length; lia.
 Qed.
 
 Definition monotone_nat_stream_prop
@@ -853,7 +853,7 @@ Lemma stream_prepend_prefix_l
   (l : ne_list A)
   (s : Stream A)
   : forall n : nat, n <= ne_list_length l ->
-    stream_prefix (stream_prepend l s) n = list_prefix (ne_list_to_list l) n.
+    stream_prefix (stream_prepend l s) n = firstn n (ne_list_to_list l).
 Proof.
   induction l; intros [| n] Hle; cbn; [done | | done |].
   - by cbn in Hle; replace n with 0 by lia.


### PR DESCRIPTION
I noticed that `list_prefix` and `list_suffix` were (almost) identical to `firstn` and `skipn` from stdpp/stdlib, so I replaced the former with the latter. We also had some lemmas proved which were already provided by stdpp/stdlib, so I removed these.