### PR TITLE
Remove `firstn` and `skipn`

### DIFF
--- a/theories/VLSM/Core/VLSM.v
+++ b/theories/VLSM/Core/VLSM.v
@@ -326,24 +326,24 @@ Qed.
 Lemma finite_trace_last_prefix
   (s : state T) (tr : list transition_item) (n : nat) (s' : state T) :
     finite_trace_nth s tr n = Some s' ->
-    finite_trace_last s (firstn n tr) = s'.
+    finite_trace_last s (take n tr) = s'.
 Proof.
   unfold finite_trace_nth, finite_trace_last.
   rewrite <- firstn_map.
   generalize (List.map destination tr); intro l; clear tr.
   destruct n; cbn.
   - by intros [= <-]; destruct l.
-  - by intros H; symmetry; apply firstn_nth_last.
+  - by intros H; symmetry; apply take_nth_last.
 Qed.
 
 Lemma finite_trace_last_suffix
   (s : state T) (tr : list transition_item) (n : nat) :
-    n < length tr -> finite_trace_last s (skipn n tr) = finite_trace_last s tr.
+    n < length tr -> finite_trace_last s (drop n tr) = finite_trace_last s tr.
 Proof.
   intros H.
   unfold finite_trace_last.
   rewrite <- skipn_map.
-  apply skipn_last.
+  apply drop_last.
   by rewrite map_length.
 Qed.
 
@@ -1273,7 +1273,7 @@ Lemma finite_valid_trace_from_prefix
   (ls : list transition_item)
   (Htr : finite_valid_trace_from s ls)
   (n : nat) :
-    finite_valid_trace_from s (firstn n ls).
+    finite_valid_trace_from s (take n ls).
 Proof.
   specialize (take_drop n ls); intro Hdecompose.
   rewrite <- Hdecompose in Htr.
@@ -1287,18 +1287,18 @@ Lemma finite_valid_trace_from_suffix
   (n : nat)
   (nth : state X)
   (Hnth : finite_trace_nth s ls n = Some nth) :
-    finite_valid_trace_from nth (skipn n ls).
+    finite_valid_trace_from nth (drop n ls).
 Proof.
   rewrite <- (take_drop n ls) in Htr.
   apply finite_valid_trace_from_app_iff in Htr.
   destruct Htr as [_ Htr].
-  replace (finite_trace_last s (firstn n ls)) with nth in Htr; [done |].
+  replace (finite_trace_last s (take n ls)) with nth in Htr; [done |].
   destruct n.
   - rewrite finite_trace_nth_first in Hnth.
     by destruct ls; cbn; congruence.
   - unfold finite_trace_last.
     rewrite <- firstn_map.
-    by apply firstn_nth_last.
+    by apply take_nth_last.
 Qed.
 
 Lemma finite_valid_trace_from_segment
@@ -1316,7 +1316,7 @@ Proof.
   - destruct n1; [done |].
     unfold finite_trace_nth in Hnth |- *.
     simpl in Hnth |- *.
-    by rewrite <- firstn_map, firstn_nth.
+    by rewrite <- firstn_map, take_nth.
 Qed.
 
 Lemma can_produce_from_valid_trace
@@ -2202,7 +2202,7 @@ Definition trace_prefix
 
 Definition trace_prefix_fn (tr : Trace) (n : nat) : Trace X :=
   match tr with
-  | Finite s ls => Finite s (firstn n ls)
+  | Finite s ls => Finite s (take n ls)
   | Infinite s st => Finite s (stream_prefix st n)
   end.
 
@@ -2312,7 +2312,7 @@ Proof.
       ; intro Heqprefix.
       * specialize (take_drop n l'); intro Hl'.
         rewrite <- Hl'. rewrite Heqprefix.
-        exists (skipn n l').
+        exists (drop n l').
         by rewrite <- app_assoc.
       * specialize (stream_prefix_suffix l' n); intro Hl'.
         rewrite <- Hl'. rewrite Heqprefix.
@@ -2372,12 +2372,12 @@ Proof.
       rewrite finite_trace_last_suffix.
       * by apply finite_trace_last_prefix.
       * apply finite_trace_nth_length in Hs2.
-        by rewrite firstn_length; lia.
+        by rewrite take_length; lia.
     + unfold stream_segment.
       rewrite unlock_finite_trace_last.
       rewrite <- skipn_map, stream_prefix_map.
       simpl in Hs2.
-      rewrite skipn_last.
+      rewrite drop_last.
       * symmetry. rewrite stream_prefix_nth_last.
         unfold Str_nth in Hs2. simpl in Hs2.
         by inversion Hs2; subst.

--- a/theories/VLSM/Lib/ListExtras.v
+++ b/theories/VLSM/Lib/ListExtras.v
@@ -208,21 +208,21 @@ Proof.
     by rewrite !unroll_last.
 Qed.
 
-Lemma firstn_prefix
+Lemma take_prefix
   {A : Type}
   (l : list A)
   (n1 n2 : nat)
   (Hn : n1 <= n2)
-  : firstn n1 (firstn n2 l) = firstn n1 l.
+  : take n1 (take n2 l) = take n1 l.
 Proof.
   by rewrite take_take, min_l.
 Qed.
 
-Lemma prefix_of_firstn
+Lemma prefix_of_take
   {A : Type}
   (l : list A)
   (n : nat)
-  : firstn n l `prefix_of` l.
+  : take n l `prefix_of` l.
 Proof. by eexists; symmetry; apply take_drop. Qed.
 
 (**
@@ -234,23 +234,23 @@ Definition list_segment
   {A : Type}
   (l : list A)
   (n1 n2 : nat)
-  := skipn n1 (firstn n2 l).
+  := drop n1 (take n2 l).
 
-Lemma firstn_segment_suffix
+Lemma take_segment_suffix
   {A : Type}
   (l : list A)
   (n1 n2 : nat)
   (Hn : n1 <= n2)
-  : firstn n1 l ++ list_segment l n1 n2 ++ skipn n2 l = l.
+  : take n1 l ++ list_segment l n1 n2 ++ drop n2 l = l.
 Proof.
   rewrite <- (take_drop n2 l) at 4.
   rewrite app_assoc.
   f_equal.
   unfold list_segment.
-  rewrite <- (take_drop n1 (firstn n2 l)) at 2.
+  rewrite <- (take_drop n1 (take n2 l)) at 2.
   f_equal.
   symmetry.
-  by apply firstn_prefix.
+  by apply take_prefix.
 Qed.
 
 (**
@@ -504,13 +504,13 @@ Proof.
   by unfold list_filter_map; rewrite filter_annotate_app, map_app.
 Qed.
 
-Lemma firstn_nth
+Lemma take_nth
   {A : Type}
   (s : list A)
   (n : nat)
   (i : nat)
   (Hi : i < n)
-  : nth_error (firstn n s) i = nth_error s i.
+  : nth_error (take n s) i = nth_error s i.
 Proof.
   revert s n Hi.
   induction i; intros [| a s] [| n] Hi; try done.
@@ -532,56 +532,56 @@ Proof.
     [| specialize (IHn l b H0)]; lia.
 Qed.
 
-Lemma firstn_nth_last
+Lemma take_nth_last
   {A : Type}
   (l : list A)
   (n : nat)
   (nth : A)
   (Hnth : nth_error l n = Some nth)
   (_last : A)
-  : nth = List.last (firstn (S n) l) _last.
+  : nth = List.last (take (S n) l) _last.
 Proof.
   specialize (nth_error_length l n nth Hnth); intro Hlen.
-  specialize (firstn_length (S n) l); intro Hpref_len.
+  specialize (take_length l (S n)); intro Hpref_len.
   symmetry in Hpref_len.
-  specialize (firstn_nth l (S n) n); intro Hpref.
+  specialize (take_nth l (S n) n); intro Hpref.
   rewrite <- Hpref in Hnth; [| by constructor].
   erewrite nth_error_last in Hnth by lia.
   by inversion Hnth.
 Qed.
 
-Lemma skipn_S_tail :
+Lemma drop_S_tail :
   forall {A : Type} (l : list A) (n : nat),
-    skipn (S n) l = skipn n (tail l).
+    drop (S n) l = drop n (tail l).
 Proof.
   by destruct l; cbn; intros; rewrite ?drop_nil.
 Qed.
 
-Lemma skipn_tail_comm :
+Lemma drop_tail_comm :
   forall {A : Type} (l : list A) (n : nat),
-    skipn n (tail l) = tail (skipn n l).
+    drop n (tail l) = tail (drop n l).
 Proof.
   intros A l n; revert l; induction n; intros l.
   - by rewrite !drop_0.
-  - by rewrite !skipn_S_tail, IHn.
+  - by rewrite !drop_S_tail, IHn.
 Qed.
 
-Lemma skipn_lookup :
+Lemma drop_lookup :
   forall {A : Type} (s : list A) (n i : nat),
-    n <= i -> skipn n s !! (i - n) = s !! i.
+    n <= i -> drop n s !! (i - n) = s !! i.
 Proof.
   intros.
   rewrite lookup_drop.
   by replace (n + (i - n)) with i by lia.
 Qed.
 
-Lemma skipn_nth
+Lemma drop_nth
   {A : Type}
   (s : list A)
   (n : nat)
   (i : nat)
   (Hi : n <= i)
-  : nth_error (skipn n s) (i - n) = nth_error s i.
+  : nth_error (drop n s) (i - n) = nth_error s i.
 Proof.
   revert s n Hi.
   induction i; intros [| a s] [| n] Hi; cbn; try done.
@@ -590,13 +590,13 @@ Proof.
   - by apply IHi; lia.
 Qed.
 
-Lemma skipn_last
+Lemma drop_last
   {A : Type}
   (l : list A)
   (i : nat)
   (Hlt : i < length l)
   (_default : A)
-  : List.last (skipn i l) _default  = List.last l _default.
+  : List.last (drop i l) _default  = List.last l _default.
 Proof.
   revert l Hlt; induction i; intros [| a l] Hlt; [done.. |].
   simpl in Hlt.
@@ -609,13 +609,13 @@ Proof.
   - by rewrite unroll_last, unroll_last.
 Qed.
 
-Lemma skipn_last_default
+Lemma drop_last_default
   {A : Type}
   (l : list A)
   (i : nat)
   (Hlast : i = length l)
   (_default : A)
-  : List.last (skipn i l) _default  = _default.
+  : List.last (drop i l) _default  = _default.
 Proof.
   revert l Hlast; induction i; intros [| a l] Hlast; [done.. |].
   by apply IHi; inversion Hlast.
@@ -632,8 +632,8 @@ Lemma list_segment_nth
   : nth_error (list_segment l n1 n2) (i - n1) = nth_error l i.
 Proof.
   unfold list_segment.
-  rewrite skipn_nth; [| done].
-  by apply firstn_nth.
+  rewrite drop_nth; [| done].
+  by apply take_nth.
 Qed.
 
 Lemma list_segment_app
@@ -645,13 +645,13 @@ Lemma list_segment_app
   : list_segment l n1 n2 ++ list_segment l n2 n3 = list_segment l n1 n3.
 Proof.
   assert (Hle : n1 <= n3) by lia.
-  specialize (firstn_segment_suffix l n1 n3 Hle); intro Hl1.
-  specialize (firstn_segment_suffix l n2 n3 H23); intro Hl2.
+  specialize (take_segment_suffix l n1 n3 Hle); intro Hl1.
+  specialize (take_segment_suffix l n2 n3 H23); intro Hl2.
   rewrite <- Hl2 in Hl1 at 4. clear Hl2.
   repeat rewrite app_assoc in Hl1.
   apply app_inv_tail in Hl1.
-  specialize (take_drop n1 (firstn n2 l)); intro Hl2.
-  rewrite (firstn_prefix l n1 n2 H12) in Hl2.
+  specialize (take_drop n1 (take n2 l)); intro Hl2.
+  rewrite (take_prefix l n1 n2 H12) in Hl2.
   rewrite <- Hl2 in Hl1.
   rewrite <- app_assoc in Hl1.
   by apply app_inv_head in Hl1.
@@ -668,16 +668,16 @@ Proof.
   unfold list_segment.
   assert (Hle : S n <= length l)
     by (apply nth_error_length in Hnth; done).
-  assert (Hlt : n < length (firstn (S n) l))
-    by (rewrite firstn_length; lia).
-  specialize (skipn_last (firstn (S n) l) n Hlt a); intro Hlast1.
-  specialize (firstn_nth_last l n a Hnth a); intro Hlast2.
+  assert (Hlt : n < length (take (S n) l))
+    by (rewrite take_length; lia).
+  specialize (drop_last (take (S n) l) n Hlt a); intro Hlast1.
+  specialize (take_nth_last l n a Hnth a); intro Hlast2.
   rewrite <- Hlast2 in Hlast1.
-  specialize (skipn_length n (firstn (S n) l)).
-  rewrite firstn_length by done.
+  specialize (drop_length (take (S n) l) n).
+  rewrite take_length by done.
   intro Hlength.
   replace (S n `min` length l - n) with 1 in Hlength by lia.
-  remember (skipn n (firstn (S n) l)) as x.
+  remember (drop n (take (S n) l)) as x.
   clear -Hlength Hlast1.
   destruct x; inversion Hlength.
   destruct x; inversion H0.
@@ -1285,7 +1285,7 @@ Proof. by inversion 1. Qed.
 Lemma fsFurther : forall a l, ForAllSuffix (a :: l) -> ForAllSuffix l.
 Proof. by inversion 1. Qed.
 
-Lemma ForAll_skipn : forall m x, ForAllSuffix x -> ForAllSuffix (skipn m x).
+Lemma ForAll_drop : forall m x, ForAllSuffix x -> ForAllSuffix (drop m x).
 Proof.
   induction m; simpl; intros [] **; [done.. |].
   by apply fsFurther in H; apply IHm.
@@ -1409,14 +1409,14 @@ Qed.
 
 (** [lastn] returns a suffix of length <<n>> from the list <<l>>. *)
 Definition lastn {A : Type} (n : nat) (l : list A) : list A :=
-  rev (firstn n (rev l)).
+  rev (take n (rev l)).
 
 (** If the list is [[]], then the result of [lastn] is also [[]]. *)
 Lemma lastn_nil :
   forall {A : Type} (n : nat),
     lastn n (@nil A) = [].
 Proof.
-  by intros A n; unfold lastn; cbn; rewrite firstn_nil.
+  by intros A n; unfold lastn; cbn; rewrite take_nil.
 Qed.
 
 (** If <<n>> is zero, then the result of [lastn] is [[]]. *)

--- a/theories/VLSM/Lib/StreamExtras.v
+++ b/theories/VLSM/Lib/StreamExtras.v
@@ -362,7 +362,7 @@ Lemma stream_prefix_app_l
   (s : Stream A)
   (n : nat)
   (Hle : n <= length l)
-  : stream_prefix (stream_app l s) n = firstn n l.
+  : stream_prefix (stream_app l s) n = take n l.
 Proof.
   revert n Hle; induction l; intros [| n] Hle; [by inversion Hle.. |].
   by cbn in *; rewrite IHl; [| lia].
@@ -558,7 +558,7 @@ Lemma stream_prefix_prefix
   (l : Stream A)
   (n1 n2 : nat)
   (Hn : n1 <= n2)
-  : firstn n1 (stream_prefix l n2) = stream_prefix l n1.
+  : take n1 (stream_prefix l n2) = stream_prefix l n1.
 Proof.
   revert l n2 Hn.
   induction n1; intros [a l]; intros [| n2] Hn; simpl; [by inversion Hn.. |].
@@ -573,7 +573,7 @@ Lemma stream_prefix_of
   : stream_prefix l n1 `prefix_of` stream_prefix l n2.
 Proof.
   rewrite <- (stream_prefix_prefix l n1 n2 Hn).
-  by apply prefix_of_firstn.
+  by apply prefix_of_take.
 Qed.
 
 Definition stream_segment
@@ -581,7 +581,7 @@ Definition stream_segment
   (l : Stream A)
   (n1 n2 : nat)
   : list A
-  := skipn n1 (stream_prefix l n2).
+  := drop n1 (stream_prefix l n2).
 
 Lemma stream_segment_nth
   {A : Type}
@@ -594,7 +594,7 @@ Lemma stream_segment_nth
   : nth_error (stream_segment l n1 n2) (i - n1) = Some (Str_nth i l).
 Proof.
   unfold stream_segment.
-  rewrite skipn_nth; [| done].
+  rewrite drop_nth; [| done].
   by apply stream_prefix_nth.
 Qed.
 
@@ -620,14 +620,14 @@ Proof.
   intro k.
   unfold stream_segment_alt. unfold stream_segment.
   destruct (decide (n2 - n1 <= k)).
-  - specialize (nth_error_None (skipn n1 (stream_prefix l n2)) k); intros [_ H].
+  - specialize (nth_error_None (drop n1 (stream_prefix l n2)) k); intros [_ H].
     specialize (nth_error_None (stream_prefix (stream_suffix l n1) (n2 - n1)) k); intros [_ H_alt].
     rewrite H, H_alt; [done | |].
     + by rewrite stream_prefix_length.
-    + by rewrite skipn_length, stream_prefix_length.
+    + by rewrite drop_length, stream_prefix_length.
   - rewrite stream_prefix_nth, stream_suffix_nth by lia.
     assert (Hle : n1 <= n1 + k) by lia.
-    specialize (skipn_nth (stream_prefix l n2) n1 (n1 + k) Hle)
+    specialize (drop_nth (stream_prefix l n2) n1 (n1 + k) Hle)
     ; intro Heq.
     clear Hle.
     assert (Hs : n1 + k - n1 = k) by lia.
@@ -681,7 +681,7 @@ Proof.
     by apply app_inv_head in Hl1.
   - repeat rewrite app_length.
     unfold stream_segment.
-    by rewrite !skipn_length, !stream_prefix_length; lia.
+    by rewrite !drop_length, !stream_prefix_length; lia.
 Qed.
 
 Definition monotone_nat_stream_prop
@@ -871,7 +871,7 @@ Lemma stream_prepend_prefix_l
   (l : ne_list A)
   (s : Stream A)
   : forall n : nat, n <= ne_list_length l ->
-    stream_prefix (stream_prepend l s) n = firstn n (ne_list_to_list l).
+    stream_prefix (stream_prepend l s) n = take n (ne_list_to_list l).
 Proof.
   induction l; intros [| n] Hle; cbn; [done | | done |].
   - by cbn in Hle; replace n with 0 by lia.


### PR DESCRIPTION
After the recent changes, we are now using `firstn` and `skipn` directly instead of `list_prefix` and `list_suffix`. Since `firstn` and `skipn` are displayed as `take` and `drop` in proof mode anyway, I replaced all uses of the former with the latter.