### PR TITLE
update README.md with tutorial breakdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Docker CI][docker-action-shield]][docker-action-link]
 [![coqdoc][coqdoc-shield]][coqdoc-link]
 
-[docker-action-shield]: https://github.com/runtimeverification/vlsm/workflows/Test%20PR/badge.svg?branch=master
-[docker-action-link]: https://github.com/runtimeverification/vlsm/actions?query=workflow:"Test%20PR"
+[docker-action-shield]: https://github.com/runtimeverification/vlsm/actions/workflows/test-pr.yml/badge.svg?branch=master
+[docker-action-link]: https://github.com/runtimeverification/vlsm/actions/workflows/test-pr.yml
 
 
 [coqdoc-shield]: https://img.shields.io/badge/docs-coqdoc-blue.svg
-[coqdoc-link]: https://runtimeverification.github.io/vlsm-docs/latest/coqdoc/toc.html
+[coqdoc-link]: https://runtimeverification.github.io/vlsm
 
 
 A validating labelled state transition and message production system
@@ -48,13 +48,22 @@ cd vlsm
 make   # or make -j <number-of-cores-on-your-machine>
 ```
 
-## Coq file organization
-
-- `theories/Lib`: Various extensions to the Coq standard library and Coq-std++.
-- `theories/Core`: Core VLSM definitions and theory.
-- `theories/Examples`: Examples of VLSM applications, including tutorials.
-
 ## Documentation
+
+### File organization
+
+- [Lib](theories/Lib): Extensions to the [Coq standard library](https://coq.inria.fr/stdlib/) and [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/).
+- [Core](theories/Core): Core VLSM definitions and results.
+- [Examples](theories/Examples): Applications of VLSMs, including tutorials.
+
+### Source documentation
 
 - [latest coqdoc presentation of the Coq files](https://runtimeverification.github.io/vlsm-docs/latest/coqdoc/toc.html)
 - [latest Alectryon presentation the Coq files](https://runtimeverification.github.io/vlsm-docs/latest/alectryon/toc.html)
+
+### Tutorials
+
+- [VLSMs that Generate Logical Formulas](theories/Examples/Tutorial/Formulas.v): construction of VLSMs corresponding to propositional logic symbols, with their composition having well-formed propositional formulas as valid messages.
+- [VLSMs that Multiply](theories/Examples/Tutorial/Multiply.v): construction of VLSMs that perform arithmetic operations, with their composition having products of powers as valid messages.
+- [Primes Composition of VLSMs](theories/Examples/Tutorial/PrimesComposition.v): construction of an infinite family of VLSMs that multiply and their composition based on primes.
+- [Round-based asynchronous muddy children puzzle](theories/Examples/Tutorial/MuddyChildrenRounds.v): the [muddy children puzzle](https://plato.stanford.edu/entries/dynamic-epistemic/appendix-B-solutions.html#muddy) as a constrained composition of VLSMs that communicate asynchronously in rounds.

--- a/coq-vlsm.opam
+++ b/coq-vlsm.opam
@@ -38,7 +38,7 @@ authors: [
   "Karl Palmskog"
   "Lucas Peña"
   "Grigore Roșu"
-  "Traian Șerbănuță"
+  "Traian Florin Șerbănuță"
   "Ioan Teodorescu"
   "Dafina Trufaș"
   "Jan Tušil"

--- a/meta.yml
+++ b/meta.yml
@@ -30,7 +30,7 @@ authors:
 - name: Karl Palmskog
 - name: Lucas Peña
 - name: Grigore Roșu
-- name: Traian Șerbănuță
+- name: Traian Florin Șerbănuță
 - name: Ioan Teodorescu
 - name: Dafina Trufaș
 - name: Jan Tušil
@@ -102,14 +102,23 @@ build: |-
   ```
 
 documentation: |-
-  ## Coq file organization
-
-  - `theories/Lib`: Various extensions to the Coq standard library and Coq-std++.
-  - `theories/Core`: Core VLSM definitions and theory.
-  - `theories/Examples`: Examples of VLSM applications, including tutorials.
-
   ## Documentation
+
+  ### File organization
+
+  - [Lib](theories/Lib): Extensions to the [Coq standard library](https://coq.inria.fr/stdlib/) and [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/).
+  - [Core](theories/Core): Core VLSM definitions and results.
+  - [Examples](theories/Examples): Applications of VLSMs, including tutorials.
+
+  ### Source documentation
 
   - [latest coqdoc presentation of the Coq files](https://runtimeverification.github.io/vlsm-docs/latest/coqdoc/toc.html)
   - [latest Alectryon presentation the Coq files](https://runtimeverification.github.io/vlsm-docs/latest/alectryon/toc.html)
+
+  ### Tutorials
+
+  - [VLSMs that Generate Logical Formulas](theories/Examples/Tutorial/Formulas.v): construction of VLSMs corresponding to propositional logic symbols, with their composition having well-formed propositional formulas as valid messages.
+  - [VLSMs that Multiply](theories/Examples/Tutorial/Multiply.v): construction of VLSMs that perform arithmetic operations, with their composition having products of powers as valid messages.
+  - [Primes Composition of VLSMs](theories/Examples/Tutorial/PrimesComposition.v): construction of an infinite family of VLSMs that multiply and their composition based on primes.
+  - [Round-based asynchronous muddy children puzzle](theories/Examples/Tutorial/MuddyChildrenRounds.v): the [muddy children puzzle](https://plato.stanford.edu/entries/dynamic-epistemic/appendix-B-solutions.html#muddy) as a constrained composition of VLSMs that communicate asynchronously in rounds.
 ---


### PR DESCRIPTION
Here, I update some boilerplate and add listings and descriptions of tutorials directly in `README.md`. Corresponding breakdowns of ELMO and Paxos can be done in future PRs.