### PR TITLE
Remove `vplan_item`

### DIFF
--- a/theories/Core/Composition.v
+++ b/theories/Core/Composition.v
@@ -1103,7 +1103,7 @@ Lemma relevant_components_free
   finite_valid_plan_from Free s' a /\
   (forall (i : index), i ∈ li -> (res' i) = res i).
 Proof.
-  induction a using rev_ind; cbn in *; [by auto using finite_valid_plan_empty |].
+  induction a using rev_ind; cbn in *; [by split; [constructor |] |].
   apply finite_valid_plan_from_app_iff in Hpr as [Hrem Hsingle].
   spec IHa.
   {

--- a/theories/Core/Composition.v
+++ b/theories/Core/Composition.v
@@ -360,7 +360,7 @@ Definition lift_to_composite_transition_item' :
     lift_to_composite_transition_item (proj1_sig composite_s0).
 
 Definition lift_to_composite_plan_item
-  (i : index) (a : vplan_item (IM i)) : composite_plan_item.
+  (i : index) (a : plan_item (IM i)) : composite_plan_item.
 Proof.
   destruct a.
   split.
@@ -988,7 +988,7 @@ Qed.
 Lemma relevant_components_one_free
   (s s' : state Free)
   (Hprs' : valid_state_prop Free s')
-  (ai : vplan_item Free)
+  (ai : plan_item Free)
   (i := projT1 (label_a ai))
   (Heq : (s i) = (s' i))
   (Hpr : finite_valid_plan_from Free s [ai]) :

--- a/theories/Core/Plans.v
+++ b/theories/Core/Plans.v
@@ -174,8 +174,7 @@ Context
   corresponding [type] and [transition].
 *)
 
-Definition vplan_item := (@plan_item _ X).
-Definition plan : Type := list vplan_item.
+Definition plan : Type := list (plan_item X).
 Definition apply_plan := (@_apply_plan _ X (@transition _ _ X)).
 Definition trace_to_plan := (@_trace_to_plan _ X).
 Definition apply_plan_app


### PR DESCRIPTION
One of the reviewers of the paper complained about the snippets referencing names which were not defined. Among these he mentioned `vTrace`. `vTrace` has been removed quite some time ago, but I think it would be a good idea to remove whatever remains of the `v`-named things. One of these is `vplan_item`, which I removed in this PR, replacing it with just `plan_item`.

Note: after this PR, casper-cbc-proofs will require a fix.