### PR TITLE
Cleanup the use of `pre_loaded_with_all_messages_vlsm`

### DIFF
--- a/theories/Core/ByzantineTraces.v
+++ b/theories/Core/ByzantineTraces.v
@@ -149,13 +149,11 @@ Qed.
 Section sec_pre_loaded_with_all_messages_byzantine_alt.
 
 (**
-  Let <<PreLoaded>> denote the [pre_loaded_with_all_messages_vlsm] of <<M>>,
-  let <<Alt>> denote the free composition of <<M>> with the [emit_any_message_vlsm],
+  Let <<Alt>> denote the free composition of <<M>> with the [emit_any_message_vlsm],
   and let <<Alt1>> denote the projection of <<Alt>> to the component of <<M>>.
 *)
 
 Context
-  (PreLoaded := pre_loaded_with_all_messages_vlsm M)
   (Alt1 := binary_free_composition_fst M emit_any_message_vlsm)
   (Alt := binary_free_composition M emit_any_message_vlsm)
   .
@@ -165,13 +163,13 @@ Context
   of <<Alt1>> into <<Preloaded>>.
 *)
 Lemma alt_pre_loaded_with_all_messages_incl :
-  VLSM_incl Alt1 PreLoaded.
+  VLSM_incl Alt1 (pre_loaded_with_all_messages_vlsm M).
 Proof.
   by intros t Hvt; apply byzantine_pre_loaded_with_all_messages, byzantine_alt_byzantine.
 Qed.
 
 (**
-  To prove the reverse inclusion (between <<PreLoaded>> and <<Alt1>>) we will use the
+  To prove the reverse inclusion (between preloaded <<M>> and <<Alt1>>) we will use the
   [basic_VLSM_incl] meta-result about proving inclusions between
   VLSMs which states that:
 
@@ -212,9 +210,9 @@ Proof. by apply any_message_is_valid_in_preloaded. Qed.
 Definition lifted_alt_state (s : state M) : state Alt :=
   lift_to_composite_state' (binary_IM M emit_any_message_vlsm) first s.
 
-(** Lifting a valid state of <<PreLoaded>> we obtain a valid state of <<Alt>>. *)
+(** Lifting a constrained state of <<M>> we obtain a valid state of <<Alt>>. *)
 Lemma preloaded_alt_valid_state :
-  forall (sj : state PreLoaded) (om : option message),
+  forall (sj : state M) (om : option message),
     constrained_state_message_prop M sj om ->
     valid_state_prop Alt (lifted_alt_state sj).
 Proof.
@@ -238,9 +236,9 @@ Qed.
   results above to show that <<Preloaded>> is included in <<Alt1>>.
 *)
 Lemma pre_loaded_with_all_messages_alt_incl :
-  VLSM_incl PreLoaded Alt1.
+  VLSM_incl (pre_loaded_with_all_messages_vlsm M) Alt1.
 Proof.
-  apply (basic_VLSM_incl PreLoaded Alt1); intro; intros;
+  apply (basic_VLSM_incl _ Alt1); intro; intros;
     [done | by apply alt_proj_option_valid_message | | by apply H].
   exists (lifted_alt_state s).
   split; [done |].
@@ -252,7 +250,7 @@ Qed.
 
 (** Hence, <<Preloaded>> and <<Alt1>> are actually trace-equivalent. *)
 Lemma pre_loaded_with_all_messages_alt_eq :
-  VLSM_eq PreLoaded Alt1.
+  VLSM_eq (pre_loaded_with_all_messages_vlsm M) Alt1.
 Proof.
   split.
   - by apply pre_loaded_with_all_messages_alt_incl.
@@ -331,17 +329,16 @@ Context
   (IM : index -> VLSM message)
   (constraint : composite_label IM -> composite_state IM  * option message -> Prop)
   (X := composite_vlsm IM constraint)
-  (PreLoadedX := pre_loaded_with_all_messages_vlsm X)
   (Hvalidator : forall i : index, component_message_validator_prop IM constraint i)
   .
 
 (**
-  Since we know that <<PreloadedX>> contains precisely the byzantine traces
-  of <<X>>, we just need to show that <<PreLoadedX>> is included in <<X>> to
+  Since we know that preloaded <<X>> contains precisely the byzantine traces
+  of <<X>>, we just need to show that preloaded <<X>> is included in <<X>> to
   prove our main result.
 *)
 Lemma validator_pre_loaded_with_all_messages_incl :
-  VLSM_incl PreLoadedX X.
+  VLSM_incl (pre_loaded_with_all_messages_vlsm X) X.
 Proof.
   apply VLSM_incl_finite_traces_characterization.
   intros s tr Htr.

--- a/theories/Core/Composition.v
+++ b/theories/Core/Composition.v
@@ -1333,7 +1333,6 @@ Context
   `{EqDecision index}
   (IM : index -> VLSM message)
   (Free := free_composite_vlsm IM)
-  (RFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
 Definition composite_valid_transition l s1 iom s2 oom : Prop :=
@@ -1344,7 +1343,9 @@ Definition composite_valid_transition_item
   composite_valid_transition (l item) s (input item) (destination item) (output item).
 
 Lemma composite_valid_transition_reachable_iff l s1 iom s2 oom :
-  composite_valid_transition l s1 iom s2 oom <-> valid_transition RFree l s1 iom s2 oom.
+  composite_valid_transition l s1 iom s2 oom
+    <->
+  valid_transition (pre_loaded_with_all_messages_vlsm Free) l s1 iom s2 oom.
 Proof.
   by split; intros []; constructor.
 Qed.
@@ -1356,7 +1357,9 @@ Definition composite_valid_transition_future : relation (composite_state IM) :=
   tc composite_valid_transition_next.
 
 Lemma composite_valid_transition_next_reachable_iff s1 s2 :
-  composite_valid_transition_next s1 s2 <-> valid_transition_next RFree s1 s2.
+  composite_valid_transition_next s1 s2
+    <->
+  valid_transition_next (pre_loaded_with_all_messages_vlsm Free) s1 s2.
 Proof.
   by split; intros []; econstructor; apply composite_valid_transition_reachable_iff.
 Qed.

--- a/theories/Core/Equivocation.v
+++ b/theories/Core/Equivocation.v
@@ -1029,7 +1029,6 @@ Proof.
   intros l s im s' om Htrans msg.
   rename Htrans into Htrans'.
   pose proof Htrans' as [[Hproto_s [Hproto_m Hvalid]] Htrans].
-  set (preloaded := pre_loaded_with_all_messages_vlsm vlsm) in * |- *.
   pose proof (valid_state_has_trace _ _ Hproto_s)
     as [is [tr [Htr Hinit]]].
   pose proof (Htr' := extend_right_finite_trace_from_to _ Htr Htrans').
@@ -2615,7 +2614,6 @@ Context
   {message : Type}
   `{EqDecision message}
   (X : VLSM message)
-  (PreX := pre_loaded_with_all_messages_vlsm X)
   `{HasBeenSentCapability message X}
   `{HasBeenReceivedCapability message X}
   .
@@ -2625,7 +2623,7 @@ Definition state_received_not_sent (s : state X) (m : message) : Prop :=
 
 Lemma state_received_not_sent_trace_iff
   (m : message)
-  (s is : state (PreX))
+  (s is : state (pre_loaded_with_all_messages_vlsm X))
   (tr : list transition_item)
   (Htr : finite_constrained_trace_init_to X is s tr)
   : state_received_not_sent s m <-> trace_received_not_sent_before_or_after tr m.
@@ -2654,7 +2652,7 @@ Definition state_received_not_sent_invariant
 
 Lemma state_received_not_sent_invariant_trace_iff
   (P : message -> Prop)
-  (s is : state (PreX))
+  (s is : state (pre_loaded_with_all_messages_vlsm X))
   (tr : list transition_item)
   (Htr : finite_constrained_trace_init_to X is s tr)
   : state_received_not_sent_invariant s P <->
@@ -2673,8 +2671,8 @@ Definition cannot_resend_message_stepwise_prop : Prop :=
 
 Lemma cannot_resend_received_message_in_future
   (Hno_resend : cannot_resend_message_stepwise_prop)
-  (s1 s2 : state (PreX))
-  (Hfuture : in_futures PreX s1 s2)
+  (s1 s2 : state (pre_loaded_with_all_messages_vlsm X))
+  (Hfuture : in_futures (pre_loaded_with_all_messages_vlsm X) s1 s2)
   : forall m : message,
     state_received_not_sent s1 m -> state_received_not_sent s2 m.
 Proof.
@@ -2715,7 +2713,7 @@ Lemma lift_preloaded_trace_to_seeded
   (P : message -> Prop)
   (tr : list transition_item)
   (Htrm : trace_received_not_sent_before_or_after_invariant tr P)
-  (is : state (PreX))
+  (is : state (pre_loaded_with_all_messages_vlsm X))
   (Htr : finite_constrained_trace X is tr)
   : finite_valid_trace (pre_loaded_vlsm X P) is tr.
 Proof.
@@ -2788,7 +2786,7 @@ Lemma lift_generated_to_seeded
   (s : state X)
   (Hequiv_s : state_received_not_sent_invariant s P)
   (m : message)
-  (Hgen : can_produce PreX s m)
+  (Hgen : can_produce (pre_loaded_with_all_messages_vlsm X) s m)
   : can_produce (pre_loaded_vlsm X P) s m.
 Proof.
   apply non_empty_valid_trace_from_can_produce.
@@ -2843,7 +2841,6 @@ Context
   `{forall i : index, (HasBeenReceivedCapability (IM i))}
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
-  (PreX := pre_loaded_with_all_messages_vlsm X)
   (Y := free_composite_vlsm IM)
   (PreY := pre_loaded_with_all_messages_vlsm Y).
 

--- a/theories/Core/Equivocation/FixedSetEquivocation.v
+++ b/theories/Core/Equivocation/FixedSetEquivocation.v
@@ -650,7 +650,6 @@ Context
   (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
   (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
   (Free := free_composite_vlsm IM)
-  (PreFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
 (**
@@ -741,7 +740,6 @@ Context
   (Free := free_composite_vlsm IM)
   (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
   (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
-  (PreFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
 (**
@@ -1041,7 +1039,6 @@ Context
   (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
   (StrongFixedNonEquivocating := pre_induced_sub_projection IM (elements non_equivocators)
                                 (strong_fixed_equivocation_constraint IM equivocators))
-  (PreFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
 (**

--- a/theories/Core/Equivocation/LimitedMessageEquivocation.v
+++ b/theories/Core/Equivocation/LimitedMessageEquivocation.v
@@ -199,7 +199,6 @@ Context
   `{RelDecision _ _ (is_equivocating_tracewise_no_has_been_sent IM A sender)}
   (Fixed := fixed_equivocation_vlsm_composition IM equivocators)
   (StrongFixed := strong_fixed_equivocation_vlsm_composition IM equivocators)
-  (PreFree := pre_loaded_with_all_messages_vlsm Free)
   (Limited : VLSM message := tracewise_limited_equivocation_vlsm_composition (Cv := Cv) IM threshold A sender)
   (HBE : BasicEquivocation (composite_state IM) validator Cv threshold :=
     equivocation_dec_tracewise IM threshold A sender)

--- a/theories/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/Core/Equivocation/TraceWiseEquivocation.v
@@ -95,7 +95,7 @@ Lemma elem_of_equivocating_senders_in_trace
   : v ∈ equivocating_senders_in_trace tr <->
     exists (m : message),
     (sender m = Some v) /\
-    equivocation_in_trace (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)) m tr.
+    equivocation_in_trace (free_composite_vlsm IM) m tr.
 Proof.
   unfold equivocating_senders_in_trace.
   rewrite elem_of_remove_dups, elem_of_list_omap.

--- a/theories/Core/Equivocation/TraceWiseEquivocation.v
+++ b/theories/Core/Equivocation/TraceWiseEquivocation.v
@@ -32,7 +32,6 @@ Context
   `{finite.Finite validator}
   (A : validator -> index)
   (sender : message -> option validator)
-  (PreFree := pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM))
   .
 
 (**
@@ -96,7 +95,7 @@ Lemma elem_of_equivocating_senders_in_trace
   : v ∈ equivocating_senders_in_trace tr <->
     exists (m : message),
     (sender m = Some v) /\
-    equivocation_in_trace PreFree m tr.
+    equivocation_in_trace (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)) m tr.
 Proof.
   unfold equivocating_senders_in_trace.
   rewrite elem_of_remove_dups, elem_of_list_omap.
@@ -170,7 +169,7 @@ Definition is_equivocating_tracewise_no_has_been_sent
   (Htr : finite_constrained_trace_init_to (free_composite_vlsm IM) is s tr),
   exists (m : message),
   (sender m = Some v) /\
-  equivocation_in_trace PreFree m tr.
+  equivocation_in_trace (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)) m tr.
 
 Lemma is_equivocating_tracewise_no_has_been_sent_equivocating_senders_in_trace
   (s : composite_state IM)

--- a/theories/Core/EquivocationProjections.v
+++ b/theories/Core/EquivocationProjections.v
@@ -423,7 +423,6 @@ Context
   (A : validator -> index)
   (sender : message -> option validator)
   (Hsender_safety : sender_safety_alt_prop IM A sender)
-  (PreFree := pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM))
   (j : index)
   (m : message)
   (Hj : option_map A (sender m) = Some j)
@@ -434,8 +433,9 @@ Context
   by the free composition (pre-loaded with all messages), then it can also be
   emitted by the component corresponding to its sender (pre-loaded with all messages).
 *)
-Lemma can_emit_projection
-  : can_emit PreFree m -> can_emit (pre_loaded_with_all_messages_vlsm (IM j)) m.
+Lemma can_emit_projection :
+  can_emit (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)) m ->
+  can_emit (pre_loaded_with_all_messages_vlsm (IM j)) m.
 Proof.
   destruct (sender m) as [v |] eqn: Hsender; simpl in Hj; [| by congruence].
   apply Some_inj in Hj.

--- a/theories/Core/Equivocators/FixedEquivocationSimulation.v
+++ b/theories/Core/Equivocators/FixedEquivocationSimulation.v
@@ -40,7 +40,6 @@ Context
   (X : VLSM message := strong_fixed_equivocation_vlsm_composition IM equivocating)
   (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM (elements equivocating))
   (FreeE := free_composite_vlsm (equivocator_IM IM))
-  (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   (SubFreeE := free_composite_vlsm (sub_IM (equivocator_IM IM) (elements equivocating)))
   (no_initial_messages_in_IM : no_initial_messages_in_IM_prop IM)
   .
@@ -393,7 +392,6 @@ Context
   (X : VLSM message := composite_vlsm IM (composite_no_equivocations IM))
   (XE : VLSM message := equivocators_fixed_equivocations_vlsm IM [])
   (FreeE := free_composite_vlsm (equivocator_IM IM))
-  (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   .
 
 Lemma no_equivocating_equivocators_finite_valid_trace_init_to_rev

--- a/theories/Core/Equivocators/FullReplayTraces.v
+++ b/theories/Core/Equivocators/FullReplayTraces.v
@@ -32,9 +32,7 @@ Context
   (equivocating : list index)
   (Free := free_composite_vlsm IM)
   (FreeE := free_composite_vlsm (equivocator_IM IM))
-  (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   (FreeSubE := free_composite_vlsm (sub_IM (equivocator_IM IM) equivocating))
-  (PreFreeSubE := pre_loaded_with_all_messages_vlsm FreeSubE)
   (SeededXE : VLSM message := seeded_equivocators_no_equivocation_vlsm IM equivocating seed)
 .
 
@@ -564,7 +562,7 @@ End sec_pre_loaded_constrained_projection.
 Lemma SeededXE_PreFreeE_weak_embedding
   (full_replay_state : composite_state (equivocator_IM IM))
   (Hfull_replay_state : constrained_state_prop FreeE full_replay_state)
-  : VLSM_weak_embedding SeededXE PreFreeE
+  : VLSM_weak_embedding SeededXE (pre_loaded_with_all_messages_vlsm FreeE)
       (lift_equivocators_sub_label_to full_replay_state)
       (lift_equivocators_sub_state_to full_replay_state).
 Proof.
@@ -583,8 +581,10 @@ Qed.
 
 Lemma PreFreeSubE_PreFreeE_weak_embedding
   (full_replay_state : composite_state (equivocator_IM IM))
-  (Hfull_replay_state : constrained_state_prop FreeE  full_replay_state)
-  : VLSM_weak_embedding PreFreeSubE PreFreeE
+  (Hfull_replay_state : constrained_state_prop FreeE  full_replay_state) :
+    VLSM_weak_embedding
+      (pre_loaded_with_all_messages_vlsm FreeSubE)
+      (pre_loaded_with_all_messages_vlsm FreeE)
       (lift_equivocators_sub_label_to full_replay_state)
       (lift_equivocators_sub_state_to full_replay_state).
 Proof.

--- a/theories/Core/Equivocators/LimitedStateEquivocation.v
+++ b/theories/Core/Equivocators/LimitedStateEquivocation.v
@@ -64,7 +64,6 @@ Context
   (HBE : BasicEquivocation (composite_state (equivocator_IM IM)) index Ci threshold
     := equivocating_indices_BasicEquivocation IM threshold)
   (FreeE : VLSM message := free_composite_vlsm (equivocator_IM IM))
-  (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   .
 
 Definition equivocators_limited_equivocations_constraint
@@ -88,8 +87,10 @@ Proof.
 Qed.
 
 (** Inclusion of preloaded machine in the preloaded free composition. *)
-Lemma preloaded_equivocators_limited_equivocations_vlsm_incl_free
-  : VLSM_incl (pre_loaded_with_all_messages_vlsm equivocators_limited_equivocations_vlsm) PreFreeE.
+Lemma preloaded_equivocators_limited_equivocations_vlsm_incl_free :
+  VLSM_incl
+    (pre_loaded_with_all_messages_vlsm equivocators_limited_equivocations_vlsm)
+    (pre_loaded_with_all_messages_vlsm FreeE).
 Proof.
   by apply basic_VLSM_incl_preloaded; intros ? *; [intro | inversion 1 | intro].
 Qed.

--- a/theories/Core/Equivocators/SimulatingFree.v
+++ b/theories/Core/Equivocators/SimulatingFree.v
@@ -38,7 +38,6 @@ Context
                   composite_state (equivocator_IM IM) * option message -> Prop)
   (CE := pre_loaded_vlsm (composite_vlsm (equivocator_IM IM) constraintE) seed)
   (FreeE := free_composite_vlsm (equivocator_IM IM))
-  (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   .
 
 Definition last_in_trace_except_from
@@ -111,7 +110,7 @@ Lemma generalized_equivocators_finite_valid_trace_init_to_rev
     finite_valid_trace_init_to CE is s tr /\
     finite_trace_last_output trX = finite_trace_last_output tr.
 Proof.
-  assert (HinclE : VLSM_incl CE PreFreeE)
+  assert (HinclE : VLSM_incl CE (pre_loaded_with_all_messages_vlsm FreeE))
     by apply constrained_pre_loaded_vlsm_incl_pre_loaded_with_all_messages.
   induction HtrX using finite_valid_trace_init_to_rev_strong_ind.
   - specialize (lift_initial_to_equivocators_state IM _ His) as Hs.
@@ -240,7 +239,6 @@ Context
   (IM : index -> VLSM message)
   `{forall i : index, HasBeenSentCapability (IM i)}
   (FreeE := free_composite_vlsm (equivocator_IM IM))
-  (PreFreeE := pre_loaded_with_all_messages_vlsm FreeE)
   (seed : message -> Prop)
   (SeededXE : VLSM message :=
     composite_no_equivocation_vlsm_with_pre_loaded (equivocator_IM IM) (free_constraint _) seed)

--- a/theories/Core/MessageDependencies.v
+++ b/theories/Core/MessageDependencies.v
@@ -275,7 +275,6 @@ Context
   `{!HasBeenSentCapability X}
   `{!HasBeenReceivedCapability X}
   `{!Irreflexive (msg_dep_happens_before message_dependencies)}
-  (R := pre_loaded_with_all_messages_vlsm X)
   .
 
 (**
@@ -294,7 +293,7 @@ Inductive HasBeenObserved (s : state X) (m : message) : Prop :=
       HasBeenObserved s m.
 
 Lemma transition_preserves_HasBeenObserved :
-  forall l s im s' om, input_valid_transition R l (s, im) (s', om) ->
+  forall l s im s' om, input_constrained_transition X l (s, im) (s', om) ->
   forall msg, HasBeenObserved s msg -> HasBeenObserved s' msg.
 Proof.
   intros * Ht msg Hbefore; inversion Hbefore as [Hobs | m Hobs Hdep].
@@ -303,7 +302,7 @@ Proof.
 Qed.
 
 Lemma HasBeenObserved_step_update :
-  forall l s im s' om, input_valid_transition R l (s, im) (s', om) ->
+  forall l s im s' om, input_constrained_transition X l (s, im) (s', om) ->
   forall msg,
     HasBeenObserved s' msg
       <->
@@ -606,7 +605,6 @@ Context
   `{forall i, HasBeenReceivedCapability (IM i)}
   `{!Irreflexive (msg_dep_happens_before message_dependencies)}
   (Free := free_composite_vlsm IM)
-  (RFree := pre_loaded_with_all_messages_vlsm Free)
   .
 
 (**
@@ -645,7 +643,7 @@ Proof.
 Qed.
 
 Lemma transition_preserves_CompositeHasBeenObserved :
-  forall l s im s' om, input_valid_transition RFree l (s, im) (s', om) ->
+  forall l s im s' om, input_constrained_transition Free l (s, im) (s', om) ->
   forall msg, CompositeHasBeenObserved s msg -> CompositeHasBeenObserved s' msg.
 Proof.
   destruct (free_composite_has_been_directly_observed_stepwise_props IM) as [].
@@ -655,7 +653,7 @@ Proof.
 Qed.
 
 Lemma CompositeHasBeenObserved_step_update :
-  forall l s im s' om, input_valid_transition RFree l (s, im) (s', om) ->
+  forall l s im s' om, input_constrained_transition Free l (s, im) (s', om) ->
   forall msg,
     CompositeHasBeenObserved s' msg
       <->
@@ -742,7 +740,7 @@ Qed.
 
 Lemma composite_observed_before_send_subsumes_msg_dep_rel
   `{forall i, MessageDependencies (IM i) message_dependencies} :
-  forall m, can_emit RFree m ->
+  forall m, can_emit (pre_loaded_with_all_messages_vlsm Free) m ->
   forall dm, msg_dep_rel message_dependencies dm m ->
     composite_observed_before_send dm m.
 Proof.

--- a/theories/Core/ProjectionTraces.v
+++ b/theories/Core/ProjectionTraces.v
@@ -198,7 +198,7 @@ Qed.
 Lemma pre_loaded_with_all_messages_projection_input_valid_transition_eq
   (s1 s2 : composite_state IM)
   (om1 om2 : option message)
-  (l : label (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM)))
+  (l : label (free_composite_vlsm IM))
   (Ht : input_constrained_transition (free_composite_vlsm IM) l (s1, om1) (s2, om2))
   (Hl : projT1 l = j)
   : input_constrained_transition (IM (projT1 l))
@@ -216,7 +216,7 @@ Qed.
 Lemma pre_loaded_with_all_messages_projection_input_valid_transition_neq
   [s1 s2 : composite_state IM]
   [om1 om2 : option message]
-  [l : label (pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM))]
+  [l : label (free_composite_vlsm IM)]
   (Ht : input_constrained_transition (free_composite_vlsm IM) l (s1, om1) (s2, om2))
   [i : index]
   (Hi : i <> projT1 l)

--- a/theories/Core/SubProjectionTraces.v
+++ b/theories/Core/SubProjectionTraces.v
@@ -374,7 +374,6 @@ Context
   (Free := free_composite_vlsm IM)
   (Sub_Free := free_composite_vlsm sub_IM)
   (X := composite_vlsm IM constraint)
-  (Pre := pre_loaded_with_all_messages_vlsm (free_composite_vlsm IM))
   .
 
 Program Definition sub_index_list_annotate : list sub_index :=

--- a/theories/Core/VLSM.v
+++ b/theories/Core/VLSM.v
@@ -791,8 +791,8 @@ Qed.
 
 (**
   For VLSMs initialized with many initial messages such as
-  the [composite_vlsm_induced_projection] or the [pre_loaded_with_all_messages_vlsm],
-  the question of whether a [VLSM] [can_emit] a message <<m>> becomes more
+  the [composite_vlsm_induced_projection] the question of
+  whether a [VLSM] [can_emit] a message <<m>> becomes more
   useful than that whether <<m>> is a [valid_message].
 *)
 

--- a/theories/Core/Validator.v
+++ b/theories/Core/Validator.v
@@ -58,7 +58,6 @@ Context
   (Y : VLSM message)
   (label_project : label X -> option (label Y))
   (state_project : state X -> state Y)
-  (PreY := pre_loaded_with_all_messages_vlsm Y)
   .
 
 (**
@@ -479,12 +478,11 @@ Context
   (Hproji :=
     projection_induced_validator_is_projection
       _ _ _ _ _ _ Hlabel_lift Hstate_lift Htransition_consistency Htransition_None)
-  (PreY := pre_loaded_with_all_messages_vlsm Y)
-  (Hproj : VLSM_projection X PreY label_project state_project)
+  (Hproj : VLSM_projection X (pre_loaded_with_all_messages_vlsm Y) label_project state_project)
   .
 
 (**
-  If there is a [VLSM_projection] from <<X>> to <<PreY>> and the
+  If there is a [VLSM_projection] from <<X>> to preloaded <<Y>> and the
   [projection_induced_validator_is_projection], then a [transition] [valid] for the
   [projection_induced_validator] has the same output as the transition on <<Y>>.
 *)
@@ -503,7 +501,7 @@ Proof.
 Qed.
 
 Lemma induced_validator_incl_preloaded_with_all_messages
-  : VLSM_incl Xi PreY.
+  : VLSM_incl Xi (pre_loaded_with_all_messages_vlsm Y).
 Proof.
   apply basic_VLSM_incl.
   - by intros is (s & <- & Hs); apply (VLSM_projection_initial_state Hproj).
@@ -586,13 +584,13 @@ Context
   .
 
 (**
-  We can show that <<PreY>> is included in <<Xi>> by applying the meta-lemma
+  We can show that preloaded <<Y>> is included in <<Xi>> by applying the meta-lemma
   [VLSM_incl_finite_traces_characterization], and by induction on the length
   of a trace. The [projection_validator_prop]erty is used to translate
   [input_valid]ity for the preloaded machine into the [pre_projection_induced_validator].
 *)
 Lemma pre_loaded_with_all_messages_validator_proj_incl
-  : VLSM_incl PreY Xi.
+  : VLSM_incl (pre_loaded_with_all_messages_vlsm Y) Xi.
 Proof.
   (* reduce inclusion to inclusion of finite traces. *)
   apply VLSM_incl_finite_traces_characterization.
@@ -617,12 +615,12 @@ Qed.
 (**
   Given that any projection is included in the [pre_loaded_with_all_messages_vlsm]
   of its component (Lemma [proj_pre_loaded_with_all_messages_incl]), we conclude
-  that <<PreY>> and <<Xi>> are trace-equal.  This means that all the
+  that preloaded <<Y>> and <<Xi>> are trace-equal.  This means that all the
   byzantine behavior of a component which is a validator
   is exhibited by its corresponding projection.
 *)
 Lemma pre_loaded_with_all_messages_validator_proj_eq
-  : VLSM_eq PreY Xi.
+  : VLSM_eq (pre_loaded_with_all_messages_vlsm Y) Xi.
 Proof.
   split.
   - by apply pre_loaded_with_all_messages_validator_proj_incl.
@@ -735,7 +733,6 @@ Context
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
   (i : index)
-  (PreXi := pre_loaded_with_all_messages_vlsm (IM i))
   .
 
 Definition composite_project_label (l : composite_label IM)
@@ -840,7 +837,6 @@ Context
   (constraint : composite_label IM -> composite_state IM * option message -> Prop)
   (X := composite_vlsm IM constraint)
   (i : index)
-  (PreXi := pre_loaded_with_all_messages_vlsm (IM i))
   .
 
 (**
@@ -1002,20 +998,18 @@ Definition self_validator_vlsm_prop :=
 
 Context
   (Hvalidator : self_validator_vlsm_prop)
-  (PreX := pre_loaded_with_all_messages_vlsm X)
   .
 
 (**
-  Let <<PreX>> be the [pre_loaded_with_all_messages_vlsm] associated to X.
   From Lemma [vlsm_incl_pre_loaded_with_all_messages_vlsm] we know that <<X>> is
-  included in <<PreX>>.
+  included in preloaded <<X>>.
 
   To prove the converse we use the [self_validator_vlsm_prop]erty to
   verify the conditions of meta-lemma [VLSM_incl_finite_traces_characterization].
 *)
 
-Lemma pre_loaded_with_all_messages_self_validator_vlsm_incl
-  : VLSM_incl PreX X.
+Lemma pre_loaded_with_all_messages_self_validator_vlsm_incl :
+  VLSM_incl (pre_loaded_with_all_messages_vlsm X) X.
 Proof.
   unfold self_validator_vlsm_prop  in Hvalidator.
   destruct X as (T & M). simpl in *.
@@ -1036,10 +1030,10 @@ Proof.
     by eapply Hvalidator.
 Qed.
 
-(** We conclude that <<X>> and <<PreX>> are trace-equal. *)
+(** We conclude that <<X>> and preloaded <<X>> are trace-equal. *)
 
 Lemma pre_loaded_with_all_messages_self_validator_vlsm_eq
-  : VLSM_eq PreX X.
+  : VLSM_eq (pre_loaded_with_all_messages_vlsm X) X.
 Proof.
   split.
   - by apply pre_loaded_with_all_messages_self_validator_vlsm_incl.

--- a/theories/Examples/Tutorial/PrimesComposition.v
+++ b/theories/Examples/Tutorial/PrimesComposition.v
@@ -544,9 +544,7 @@ Lemma even_constrained_primes_composition_no_validator :
         EvenConstraint p.
 Proof.
   intros p Hnv.
-  cut (input_valid
-    (pre_loaded_with_all_messages_vlsm
-      (indexed_radix_vlsms (λ p0 : primes, `p0) p)) () (3, Some 3)).
+  cut (input_constrained (indexed_radix_vlsms (λ p0 : primes, `p0) p) () (3, Some 3)).
   {
     intro Hiv.
     apply Hnv in Hiv as (s & _ & _ & _ & _ & Hc).


### PR DESCRIPTION
In this PR I:
- replace the remainig uses of valid/preloaded that were missed in previous PRs
- remove a lot of abbreviations for `pre_loaded_with_all_messages_vlsm` which are not longer needed