### PR TITLE
Tweak printing records in ELMO

### DIFF
--- a/theories/Examples/ELMO/BaseELMO.v
+++ b/theories/Examples/ELMO/BaseELMO.v
@@ -46,7 +46,7 @@ with Message : Type := MkMessage
   types, using their constructor names, instead of as records with the
   {| ... |} notation.
 *)
-#[export] Unset Printing Records.
+Add Printing Constructor State Observation Message.
 
 (** Two states are equal when they have equal observations and equal addresses. *)
 Lemma eq_State :
@@ -789,3 +789,9 @@ Proof.
 Qed.
 
 End sec_BaseELMO_Observations.
+
+(**
+  We want to display State, Observation and Message using constructors
+  also outside of the current module.
+*)
+Add Printing Constructor State Observation Message.


### PR DESCRIPTION
The command `#[export] Unset Printing Records.` used to force printing of some record types using constructors in `BaseELMO.v` was a bit of an overkill, because it was exported out of the module and then reexported from `AllELMO.v`, so it could possibly wreak some havoc for the users.

In this PR I changed it to the more fine-grained command `Add Printing Constructor`. This makes `State`, `Observation` and `Message` be displayed using the constructor, and this setting is exported to the outside world, but all other records are unaffected.