### PR TITLE
Use record constructors instead of record syntax in the Muddy Children example

### DIFF
--- a/theories/Examples/Tutorial/MuddyChildrenRounds.v
+++ b/theories/Examples/Tutorial/MuddyChildrenRounds.v
@@ -72,7 +72,7 @@ Record RoundStatus : Type := mkRS
   rs_status : ChildStatus;
 }.
 
-(** We want to display [RoundStatus] using the constructor instead of the record syntax. *)
+(** Show [RoundStatus] using the constructor instead of the record syntax. *)
 Add Printing Constructor RoundStatus.
 
 Section sec_muddy.
@@ -95,6 +95,7 @@ Record State : Type := mkSt
   st_rs : option RoundStatus;
 }.
 
+(** Show [State] using the constructor instead of the record syntax. *)
 Add Printing Constructor State.
 
 (**
@@ -108,6 +109,7 @@ Record Message : Type := mkMsg
   msg_status : ChildStatus;
 }.
 
+(** Show [Message] using the constructor instead of the record syntax. *)
 Add Printing Constructor Message.
 
 Definition MCType : VLSMType Message :=


### PR DESCRIPTION
In the Muddy Children example, records were sometimes written using constructors and sometimes using the record syntax, and then displayed (in the proof mode) using the record syntax, which might be a little confusing, especially in a tutorial.

In this PR, I made `RoundStatus`, `State` and `Message` always use the constructor, and I also used the `Add Printing Constructor` command to make them display using the constructor.