### PR TITLE
Replace `map_option` with `omap` from stdpp

### DIFF
--- a/theories/Core/Equivocation.v
+++ b/theories/Core/Equivocation.v
@@ -1772,7 +1772,7 @@ Proof.
   ; [| by apply stepwise_props | by eapply finite_valid_trace_from_to_last_pstate, Hpre_tr].
   specialize (Horacle _ _ Hpre_tr); clear Hpre_tr.
   apply Exists_exists in Horacle as (item & Hitem & Hout).
-  apply elem_of_map_option in Hitem as (itemX & HitemX & HitemX_pr).
+  apply elem_of_list_omap in Hitem as (itemX & HitemX & HitemX_pr).
   apply elem_of_list_split in HitemX as (pre & suf & Htr_pr).
   exists (finite_trace_last is pre), itemX.
   rewrite cons_middle in Htr_pr.

--- a/theories/Core/Equivocation/MsgDepLimitedEquivocation.v
+++ b/theories/Core/Equivocation/MsgDepLimitedEquivocation.v
@@ -38,7 +38,7 @@ Definition coeqv_message_equivocators (s : composite_state IM) (m : message)
   then (* no additional equivocation *)
     ∅
   else (* m itself and all its non-observed dependencies are equivocating. *)
-    list_to_set (map_option sender [m] ++ (elements (coequivocating_senders s m))).
+    list_to_set (omap sender [m] ++ (elements (coequivocating_senders s m))).
 
 Definition coeqv_composite_transition_message_equivocators
   (l : composite_label IM)
@@ -141,7 +141,7 @@ Definition not_directly_observed_happens_before_dependencies (s : composite_stat
 
 Definition msg_dep_coequivocating_senders (s : composite_state IM) (m : message)
   : Cv :=
-  list_to_set (map_option sender (elements (not_directly_observed_happens_before_dependencies s m))).
+  list_to_set (omap sender (elements (not_directly_observed_happens_before_dependencies s m))).
 
 Definition msg_dep_limited_equivocation_vlsm : VLSM message :=
   coeqv_limited_equivocation_vlsm IM threshold sender msg_dep_coequivocating_senders.
@@ -241,7 +241,7 @@ Proof.
   intro; split; intro Hx; [| by contradict Hx; apply not_elem_of_empty].
   exfalso; contradict Hx.
   unfold msg_dep_coequivocating_senders.
-  rewrite elem_of_list_to_set, elem_of_map_option.
+  rewrite elem_of_list_to_set, elem_of_list_omap.
   setoid_rewrite elem_of_elements; setoid_rewrite elem_of_filter.
   intros (dm & [Hnobs Hdm]  & _).
   contradict Hnobs; exists i.
@@ -280,7 +280,7 @@ Proof.
   apply sets.union_proper; [done |].
   unfold coeqv_message_equivocators, msg_dep_coequivocating_senders.
   case_decide as Hobs; [done |].
-  remember (list_to_set (map_option _ _)) as equivs.
+  remember (list_to_set (omap _ _)) as equivs.
   cut (equivs ≡@{Cv} ∅); [by intros -> |].
   by subst; eapply full_node_msg_dep_coequivocating_senders.
 Qed.
@@ -424,7 +424,7 @@ Proof.
     unfold msg_dep_message_equivocators, coeqv_message_equivocators,
       msg_dep_coequivocating_senders, not_directly_observed_happens_before_dependencies.
     rewrite decide_False, elem_of_list_to_set, elem_of_app, elem_of_elements,
-      elem_of_list_to_set, !elem_of_map_option by done.
+      elem_of_list_to_set, !elem_of_list_omap by done.
     right; exists dm.
     rewrite elem_of_elements, elem_of_filter.
     by setoid_rewrite full_message_dependencies_happens_before.
@@ -627,7 +627,7 @@ Proof.
   unfold msg_dep_coequivocating_senders,
          not_directly_observed_happens_before_dependencies in Heqv
   ; rewrite elem_of_list_to_set, elem_of_app,
-      elem_of_elements, elem_of_list_to_set, !elem_of_map_option in Heqv
+      elem_of_elements, elem_of_list_to_set, !elem_of_list_omap in Heqv
   ; setoid_rewrite elem_of_list_singleton in Heqv
   ; setoid_rewrite elem_of_elements in Heqv
   ; setoid_rewrite elem_of_filter in Heqv.

--- a/theories/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/Core/Equivocation/TraceWiseEquivocation.v
@@ -68,8 +68,8 @@ Definition equivocating_senders_in_trace
   let equivocating_items :=
     map (fun d => match d with (_, item, _) => item end)
       (filter test decompositions) in
-  let equivocating_messages := map_option input equivocating_items in
-  let equivocating_senders := map_option sender equivocating_messages in
+  let equivocating_messages := omap input equivocating_items in
+  let equivocating_senders := omap sender equivocating_messages in
   remove_dups equivocating_senders.
 
 Lemma no_input_no_equivocating_senders_in_trace tr
@@ -80,8 +80,8 @@ Proof.
   intros v Hv.
   unfold equivocating_senders_in_trace in Hv.
   rewrite elem_of_remove_dups in Hv.
-  apply elem_of_map_option in Hv as [msg [Hmsg Hv]].
-  apply elem_of_map_option in Hmsg as [item [Hitem Hmsg]].
+  apply elem_of_list_omap in Hv as [msg [Hmsg Hv]].
+  apply elem_of_list_omap in Hmsg as [item [Hitem Hmsg]].
   apply elem_of_list_fmap in Hitem as [((pre, _item), _suf) [Heq_item Hitem]].
   apply elem_of_list_filter, proj2, elem_of_one_element_decompositions in Hitem.
   subst tr _item.
@@ -99,8 +99,8 @@ Lemma elem_of_equivocating_senders_in_trace
     equivocation_in_trace PreFree m tr.
 Proof.
   unfold equivocating_senders_in_trace.
-  rewrite elem_of_remove_dups, elem_of_map_option.
-  setoid_rewrite elem_of_map_option.
+  rewrite elem_of_remove_dups, elem_of_list_omap.
+  setoid_rewrite elem_of_list_omap.
   setoid_rewrite elem_of_list_fmap.
   split.
   - intros [im [[item [[((prefix, _item), suffix) [Heq_item Hfilter]] Hinput]] Hsender]].

--- a/theories/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -900,7 +900,7 @@ Proof.
     destruct IHtr as [Heqv_initial Hpr_trXi'].
     split; [done |].
     subst.
-    by apply map_option_app.
+    by apply omap_app.
 Qed.
 
 (**

--- a/theories/Core/ProjectionTraces.v
+++ b/theories/Core/ProjectionTraces.v
@@ -254,7 +254,7 @@ Lemma finite_trace_projection_list_in
       ∈
     VLSM_projection_finite_trace_project (preloaded_component_projection IM j) tr.
 Proof.
-  apply elem_of_map_option.
+  apply elem_of_list_omap.
   exists itemX; split; [done |].
   unfold pre_VLSM_projection_transition_item_project, composite_project_label; subst j.
   case_decide; [| by elim H].
@@ -274,7 +274,7 @@ Lemma finite_trace_projection_list_in_rev
     exists (Hl1 : j = projT1 (l itemX)),
     eq_rect_r _ (projT2 (l itemX)) Hl1 = l itemj.
 Proof.
-  apply elem_of_map_option in Hitemj as [itemX [HitemX HitemX_pr]].
+  apply elem_of_list_omap in Hitemj as [itemX [HitemX HitemX_pr]].
   exists itemX. split; [done |].
   unfold pre_VLSM_projection_transition_item_project in HitemX_pr.
   destruct (composite_project_label _ _ _) as [lY |] eqn: Hly; [| by congruence].

--- a/theories/Core/SubProjectionTraces.v
+++ b/theories/Core/SubProjectionTraces.v
@@ -564,7 +564,7 @@ Proof.
       as [itemX HitemX].
     exists itemX.
     split.
-    + by apply elem_of_map_option; exists item.
+    + by apply elem_of_list_omap; exists item.
     + unfold pre_VLSM_projection_transition_item_project in HitemX.
       destruct (composite_label_sub_projection_option _); [| by congruence].
       by inversion HitemX.
@@ -606,7 +606,7 @@ Proof.
       [| contradict Hsome; apply is_Some_None].
       cbn.
       split.
-      * by apply elem_of_map_option; exists item.
+      * by apply elem_of_list_omap; exists item.
       * unfold pre_VLSM_projection_transition_item_project in Hproj.
         by destruct (composite_label_sub_projection_option _); [inversion Hproj | congruence].
 Qed.

--- a/theories/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/Core/VLSMProjections/VLSMTotalProjection.v
@@ -97,7 +97,7 @@ Qed.
 Definition pre_VLSM_projection_finite_trace_project
   : list (transition_item TX) -> list (transition_item TY)
   :=
-  map_option pre_VLSM_projection_transition_item_project.
+  omap pre_VLSM_projection_transition_item_project.
 
 Definition pre_VLSM_projection_infinite_trace_project
   (s : Streams.Stream (transition_item TX))
@@ -116,7 +116,7 @@ Lemma pre_VLSM_projection_finite_trace_project_app :
   forall l1 l2, pre_VLSM_projection_finite_trace_project (l1 ++ l2) =
     pre_VLSM_projection_finite_trace_project l1 ++ pre_VLSM_projection_finite_trace_project l2.
 Proof.
-  exact (map_option_app _).
+  exact (omap_app _).
 Qed.
 
 Lemma pre_VLSM_projection_finite_trace_project_app_rev :
@@ -125,21 +125,21 @@ Lemma pre_VLSM_projection_finite_trace_project_app_rev :
       pre_VLSM_projection_finite_trace_project l1 = l1' /\
       pre_VLSM_projection_finite_trace_project l2 = l2'.
 Proof.
-  exact (map_option_app_rev _).
+  exact (omap_app_rev _).
 Qed.
 
 Lemma pre_VLSM_projection_finite_trace_project_elem_of_iff :
   forall trX itemY, itemY ∈ pre_VLSM_projection_finite_trace_project trX <->
     exists itemX, itemX ∈ trX /\ pre_VLSM_projection_transition_item_project itemX = Some itemY.
 Proof.
-  exact (elem_of_map_option _).
+  exact (elem_of_list_omap _).
 Qed.
 
 Lemma elem_of_pre_VLSM_projection_finite_trace_project :
   forall trX itemY, itemY ∈ pre_VLSM_projection_finite_trace_project trX <->
     exists itemX, itemX ∈ trX /\ pre_VLSM_projection_transition_item_project itemX = Some itemY.
 Proof.
-  exact (elem_of_map_option _).
+  exact (elem_of_list_omap _).
 Qed.
 
 Lemma pre_VLSM_projection_finite_trace_project_elem_of :
@@ -148,7 +148,7 @@ Lemma pre_VLSM_projection_finite_trace_project_elem_of :
   forall trX,
     itemX ∈ trX -> itemY ∈ pre_VLSM_projection_finite_trace_project trX.
 Proof.
-  by intros; apply elem_of_map_option; exists itemX.
+  by intros; apply elem_of_list_omap; exists itemX.
 Qed.
 
 End sec_pre_definitions.
@@ -916,7 +916,7 @@ Context
 Proof.
   induction Htr using finite_valid_trace_init_to_rev_strong_ind; [by constructor; apply Hstate |].
   unfold pre_VLSM_projection_finite_trace_project.
-  rewrite map_option_app.
+  rewrite omap_app.
   apply finite_valid_trace_from_to_app with (state_project s)
   ; [done |].
   simpl. unfold pre_VLSM_projection_transition_item_project.

--- a/theories/Lib/StdppExtras.v
+++ b/theories/Lib/StdppExtras.v
@@ -429,14 +429,14 @@ Proof.
   by destruct (Nat.max_spec_le a (list_max l)) as [[H ->] | [H ->]]; itauto lia.
 Qed.
 
-Lemma map_option_subseteq
+Lemma omap_subseteq
   {A B : Type}
   (f : A -> option B)
   (l1 l2 : list A)
   (Hincl : l1 ⊆ l2)
-  : map_option f l1 ⊆ map_option f l2.
+  : omap f l1 ⊆ omap f l2.
 Proof.
-  by intros b; rewrite !elem_of_map_option; firstorder.
+  by intros b; rewrite !elem_of_list_omap; firstorder.
 Qed.
 
 Lemma elem_of_cat_option
@@ -445,7 +445,7 @@ Lemma elem_of_cat_option
   (a : A)
   : a ∈ cat_option l <-> exists b : option A, b ∈ l /\ b = Some a.
 Proof.
-  by apply elem_of_map_option.
+  by apply elem_of_list_omap.
 Qed.
 
 Lemma list_max_elem_of_exists2

--- a/theories/Lib/StreamFilters.v
+++ b/theories/Lib/StreamFilters.v
@@ -600,12 +600,12 @@ Definition stream_map_option
 Lemma stream_map_option_prefix
   (Hinf : InfinitelyOften P s)
   (n : nat)
-  (map_opt_pre := map_option f (stream_prefix s n))
+  (map_opt_pre := omap f (stream_prefix s n))
   (m := length map_opt_pre)
   : stream_prefix (stream_map_option Hinf) m = map_opt_pre.
 Proof.
   subst map_opt_pre m.
-  rewrite !(map_option_as_filter f (stream_prefix s n)).
+  rewrite !(omap_as_filter f (stream_prefix s n)).
   by apply fitering_subsequence_stream_filter_map_prefix.
 Qed.
 
@@ -613,19 +613,19 @@ Program Definition stream_map_option_prefix_ex
   (Hinf : InfinitelyOften P s)
   (Hfs := stream_filter_positions_filtering_subsequence _ _ Hinf)
   (k : nat)
-  : { n | stream_prefix (stream_map_option Hinf) k = map_option f (stream_prefix s n)} :=
+  : { n | stream_prefix (stream_map_option Hinf) k = omap f (stream_prefix s n)} :=
   let (n, Heq) := (fitering_subsequence_stream_filter_map_prefix_ex P
                     (fun k => is_Some_proj (proj2_dsig k)) _ _ Hfs k)
   in exist _ n _.
 Next Obligation.
 Proof.
-  by intros; cbn; rewrite !map_option_as_filter.
+  by intros; cbn; rewrite !omap_as_filter.
 Qed.
 
 Definition bounded_stream_map_option
   (Hfin : FinitelyManyBound P s)
   : list B :=
-  map_option f (stream_prefix s (` Hfin)).
+  omap f (stream_prefix s (` Hfin)).
 
 End sec_stream_map_option.
 


### PR DESCRIPTION
`ListExtras.v` had a definition of `map_option`, which was definitionally equal to `omap` from stdpp. I replaced all uses of the former with the latter and removed some duplicated lemmas. I also simplified some proofs for `cap_option` which was defined using `map_option`.