### PR TITLE
avoid collision between names in Voting.v and Paxos.v

### DIFF
--- a/theories/Examples/Paxos/Paxos.v
+++ b/theories/Examples/Paxos/Paxos.v
@@ -155,7 +155,7 @@ Definition paxos_acceptor_valid :
     end.
 
 Definition paxos_acceptor_transition
- (l : paxos_acceptor_label) (som : paxos_acceptor_state * option paxos_message)
+  (l : paxos_acceptor_label) (som : paxos_acceptor_state * option paxos_message)
   : paxos_acceptor_state * option paxos_message :=
   match l, som with
   | A_send_1b, (s, Some (b, m_1a)) =>
@@ -183,15 +183,15 @@ Definition paxos_acceptor_machine : VLSMMachine paxos_acceptor_type :=
 Definition paxos_acceptor_vlsm : VLSM paxos_message := mk_vlsm paxos_acceptor_machine.
 
 Definition paxos_acceptor_has_been_sent
- (s : state paxos_acceptor_vlsm) (m : paxos_message) : Prop :=
-  m ∈ sent_messages s.
+  (s : state paxos_acceptor_vlsm) (m : paxos_message) : Prop :=
+    m ∈ sent_messages s.
 
 #[export] Instance paxos_acceptor_has_been_sent_dec :
- RelDecision paxos_acceptor_has_been_sent :=
+  RelDecision paxos_acceptor_has_been_sent :=
   fun s m => elem_of_list_dec m (sent_messages s).
 
 Lemma paxos_acceptor_has_been_sent_stepwise_props :
- has_been_sent_stepwise_prop paxos_acceptor_has_been_sent.
+  has_been_sent_stepwise_prop paxos_acceptor_has_been_sent.
 Proof.
   constructor.
   - intros s Hs m.
@@ -212,7 +212,7 @@ Proof.
 Qed.
 
 #[export] Instance paxos_acceptor_has_been_sent_inst :
- HasBeenSentCapability paxos_acceptor_vlsm :=
+  HasBeenSentCapability paxos_acceptor_vlsm :=
 {|
   has_been_sent := paxos_acceptor_has_been_sent;
   has_been_sent_dec := paxos_acceptor_has_been_sent_dec;

--- a/theories/Examples/Paxos/Voting.v
+++ b/theories/Examples/Paxos/Voting.v
@@ -90,10 +90,10 @@ Record acceptor_state : Type :=
 Section sec_acceptor_state_predicates.
 
 Context
-  (S : acceptor_state)
+  (AState : acceptor_state)
   .
 
-Definition voted_for (b : Ballot) (v : Value) := v ∈ votes S !!! b.
+Definition voted_for (b : Ballot) (v : Value) := v ∈ votes AState !!! b.
 
 #[export] Instance voted_for_dec (b : Ballot) (v : Value) : Decision (voted_for b v) :=
   VSDec _ _.
@@ -139,8 +139,8 @@ Definition acceptor_initial : acceptor_state :=
   maxBal := None;
 |}.
 
-Definition acceptor_initial_state_prop (S : acceptor_state) : Prop :=
-  S = acceptor_initial.
+Definition acceptor_initial_state_prop (s : acceptor_state) : Prop :=
+  s = acceptor_initial.
 
 Definition acceptor_valid : acceptor_label -> acceptor_state * option False -> Prop :=
   fun l '(s, _) =>

--- a/theories/Examples/Paxos/Voting.v
+++ b/theories/Examples/Paxos/Voting.v
@@ -133,16 +133,16 @@ Definition acceptor_type : VLSMType False :=
   label := acceptor_label;
 |}.
 
-Definition acceptor_s0 : acceptor_state :=
+Definition acceptor_initial : acceptor_state :=
 {|
   votes := ∅;
   maxBal := None;
 |}.
 
 Definition acceptor_initial_state_prop (S : acceptor_state) : Prop :=
-  S = acceptor_s0.
+  S = acceptor_initial.
 
-Definition acceptor_locally_valid : acceptor_label -> acceptor_state * option False -> Prop :=
+Definition acceptor_valid : acceptor_label -> acceptor_state * option False -> Prop :=
   fun l '(s, _) =>
     match l with
     | SkipToRound b => (maxBal s < b)%Z
@@ -158,16 +158,16 @@ Definition acceptor_transition
     | Vote b v => ({| votes := mmap_insert b v s_votes; maxBal := Some b; |}, None)
     end.
 
-Definition acceptor_vlsm_machine : VLSMMachine acceptor_type :=
+Definition acceptor_machine : VLSMMachine acceptor_type :=
 {|
-  initial_state_prop := eq acceptor_s0;
-  s0 := populate (exist _ acceptor_s0 eq_refl);
+  initial_state_prop := (.= acceptor_initial);
+  s0 := populate (exist _ acceptor_initial eq_refl);
   initial_message_prop := (fun _ => False);
   transition := acceptor_transition;
-  valid := acceptor_locally_valid;
+  valid := acceptor_valid;
 |}.
 
-Definition acceptor_vlsm : VLSM False := mk_vlsm acceptor_vlsm_machine.
+Definition acceptor_vlsm : VLSM False := mk_vlsm acceptor_machine.
 
 End sec_acceptor_vlsm.
 
@@ -536,7 +536,7 @@ Lemma inv_acceptor_no_conflict :
 Proof.
   intros s Hs.
   induction Hs using valid_state_prop_ind; intros a b v w.
-  - rewrite <- (Hs a); clear Hs s a.
+  - rewrite (Hs a); clear Hs s a.
     intro Hv; exfalso; contradict Hv.
     unfold voted_for; cbn.
     rewrite lookup_total_empty. (* matching a typo in stdpp *)
@@ -562,7 +562,7 @@ Proof.
   intros s Hs.
   induction Hs using valid_state_prop_ind; intros a b.
   - intros _ v.
-    rewrite <- (Hs a).
+    rewrite (Hs a).
     unfold voted_for; cbn.
     rewrite lookup_total_empty; cbn.
     by apply not_elem_of_empty.
@@ -718,7 +718,7 @@ Proof.
   intros s Hs.
   induction Hs using valid_state_prop_ind; unfold acceptor_votes_safe_prop; intros a b v.
   - intros Hvote; contradict Hvote.
-    rewrite <- (Hs a).
+    rewrite (Hs a).
     unfold voted_for; cbn.
     rewrite lookup_total_empty; cbn.
     by apply not_elem_of_empty.
@@ -915,7 +915,7 @@ Proof.
   destruct Hv as [Q HvQ], (QA Q Q) as [a Ha].
   lapply (HvQ a); [| by set_solver].
   unfold voted_for.
-  rewrite <- (Hs a); cbn.
+  rewrite (Hs a); cbn.
   rewrite lookup_total_empty.
   by apply elem_of_empty.
 Qed.


### PR DESCRIPTION
This is to allow people to `Import` both `Voting` and `Paxos` and allow names to be unique. I also uniformized some VLSM-related names and annotations.