### PR TITLE
Use constrained instead of preloaded in Paxos

### DIFF
--- a/theories/Examples/Paxos/Paxos.v
+++ b/theories/Examples/Paxos/Paxos.v
@@ -812,9 +812,7 @@ Proof.
 Qed.
 
 Notation Pred_Stable_In VLSM P :=
-  (forall l s im s' om,
-    input_valid_transition (pre_loaded_with_all_messages_vlsm VLSM) l (s, im) (s', om) ->
-    P s -> P s').
+  (forall l s im s' om, input_constrained_transition VLSM l (s, im) (s', om) -> P s -> P s').
 
 Lemma lift_component_stable_prop ix (P : state (IM ix) -> Prop) :
   Pred_Stable_In (IM ix) P ->

--- a/theories/Examples/Paxos/Paxos.v
+++ b/theories/Examples/Paxos/Paxos.v
@@ -778,7 +778,7 @@ Definition message_sender (m : paxos_message_body) : paxos_index :=
 
 Lemma localize_send :
   forall l s im s' om,
-    transition (pre_loaded_with_all_messages_vlsm paxos_vlsm) l (s, im) = (s', Some om) ->
+    transition paxos_vlsm l (s, im) = (s', Some om) ->
     projT1 l = message_sender (snd om).
 Proof.
   intros * Ht; destruct om as [ob omb]; cbn in Ht |- *.


### PR DESCRIPTION
This PR follows #358

In this PR I:
- replace uses of `..._valid_... (pre_loaded_with_all_messages_vlsm ...)` with `..._constrained_...`
- get rid of the notation `preloaded_paxos_vlsm`
- refactor the notation `Pred_Stable_In` so that constrainedness is built into it