### PR TITLE
Uniformize coqdoc module titles, add prefix

### DIFF
--- a/theories/Core/AnnotatedVLSM.v
+++ b/theories/Core/AnnotatedVLSM.v
@@ -4,7 +4,7 @@ From VLSM.Lib Require Import ListExtras.
 From VLSM.Core Require Import VLSM PreloadedVLSM VLSMProjections Validator Composition.
 From VLSM.Core Require Import ConstrainedVLSM.
 
-(** * State-annotated VLSMs
+(** * Core: State-Annotated VLSMs
 
   This module describes the VLSM obtained by augmenting the states of an existing
   VLSM with annotations and providing additional validity constraints taking into
@@ -205,7 +205,7 @@ End sec_annotated_vlsm_projections.
 
 Section sec_composite_annotated_vlsm_projections.
 
-(** ** Specializing [projection_validator_prop]erties to annotated compositions. *)
+(** ** Specializing projection validator properties to annotated compositions *)
 
 Context
   {message : Type}

--- a/theories/Core/ByzantineTraces.v
+++ b/theories/Core/ByzantineTraces.v
@@ -3,7 +3,7 @@ From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces Validator.
 From VLSM.Core Require Import PreloadedVLSM.
 
-(** * VLSM Byzantine Traces
+(** * Core: VLSM Byzantine Traces
 
   In this section, we introduce two definitions of Byzantine traces,
   prove that they are equivalent (lemma [byzantine_alt_byzantine_iff]),

--- a/theories/Core/ByzantineTraces/FixedSetByzantineTraces.v
+++ b/theories/Core/ByzantineTraces/FixedSetByzantineTraces.v
@@ -7,7 +7,7 @@ From VLSM.Core Require Import Composition SubProjectionTraces ByzantineTraces.
 From VLSM.Core Require Import Validator Equivocation EquivocationProjections.
 From VLSM.Core Require Import Equivocation.NoEquivocation Equivocation.FixedSetEquivocation.
 
-(** * VLSM Compositions with a fixed set of byzantine nodes
+(** * Core: VLSM Compositions with a Fixed Set of Byzantine Nodes
 
   In this module we study a composition in which a fixed subset of nodes are
   replaced by byzantine nodes, i.e., nodes which can send arbitrary

--- a/theories/Core/ByzantineTraces/LimitedByzantineTraces.v
+++ b/theories/Core/ByzantineTraces/LimitedByzantineTraces.v
@@ -10,9 +10,9 @@ From VLSM.Core Require Import Equivocation.LimitedMessageEquivocation.
 From VLSM.Core Require Import Equivocation.MsgDepLimitedEquivocation.
 From VLSM.Core Require Import Equivocation.TraceWiseEquivocation.
 
-(** * VLSM Compositions with Byzantine nodes of limited weight
+(** * Core: VLSM Compositions with Byzantine Nodes of Limited Weight
 
-  In this module we define and study protocol executions allowing a
+  In this module, we define and study protocol executions allowing a
   (weight-)limited amount of byzantine faults.
 
   We will show that, if the non-byzantine nodes are validators for a

--- a/theories/Core/Composition.v
+++ b/theories/Core/Composition.v
@@ -5,7 +5,7 @@ From VLSM.Lib Require Import Preamble ListExtras.
 From VLSM.Core Require Import VLSM Plans VLSMProjections.
 From VLSM.Core Require Import PreloadedVLSM ConstrainedVLSM.
 
-(** * VLSM Composition
+(** * Core: VLSM Composition
 
   This module provides Coq definitions for composite VLSMs and their projections
   to components.

--- a/theories/Core/ConstrainedVLSM.v
+++ b/theories/Core/ConstrainedVLSM.v
@@ -4,7 +4,7 @@ From Coq Require Import Streams.
 From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM PreloadedVLSM VLSMInclusion VLSMEmbedding VLSMEquality.
 
-(** * Constrained VLSM
+(** * Core: Constrained VLSMs
 
   Given a base VLSM <<X>>, we can further constrain its validity
   condition with the given predicate, producing a new VLSM.

--- a/theories/Core/Equivocation.v
+++ b/theories/Core/Equivocation.v
@@ -6,7 +6,7 @@ From VLSM.Lib Require Import ListSetExtras Measurable.
 From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces Validator.
 From VLSM.Core Require Export PreloadedVLSM ConstrainedVLSM ReachableThreshold.
 
-(** * VLSM Equivocation Definitions
+(** * Core: VLSM Equivocation Definitions
 
   This module is dedicated to building the vocabulary for discussing equivocation.
   Equivocation occurs on the receipt of a message which has not been previously sent.
@@ -15,6 +15,7 @@ From VLSM.Core Require Export PreloadedVLSM ConstrainedVLSM ReachableThreshold.
   and limit equivocation by means of a composition constraint.
 *)
 
+(* FIXME: move to preamble *)
 Lemma exists_proj1_sig {A : Type} (P : A -> Prop) (a : A) :
   (exists xP : {x | P x}, proj1_sig xP = a) <-> P a.
 Proof.

--- a/theories/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/Core/Equivocation/FixedSetEquivocation.v
@@ -5,11 +5,11 @@ From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM VLSMProjections Composition Validator ProjectionTraces.
 From VLSM.Core Require Import SubProjectionTraces Equivocation Equivocation.NoEquivocation.
 
-(** * Fixed Set Equivocation
+(** * Core: Fixed Set Equivocation
 
-  In this section we define fixed equivocation for the regular composition.
+  In this module, we define fixed equivocation for the regular VLSM composition.
 
-  Assuming that a only a fixed subset of the nodes (here called equivocating)
+  Assuming that a only a fixed subset of the nodes (here called _equivocating_)
   are allowed to equivocate, inspired by the results leading to
   Lemma [equivocators_valid_trace_from_project] which links state equivocation
   to free composition, we can say that a message can be produced by a network

--- a/theories/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/Core/Equivocation/LimitedMessageEquivocation.v
@@ -8,9 +8,9 @@ From VLSM.Core Require Import Equivocation.FixedSetEquivocation.
 From VLSM.Core Require Import Equivocation.TraceWiseEquivocation.
 From VLSM.Core Require Import Equivocation.WitnessedEquivocation.
 
-(** * VLSM Limited Message Equivocation
+(** * Core: VLSM Limited Message Equivocation
 
-  In this section we define the notion of limited (message-based) equivocation.
+  In this module, we define the notion of limited (message-based) equivocation.
 
   This notion is slightly harder to define than that of fixed-set equivocation,
   because, while for the latter we fix a set and let only the nodes belonging to

--- a/theories/Core/Equivocation/MinimalEquivocationTrace.v
+++ b/theories/Core/Equivocation/MinimalEquivocationTrace.v
@@ -3,9 +3,9 @@ From VLSM.Lib Require Import Preamble ListExtras StdppListSet StdppExtras NatExt
 From VLSM.Core Require Import VLSM Composition.
 From VLSM.Core Require Import Equivocation MessageDependencies TraceableVLSM.
 
-(** * Minimally-equivocating traces
+(** * Core: Minimally Equivocating Traces
 
-  In this module we define a [choice_function], [minimal_equivocation_choice],
+  In this module, we define a [choice_function] and [minimal_equivocation_choice],
   guaranteeing that the transition it chooses does not decrease the set of
   validators which are equivocating according to the [msg_dep_is_globally_equivocating]
   relation (see [minimal_equivocation_choice_monotone]).

--- a/theories/Core/Equivocation/NoEquivocation.v
+++ b/theories/Core/Equivocation/NoEquivocation.v
@@ -2,7 +2,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM VLSMProjections Composition Equivocation.
 
-(** * VLSM No Equivocation Composition Constraints *)
+(** * Core: VLSM No-Equivocation Composition Constraints *)
 
 Section sec_no_equivocations.
 

--- a/theories/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/Core/Equivocation/TraceWiseEquivocation.v
@@ -6,9 +6,9 @@ From VLSM.Core Require Import VLSM Composition ProjectionTraces.
 From VLSM.Core Require Import Equivocation.
 From VLSM.Lib Require Import Preamble StdppExtras.
 
-(** * VLSM Trace-wise Equivocation
+(** * Core: VLSM Trace-Wise Equivocation
 
-  In this section we define a more precise notion of message equivocation,
+  In this module, we define a more precise notion of message equivocation,
   based on analyzing (all) traces leading to a state. Although in some cases
   we might be able to actually compute this, its purpose is more to identify
   the ideal notion of detectable equivocation which would be used to

--- a/theories/Core/Equivocation/WitnessedEquivocation.v
+++ b/theories/Core/Equivocation/WitnessedEquivocation.v
@@ -5,7 +5,7 @@ From VLSM.Core Require Import VLSM VLSMProjections Composition.
 From VLSM.Core Require Import SubProjectionTraces MessageDependencies Equivocation.
 From VLSM.Core Require Import NoEquivocation FixedSetEquivocation TraceWiseEquivocation.
 
-(** * Witnessed equivocation
+(** * Core: Witnessed Equivocation
 
   Although [is_equivocating_tracewise] provides a very precise notion of
   equivocation, it does not guarantee the monotonicity of the set of equivocators
@@ -23,7 +23,7 @@ From VLSM.Core Require Import NoEquivocation FixedSetEquivocation TraceWiseEquiv
   In particular, the set of equivocators is monotonically increasing for such a
   trace (Lemma [strong_witness_equivocating_validators_prefix_monotonicity]).
 
-  We then use this result to show that any Free valid state is also a valid
+  We then use this result to show that any free valid state is also a valid
   state for the composition of nodes under the [fixed_equivocation_constraint]
   induced by its set of equivocators.
 *)

--- a/theories/Core/EquivocationProjections.v
+++ b/theories/Core/EquivocationProjections.v
@@ -3,16 +3,16 @@ From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM Equivocation.
 From VLSM.Core Require Import Composition VLSMProjections Validator ProjectionTraces.
 
-(** * VLSM projections and messages properties
+(** * Core: VLSM Projections and Messages Properties
 
-  In this section we show that messages properties (oracles like [has_been_sent],
+  In this section, we show that messages properties (oracles like [has_been_sent],
   [has_been_received], and [has_been_directly_observed]) are reflected and, in some cases,
   preserved by VLSM projections.
 *)
 
 Section sec_projection_oracle.
 
-(** ** [VLSM_projection]s reflect message properties *)
+(** ** VLSM projections reflect message properties *)
 
 Context
   {message : Type}

--- a/theories/Core/Equivocators/EquivocatorReplay.v
+++ b/theories/Core/Equivocators/EquivocatorReplay.v
@@ -2,7 +2,7 @@ From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM VLSMProjections Equivocators.Equivocators.
 From VLSM.Core Require Import Equivocation EquivocationProjections Equivocators.MessageProperties.
 
-(** * Equivocator State Append Determines a Projection
+(** * Core: Equivocator State Append Determines a Projection
 
   In this module, we show that we can "append" two equivocator traces by
   simulating the second at the end of the first.

--- a/theories/Core/Equivocators/Equivocators.v
+++ b/theories/Core/Equivocators/Equivocators.v
@@ -4,7 +4,7 @@ From Coq Require Import Eqdep Fin FunctionalExtensionality.
 From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM PreloadedVLSM VLSMProjections Composition.
 
-(** * VLSM Equivocation
+(** * Core: VLSM Equivocation
 
   An [equivocator_vlsm] for a given [VLSM] <<X>> is a VLSM which starts as a
   regular machine X, and then, at any moment:

--- a/theories/Core/Equivocators/EquivocatorsComposition.v
+++ b/theories/Core/Equivocators/EquivocatorsComposition.v
@@ -9,7 +9,7 @@ From VLSM.Core Require Import Equivocation.NoEquivocation.
 From VLSM.Core Require Import Equivocators.Equivocators.
 From VLSM.Core Require Import Equivocators.MessageProperties.
 
-(** * VLSM Equivocator Composition
+(** * Core: VLSM Equivocator Composition
 
   Given a composition <<X>> of VLSMs, we can model equivocator behavior by
   creating an _equivocator composition_ which replaces each component of <<X>>

--- a/theories/Core/Equivocators/EquivocatorsCompositionProjections.v
+++ b/theories/Core/Equivocators/EquivocatorsCompositionProjections.v
@@ -9,7 +9,7 @@ From VLSM.Core Require Import Equivocators.Equivocators Equivocators.Equivocator
 From VLSM.Core Require Import Equivocators.EquivocatorsComposition.
 From VLSM.Core Require Import Equivocators.MessageProperties.
 
-(** * VLSM Equivocator Composition Projections *)
+(** * Core: VLSM Equivocator Composition Projections *)
 
 Section sec_equivocators_composition_projections.
 

--- a/theories/Core/Equivocators/EquivocatorsProjections.v
+++ b/theories/Core/Equivocators/EquivocatorsProjections.v
@@ -2,7 +2,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM PreloadedVLSM VLSMProjections Equivocators.Equivocators.
 
-(** * VLSM Projecting Equivocator Traces *)
+(** * Core: VLSM Projecting Equivocator Traces *)
 
 Section sec_equivocator_vlsm_projections.
 

--- a/theories/Core/Equivocators/FixedEquivocation.v
+++ b/theories/Core/Equivocators/FixedEquivocation.v
@@ -10,7 +10,7 @@ From VLSM.Core Require Import Equivocators.MessageProperties.
 From VLSM.Core Require Import Equivocators.EquivocatorsComposition.
 From VLSM.Core Require Import Equivocators.EquivocatorsCompositionProjections.
 
-(** * VLSM Equivocators Fixed Equivocation *)
+(** * Core: VLSM Equivocators Fixed Equivocation *)
 
 Section sec_equivocators_fixed_equivocations_vlsm.
 

--- a/theories/Core/Equivocators/FixedEquivocationSimulation.v
+++ b/theories/Core/Equivocators/FixedEquivocationSimulation.v
@@ -12,9 +12,9 @@ From VLSM.Core Require Import Equivocators.FullReplayTraces.
 From VLSM.Core Require Import Equivocators.FixedEquivocation.
 From VLSM.Core Require Import Equivocators.SimulatingFree.
 
-(** * VLSM Equivocators Simulating fixed-set equivocation composition
+(** * Core: VLSM Equivocators Simulating Fixed Set Equivocation Composition
 
-  In this module we show that the composition of equivocators with no
+  In this module, we show that the composition of equivocators with no
   message-equivocation and fixed-set state-equivocation can simulate the
   fixed-set message-equivocation composition of regular nodes.
 

--- a/theories/Core/Equivocators/FullReplayTraces.v
+++ b/theories/Core/Equivocators/FullReplayTraces.v
@@ -9,9 +9,9 @@ From VLSM.Core Require Import Equivocators.EquivocatorReplay Equivocators.Messag
 From VLSM.Core Require Import Equivocators.EquivocatorsComposition.
 From VLSM.Core Require Import Equivocators.EquivocatorsCompositionProjections Plans.
 
-(** * VLSM Equivocator Full Replay Traces
+(** * Core: VLSM Equivocator Full Replay Traces
 
-  In this section we show that given a trace of equivocators, one can "replay"
+  In this module, we show that given a trace of equivocators, one can "replay"
   that at the end of an existing trace, by first equivocating for each initial
   state and then performing each transition, but appropriately "shifted".
 

--- a/theories/Core/Equivocators/LimitedEquivocationSimulation.v
+++ b/theories/Core/Equivocators/LimitedEquivocationSimulation.v
@@ -16,9 +16,9 @@ From VLSM.Core Require Import
   Equivocators.FixedEquivocationSimulation.
 From VLSM.Core Require Import Equivocators.FixedEquivocation.
 
-(** * VLSM Equivocators Simulating limited message equivocation traces
+(** * Core: VLSM Equivocators Simulating Limited Message Equivocation Traces
 
-  In this module we show that the composition of equivocators with no-message
+  In this module, we show that the composition of equivocators with no-message
   equivocation and limited state-equivocation can simulate all traces with the
   [fixed_limited_equivocation_prop]erty.
 

--- a/theories/Core/Equivocators/LimitedStateEquivocation.v
+++ b/theories/Core/Equivocators/LimitedStateEquivocation.v
@@ -12,7 +12,8 @@ From VLSM.Core Require Import Equivocators.EquivocatorsComposition.
 From VLSM.Core Require Import Equivocators.EquivocatorsCompositionProjections.
 From VLSM.Core Require Import Equivocators.FixedEquivocation.
 
-(** * VLSM Limited Equivocation *)
+(** * Core: VLSM Limited Equivocation *)
+
 Definition composite_constraint
   {index message} (IM : index -> VLSM message) : Type :=
   composite_label IM -> composite_state IM * option message -> Prop.

--- a/theories/Core/Equivocators/MessageProperties.v
+++ b/theories/Core/Equivocators/MessageProperties.v
@@ -5,7 +5,7 @@ From VLSM.Lib Require Import ListSetExtras NatExtras.
 From VLSM.Core Require Import VLSM Equivocation.
 From VLSM.Core Require Import Equivocators.Equivocators Equivocators.EquivocatorsProjections.
 
-(** * VLSM Message Properties *)
+(** * Core: VLSM Message Properties *)
 
 Section sec_equivocator_vlsm_message_properties.
 

--- a/theories/Core/Equivocators/SimulatingFree.v
+++ b/theories/Core/Equivocators/SimulatingFree.v
@@ -8,9 +8,9 @@ From VLSM.Core Require Import Equivocators.EquivocatorsComposition.
 From VLSM.Core Require Import Equivocators.EquivocatorsCompositionProjections.
 From VLSM.Core Require Import Equivocators.FullReplayTraces.
 
-(** * Equivocators simulating regular nodes
+(** * Core: Equivocators Simulating Regular Nodes
 
-  In this module we prove a general simulation result parameterized by
+  In this module, we prove a general simulation result parameterized by
   constraints with good properties, then we instantiate the general result for
   the free composition of regular nodes.
 *)

--- a/theories/Core/HistoryVLSM.v
+++ b/theories/Core/HistoryVLSM.v
@@ -4,7 +4,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras.
 From VLSM.Core Require Import VLSM PreloadedVLSM Composition.
 
-(** * HistoryVLSMs *)
+(** * Core: History VLSMs *)
 
 Class HistoryVLSM `(X : VLSM message) : Prop :=
 {

--- a/theories/Core/MessageDependencies.v
+++ b/theories/Core/MessageDependencies.v
@@ -4,7 +4,7 @@ From VLSM.Lib Require Import Preamble ListExtras.
 From VLSM.Core Require Import VLSM VLSMProjections Composition ProjectionTraces.
 From VLSM.Core Require Import SubProjectionTraces Equivocation EquivocationProjections. 
 
-(** * VLSM Message Dependencies
+(** * Core: VLSM Message Dependencies
 
   An abstract framework for the full-node condition.
   Assumes that each message has an associated set of <<message_dependencies>>.

--- a/theories/Core/Plans.v
+++ b/theories/Core/Plans.v
@@ -2,7 +2,11 @@ From VLSM.Lib Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM.
 
-(** * VLSM Plans *)
+(** * Core: VLSM Plans
+
+  A plan is a (sequence of actions) which can be attempted on a
+  given state to yield a trace.
+*)
 
 Section sec_plans.
 
@@ -11,9 +15,6 @@ Context
   {T : VLSMType message}.
 
 (**
-  A plan is a (sequence of actions) which can be attempted on a
-  given state to yield a trace.
-
   A [plan_item] is a singleton plan, and contains a label and an input
   which would allow to transition from any given state
   (note that we don't address validity for now).

--- a/theories/Core/PreloadedVLSM.v
+++ b/theories/Core/PreloadedVLSM.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras.
 From VLSM.Core Require Import VLSM VLSMProjections.
 
-(** * Pre-loaded VLSMs
+(** * Core: Preloaded VLSMs
 
   Given a VLSM <<X>>, we introduce the _pre-loaded_ version of it, which is
   identical to <<X>>, except that all messages are initial. The high degree

--- a/theories/Core/ProjectionTraces.v
+++ b/theories/Core/ProjectionTraces.v
@@ -5,7 +5,7 @@ From VLSM.Core Require Import VLSM PreloadedVLSM Composition VLSMProjections Val
 
 Section sec_projections.
 
-(** * Composite VLSM induced projections
+(** * Core: Composite VLSM Induced Projections
 
   In this section we define a VLSM representing the induced projection of a
   composite VLSM to a single node ([composite_vlsm_induced_projection]), and we

--- a/theories/Core/ReachableThreshold.v
+++ b/theories/Core/ReachableThreshold.v
@@ -2,7 +2,8 @@ From stdpp Require Import prelude.
 From Coq Require Import Reals Lra.
 From VLSM.Lib Require Import RealsExtras Measurable ListExtras StdppListSet.
 
-(**
+(** * Core: Reachable Thresholds
+
   Given a set of validators and a [threshold] (a positive real number), we say
   that the threshold is reachable ([rt_reachable]) when there exists a
   set of validators whose combined weight passes the threshold.

--- a/theories/Core/SubProjectionTraces.v
+++ b/theories/Core/SubProjectionTraces.v
@@ -5,7 +5,7 @@ From VLSM.Lib Require Import Preamble ListExtras StdppListSet StdppExtras.
 From VLSM.Core Require Import VLSM VLSMProjections ProjectionTraces Composition Validator.
 From VLSM.Core Require Import Equivocation EquivocationProjections Equivocation.NoEquivocation.
 
-(** * VLSM Subcomposition *)
+(** * Core: VLSM Subcomposition *)
 
 Section sec_sub_composition.
 

--- a/theories/Core/TraceableVLSM.v
+++ b/theories/Core/TraceableVLSM.v
@@ -4,7 +4,7 @@ From VLSM.Lib Require Import EquationsExtras.
 From VLSM.Lib Require Import Preamble ListSetExtras.
 From VLSM.Core Require Import VLSM PreloadedVLSM Composition VLSMEmbedding.
 
-(** * Traceable VLSMs
+(** * Core: Traceable VLSMs
 
   This section introduces [TraceableVLSM]s, characterized by the fact that from
   any constrained state we can derive the possible (valid) transitions leading
@@ -93,6 +93,8 @@ Class TraceableVLSM
 
 #[global] Hint Mode TraceableVLSM - ! - - : typeclass_instances.
 
+(** ** Traceable VLSM properties *)
+
 Section sec_traceable_vlsm_props.
 
 Context
@@ -166,7 +168,7 @@ Qed.
 
 End sec_traceable_vlsm_props.
 
-(** * Composition of TraceableVLSMs *)
+(** ** Composition of traceable VLSMs *)
 
 Section sec_traceable_vlsm_composition.
 

--- a/theories/Core/VLSM.v
+++ b/theories/Core/VLSM.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude.
 From Coq Require Import Streams.
 From VLSM.Lib Require Import Preamble ListExtras StreamExtras.
 
-(** * VLSM Basics
+(** * Core: VLSM Basics
 
   This module provides basic VLSM infrastructure.
 *)
@@ -2670,7 +2670,7 @@ End sec_valid_transition_props.
 
 Section sec_finite_valid_trace_init_to_alt.
 
-(** ** Alternate definitions to valid traces and states
+(** ** Alternate definitions of valid traces and states
 
   Inspired from the [constrained_transitions_from_to] definition we can
   derive an alternate definition for valid traces which is easier to use

--- a/theories/Core/VLSMProjections.v
+++ b/theories/Core/VLSMProjections.v
@@ -6,7 +6,7 @@ From VLSM.Core Require Export VLSMPartialProjection VLSMStutteringEmbedding.
 From VLSM.Core Require Export VLSMTotalProjection VLSMEmbedding.
 From VLSM.Core Require Export VLSMInclusion VLSMEquality.
 
-(** * VLSM Projection Properties *)
+(** * Core: VLSM Projection Properties *)
 
 Section sec_same_VLSM_embedding.
 

--- a/theories/Core/VLSMProjections/VLSMEmbedding.v
+++ b/theories/Core/VLSMProjections/VLSMEmbedding.v
@@ -3,9 +3,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras StreamExtras StreamFilters.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMTotalProjection.
 
-Section sec_VLSM_embedding.
-
-(** * VLSM Embedding (Embedding)
+(** * Core: VLSM Embedding
 
   A VLSM projection guaranteeing the existence of projection for all labels and
   states, and the full correspondence between [transition_item]s.
@@ -23,6 +21,8 @@ Section sec_VLSM_embedding.
   [lift_to_composite_VLSM_embedding] or
   [projection_friendliness_lift_to_composite_VLSM_embedding]).
 *)
+
+Section sec_VLSM_embedding.
 
 Section sec_pre_definitions.
 

--- a/theories/Core/VLSMProjections/VLSMEquality.v
+++ b/theories/Core/VLSMProjections/VLSMEquality.v
@@ -3,9 +3,9 @@ From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM.
 From VLSM.Core.VLSMProjections Require Import VLSMInclusion VLSMEmbedding.
 
-(** * VLSM Trace Equality
+(** * Core: VLSM Trace Equality
 
-  We can also define VLSM _equality_ in terms of traces.
+  In this module, we define VLSM _equality_ in terms of traces.
   When both VLSMs have the same state and label types they also share the
   same [Trace] type, and sets of traces can be compared without conversion.
   Then VLSM <<X>> and VLSM <<Y>> are _equal_ if their [valid_trace]s are exactly the same.

--- a/theories/Core/VLSMProjections/VLSMInclusion.v
+++ b/theories/Core/VLSMProjections/VLSMInclusion.v
@@ -3,13 +3,14 @@ From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM.
 From VLSM.Core.VLSMProjections Require Import VLSMEmbedding VLSMTotalProjection.
 
-(** * VLSM Inclusion
+(** * Core: VLSM Inclusion
 
   When both VLSMs have the same state and label types they also share the
   same [Trace] type, and sets of traces can be compared without conversion.
   Then VLSM <<X>> is _included_ in VLSM <<Y>> if every [valid_trace] available to <<X>>
   is also available to <<Y>>.
 *)
+
 Section sec_VLSM_inclusion.
 
 Context

--- a/theories/Core/VLSMProjections/VLSMPartialProjection.v
+++ b/theories/Core/VLSMProjections/VLSMPartialProjection.v
@@ -3,9 +3,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble.
 From VLSM.Core Require Import VLSM.
 
-Section sec_VLSM_partial_projection.
-
-(** * VLSM Partial Projections
+(** * Core: VLSM Partial Projections
 
   A generic notion of VLSM projection. We say that VLSM <<X>> partially projects to
   VLSM <<Y>> (sharing the same messages) if there exists a partial map <<partial_trace_project>>
@@ -26,6 +24,8 @@ Section sec_VLSM_partial_projection.
   of regular nodes guided by a specific start [MachineDescriptor] (see, e.g.,
   [equivocators_no_equivocations_vlsm_X_vlsm_partial_projection]).
 *)
+
+Section sec_VLSM_partial_projection.
 
 Record VLSM_partial_projection_type
   {message : Type}

--- a/theories/Core/VLSMProjections/VLSMStutteringEmbedding.v
+++ b/theories/Core/VLSMProjections/VLSMStutteringEmbedding.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble StreamExtras StreamFilters StdppExtras.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMPartialProjection.
 
-(** * VLSM Stuttering Embeddings
+(** * Core: VLSM Stuttering Embeddings
 
   Stuttering embeddings are VLSM projections guaranteeing the existence of
   translations for all states and traces, in which a transition in the source

--- a/theories/Core/VLSMProjections/VLSMTotalProjection.v
+++ b/theories/Core/VLSMProjections/VLSMTotalProjection.v
@@ -3,19 +3,15 @@ From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras StreamExtras StreamFilters StdppExtras.
 From VLSM.Core Require Import VLSM VLSMProjections.VLSMPartialProjection.
 
-Section sec_VLSM_projection.
-
-(** * VLSM Total Projections
+(** * Core: VLSM Total Projections
 
   A VLSM projection guaranteeing the existence of projection for all states and
   traces. We say that VLSM <<X>> projects to VLSM <<Y>> (sharing the same messages) if
   there exists maps <<state_project>> taking <<X>>-states to <<Y>>-states,
   and <<trace_project>>, taking list of transitions from <<X>> to <<Y>>, such that:
 
-  - state and [trace_project_preserves_valid_trace]s.
-
+  - state and [trace_project_preserves_valid_trace]s
   - [trace_project_app]: trace projection commutes with concatenation of traces
-
   - [final_state_project]: state projection commutes with [finite_trace_last]
 
   Proper examples of total projections (which are not [VLSM_embedding]s)
@@ -26,6 +22,8 @@ Section sec_VLSM_projection.
   first (original) node instance for each equivocator (e.g.,
   [equivocators_no_equivocations_vlsm_X_vlsm_projection]).
 *)
+
+Section sec_VLSM_projection.
 
 Section sec_pre_definitions.
 

--- a/theories/Core/Validator.v
+++ b/theories/Core/Validator.v
@@ -2,12 +2,12 @@ From VLSM.Lib Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Core Require Import VLSM PreloadedVLSM VLSMProjections Composition.
 
-(** * VLSM Projection Validators
+(** * Core: VLSM Projection Validators
 
-  In the sequel we fix VLSMs <<X>> and <<Y>> and some <<label_project>>
+  Below, we fix VLSMs <<X>> and <<Y>> and some <<label_project>>
   and <state_project>> [VLSM_projection] mappings from <<X>> to <<Y>>.
 
-  The Transition Input Validation property validates an input corresponding to
+  The _transition input validation_ property validates an input corresponding to
   a projection by ensuring that that input can be "lifted" to the original VLSM.
 *)
 

--- a/theories/Examples/ELMO/AllELMO.v
+++ b/theories/Examples/ELMO/AllELMO.v
@@ -1,4 +1,4 @@
-(** * ELMO definitions and results exports *)
+(** * ELMO: Exporting of All ELMO Modules *)
 
 From VLSM.Examples Require Export BaseELMO UMO MO ELMO.
 

--- a/theories/Examples/ELMO/BaseELMO.v
+++ b/theories/Examples/ELMO/BaseELMO.v
@@ -4,7 +4,7 @@ From VLSM.Lib Require Import EquationsExtras.
 From VLSM.Lib Require Import Preamble StdppExtras.
 From VLSM.Core Require Import VLSM PreloadedVLSM MessageDependencies.
 
-(** * Basic Definitions and Lemmas for UMO, MO and ELMO
+(** * ELMO: Basic Definitions and Results for UMO, MO and ELMO
 
   This module contains basic definitions and lemmas needed for the UMO, MO and
   ELMO protocols. In contrast to the paper, which uses natural numbers,

--- a/theories/Examples/ELMO/ELMO.v
+++ b/theories/Examples/ELMO/ELMO.v
@@ -11,7 +11,7 @@ Create HintDb ELMO_hints.
 
 #[local] Hint Resolve submseteq_tail_l : ELMO_hints.
 
-(** * ELMO Protocol Definitions and Properties
+(** * ELMO: Protocol Definitions and Properties for ELMO
 
   This module contains definitions and properties of ELMO components and
   the ELMO protocol.

--- a/theories/Examples/ELMO/MO.v
+++ b/theories/Examples/ELMO/MO.v
@@ -6,7 +6,7 @@ From VLSM.Core Require Import VLSM PreloadedVLSM VLSMProjections Composition.
 From VLSM.Core Require Import Validator ProjectionTraces.
 From VLSM.Examples Require Import BaseELMO UMO.
 
-(** * MO Protocol Definitions and Properties
+(** * ELMO: Protocol Definitions and Properties for MO
 
   This module contains definitions and properties of MO components and
   the MO protocol.

--- a/theories/Examples/ELMO/UMO.v
+++ b/theories/Examples/ELMO/UMO.v
@@ -5,7 +5,7 @@ From VLSM.Lib Require Import Preamble StdppExtras StdppListSet.
 From VLSM.Core Require Import VLSM VLSMProjections Composition Equivocation ProjectionTraces.
 From VLSM.Examples Require Import BaseELMO.
 
-(** * UMO Protocol Definitions and Properties
+(** * ELMO: Protocol Definitions and Properties for UMO
 
   This module contains definitions and properties of UMO components and
   the UMO protocol.

--- a/theories/Examples/Paxos/Consensus.v
+++ b/theories/Examples/Paxos/Consensus.v
@@ -4,7 +4,7 @@ From Coq Require Import Streams FunctionalExtensionality Eqdep_dec.
 From VLSM.Lib Require Import Preamble ListExtras.
 From VLSM.Core Require Import VLSM Plans VLSMProjections.
 
-(** * Consensus Specification
+(** * Paxos: Abstract Specification of Consensus
 
   A very high-level specification of the consensus problem,
   following Lamport.

--- a/theories/Examples/Paxos/Paxos.v
+++ b/theories/Examples/Paxos/Paxos.v
@@ -12,6 +12,7 @@ Create HintDb list_simpl discriminated.
 Ltac simpl_elem_of_list := rewrite_strat any (topdown (hints list_simpl)).
 Ltac simpl_elem_of_list_in H := rewrite_strat any (topdown (hints list_simpl)) in H.
 
+(* FIXME: move to Core *)
 Lemma from_send_to_from_sent_argument
   [message] (V : VLSM message)
   `{!HasBeenSentCapability V}
@@ -37,7 +38,7 @@ Proof.
   - by eapply P_stable, IHHs.
 Qed.
 
-(** * A Basic Paxos Protocol
+(** * Paxos: A Basic Paxos Protocol
 
   This protocol maintains safety in the presence of message loss,
   but may not be safe for Byzantine failures.

--- a/theories/Examples/Paxos/Voting.v
+++ b/theories/Examples/Paxos/Voting.v
@@ -5,7 +5,7 @@ From VLSM.Lib Require Import Preamble ListExtras FinSetExtras.
 From VLSM.Core Require Import VLSM Plans VLSMProjections Composition.
 From VLSM.Examples Require Import Consensus.
 
-(** * Consensus by Voting
+(** * Paxos: Specification of Consensus by Voting
 
   A specification of a consensus algorithm where a set of nodes,
   the _acceptors_, agree on a value by voting.

--- a/theories/Lib/Ctauto.v
+++ b/theories/Lib/Ctauto.v
@@ -1,6 +1,6 @@
 From Cdcl Require Export Itauto.
 
-(** * Classical Itauto tactic
+(** * Utility: Classical Itauto Tactic
 
   This module contains a version of the itauto tactic that uses classical logic
   freely. See the comments in VLSM.Lib.Itauto for more details.

--- a/theories/Lib/EquationsExtras.v
+++ b/theories/Lib/EquationsExtras.v
@@ -1,7 +1,7 @@
 From Equations Require Export Equations.
 Export Equations.Prop.Logic.
 
-(** * Equations utility definitions
+(** * Utility: Equations Definitions
 
   The [inspect] definition is used to pack a value with a proof
   of an equality to itself. When pattern matching on the first component in

--- a/theories/Lib/FinSetExtras.v
+++ b/theories/Lib/FinSetExtras.v
@@ -2,7 +2,7 @@ From VLSM.Lib Require Import Itauto.
 From stdpp Require Import prelude fin_maps.
 From VLSM.Lib Require Import Preamble.
 
-(** * Finite set utility definitions and lemmas *)
+(** * Utility: Finite Set Utility Definitions and Results *)
 
 Section sec_fin_set.
 

--- a/theories/Lib/FinSuppFn.v
+++ b/theories/Lib/FinSuppFn.v
@@ -3,7 +3,7 @@ From Coq Require Import FunctionalExtensionality.
 From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import Preamble StdppExtras ListExtras.
 
-(** * Finitely supported functions *)
+(** * Utility: Finitely Supported Functions *)
 
 (**
   The support of a function (w.r.t. a specified codomain value) is the type of

--- a/theories/Lib/Itauto.v
+++ b/theories/Lib/Itauto.v
@@ -1,6 +1,6 @@
 From Cdcl Require Export Itauto.
 
-(** * Constructive Itauto tactic
+(** * Utility: Constructive Itauto Tactic
 
   This module contains a workaround that prevents the itauto tactic from using
   classical logic.

--- a/theories/Lib/ListExtras.v
+++ b/theories/Lib/ListExtras.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude finite.
 From Coq Require Import FinFun.
 From VLSM.Lib Require Import Preamble.
 
-(** * Utility lemmas about lists *)
+(** * Utility: Lemmas About Lists *)
 
 (**
   A list is either empty or it can be decomposed into an initial prefix

--- a/theories/Lib/ListSetExtras.v
+++ b/theories/Lib/ListSetExtras.v
@@ -2,7 +2,7 @@ From VLSM.Lib Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras StdppExtras StdppListSet.
 
-(** * List set utility definitions and lemmas *)
+(** * Utility: List Set Definitions and Results *)
 
 Definition set_eq {A} (s1 s2 : set A) : Prop :=
   s1 ⊆ s2 /\ s2 ⊆ s1.

--- a/theories/Lib/Measurable.v
+++ b/theories/Lib/Measurable.v
@@ -2,7 +2,7 @@ From stdpp Require Import prelude.
 From Coq Require Import Reals Lra.
 From VLSM.Lib Require Import Preamble ListExtras StdppListSet.
 
-(** * Measure-related definitions and lemmas *)
+(** * Utility: Measure Related Definitions and Results *)
 
 (** The type of positive real numbers. *)
 Definition pos_R := {r : R | (r > 0)%R}.

--- a/theories/Lib/NatExtras.v
+++ b/theories/Lib/NatExtras.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude finite.
 From VLSM.Lib Require Import EquationsExtras.
 From VLSM.Lib Require Import Preamble FinSuppFn StdppExtras ListExtras.
 
-(** * Natural number utility definitions and lemmas *)
+(** * Utility: Natural Number Definitions and Results *)
 
 (** Compute the list of all naturals less than <<n>>. *)
 Fixpoint up_to_n_listing (n : nat) : list nat :=

--- a/theories/Lib/NeList.v
+++ b/theories/Lib/NeList.v
@@ -1,7 +1,7 @@
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import ListExtras StdppExtras.
 
-(** * Non-empty lists *)
+(** * Utility: Non-Empty Lists *)
 
 (** ** Positive definition *)
 

--- a/theories/Lib/Preamble.v
+++ b/theories/Lib/Preamble.v
@@ -3,7 +3,7 @@ Obligation Tactic := idtac.
 From stdpp Require Import prelude.
 From Coq Require Import Eqdep_dec.
 
-(** * General utility definitions, lemmas, and tactics *)
+(** * Utility: General Definitions, Results and Tactics *)
 
 Tactic Notation "spec" hyp(H) :=
   match type of H with ?a -> _ =>

--- a/theories/Lib/RealsExtras.v
+++ b/theories/Lib/RealsExtras.v
@@ -1,7 +1,7 @@
 From Coq Require Import Reals.
 From stdpp Require Import prelude.
 
-(** * Real number utility definitions and lemmas *)
+(** * Utility: Real Number Definitions and Results *)
 
 #[export] Instance Rle_transitive : Transitive Rle.
 Proof.

--- a/theories/Lib/SortedLists.v
+++ b/theories/Lib/SortedLists.v
@@ -3,7 +3,7 @@ From stdpp Require Import prelude.
 From Coq Require Import Sorting.
 From VLSM.Lib Require Import Preamble ListExtras ListSetExtras.
 
-(** * Sorted list utility functions and lemmas *)
+(** * Utility: Sorted List Functions and Results *)
 
 (** Insert an element into a sorted list. *)
 Fixpoint add_in_sorted_list_fn

--- a/theories/Lib/SsrExport.v
+++ b/theories/Lib/SsrExport.v
@@ -1,4 +1,4 @@
-(** * SSReflect exports *)
+(** * Utility: SSReflect Exports *)
 
 From Coq Require Export ssreflect.
 #[export] Set SsrOldRewriteGoalsOrder.

--- a/theories/Lib/StdppExtras.v
+++ b/theories/Lib/StdppExtras.v
@@ -2,7 +2,7 @@ From VLSM.Lib Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras.
 
-(** * Std++ Related Results *)
+(** * Utility: Std++ General Results *)
 
 Lemma elem_of_take {A : Type} (l : list A) (n : nat) (x : A) :
   elem_of x (take n l) -> elem_of x l.

--- a/theories/Lib/StdppListSet.v
+++ b/theories/Lib/StdppListSet.v
@@ -1,6 +1,8 @@
 From VLSM.Lib Require Import Itauto.
 From stdpp Require Import prelude.
 
+(** * Utility: Std++ List Sets *)
+
 Section sec_fst_defs.
 
 Context `{EqDecision A}.

--- a/theories/Lib/StreamExtras.v
+++ b/theories/Lib/StreamExtras.v
@@ -2,7 +2,7 @@ From stdpp Require Import prelude.
 From Coq Require Import Streams Classical Sorted.
 From VLSM.Lib Require Import Preamble ListExtras StdppExtras SortedLists NeList.
 
-(** * Stream utility definitions and lemmas *)
+(** * Utility: Stream Definitions and Results *)
 
 Lemma stream_eq_hd_tl {A} (s s' : Stream A) :
   hd s = hd s' -> tl s = tl s' -> s = s'.

--- a/theories/Lib/StreamFilters.v
+++ b/theories/Lib/StreamFilters.v
@@ -1,6 +1,9 @@
 From stdpp Require Import prelude.
 From Coq Require Import Streams Sorted.
-From VLSM.Lib Require Import Preamble StreamExtras SortedLists ListExtras StdppExtras NeList.
+From VLSM.Lib Require Import Preamble StreamExtras SortedLists.
+From VLSM.Lib Require Import ListExtras StdppExtras NeList.
+
+(** * Utility: Stream Filters *)
 
 (**
   Given a predicate <<P>> and a stream <<s>>, a stream of naturals <<ns>>

--- a/theories/Lib/TopSort.v
+++ b/theories/Lib/TopSort.v
@@ -2,7 +2,7 @@ From VLSM.Lib Require Import Itauto.
 From stdpp Require Import prelude.
 From VLSM.Lib Require Import Preamble ListExtras ListSetExtras StdppListSet StdppExtras.
 
-(** * Topological sorting implementation
+(** * Utility: Topological Sorting
 
   This module implements an algorithm producing a linear extension for a
   given partial order using an approach similar to that of Kahn's topological

--- a/theories/Lib/TraceClassicalProperties.v
+++ b/theories/Lib/TraceClassicalProperties.v
@@ -5,7 +5,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Import Prenex Implicits.
 
-(** * Properties of possibly-infinite traces requiring classical logic *)
+(** * Utility: Properties of Possibly-Infinite Traces Requiring Classical Logic *)
 
 Section sec_trace_classical_properties.
 

--- a/theories/Lib/TraceProperties.v
+++ b/theories/Lib/TraceProperties.v
@@ -5,7 +5,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Import Prenex Implicits.
 
-(** * Core properties of possibly-infinite traces *)
+(** * Properties of possibly-infinite traces *)
 
 (**
   The property encodings and many specific properties are adapted from the paper

--- a/theories/Lib/TraceProperties.v
+++ b/theories/Lib/TraceProperties.v
@@ -5,7 +5,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Import Prenex Implicits.
 
-(** * Properties of possibly-infinite traces *)
+(** * Utility: Properties of Possibly-Infinite Traces *)
 
 (**
   The property encodings and many specific properties are adapted from the paper

--- a/theories/Lib/Traces.v
+++ b/theories/Lib/Traces.v
@@ -4,7 +4,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Import Prenex Implicits.
 
-(** * Definition of possibly-infinite traces *)
+(** * Utility: Definition of Possibly-Infinite Traces *)
 
 Ltac invs h := inversion h; subst => {h}.
 


### PR DESCRIPTION
This is both to make coqdoc module titles consistent and make the coqdoc table of contents more easy to navigate.