### PR TITLE
Fix 8.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ contains a formalization of VLSMs and their theory in the Coq proof assistant.
 - License: [BSD 3-Clause "New" or "Revised" License](LICENSE.md)
 - Compatible Coq versions: 8.16 and later
 - Additional dependencies:
-  - [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.9.0
+  - [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.9.0 and later
   - [Itauto](https://gitlab.inria.fr/fbesson/itauto)
   - [Coq-Equations](https://github.com/mattam82/Coq-Equations)
 - Coq namespace: `VLSM`

--- a/coq-vlsm.opam
+++ b/coq-vlsm.opam
@@ -17,7 +17,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "3.5"}
   "coq" {>= "8.16"}
-  "coq-stdpp" {= "1.9.0"}
+  "coq-stdpp" {>= "1.9.0"}
   "coq-itauto"
   "coq-equations"
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -52,9 +52,9 @@ supported_coq_versions:
 dependencies:
 - opam:
     name: coq-stdpp
-    version: '{= "1.9.0"}'
+    version: '{>= "1.9.0"}'
   description: |-
-    [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.9.0
+    [Coq-std++](https://gitlab.mpi-sws.org/iris/stdpp/) 1.9.0 and later
 - opam:
     name: coq-itauto
   description: |-

--- a/theories/Examples/ELMO/BaseELMO.v
+++ b/theories/Examples/ELMO/BaseELMO.v
@@ -285,7 +285,7 @@ Inductive immediate_substate : State -> State -> Prop :=
 | substate_prev : forall s ob, immediate_substate s (s <+> ob)
 | substate_new : forall s ob, immediate_substate (state (message ob)) (s <+> ob).
 
-Lemma immediate_substate_wf : wf immediate_substate.
+Lemma immediate_substate_wf : well_founded immediate_substate.
 Proof.
   intro s; induction s using addObservation_both_ind; constructor.
   - by inversion 1.

--- a/theories/Examples/ELMO/ELMO.v
+++ b/theories/Examples/ELMO/ELMO.v
@@ -428,10 +428,9 @@ Lemma ELMO_input_constrained_transition_inj :
       l0 = l /\ s0 = s /\ om0 = om /\ om'0 = om'.
 Proof.
   intros l s om s' om' [(_ & _ & Hvalid) Ht] l0 s0 om0 om'0 [(_ & _ & Hvalid0) Ht0].
-  by inversion Hvalid; subst; cbn in Ht;
-  injection Ht as [= <- <-];
-  inversion Hvalid0; subst; inversion Ht0;
-  [replace s0 with s by (apply eq_State; done)|].
+  inversion Hvalid; subst; cbn in Ht; injection Ht as [= <- <-];
+    inversion Hvalid0; subst; inversion Ht0; [| done].
+  by replace s0 with s by (apply eq_State; done).
 Qed.
 
 Lemma ELMO_component_valid_transition_size :

--- a/theories/Examples/ELMO/ELMO.v
+++ b/theories/Examples/ELMO/ELMO.v
@@ -429,9 +429,9 @@ Lemma ELMO_input_constrained_transition_inj :
 Proof.
   intros l s om s' om' [(_ & _ & Hvalid) Ht] l0 s0 om0 om'0 [(_ & _ & Hvalid0) Ht0].
   by inversion Hvalid; subst; cbn in Ht;
-    injection Ht as [= <- <-];
-    inversion Hvalid0; subst; inversion Ht0;
-    replace s0 with s by (apply eq_State; done).
+  injection Ht as [= <- <-];
+  inversion Hvalid0; subst; inversion Ht0;
+  [replace s0 with s by (apply eq_State; done)|].
 Qed.
 
 Lemma ELMO_component_valid_transition_size :

--- a/theories/Examples/Paxos/Voting.v
+++ b/theories/Examples/Paxos/Voting.v
@@ -35,7 +35,7 @@ Coercion Ballot'_to_Z : Ballot' >-> Z.
 
 Ltac ballot_lia := unfold Ballot_to_Z in *; lia.
 
-Lemma Ballot_lt_wf : wf (fun (x y : Ballot) => (x < y)%Z).
+Lemma Ballot_lt_wf : well_founded (fun (x y : Ballot) => (x < y)%Z).
 Proof.
   generalize N.lt_wf_0.
   by apply (wf_projected N.lt id), N2Z.inj_lt.

--- a/theories/Lib/Preamble.v
+++ b/theories/Lib/Preamble.v
@@ -84,7 +84,7 @@ Qed.
 Lemma tc_wf_projected
   `{R1 : relation A} `(R2 : relation B) `{!Transitive R2} (f : A -> B) :
   (forall x y, R1 x y -> R2 (f x) (f y)) ->
-  wf R2 -> wf (tc R1).
+  well_founded R2 -> well_founded (tc R1).
 Proof.
   intros Hpreserve.
   apply wf_projected with f.


### PR DESCRIPTION
These changes are entirely based on what is required to be compatible with 8.19 while maintaining backwards compatibility. For example, the latest stdpp removed the `wf` shorthand.