### PR TITLE
Refactor PreloadedVLSM.v

### DIFF
--- a/theories/Core/Equivocation/NoEquivocation.v
+++ b/theories/Core/Equivocation/NoEquivocation.v
@@ -207,7 +207,7 @@ End sec_composite_no_equivocation_invariants.
 
 Section sec_seeded_composite_vlsm_no_equivocation.
 
-(** ** Pre-loading a VLSM composition with no equivocations constraint
+(** ** Preloading a VLSM composition with no equivocations constraint
 
   When adding initial messages to a VLSM composition with a no equivocation
   constraint, we cannot simply use the [preloaded_vlsm] construct

--- a/theories/Core/PreloadedVLSM.v
+++ b/theories/Core/PreloadedVLSM.v
@@ -5,7 +5,7 @@ From VLSM.Core Require Import VLSM VLSMProjections.
 
 (** * Core: Preloaded VLSMs
 
-  Given a VLSM <<X>>, we can _preloaded_ it with some messages, i.e. construct
+  Given a VLSM <<X>>, we can _preload_ it with some messages, i.e. construct
   an identical VLSM, except that these messages are now considered initial. In
   particular, we can preload <<X>> with all messages, i.e. make a copy of <<X>>
   in which all messages are initial. The high degree of freedom allowed by the

--- a/theories/Core/PreloadedVLSM.v
+++ b/theories/Core/PreloadedVLSM.v
@@ -5,27 +5,27 @@ From VLSM.Core Require Import VLSM VLSMProjections.
 
 (** * Core: Preloaded VLSMs
 
-  Given a VLSM <<X>>, we introduce the _preloaded_ version of it, which is
-  identical to <<X>>, except that all messages are initial. The high degree
-  of freedom allowed to the preloaded version lets it experience everything
-  experienced by <<X>> but also other kinds of behavior, including _Byzantine_
-  behavior, which makes it a useful concept in Byzantine fault tolerance analysis.
+  Given a VLSM <<X>>, we can _preloaded_ it with some messages, i.e. construct
+  an identical VLSM, except that these messages are now considered initial. In
+  particular, we can preload <<X>> with all messages, i.e. make a copy of <<X>>
+  in which all messages are initial. The high degree of freedom allowed by the
+  preloaded version lets it experience everything experienced by <<X>> but also
+  other kinds of behavior, including _Byzantine_ behavior, which makes it a useful
+  concept in Byzantine fault tolerance analysis.
 *)
 
 Definition preloaded_vlsm_machine
-  {message : Type} {T : VLSMType message} (M : VLSMMachine T) (initial : message -> Prop)
-  : VLSMMachine T :=
+  `(X : VLSM message) (initial : message -> Prop) : VLSMMachine X :=
 {|
-  initial_state_prop := @initial_state_prop _ _ M;
-  initial_message_prop := fun m => @initial_message_prop _ _ M  m \/ initial m;
-  s0 := @s0 _ _ M;
-  transition := @transition _ _ M;
-  valid := @valid _ _ M;
+  initial_state_prop := @initial_state_prop _ _ X;
+  initial_message_prop := fun m => @initial_message_prop _ _ X  m \/ initial m;
+  s0 := @s0 _ _ X;
+  transition := @transition _ _ X;
+  valid := @valid _ _ X;
 |}.
 
-Definition preloaded_vlsm {message : Type} (X : VLSM message) (initial : message -> Prop)
-  : VLSM message :=
-    mk_vlsm (preloaded_vlsm_machine X initial).
+Definition preloaded_vlsm `(X : VLSM message) (initial : message -> Prop) : VLSM message :=
+  mk_vlsm (preloaded_vlsm_machine X initial).
 
 Definition preloaded_with_all_messages_vlsm `(X : VLSM message) : VLSM message :=
   preloaded_vlsm X (fun _ => True).
@@ -88,68 +88,64 @@ End sec_constrained_defs.
 Section sec_preloaded_with_all_messages_vlsm.
 
 Context
-  {message : Type}
-  (X : VLSM message)
+  `(X : VLSM message)
   .
 
 (**
   A message which can be emitted during a protocol run of the
   [preloaded_with_all_messages_vlsm] is called a [byzantine_message],
   because as shown by [byzantine_preloaded_with_all_messages] and
-  [preloaded_with_all_messages_alt_eq], byzantine traces for a [VLSM]
+  [preloaded_with_all_messages_alt_eq], byzantine traces for a VLSM
   are precisely the valid traces of the [preloaded_with_all_messages_vlsm],
   hence a byzantine message is any message which a byzantine trace [can_emit].
 *)
 
-Definition byzantine_message_prop
-  (m : message)
-  : Prop
-  := can_emit (preloaded_with_all_messages_vlsm X) m.
+Definition byzantine_message_prop (m : message) : Prop :=
+  can_emit (preloaded_with_all_messages_vlsm X) m.
 
-Definition byzantine_message : Type
-  := sig byzantine_message_prop.
+Definition byzantine_message : Type :=
+  {m : message | byzantine_message_prop m}.
 
-Lemma preloaded_with_all_messages_message_valid_initial_state_message
-  (om : option message)
-  : constrained_state_message_prop X (proj1_sig (vs0 X)) om.
+Lemma preloaded_with_all_messages_message_valid_initial_state_message :
+  forall (om : option message),
+    constrained_state_message_prop X (proj1_sig (vs0 X)) om.
 Proof.
-  by apply valid_initial_state_message; [apply proj2_sig | destruct om]; cbn; [right |].
+  by intros; apply valid_initial_state_message;
+    [apply proj2_sig | destruct om]; cbn; [right |].
 Qed.
 
-Lemma preloaded_with_all_messages_valid_state_message_preservation
-  (s : state X)
-  (om : option message)
-  (Hps : valid_state_message_prop X s om)
-  : constrained_state_message_prop X s om.
+Lemma preloaded_with_all_messages_valid_state_message_preservation :
+  forall (s : state X) (om : option message),
+    valid_state_message_prop X s om ->
+    constrained_state_message_prop X s om.
 Proof.
-  induction Hps.
+  induction 1.
   - apply valid_initial_state_message; cbn; [done |].
     by destruct om; cbn; [right |].
   - by eapply valid_generated_state_message; cycle 2.
 Qed.
 
-Lemma preloaded_with_all_messages_valid_state_prop
-  (s : state X)
-  (Hps : valid_state_prop X s)
-  : constrained_state_prop X s.
+Lemma preloaded_with_all_messages_valid_state_prop :
+  forall (s : state X),
+    valid_state_prop X s ->
+    constrained_state_prop X s.
 Proof.
-  unfold valid_state_prop in *.
-  destruct Hps as [om Hprs].
+  intros s [om Hvsp].
   exists om.
-  apply preloaded_with_all_messages_valid_state_message_preservation.
-  by itauto.
+  by apply preloaded_with_all_messages_valid_state_message_preservation.
 Qed.
 
-Lemma any_message_is_valid_in_preloaded (om : option message) :
-  option_valid_message_prop (preloaded_with_all_messages_vlsm X) om.
+Lemma any_message_is_valid_in_preloaded :
+  forall (om : option message),
+    option_valid_message_prop (preloaded_with_all_messages_vlsm X) om.
 Proof.
-  eexists.
-  by apply preloaded_with_all_messages_message_valid_initial_state_message.
+  by eexists; apply preloaded_with_all_messages_message_valid_initial_state_message.
 Qed.
 
-Lemma preloaded_weaken_valid_state_message_prop s om :
-  valid_state_message_prop X s om ->
-  constrained_state_message_prop X s om.
+Lemma preloaded_weaken_valid_state_message_prop :
+  forall (s : state X) (om : option message),
+    valid_state_message_prop X s om ->
+    constrained_state_message_prop X s om.
 Proof.
   induction 1.
   - apply valid_initial_state_message; [done |].
@@ -157,59 +153,65 @@ Proof.
   - by eapply valid_generated_state_message; cycle 2.
 Qed.
 
-Lemma preloaded_weaken_input_valid_transition
-      l s om s' om' :
-  input_valid_transition X l (s, om) (s', om') ->
-  input_constrained_transition X l (s, om) (s', om').
+Lemma preloaded_weaken_input_valid_transition :
+  forall (l : label X) (s : state X) (om : option message) (s' : state X) (om' : option message),
+    input_valid_transition X l (s, om) (s', om') ->
+    input_constrained_transition X l (s, om) (s', om').
 Proof.
-  unfold input_constrained_transition, input_valid_transition.
-  intros [[[_om valid_s] [_ Hvalid]] Htrans].
-  repeat split; [| | done..].
+  unfold input_constrained_transition, input_valid_transition; cbn.
+  intros * [[[_om valid_s] [_ Hvalid]] Htrans].
+  split_and!; [| | done..].
   - by exists _om; apply preloaded_weaken_valid_state_message_prop.
   - by apply any_message_is_valid_in_preloaded.
 Qed.
 
-Lemma preloaded_weaken_valid_trace_from s tr
-  : finite_valid_trace_from X s tr ->
+Lemma preloaded_weaken_valid_trace_from :
+  forall (s : state X) (tr : list (transition_item X)),
+    finite_valid_trace_from X s tr ->
     finite_constrained_trace_from X s tr.
 Proof.
   induction 1 using finite_valid_trace_from_rev_ind.
   - apply (finite_valid_trace_from_empty (preloaded_with_all_messages_vlsm X)).
-    destruct H as [om H]. exists om.
-    by revert H; apply preloaded_weaken_valid_state_message_prop.
+    destruct H as [om H].
+    exists om.
+    by apply preloaded_weaken_valid_state_message_prop.
   - apply (finite_valid_trace_from_app_iff (preloaded_with_all_messages_vlsm X)).
     split; [done |].
     apply (finite_valid_trace_singleton (preloaded_with_all_messages_vlsm X)).
-    by revert Hx; apply preloaded_weaken_input_valid_transition.
+    by apply preloaded_weaken_input_valid_transition.
 Qed.
 
-Lemma pre_trace_segments_with_valid_inputs_are_valid s f tr
-  (Htr : finite_constrained_trace_from_to X s f tr)
-  (Hs : valid_state_prop X s)
-  (Hobs : Forall (fun item => option_valid_message_prop X (input item)) tr)
-  : finite_valid_trace_from_to X s f tr.
+Lemma pre_trace_segments_with_valid_inputs_are_valid :
+  forall (s f : state (preloaded_with_all_messages_vlsm X)) (tr : list transition_item),
+    finite_constrained_trace_from_to X s f tr ->
+    valid_state_prop X s ->
+    Forall (fun item => option_valid_message_prop X (input item)) tr ->
+    finite_valid_trace_from_to X s f tr.
 Proof.
-  revert Hs Hobs; induction Htr using finite_valid_trace_from_to_ind;
+  intros * Htr Hs Hobs; revert Hs Hobs.
+  induction Htr using finite_valid_trace_from_to_ind;
     [by intros; apply (finite_valid_trace_from_to_empty X) |].
   rewrite Forall_cons; intros ? [].
   cut (input_valid_transition X l (s', iom) (s, oom)).
   {
-    intro; apply (finite_valid_trace_from_to_extend X); [| done].
+    intros; apply (finite_valid_trace_from_to_extend X); [| done].
     by apply IHHtr; [eapply input_valid_transition_destination |].
   }
   destruct Ht as [(_ & _ & Hv) Ht].
   repeat split; [done | | done..].
-  by destruct iom as [m |]; [| apply option_valid_message_None].
+  by destruct iom; [| apply option_valid_message_None].
 Qed.
 
-Lemma pre_traces_with_valid_inputs_are_valid s f tr
-  (Htr : finite_constrained_trace_init_to X s f tr)
-  (Hobs : Forall (fun item => option_valid_message_prop X (input item)) tr)
-  : finite_valid_trace_init_to X s f tr.
+Lemma pre_traces_with_valid_inputs_are_valid :
+  forall (s f : state (preloaded_with_all_messages_vlsm X)) (tr : list transition_item),
+    finite_constrained_trace_init_to X s f tr ->
+    Forall (fun item => option_valid_message_prop X (input item)) tr ->
+    finite_valid_trace_init_to X s f tr.
 Proof.
-  destruct Htr as [Htr Hinit]; split; [| done].
-  by apply pre_trace_segments_with_valid_inputs_are_valid;
-    [| apply initial_state_is_valid |].
+  intros s f tr [Htr Hinit] Hobs.
+  split; [| done].
+  apply pre_trace_segments_with_valid_inputs_are_valid; [done | | done].
+  by apply initial_state_is_valid.
 Qed.
 
 End sec_preloaded_with_all_messages_vlsm.
@@ -221,19 +223,19 @@ Context
   .
 
 Lemma valid_transition_preloaded_iff :
-  forall l s1 iom s2 oom,
+  forall (l : label X) (s1 : state X) (iom : option message) (s2 : state X) (oom : option message),
     valid_transition X l s1 iom s2 oom
       <->
     valid_transition (preloaded_with_all_messages_vlsm X) l s1 iom s2 oom.
 Proof. by firstorder. Qed.
 
 Lemma valid_transition_next_preloaded_iff :
-  forall s1 s2,
+  forall (s1 s2 : state X),
     valid_transition_next X s1 s2
       <->
     valid_transition_next (preloaded_with_all_messages_vlsm X) s1 s2.
 Proof.
-  by intros; split; intros []; econstructor; apply valid_transition_preloaded_iff.
+  by split; intros []; econstructor; apply valid_transition_preloaded_iff.
 Qed.
 
 End sec_preloaded_valid_transition.
@@ -251,7 +253,7 @@ Context
   (Htransition_None : strong_projection_transition_consistency_None _ _ label_project state_project)
   (Hstate : strong_projection_initial_state_preservation X Y state_project)
   (Hmessage : weak_projection_valid_message_preservation
-                (preloaded_vlsm X P) (preloaded_vlsm Y Q) label_project state_project)
+    (preloaded_vlsm X P) (preloaded_vlsm Y Q) label_project state_project)
   .
 
 Lemma basic_VLSM_projection_type_preloaded :
@@ -263,16 +265,17 @@ Proof.
   rewrite pre_VLSM_projection_finite_trace_project_app, finite_trace_last_is_last,
     finite_trace_last_app, <- IHHtr; cbn.
   unfold pre_VLSM_projection_transition_item_project.
-  destruct (label_project _) as [lY |] eqn: Hl; [done |].
+  destruct (label_project _) as [lY |] eqn: Hl; cbn; [done |].
   by rewrite Htransition_None; [.. | apply Hx].
 Qed.
 
 Lemma basic_VLSM_projection_preloaded :
   VLSM_projection
     (preloaded_with_all_messages_vlsm X)
-    (preloaded_with_all_messages_vlsm Y) label_project state_project.
+    (preloaded_with_all_messages_vlsm Y)
+    label_project state_project.
 Proof.
-  specialize (basic_VLSM_projection_type_preloaded) as Htype.
+  pose proof (Htype := basic_VLSM_projection_type_preloaded).
   constructor; [done |].
   intros sX trX HtrX.
   split; [| by apply Hstate; apply HtrX].
@@ -281,15 +284,15 @@ Proof.
   rewrite pre_VLSM_projection_finite_trace_project_app.
   apply finite_valid_trace_from_app_iff.
   split; [done |].
-  cbn; unfold pre_VLSM_projection_transition_item_project; cbn.
   apply finite_valid_trace_last_pstate in IHHtrX.
   rewrite <- (final_state_project _ _ _ _ Htype) in IHHtrX |- * by apply HtrX.
+  cbn; unfold pre_VLSM_projection_transition_item_project; cbn.
   destruct (label_project l) as [lY |] eqn: Hl;
     [| by apply (finite_valid_trace_from_empty (preloaded_with_all_messages_vlsm Y))].
   apply (finite_valid_trace_singleton (preloaded_with_all_messages_vlsm Y)).
-  destruct Hx as [[_ [_ Hv]] Ht].
+  destruct Hx as [(_ & _ & Hv) Ht].
   repeat split; [done | ..].
-  - destruct iom as [im |]; [| by apply option_valid_message_None].
+  - destruct iom; [| by apply option_valid_message_None].
     by apply any_message_is_valid_in_preloaded.
   - by eapply Hvalid.
   - by eapply Htransition_Some.
@@ -311,7 +314,7 @@ Qed.
 Lemma basic_VLSM_projection_preloaded_with :
   VLSM_projection (preloaded_vlsm X P) (preloaded_vlsm Y Q) label_project state_project.
 Proof.
-  specialize (basic_VLSM_projection_type_preloaded_with) as Htype.
+  pose proof (Htype := basic_VLSM_projection_type_preloaded_with).
   constructor; [done |].
   intros sX trX HtrX.
   split; [| by apply Hstate; apply HtrX].
@@ -320,16 +323,16 @@ Proof.
   rewrite pre_VLSM_projection_finite_trace_project_app.
   apply (finite_valid_trace_from_app_iff (preloaded_vlsm Y Q)).
   split; [done |].
-  cbn; unfold pre_VLSM_projection_transition_item_project; cbn.
   apply finite_valid_trace_last_pstate in IHHtrX.
   apply proj1 in Hx as Hpv.
-  destruct Hx as [[_ [_ Hv]] Ht].
+  destruct Hx as [(_ & _ & Hv) Ht].
   rewrite <- (final_state_project _ _ _ _ Htype) in IHHtrX |- * by apply HtrX.
+  cbn; unfold pre_VLSM_projection_transition_item_project; cbn.
   destruct (label_project l) as [lY |] eqn: Hl;
     [| by apply (finite_valid_trace_from_empty (preloaded_vlsm Y Q))].
   apply (finite_valid_trace_singleton (preloaded_vlsm Y Q)).
   repeat split; [done | ..].
-  - destruct iom as [im |]; [| by apply option_valid_message_None].
+  - destruct iom; [| by apply option_valid_message_None].
     by eapply Hmessage.
   - by eapply Hvalid.
   - by eapply Htransition_Some.
@@ -353,7 +356,9 @@ Context
   .
 
 Lemma basic_VLSM_embedding_preloaded :
-  VLSM_embedding (preloaded_with_all_messages_vlsm X) (preloaded_with_all_messages_vlsm Y)
+  VLSM_embedding
+    (preloaded_with_all_messages_vlsm X)
+    (preloaded_with_all_messages_vlsm Y)
     label_project state_project.
 Proof.
   constructor.
@@ -365,7 +370,7 @@ Proof.
   apply finite_valid_trace_from_app_iff.
   split; cbn; [done |].
   apply (finite_valid_trace_singleton (preloaded_with_all_messages_vlsm Y)).
-  destruct Hx as [[_ [_ Hv]] Ht].
+  destruct Hx as [(_ & _ & Hv) Ht].
   apply Hvalid in Hv.
   apply Htransition in Ht.
   rewrite (pre_VLSM_embedding_finite_trace_last _ _ label_project state_project) in Hv, Ht.
@@ -387,7 +392,7 @@ Proof.
   apply finite_valid_trace_from_app_iff.
   split; cbn; [done |].
   apply (finite_valid_trace_singleton (preloaded_vlsm Y Q)).
-  destruct Ht as [[_ [_ Hv]] Ht].
+  destruct Ht as [(_ & _ & Hv) Ht].
   apply Hvalid in Hv.
   apply Htransition in Ht.
   apply valid_trace_get_last in HtrX1.
@@ -397,7 +402,7 @@ Proof.
   destruct iom as [m |]; [| by apply option_valid_message_None].
   unfold empty_initial_message_or_final_output in Heqiom.
   destruct_list_last iom_tr iom_tr' iom_lst Heqiom_tr.
-  - by apply option_initial_message_is_valid; destruct Heqiom as [Him | Hp]; cbn; itauto.
+  - by apply option_initial_message_is_valid; destruct Heqiom; cbn; itauto.
   - eapply valid_trace_output_is_valid; [done |].
     setoid_rewrite map_app.
     by apply Exists_app; right; left.
@@ -418,8 +423,8 @@ Context
 Lemma basic_VLSM_incl_preloaded
   (Hinitial_state : strong_incl_initial_state_preservation MX MY)
   (Hvalid : strong_incl_valid_preservation MX MY)
-  (Htransition : strong_incl_transition_preservation MX MY)
-  : VLSM_incl (preloaded_with_all_messages_vlsm X) (preloaded_with_all_messages_vlsm Y).
+  (Htransition : strong_incl_transition_preservation MX MY) :
+    VLSM_incl (preloaded_with_all_messages_vlsm X) (preloaded_with_all_messages_vlsm Y).
 Proof.
   by apply VLSM_incl_embedding_iff, (basic_VLSM_embedding_preloaded X Y id id).
 Qed.
@@ -430,8 +435,8 @@ Lemma basic_VLSM_incl_preloaded_with
   (Hvalid : strong_incl_valid_preservation MX MY)
   (Htransition : strong_incl_transition_preservation  MX MY)
   (Hstate : strong_incl_initial_state_preservation MX MY)
-  (Hmessage : strong_incl_initial_message_preservation MX MY)
-  : VLSM_incl (preloaded_vlsm X P) (preloaded_vlsm Y Q).
+  (Hmessage : strong_incl_initial_message_preservation MX MY) :
+    VLSM_incl (preloaded_vlsm X P) (preloaded_vlsm Y Q).
 Proof.
   by apply VLSM_incl_embedding_iff, (basic_VLSM_embedding_preloaded_with X Y _ _ PimpliesQ id id).
 Qed.
@@ -441,8 +446,7 @@ End sec_preloaded_vlsm_inclusion.
 Section sec_VLSM_incl_preloaded_properties.
 
 Context
-  {message : Type}
-  (X : VLSM message)
+  `(X : VLSM message)
   .
 
 Lemma vlsm_incl_preloaded :
@@ -458,24 +462,25 @@ Proof.
   by apply vlsm_incl_preloaded.
 Qed.
 
-Lemma preloaded_vlsm_incl_relaxed
-  (P Q : message -> Prop)
-  (PimpliesQorValid : forall m : message, P m -> Q m \/ valid_message_prop (preloaded_vlsm X Q) m)
-  : VLSM_incl (preloaded_vlsm X P) (preloaded_vlsm X Q).
+Lemma preloaded_vlsm_incl_relaxed :
+  forall (P Q : message -> Prop),
+    (forall m : message, P m -> Q m \/ valid_message_prop (preloaded_vlsm X Q) m) ->
+    VLSM_incl (preloaded_vlsm X P) (preloaded_vlsm X Q).
 Proof.
+  intros P Q PimpliesQorValid.
   apply basic_VLSM_incl; cycle 1; [| by cbv; itauto..].
   intros _ _ m _ _ [Him | Hp].
   - by apply initial_message_is_valid; left.
-  - apply PimpliesQorValid in Hp as [Hq | Hvalid]; [| done].
+  - apply PimpliesQorValid in Hp as []; [| done].
     by apply initial_message_is_valid; right.
 Qed.
 
-Lemma preloaded_vlsm_incl
-  (P Q : message -> Prop)
-  (PimpliesQ : forall m : message, P m -> Q m)
-  : VLSM_incl (preloaded_vlsm X P) (preloaded_vlsm X Q).
+Lemma preloaded_vlsm_incl :
+  forall (P Q : message -> Prop),
+    (forall m : message, P m -> Q m) ->
+    VLSM_incl (preloaded_vlsm X P) (preloaded_vlsm X Q).
 Proof.
-  by apply preloaded_vlsm_incl_relaxed; itauto.
+  by intros; apply preloaded_vlsm_incl_relaxed; itauto.
 Qed.
 
 Lemma preloaded_vlsm_idem_l :
@@ -499,28 +504,29 @@ Proof.
   by intros; apply preloaded_vlsm_incl.
 Qed.
 
-Lemma preloaded_with_all_messages_can_emit
-  (m : message)
-  (Hm : can_emit X m)
-  : can_emit (preloaded_with_all_messages_vlsm X) m.
+Lemma preloaded_with_all_messages_can_emit :
+  forall (m : message),
+    can_emit X m ->
+    can_emit (preloaded_with_all_messages_vlsm X) m.
 Proof.
+  intros m Hm.
   apply (VLSM_incl_can_emit vlsm_incl_preloaded_with_all_messages_vlsm).
   by rewrite mk_vlsm_machine.
 Qed.
 
-Lemma preloaded_weaken_finite_valid_trace_from
-  (from : state X) (tr : list transition_item)
-  : finite_valid_trace_from X from tr ->
-    finite_valid_trace_from (preloaded_with_all_messages_vlsm X) from tr.
+Lemma preloaded_weaken_finite_valid_trace_from :
+  forall (from : state X) (tr : list transition_item),
+    finite_valid_trace_from X from tr ->
+    finite_constrained_trace_from X from tr.
 Proof.
   by intros; eapply VLSM_incl_finite_valid_trace_from;
     [apply vlsm_incl_preloaded_with_all_messages_vlsm | destruct X].
 Qed.
 
-Lemma preloaded_weaken_finite_valid_trace_from_to
-  (from to : state X) (tr : list transition_item)
-  : finite_valid_trace_from_to X from to tr ->
-    finite_valid_trace_from_to (preloaded_with_all_messages_vlsm X) from to tr.
+Lemma preloaded_weaken_finite_valid_trace_from_to :
+  forall (from to : state X) (tr : list transition_item),
+    finite_valid_trace_from_to X from to tr ->
+    finite_constrained_trace_from_to X from to tr.
 Proof.
   by intros; eapply VLSM_incl_finite_valid_trace_from_to;
     [apply vlsm_incl_preloaded_with_all_messages_vlsm | destruct X].
@@ -531,37 +537,35 @@ End sec_VLSM_incl_preloaded_properties.
 Section sec_VLSM_eq_preloaded_properties.
 
 Context
-  {message : Type}
-  (X : VLSM message)
+  `(X : VLSM message)
   .
 
-Lemma preloaded_vlsm_with_valid_eq
-  (P Q : message -> Prop)
-  (QimpliesValid : forall m, Q m -> valid_message_prop (preloaded_vlsm X P) m)
-  : VLSM_eq (preloaded_vlsm X (fun m => P m \/ Q m)) (preloaded_vlsm X P).
+Lemma preloaded_vlsm_with_valid_eq :
+  forall (P Q : message -> Prop),
+    (forall m, Q m -> valid_message_prop (preloaded_vlsm X P) m) ->
+    VLSM_eq (preloaded_vlsm X (fun m => P m \/ Q m)) (preloaded_vlsm X P).
 Proof.
   split; cbn.
   - by apply preloaded_vlsm_incl_relaxed; itauto.
   - by apply preloaded_vlsm_incl; itauto.
 Qed.
 
-Lemma preloaded_vlsm_idem
-  (P : message -> Prop)
-  : VLSM_eq (preloaded_vlsm (preloaded_vlsm X P) P) (preloaded_vlsm X P).
+Lemma preloaded_vlsm_idem :
+  forall (P : message -> Prop),
+    VLSM_eq (preloaded_vlsm (preloaded_vlsm X P) P) (preloaded_vlsm X P).
 Proof.
   split; cbn.
   - by apply preloaded_vlsm_idem_l.
   - by apply preloaded_vlsm_idem_r.
 Qed.
 
-Lemma preloaded_with_all_messages_eq_validating_preloaded_vlsm
-  (P : message -> Prop)
-  (Hvalidating :
-    forall (l : label _) (s : state _) (m : message)
-      (Hv : input_constrained X l (s, Some m)),
-      valid_message_prop (preloaded_vlsm X P) m)
-  : VLSM_eq (preloaded_with_all_messages_vlsm X) (preloaded_vlsm X P).
+Lemma preloaded_with_all_messages_eq_validating_preloaded_vlsm :
+  forall (P : message -> Prop),
+    (forall (l : label _) (s : state _) (m : message),
+      input_constrained X l (s, Some m) -> valid_message_prop (preloaded_vlsm X P) m) ->
+  VLSM_eq (preloaded_with_all_messages_vlsm X) (preloaded_vlsm X P).
 Proof.
+  intros P Hvalidating.
   split; cbn; [| by apply preloaded_vlsm_incl_preloaded_with_all_messages].
   apply basic_VLSM_incl.
   - by intro.
@@ -585,16 +589,18 @@ Qed.
 Lemma vlsm_is_preloaded_with_False_initial_message_rev :
   strong_embedding_initial_message_preservation (preloaded_vlsm X (fun _ => False)) X.
 Proof.
-  by intros m [Hm | Hfalse].
+  by intros m [].
 Qed.
 
-Lemma vlsm_is_preloaded_with_False_valid_state_message s om :
-  valid_state_message_prop X s om <->
-  valid_state_message_prop (preloaded_vlsm X (fun _ => False)) s om.
+Lemma vlsm_is_preloaded_with_False_valid_state_message :
+  forall (s : state X) (om : option message),
+    valid_state_message_prop X s om
+      <->
+    valid_state_message_prop (preloaded_vlsm X (fun _ => False)) s om.
 Proof.
-  pose proof vlsm_is_preloaded_with_False as Heq.
-  destruct X as (T, M); simpl in *.
-  by split; (apply VLSM_incl_valid_state_message; [| cbv; tauto]); apply Heq.
+  destruct vlsm_is_preloaded_with_False as [Heq1 Heq2].
+  destruct X as [T M]; cbn in *.
+  by split; (apply VLSM_incl_valid_state_message; [| cbv]); itauto.
 Qed.
 
 End sec_VLSM_eq_preloaded_properties.
@@ -607,7 +613,7 @@ End sec_VLSM_eq_preloaded_properties.
 
   In this section we state the original mathematical definitions (as presented
   in the #<a href="https://doi.org/10.48550/arXiv.2202.12662">VLSM paper</a>#)
-  and we show them equivalent with the ones defined above.
+  and we show them equivalent to the ones defined above.
 *)
 
 Section sec_constrained_direct_defs.
@@ -620,42 +626,46 @@ Context
   A sequence of constrained transitions, without any requirements on the
   starting state.
 *)
-Inductive constrained_transitions_from_to :
-  state X -> state X -> list (transition_item X) -> Prop :=
-| ct_empty : forall s, constrained_transitions_from_to s s []
-| ct_extend : forall s s' om om' l f tr, transition X l (s, om) = (s', om') ->
-    valid X l (s, om) -> constrained_transitions_from_to s' f tr ->
-    constrained_transitions_from_to s f
-      ((Build_transition_item l om s' om') :: tr).
+Inductive constrained_transitions_from_to
+  : state X -> state X -> list (transition_item X) -> Prop :=
+| ct_empty :
+    forall (s : state X),
+      constrained_transitions_from_to s s []
+| ct_extend :
+    forall (s s' f : state X) (om om' : option message) (l : label X) (tr : list transition_item),
+      transition X l (s, om) = (s', om') ->
+      valid X l (s, om) -> constrained_transitions_from_to s' f tr ->
+      constrained_transitions_from_to s f (Build_transition_item l om s' om' :: tr).
 
 (**
   A constrained state is a sequence of constrained transitions originating in
   an initial state.
 *)
 Definition finite_constrained_trace_init_to_direct
-  (s f : state X) (tr : list (transition_item X)) :=
-  constrained_transitions_from_to s f tr /\ initial_state_prop X s.
+  (s f : state X) (tr : list (transition_item X)) : Prop :=
+    constrained_transitions_from_to s f tr /\ initial_state_prop X s.
 
 Lemma finite_constrained_trace_init_to_direct_right_impl :
   forall (s f : state X) (tr : list (transition_item X)),
-    finite_constrained_trace_init_to X s f tr -> finite_constrained_trace_init_to_direct s f tr.
+    finite_constrained_trace_init_to X s f tr ->
+    finite_constrained_trace_init_to_direct s f tr.
 Proof.
   intros s f tr [Htr Hinit].
   constructor; [| done]; clear Hinit.
   induction Htr.
-  - by apply ct_empty.
-  - by apply ct_extend; [apply Ht..|].
+  - by constructor.
+  - by constructor; [apply Ht..|].
 Qed.
 
 Lemma finite_constrained_trace_init_to_direct_left_impl :
   forall (s f : state X) (tr : list (transition_item X)),
-    finite_constrained_trace_init_to_direct s f tr -> finite_constrained_trace_init_to X s f tr.
+    finite_constrained_trace_init_to_direct s f tr ->
+    finite_constrained_trace_init_to X s f tr.
 Proof.
   intros s f tr [Htr Hs].
   split; [| done].
   apply (initial_state_is_valid (preloaded_with_all_messages_vlsm X)) in Hs.
-  revert s Hs Htr.
-  induction tr; intros; inversion Htr; subst.
+  revert s Hs Htr; induction tr; intros; inversion Htr; subst.
   - by apply (finite_valid_trace_from_to_empty (preloaded_with_all_messages_vlsm X)).
   - apply (finite_valid_trace_from_to_extend (preloaded_with_all_messages_vlsm X)); cycle 1.
     + by repeat split; [| apply any_message_is_valid_in_preloaded | ..].
@@ -667,7 +677,9 @@ Qed.
 
 Lemma finite_constrained_trace_init_to_direct_equiv :
   forall (s f : state X) (tr : list (transition_item X)),
-    finite_constrained_trace_init_to_direct s f tr <-> finite_constrained_trace_init_to X s f tr.
+    finite_constrained_trace_init_to_direct s f tr
+      <->
+    finite_constrained_trace_init_to X s f tr.
 Proof.
   split.
   - by apply finite_constrained_trace_init_to_direct_left_impl.
@@ -683,9 +695,9 @@ Lemma constrained_state_prop_direct_equiv :
   forall (s : state X),
     constrained_state_prop_direct s <-> constrained_state_prop X s.
 Proof.
-  intros s.
-  unfold constrained_state_prop_direct;
-    setoid_rewrite finite_constrained_trace_init_to_direct_equiv; split.
+  unfold constrained_state_prop_direct.
+  setoid_rewrite finite_constrained_trace_init_to_direct_equiv.
+  split.
   - by intros (? & ? & []); eapply finite_valid_trace_from_to_last_pstate.
   - by intro Hs; apply valid_state_has_trace in Hs as (? & ? & ?); eexists _, _.
 Qed.
@@ -703,11 +715,14 @@ Lemma constrained_message_prop_direct_equiv :
     constrained_message_prop_direct m <-> constrained_message_prop X m.
 Proof.
   intros m.
-  unfold constrained_message_prop_direct, constrained_message_prop; rewrite can_emit_iff.
-  setoid_rewrite finite_constrained_trace_init_to_direct_equiv.
-  setoid_rewrite non_empty_valid_trace_from_can_produce; split.
+  unfold constrained_message_prop_direct, constrained_message_prop.
+  rewrite can_emit_iff.
+  setoid_rewrite finite_constrained_trace_init_to_direct_equiv;
+    setoid_rewrite non_empty_valid_trace_from_can_produce.
+  split.
   - intros (is & s & tr & item & Htr & Hm).
-    exists s, is, (tr ++ [item]), item; split_and!; [..| done].
+    exists s, is, (tr ++ [item]), item.
+    split_and!; [.. | done].
     + by eapply valid_trace_forget_last.
     + by apply last_error_is_last.
     + apply finite_valid_trace_init_to_last in Htr.
@@ -724,36 +739,36 @@ Qed.
   Here we state the original mathematical definitions (as presented in the
   #<a href="https://doi.org/10.48550/arXiv.2202.12662">VLSM paper</a>#)
   for valid traces, states, and messages, deriving them from the "constrained"
-  notions, and we showing them equivalent with the ones defined in the VLSM module.
+  notions, and we show them equivalent to the ones defined in the VLSM module.
 *)
 
 (**
   A valid trace is a constrained trace whose [input]s are all valid messages;
   a valid message is either an initial message or an [output] of a valid trace.
 *)
-Inductive
-  finite_valid_trace_init_to_from_constrained :
-    state X -> state X -> list (transition_item X) -> Prop :=
-| fvtit_def : forall (s f : state X) (tr : list (transition_item X)),
-    finite_constrained_trace_init_to_direct s f tr ->
-    (forall item, item ∈ tr ->
-      option_valid_message_prop_from_constrained (input item)) ->
-    finite_valid_trace_init_to_from_constrained s f tr
-with
-  option_valid_message_prop_from_constrained : option message -> Prop :=
+Inductive finite_valid_trace_init_to_from_constrained
+  : state X -> state X -> list (transition_item X) -> Prop :=
+| fvtit_def :
+    forall (s f : state X) (tr : list (transition_item X)),
+      finite_constrained_trace_init_to_direct s f tr ->
+      (forall item, item ∈ tr -> option_valid_message_prop_from_constrained (input item)) ->
+      finite_valid_trace_init_to_from_constrained s f tr
+
+with option_valid_message_prop_from_constrained : option message -> Prop :=
 | ovmp_def_initial :
-  forall om, option_initial_message_prop X om ->
-    option_valid_message_prop_from_constrained om
+    forall (om : option message),
+      option_initial_message_prop X om ->
+      option_valid_message_prop_from_constrained om
 | ovmp_def_emit :
-  forall (s f : state X) (tr : list (transition_item X)),
-   finite_valid_trace_init_to_from_constrained s f tr ->
-   forall (item : transition_item X), item ∈ tr ->
-   option_valid_message_prop_from_constrained (output item).
+    forall (s f : state X) (tr : list (transition_item X)),
+      finite_valid_trace_init_to_from_constrained s f tr ->
+      forall (item : transition_item X), item ∈ tr ->
+      option_valid_message_prop_from_constrained (output item).
 
 Lemma finite_valid_trace_init_to_from_constrained_right_impl :
   forall (s f : state X) (tr : list (transition_item X)),
-  finite_valid_trace_init_to X s f tr ->
-  finite_valid_trace_init_to_from_constrained s f tr.
+    finite_valid_trace_init_to X s f tr ->
+    finite_valid_trace_init_to_from_constrained s f tr.
 Proof.
   intros * Htr.
   induction Htr using finite_valid_trace_init_to_rev_strong_ind;
@@ -761,14 +776,16 @@ Proof.
   constructor.
   - clear -Htr1 Ht.
     apply finite_constrained_trace_init_to_direct_equiv.
-    destruct X.
+    destruct X as [T M].
     eapply VLSM_incl_finite_valid_trace_init_to;
       [by apply vlsm_incl_preloaded_with_all_messages_vlsm |].
-    destruct Htr1 as [Htr1 Hinit]; split; [| done].
+    destruct Htr1 as [Htr1 Hinit].
+    split; [| done].
     eapply finite_valid_trace_from_to_app; [done |].
     by apply finite_valid_trace_from_to_singleton.
   - inversion IHHtr1 as [? ? ? _ IHoutput]; subst; clear IHHtr1.
-    intro item; rewrite elem_of_app, elem_of_list_singleton.
+    intros item.
+    rewrite elem_of_app, elem_of_list_singleton.
     intros [| ->]; [by apply IHoutput |].
     unfold empty_initial_message_or_final_output in Heqiom.
     destruct_list_last iom_tr iom_tr' item Heq; [by constructor 1 |].
@@ -778,28 +795,32 @@ Qed.
 
 Lemma finite_valid_trace_init_to_from_constrained_left_impl :
   forall (s f : state X) (tr : list (transition_item X)),
-  finite_valid_trace_init_to_from_constrained s f tr -> finite_valid_trace_init_to X s f tr
+    finite_valid_trace_init_to_from_constrained s f tr ->
+    finite_valid_trace_init_to X s f tr
+
 with option_valid_message_prop_from_constrained_left_impl :
-  forall om, option_valid_message_prop_from_constrained om -> option_valid_message_prop X om.
+  forall (om : option message),
+    option_valid_message_prop_from_constrained om ->
+    option_valid_message_prop X om.
 Proof.
-  - intros * Htr; inversion Htr as [? ? ? [Htrc Hinit] Hmsgs]; subst; clear Htr.
+  - intros s f tr [? ? ? [Htrc Hinit] Hmsgs]; subst.
     apply pre_traces_with_valid_inputs_are_valid;
       [by apply finite_constrained_trace_init_to_direct_left_impl |].
     rewrite Forall_forall in *; intros.
     by apply option_valid_message_prop_from_constrained_left_impl, Hmsgs.
-  - intros om Hom.
-    inversion Hom as [? Hinit | ? ? ? Hemit ? Hitem]; subst;
+  - intros om [? Hinit | ? ? ? Hemit ? Hitem]; subst;
       [by apply option_initial_message_is_valid |].
-    destruct (output item) as [m |] eqn:Houtput;
+    destruct (output item) as [m |] eqn: Houtput;
       [| by apply option_valid_message_None].
     eapply option_valid_message_Some, valid_trace_output_is_valid;
       [| by apply Exists_exists; eexists].
-    by eapply valid_trace_forget_last, finite_valid_trace_init_to_from_constrained_left_impl.
+    by eapply valid_trace_forget_last,
+      finite_valid_trace_init_to_from_constrained_left_impl.
 Qed.
 
 Lemma finite_valid_trace_init_to_from_constrained_equiv :
   forall (s f : state X) (tr : list (transition_item X)),
-  finite_valid_trace_init_to_from_constrained s f tr <-> finite_valid_trace_init_to X s f tr.
+    finite_valid_trace_init_to_from_constrained s f tr <-> finite_valid_trace_init_to X s f tr.
 Proof.
   split.
   - by apply finite_valid_trace_init_to_from_constrained_left_impl.
@@ -807,7 +828,9 @@ Proof.
 Qed.
 
 Lemma option_valid_message_prop_from_constrained_right_impl :
-  forall om, option_valid_message_prop X om -> option_valid_message_prop_from_constrained om.
+  forall (om : option message),
+    option_valid_message_prop X om ->
+    option_valid_message_prop_from_constrained om.
 Proof.
   intros [m |] Hm; [| by apply ovmp_def_initial].
   apply emitted_messages_are_valid_iff in Hm as [| Hm]; [by apply ovmp_def_initial |].
@@ -818,7 +841,8 @@ Proof.
 Qed.
 
 Lemma option_valid_message_prop_from_constrained_equiv :
-  forall om, option_valid_message_prop_from_constrained om <-> option_valid_message_prop X om.
+  forall (om : option message),
+    option_valid_message_prop_from_constrained om <-> option_valid_message_prop X om.
 Proof.
   split.
   - by apply option_valid_message_prop_from_constrained_left_impl.
@@ -831,14 +855,18 @@ Definition valid_state_prop_from_constrained (s : state X) : Prop :=
     finite_valid_trace_init_to_from_constrained is s tr.
 
 Lemma valid_state_prop_from_constrained_left_impl :
-  forall (s : state X), valid_state_prop_from_constrained s -> valid_state_prop X s.
+  forall (s : state X),
+    valid_state_prop_from_constrained s ->
+    valid_state_prop X s.
 Proof.
   intros s (is & tr & Htr).
   by apply finite_valid_trace_init_to_from_constrained_equiv, valid_trace_last_pstate in Htr.
 Qed.
 
 Lemma valid_state_prop_from_constrained_right_impl :
-  forall (s : state X), valid_state_prop X s -> valid_state_prop_from_constrained s.
+  forall (s : state X),
+    valid_state_prop X s ->
+    valid_state_prop_from_constrained s.
 Proof.
   intros s Hs.
   apply valid_state_has_trace in Hs as (is & tr & Htr).
@@ -846,7 +874,8 @@ Proof.
 Qed.
 
 Lemma valid_state_prop_from_constrained_equiv :
-  forall (s : state X), valid_state_prop_from_constrained s <-> valid_state_prop X s.
+  forall (s : state X),
+    valid_state_prop_from_constrained s <-> valid_state_prop X s.
 Proof.
   split.
   - by apply valid_state_prop_from_constrained_left_impl.


### PR DESCRIPTION
Since `PreloadedVLSM.v` got so much scrutiny recently, it would be a sin not to modernize it a bit. The most significant change is that I changed the definition of `preloaded_vlsm_machine` to depend on an entire `X : VLSM message`, not just on a machine (this is similar to how we define other VLSM constructions). The remainig changes are just reformatting and some minor changes to comments and proofs.